### PR TITLE
Fix remaining core-database-sequelize tests

### DIFF
--- a/packages/core-database-sequelize/__tests__/connection.test.js
+++ b/packages/core-database-sequelize/__tests__/connection.test.js
@@ -159,7 +159,9 @@ describe('Sequelize Connection', () => {
       const wallet = connection.walletManager.getWalletByPublicKey('03e59140fde881ac437ec3dc3e372bf25f7c19f0b471a5b35cc30f783e8a7b811b')
       expect(wallet.missedBlocks).toBe(0)
 
-      await connection.updateDelegateStats(genesisBlock, delegates)
+      const { height } = genesisBlock.data
+      await connection.applyRound(height)
+      await connection.updateDelegateStats(height, delegates)
 
       expect(wallet.missedBlocks).toBe(1)
     })


### PR DESCRIPTION
~~The test `should find all transactions that holds all the conditions (AND)`  didn't pass, because the genesis transaction is of type 0.~~

The test `should update the delegate` didn't pass, because calling `updateDelegateStats`  when `blocksInCurrentRound` is not set has no effect. Calling `applyRound` ensures that `blocksInCurrentRound` is set and the last failing test passes.
