### PR TITLE
pretty-ms revisit (local environment difficulties)

### DIFF
--- a/packages/core-blockchain/lib/utils/tick-sync-tracker.js
+++ b/packages/core-blockchain/lib/utils/tick-sync-tracker.js
@@ -6,8 +6,8 @@ const database = container.resolvePlugin('database')
 let tracker = null
 
 module.exports = async block => {
+  const { height } = await database.blocks.getLastHeight()
   if (!tracker) {
-    const { height } = await database.blocks.getLastHeight()
 
     tracker = {
       start: new Date().getTime(),
@@ -19,10 +19,9 @@ module.exports = async block => {
     }
   }
 
-  tracker.downloadedBlocks += block.data.height
-  tracker.percent = (tracker.downloadedBlocks * 100) / tracker.networkHeight
-  tracker.blockPerMs = ((new Date().getTime()) - tracker.start) / tracker.downloadedBlocks
-  tracker.timeLeft = Math.abs((tracker.networkHeight - tracker.downloadedBlocks) / tracker.blockPerMs)
+  tracker.percent = (height * 100) / tracker.networkHeight
+  tracker.blockPerMs = (new Date().getTime()) - tracker.start) / (height - tracker.downloadedBlocks)
+  tracker.timeLeft = Math.abs((tracker.networkHeight - height) / tracker.blockPerMs)
 
   if (tracker.percent < 100 && isFinite(tracker.timeLeft)) {
     const downloadedBlocks = tracker.downloadedBlocks.toLocaleString()


### PR DESCRIPTION
cloned sync-estimate and modified a little bit

Issue #688 - looking for feedback as my testing environment is not proper atm. The package is included properly and should work, but again my environment is limited I would like someone to validate it gets printed to the logger properly.

closes #689 in favor of self

## Further comments

1. height of last downloaded block gets queried every time the sync gets called 
2. tracker.downloadedBlocks gets set only once, when tracker is initiated and reflects the block where the sync begins as a Point of Reference for calculations 
3. percent is really the height * 100 / networkHeight and is independent of how many blocks were downloaded before the sync started at the current iteration
4. blockPerMs takes the elapsed time and divides it by the height minus block start from tracker.downloadedBlocks static constant 
5. timeleft is remaining blocks by blockPerMs

these changes, specifically regarding tracker.downloadedBlocks being constant, help maintain a steady sync timeleft estimate.