### PR TITLE
Fix : acceptNewPeer condition to accept peers others than 'myself'

### DIFF
--- a/packages/core-p2p/lib/monitor.js
+++ b/packages/core-p2p/lib/monitor.js
@@ -148,10 +148,6 @@ module.exports = class Monitor {
       throw new Error('Request is made on the wrong network')
     }
 
-    if (peer.ip === '::ffff:127.0.0.1' || peer.ip === '127.0.0.1') {
-      return
-    }
-
     const newPeer = new Peer(peer.ip, peer.port)
 
     try {

--- a/packages/core-p2p/lib/monitor.js
+++ b/packages/core-p2p/lib/monitor.js
@@ -140,7 +140,7 @@ module.exports = class Monitor {
    * @throws {Error} If invalid peer
    */
   async acceptNewPeer (peer) {
-    if (this.getPeer(peer.ip) || this.__isSuspended(peer) || process.env.ARK_ENV === 'test' || !isMyself(peer.ip)) {
+    if (this.getPeer(peer.ip) || this.__isSuspended(peer) || process.env.ARK_ENV === 'test' || isMyself(peer.ip)) {
       return
     }
 


### PR DESCRIPTION
## Proposed changes

acceptNewPeer was accepting only its own IP, this fixes it by accepting peers others than 'myself'.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/docs/contributing) documentation
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works : **tested on community-run v2 devnet**

## Further comments

This was tested on community-run v2 devnet. I'm not sure how to add this kind of test to be run on testnet (need 2 peers + ark_env test is changing behaviour).