### PR TITLE
Rebuild and sync fix

### DIFF
--- a/packages/core-database-sequelize/lib/connection.js
+++ b/packages/core-database-sequelize/lib/connection.js
@@ -487,7 +487,8 @@ module.exports = class SequelizeConnection extends ConnectionInterface {
         height: {
           [Sequelize.Op.between]: [offset, last]
         }
-      }
+      },
+      order: [['height', 'ASC']]
     })
 
     const nblocks = blocks.map(block => {


### PR DESCRIPTION
Adding order by height to peer/blocks. Otherwise returning random order with bigger blocks and verification fails as blocks are not in order...