### PR TITLE
p2p / peer status height fix - adjusting api to serialized block

### DIFF
--- a/packages/core-p2p/lib/server/versions/1/handlers.js
+++ b/packages/core-p2p/lib/server/versions/1/handlers.js
@@ -128,7 +128,7 @@ exports.getStatus = {
     } else {
       return {
         success: true,
-        height: lastBlock.height,
+        height: lastBlock.data.height,
         forgingAllowed: slots.getSlotNumber() === slots.getSlotNumber(slots.getTime() + slots.interval / 2),
         currentSlot: slots.getSlotNumber(),
         header: lastBlock.getHeader()


### PR DESCRIPTION
there was no height in peer/status .. so comparisons and all other stuff was ...