### PR TITLE
Fix `core-webhooks` tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   bail: false,
   verbose: true,
+  testEnvironment: 'node',
   testMatch: [
     // '**/packages/**/__tests__/**/*.test.js'
 

--- a/packages/core-webhooks/__tests__/__support__/setup.js
+++ b/packages/core-webhooks/__tests__/__support__/setup.js
@@ -18,12 +18,6 @@ module.exports = async () => {
     ]
   })
 
-  await require('../../lib/database').setUp({
-    dialect: 'sqlite',
-    storage: ':memory:',
-    logging: false
-  })
-
   await require('../../lib/manager').setUp({
     redis: {
       host: process.env.ARK_REDIS_HOST || 'localhost',

--- a/packages/core-webhooks/__tests__/api/handler.test.js
+++ b/packages/core-webhooks/__tests__/api/handler.test.js
@@ -45,6 +45,10 @@ describe('API 2.0 - Webhooks', () => {
       const response = await utils.request('GET', `webhooks/${webhook.data.data.id}`)
       utils.expectSuccessful(response)
       utils.expectResource(response)
+
+      const { data } = response.data
+      const webhookData = Object.assign(webhook.data.data, { token: data.token.substring(0, 32) })
+      expect(data).toEqual(webhookData)
     })
   })
 

--- a/packages/core-webhooks/lib/database/index.js
+++ b/packages/core-webhooks/lib/database/index.js
@@ -15,7 +15,7 @@ class Database {
    */
   async setUp (config) {
     if (this.connection) {
-      throw new Error('Already initialised')
+      throw new Error('Webhooks database already initialised')
     }
 
     if (config.dialect === 'sqlite' && config.storage !== ':memory:') {

--- a/packages/core-webhooks/lib/index.js
+++ b/packages/core-webhooks/lib/index.js
@@ -28,7 +28,7 @@ exports.plugin = {
       return require('./server')(options.server)
     }
 
-    logger.info('Webhooks API is disabled :grey_exclamation:')
+    logger.info('Webhooks API server is disabled :grey_exclamation:')
   },
   async deregister (container, options) {
     if (options.server.enabled) {


### PR DESCRIPTION
Apart from fixing a problem that provokes that `core-webhooks` can't run due to database already initialised, this PR changes the Jest environment to Node.js, which means faster tests and avoids problems with `jsdom`.
It also means that we should have a different configuration for other tests, like the `client` package that should be tested on browser too. But that's a different and future task.