### PR TITLE
Add a pre-push git-hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
   ],
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged"
+      "pre-commit": "lint-staged",
+      "pre-push": "yarn run test"
     }
   },
   "lint-staged": {


### PR DESCRIPTION
Why this pre-push Git-hook?
 - We don't have CI yet, so it's a way to ensure that we don't break tests
 - It's easy to skip: just use `git push` with `--no-verify`
 - It'd make fixing the failing tests easier