### PR TITLE
Add a docker-compose configuration for development

### DIFF
--- a/docker/development/docker-compose.yml
+++ b/docker/development/docker-compose.yml
@@ -1,0 +1,29 @@
+#
+# For running some services on development without tainting your system
+#
+version: '2'
+services:
+
+  redis:
+    image: "redis:alpine"
+    container_name: ark-development-redis
+    ports:
+      - '127.0.0.1:6379:6379'
+    volumes:
+      - 'redis:/data'
+
+  postgres:
+    image: "postgres:alpine"
+    container_name: ark-development-postgres
+    ports:
+      - '127.0.0.1:5432:5432'
+    volumes:
+      - 'postgres:/var/lib/postgresql/data'
+    environment:
+     POSTGRES_PASSWORD: ark_development_not_random_password
+     POSTGRES_DB: ark_development
+     POSTGRES_USER: ark_development
+
+volumes:
+  redis:
+  postgres:


### PR DESCRIPTION
The aim of this PR is provide an easy way to run `core` without installing and configuring PostgreSQL and Redis.

- [X] `docker-compose.yml` file
- [ ] Update docs: https://docs.ark.io/v1.0/docs/docker (after merging the PR)