### PR TITLE
Speed up Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,9 @@ env:
   ARK_CI_TEST: true
 
 before_install:
-  - npm install yarn
+  # - npm install yarn
+  - curl -o- -L https://yarnpkg.com/install.sh | bash
+  - export PATH="$HOME/.yarn/bin:$PATH"
   - yarn config set cache-folder $HOME/.cache/yarn
 
 install: yarn

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,3 +54,7 @@ cache:
     - $HOME/.yarn-cache
     # - node_modules
     # - packages/**/node_modules
+
+git:
+  # It's not necessary to get more than the last commit (and this branch alone)
+  depth: 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
 
 before_install:
   - npm install yarn lerna
+  - yarn config set cache-folder $HOME/.yarn-cache
 
 install:
   - yarn bootstrap
@@ -46,4 +47,10 @@ jobs:
     #   node_js: 9
     #   script: yarn test:coverage
 
-cache: yarn
+cache:
+  yarn: true # This wouldn't do anything because it needs a yarn.lock
+  directories:
+    - $HOME/.npm
+    - $HOME/.yarn-cache
+    # - node_modules
+    # - packages/**/node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,11 @@ env:
   ARK_CI_TEST: true
 
 before_install:
-  - npm install yarn lerna
-  - yarn config set cache-folder $HOME/.yarn-cache
+  - npm install yarn
+  - yarn config set cache-folder $HOME/.cache/yarn
 
-install:
-  - yarn bootstrap
+install: yarn
+#   - yarn bootstrap
 
 stages:
   - lint
@@ -50,10 +50,10 @@ jobs:
 cache:
   yarn: true # This wouldn't do anything because it needs a yarn.lock
   directories:
-    - $HOME/.npm
-    - $HOME/.yarn-cache
-    # - node_modules
-    # - packages/**/node_modules
+    - $HOME/.nvm/.cache
+    - $HOME/.cache/yarn
+    - node_modules
+    - packages/**/node_modules
 
 git:
   # It's not necessary to get more than the last commit (and this branch alone)


### PR DESCRIPTION
The Travis CI cache for Yarn wasn't working. The reason is that it requires a `yarn.lock` (https://blog.travis-ci.com/2016-11-21-travis-ci-now-supports-yarn).