### PR TITLE
imp: change delegate "votes" property to "vote" as in v1

### DIFF
--- a/packages/core-api/lib/versions/1/transformers/delegate.js
+++ b/packages/core-api/lib/versions/1/transformers/delegate.js
@@ -12,7 +12,7 @@ module.exports = (delegate) => {
     username: delegate.username,
     address: delegate.address,
     publicKey: delegate.publicKey,
-    votes: delegate.votebalance,
+    vote: delegate.votebalance + '',
     producedblocks: delegate.producedBlocks,
     missedblocks: delegate.missedBlocks,
     forged: delegate.forged,


### PR DESCRIPTION
## Proposed changes

Changes the "votes" property that is currently returned by the delegates API to "vote" (and also from Number to String) to be in line with the v1 api

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [ ] Docs (documentation only changes)
- [ ] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/docs/contributing) documentation
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
