### PR TITLE
VendorField type change blob to varchar

### DIFF
--- a/packages/core-database-sequelize/lib/migrations/20180305163243-create-transaction.js
+++ b/packages/core-database-sequelize/lib/migrations/20180305163243-create-transaction.js
@@ -45,7 +45,7 @@ module.exports = {
         // }
       },
       type: Sequelize.SMALLINT,
-      vendorFieldHex: Sequelize.BLOB,
+      vendorFieldHex: Sequelize.STRING(256),
       amount: Sequelize.BIGINT,
       fee: Sequelize.BIGINT,
       serialized: Sequelize.BLOB,

--- a/packages/core-database-sequelize/lib/models/transaction.js
+++ b/packages/core-database-sequelize/lib/models/transaction.js
@@ -41,7 +41,7 @@ module.exports = (sequelize, DataTypes) => {
       // }
     },
     type: DataTypes.SMALLINT,
-    vendorFieldHex: DataTypes.BLOB,
+    vendorFieldHex: DataTypes.STRING(256),
     amount: DataTypes.BIGINT,
     fee: DataTypes.BIGINT,
     serialized: DataTypes.BLOB


### PR DESCRIPTION
- change field as agreed to be in hex string
- can now be searched `select * from tx where vendorFieldHex like '%f093%'`
- on API level human readable conversion from plain string to hexString should be made so user API could still be 
- it's a balance between transaction mechanics and not too much business logic...

rebuild from scratch needed