### PR TITLE
Fix: Start p2p api before starting monitor to be able to be pinged by external peers

### DIFF
--- a/packages/core-p2p/lib/manager.js
+++ b/packages/core-p2p/lib/manager.js
@@ -25,9 +25,9 @@ module.exports = class PeerManager {
     await this.__checkDNSConnectivity()
     await this.__checkNTPConnectivity()
 
-    await this.monitor.start(this.config.networkStart)
-
     this.api = await startServer(this, this.config)
+
+    await this.monitor.start(this.config.networkStart)
 
     return this
   }


### PR DESCRIPTION
## Proposed changes

On p2p initialization, we were starting monitor before p2p api.

Problem is, when starting monitor we query remote nodes /peer endpoint, so remote node will try to add us as a peer querying our own /peer endpoint (ping to check we are alive).
But as our p2p api isn't started yet, we are unresponsive and therefore added to suspendedPeers list on remote (we are suspended for 1 hour).

Solution is simple, just start p2p api before monitor.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/docs/contributing) documentation
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works : **tested on community-run v2 devnet**

## Further comments

This was tested on community-run v2 devnet, I'm not sure how to add this kind of test to be run on testnet (need 2 peers + ark_env test is changing behaviour).
