### PR TITLE
Ensure that values are added and not concatenated

### DIFF
--- a/packages/core-api/lib/versions/1/handlers/delegates.js
+++ b/packages/core-api/lib/versions/1/handlers/delegates.js
@@ -162,7 +162,7 @@ exports.forged = {
     return utils.respondWith({
       fees: wallet.forgedFees,
       rewards: wallet.forgedRewards,
-      forged: (wallet.forgedFees + wallet.forgedRewards)
+      forged: (Number(wallet.forgedFees) + Number(wallet.forgedRewards))
     })
   },
   config: {


### PR DESCRIPTION
## Proposed changes
To return the total forged amount, `forgedFees` and `forgedRewards` need to be added, but were concatenated instead (Wooh, JavaScript). This PR ensures that the values are being added (as intended) by converting them to `Number` first.
Resolves #654 

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [ ] Docs (documentation only changes)
- [ ] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/docs/contributing) documentation
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
