### PR TITLE
Fix some problems of packages with tests that run indefinitevely

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,8 @@ before_script:
   - sudo redis-server /etc/redis/redis.conf --port 6379
 
 script:
-  - yarn test:coverage --ci
+  # See https://jestjs.io/docs/en/troubleshooting.html#tests-are-extremely-slow-on-docker-and-or-continuous-integration-ci-server
+  - yarn test:coverage --ci --maxWorkers 4
   - codecov
 
 jobs:


### PR DESCRIPTION
## Proposed changes

The packages that mount a blockchain during tests keep running without executing all their tests or even after having finished.

This PR fixed that, although it doesn't enable all those packages, because some of them have failing tests.

## Further comments

The changes are:
  - Close the Redis connection (of the database cache) when Sequelize is disconnected
  - Add a new state (`stopped`) to the blockchain state machine to be able to stop the blockchain when tests are finished
  - Change Travis configuration and test script to increase the speed and detect problems