### PR TITLE
fix: move getLastBlock call into try/catch for getRound

### DIFF
--- a/packages/core-p2p/lib/server/versions/internal/handlers.js
+++ b/packages/core-p2p/lib/server/versions/internal/handlers.js
@@ -49,11 +49,11 @@ exports.getRound = {
    * @return {Hapi.Response}
    */
   async handler (request, h) {
-    const blockchain = container.resolvePlugin('blockchain')
-
-    const lastBlock = await blockchain.getLastBlock()
-
     try {
+      const blockchain = container.resolvePlugin('blockchain')
+
+      const lastBlock = await blockchain.getLastBlock()
+
       const height = lastBlock.data.height + 1
       const maxActive = config.getConstants(height).activeDelegates
       const blockTime = config.getConstants(height).blocktime


### PR DESCRIPTION
Calling it outside causes an uncaught exception if the blockchain is still syncing and not ready yet.