### PR TITLE
Fix getPBFTForgingStatus returning NaN

### DIFF
--- a/packages/core-p2p/lib/monitor.js
+++ b/packages/core-p2p/lib/monitor.js
@@ -316,7 +316,8 @@ module.exports = class Monitor {
     }
 
     console.log(heights)
-    return allowedToForge / syncedPeers
+    const pbft = allowedToForge / syncedPeers
+    return isNaN(pbft) ? 0 : pbft
   }
 
   async getNetworkState () {


### PR DESCRIPTION
When both allowedToForge and syncedPeers are 0 the division returns NaN which looks a bit weird in the log. Return 0 instead of NaN.

Before:
`[2018-07-10 19:11:28][INFO]    : Network PBFT status: NaN`
After:
`[2018-07-10 19:13:17][INFO]    : Network PBFT status: 0`
