### PR TITLE
Fix issue with unconfirmedBalance being undefined

### DIFF
--- a/packages/core-api/lib/versions/1/transformers/account.js
+++ b/packages/core-api/lib/versions/1/transformers/account.js
@@ -15,7 +15,7 @@ module.exports = (model) => {
     votes: model.votes,
     username: model.username,
     balance: `${model.balance}`,
-    unconfirmedBalance: `${model.unconfirmedBalance}`,
+    unconfirmedBalance: `${model.balance}`,
     multisignatures: [],
     u_multisignatures: [],
     unconfirmedSignature: hasSecondSignature ? 1 : 0,


### PR DESCRIPTION
## Proposed changes

When querying the `accounts/getAllAccounts` endpoint, the unconfirmedBalance would be `undefined` (and some other account endpoints that made use of the same transformer had this too) as it was not available in the `wallet` model. Simple fix: use `balance` also for `unconfirmedBalance`, since they are already interchangeably used for other endpoints such as `accounts/get`:

```
return utils.respondWith({
      balance: account ? `${account.balance}` : '0',
      unconfirmedBalance: account ? `${account.balance}` : '0'
    })
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [ ] Docs (documentation only changes)
- [ ] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/docs/contributing) documentation
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)