### PR TITLE
Fix: Delay creation of Genesis Block in unit tests to after setup

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -16,11 +16,10 @@ module.exports = {
     '**/packages/core-tester-cli/**/__tests__/**/*.test.js',
     '**/packages/core-transaction-pool-redis/**/__tests__/**/*.test.js',
     '**/packages/core-webhooks/**/__tests__/**/*.test.js',
-    '**/packages/validation/**/__tests__/**/*.test.js'
+    '**/packages/validation/**/__tests__/**/*.test.js',
+    '**/packages/core-database-sequelize/**/__tests__/**/*.test.js'
 
     /* These packages have failing tests */
-
-    // '**/packages/core-database-sequelize/**/__tests__/**/*.test.js'
 
     /* These packages don't have any test yet */
 

--- a/packages/core-api/__tests__/__support__/setup.js
+++ b/packages/core-api/__tests__/__support__/setup.js
@@ -7,9 +7,9 @@ const generateRound = require('./utils/generate-round')
 const activeDelegates = require('../__fixtures__/delegates.json')
 const round = generateRound(activeDelegates, 1)
 
-jest.setTimeout(60000)
+exports.setUp = async () => {
+  jest.setTimeout(60000)
 
-beforeAll(async () => {
   process.env.ARK_SKIP_BLOCKCHAIN_STARTED_CHECK = true
 
   await container.setUp({
@@ -24,8 +24,8 @@ beforeAll(async () => {
   await connection.buildWallets(1)
   await connection.saveWallets(true)
   await connection.saveRound(round)
-})
+}
 
-afterAll(async () => {
+exports.tearDown = async () => {
   await container.tearDown()
-})
+}

--- a/packages/core-api/__tests__/v1/handlers/accounts.test.js
+++ b/packages/core-api/__tests__/v1/handlers/accounts.test.js
@@ -1,10 +1,17 @@
 'use strict'
 
-require('../../__support__/setup')
-
+const app = require('../../__support__/setup')
 const utils = require('../utils')
 
 const address = 'AG8kwwk4TsYfA2HdwaWBVAJQBj6VhdcpMo'
+
+beforeAll(async () => {
+  await app.setUp()
+})
+
+afterAll(async () => {
+  await app.tearDown()
+})
 
 describe('API 1.0 - Wallets', () => {
   describe('GET api/accounts/getAllAccounts', () => {

--- a/packages/core-api/__tests__/v1/handlers/blocks.test.js
+++ b/packages/core-api/__tests__/v1/handlers/blocks.test.js
@@ -1,9 +1,21 @@
 'use strict'
 
-require('../../__support__/setup')
-
+const app = require('../../__support__/setup')
 const utils = require('../utils')
-const genesisBlock = require('../../__support__/config/genesisBlock.json')
+
+let genesisBlock
+
+beforeAll(async () => {
+  await app.setUp()
+
+  // Create the genesis block after the setup has finished or else it uses a potentially
+  // wrong network config.
+  genesisBlock = require('../../__support__/config/genesisBlock.json')
+})
+
+afterAll(async () => {
+  await app.tearDown()
+})
 
 describe('API 1.0 - Blocks', () => {
   describe('GET /blocks/get?id', () => {

--- a/packages/core-api/__tests__/v1/handlers/delegates.test.js
+++ b/packages/core-api/__tests__/v1/handlers/delegates.test.js
@@ -1,13 +1,20 @@
 'use strict'
 
-require('../../__support__/setup')
-
+const app = require('../../__support__/setup')
 const utils = require('../utils')
 
 const delegate = {
   username: 'genesis_9',
   publicKey: '0377f81a18d25d77b100cb17e829a72259f08334d064f6c887298917a04df8f647'
 }
+
+beforeAll(async () => {
+  await app.setUp()
+})
+
+afterAll(async () => {
+  await app.tearDown()
+})
 
 describe('API 1.0 - Delegates', () => {
   describe('GET /delegates', () => {

--- a/packages/core-api/__tests__/v1/handlers/loader.test.js
+++ b/packages/core-api/__tests__/v1/handlers/loader.test.js
@@ -1,8 +1,15 @@
 'use strict'
 
-require('../../__support__/setup')
-
+const app = require('../../__support__/setup')
 const utils = require('../utils')
+
+beforeAll(async () => {
+  await app.setUp()
+})
+
+afterAll(async () => {
+  await app.tearDown()
+})
 
 describe('API 1.0 - Loader', () => {
   describe('GET /loader/status', () => {

--- a/packages/core-api/__tests__/v1/handlers/peers.test.js
+++ b/packages/core-api/__tests__/v1/handlers/peers.test.js
@@ -1,11 +1,18 @@
 'use strict'
 
-require('../../__support__/setup')
-
+const app = require('../../__support__/setup')
 const utils = require('../utils')
 
 const peerIp = '167.114.29.55'
 const peerPort = '4002'
+
+beforeAll(async () => {
+  await app.setUp()
+})
+
+afterAll(async () => {
+  await app.tearDown()
+})
 
 describe('API 1.0 - Peers', () => {
   describe('GET /peers/version', () => {

--- a/packages/core-api/__tests__/v1/handlers/signatures.test.js
+++ b/packages/core-api/__tests__/v1/handlers/signatures.test.js
@@ -1,8 +1,15 @@
 'use strict'
 
-require('../../__support__/setup')
-
+const app = require('../../__support__/setup')
 const utils = require('../utils')
+
+beforeAll(async () => {
+  await app.setUp()
+})
+
+afterAll(async () => {
+  await app.tearDown()
+})
 
 describe('API 1.0 - Signatures', () => {
   describe('GET /signatures/fee', () => {

--- a/packages/core-api/__tests__/v1/handlers/transactions.test.js
+++ b/packages/core-api/__tests__/v1/handlers/transactions.test.js
@@ -1,16 +1,28 @@
 'use strict'
 
-require('../../__support__/setup')
-
 require('@arkecosystem/core-test-utils')
 
+const app = require('../../__support__/setup')
 const utils = require('../utils')
-const genesisBlock = require('../../__support__/config/genesisBlock.json')
 
 const address1 = 'APnhwwyTbMiykJwYbGhYjNgtHiVJDSEhSn'
 const address2 = 'AHXtmB84sTZ9Zd35h9Y1vfFvPE2Xzqj8ri'
 
-const transactionList = genesisBlock.transactions
+let genesisBlock
+let transactionList
+
+beforeAll(async () => {
+  await app.setUp()
+
+  // Create the genesis block after the setup has finished or else it uses a potentially
+  // wrong network config.
+  genesisBlock = require('../../__support__/config/genesisBlock.json')
+  transactionList = genesisBlock.transactions
+})
+
+afterAll(async () => {
+  await app.tearDown()
+})
 
 describe('API 1.0 - Transactions', () => {
   describe('GET /transactions', () => {

--- a/packages/core-api/__tests__/v2/handlers/blocks.test.js
+++ b/packages/core-api/__tests__/v2/handlers/blocks.test.js
@@ -1,9 +1,21 @@
 'use strict'
 
-require('../../__support__/setup')
-
+const app = require('../../__support__/setup')
 const utils = require('../utils')
-const genesisBlock = require('../../__support__/config/genesisBlock.json')
+
+let genesisBlock
+
+beforeAll(async () => {
+  await app.setUp()
+
+  // Create the genesis block after the setup has finished or else it uses a potentially
+  // wrong network config.
+  genesisBlock = require('../../__support__/config/genesisBlock.json')
+})
+
+afterAll(async () => {
+  await app.tearDown()
+})
 
 describe('API 2.0 - Blocks', () => {
   describe('GET /blocks', () => {

--- a/packages/core-api/__tests__/v2/handlers/delegates.test.js
+++ b/packages/core-api/__tests__/v2/handlers/delegates.test.js
@@ -1,7 +1,6 @@
 'use strict'
 
-require('../../__support__/setup')
-
+const app = require('../../__support__/setup')
 const utils = require('../utils')
 
 const delegate = {
@@ -9,6 +8,14 @@ const delegate = {
   address: 'AG8kwwk4TsYfA2HdwaWBVAJQBj6VhdcpMo',
   publicKey: '0377f81a18d25d77b100cb17e829a72259f08334d064f6c887298917a04df8f647'
 }
+
+beforeAll(async () => {
+  await app.setUp()
+})
+
+afterAll(async () => {
+  await app.tearDown()
+})
 
 describe('API 2.0 - Delegates', () => {
   describe('GET /delegates', () => {

--- a/packages/core-api/__tests__/v2/handlers/node.test.js
+++ b/packages/core-api/__tests__/v2/handlers/node.test.js
@@ -1,8 +1,15 @@
 'use strict'
 
-require('../../__support__/setup')
-
+const app = require('../../__support__/setup')
 const utils = require('../utils')
+
+beforeAll(async () => {
+  await app.setUp()
+})
+
+afterAll(async () => {
+  await app.tearDown()
+})
 
 describe('API 2.0 - Loader', () => {
   describe('GET /node/status', () => {

--- a/packages/core-api/__tests__/v2/handlers/peers.test.js
+++ b/packages/core-api/__tests__/v2/handlers/peers.test.js
@@ -1,10 +1,17 @@
 'use strict'
 
-require('../../__support__/setup')
-
+const app = require('../../__support__/setup')
 const utils = require('../utils')
 
 const peerIp = '167.114.29.32'
+
+beforeAll(async () => {
+  await app.setUp()
+})
+
+afterAll(async () => {
+  await app.tearDown()
+})
 
 describe('API 2.0 - Peers', () => {
   describe('GET /peers', () => {

--- a/packages/core-api/__tests__/v2/handlers/statistics.test.js
+++ b/packages/core-api/__tests__/v2/handlers/statistics.test.js
@@ -1,8 +1,15 @@
 'use strict'
 
-require('../../__support__/setup')
-
+const app = require('../../__support__/setup')
 const utils = require('../utils')
+
+beforeAll(async () => {
+  await app.setUp()
+})
+
+afterAll(async () => {
+  await app.tearDown()
+})
 
 describe.skip('API 2.0 - Statistics', () => {
   describe('GET /statistics/blockchain', () => {

--- a/packages/core-api/__tests__/v2/handlers/transactions.test.js
+++ b/packages/core-api/__tests__/v2/handlers/transactions.test.js
@@ -1,28 +1,59 @@
 'use strict'
 
-require('../../__support__/setup')
-
+const app = require('../../__support__/setup')
 const utils = require('../utils')
-const genesisBlock = require('../../__support__/config/genesisBlock.json')
-const genesisTransactions = genesisBlock.transactions[0]
 
-const transactionId = genesisTransactions.id
-const blockId = genesisBlock.id
-const type = genesisTransactions.type
-const wrongType = 3
-const version = 1
-const senderPublicKey = genesisTransactions.senderPublicKey
-const senderAddress = genesisTransactions.senderId
-const recipientAddress = genesisTransactions.recipientId
-const timestamp = genesisTransactions.timestamp
-const timestampFrom = timestamp
-const timestampTo = timestamp
-const amount = genesisTransactions.amount
-const amountFrom = amount
-const amountTo = amount
-const fee = genesisTransactions.fee
-const feeFrom = fee
-const feeTo = fee
+let genesisBlock
+let genesisTransactions
+
+let transactionId
+let blockId
+let type
+let wrongType
+let version
+let senderPublicKey
+let senderAddress
+let recipientAddress
+let timestamp
+let timestampFrom
+let timestampTo
+let amount
+let amountFrom
+let amountTo
+let fee
+let feeFrom
+let feeTo
+
+beforeAll(async () => {
+  await app.setUp()
+
+  // Create the genesis block after the setup has finished or else it uses a potentially
+  // wrong network config.
+  genesisBlock = require('../../__support__/config/genesisBlock.json')
+  genesisTransactions = genesisBlock.transactions[0]
+
+  transactionId = genesisTransactions.id
+  blockId = genesisBlock.id
+  type = genesisTransactions.type
+  wrongType = 3
+  version = 1
+  senderPublicKey = genesisTransactions.senderPublicKey
+  senderAddress = genesisTransactions.senderId
+  recipientAddress = genesisTransactions.recipientId
+  timestamp = genesisTransactions.timestamp
+  timestampFrom = timestamp
+  timestampTo = timestamp
+  amount = genesisTransactions.amount
+  amountFrom = amount
+  amountTo = amount
+  fee = genesisTransactions.fee
+  feeFrom = fee
+  feeTo = fee
+})
+
+afterAll(async () => {
+  await app.tearDown()
+})
 
 describe('API 2.0 - Transactions', () => {
   describe('GET /transactions', () => {

--- a/packages/core-api/__tests__/v2/handlers/votes.test.js
+++ b/packages/core-api/__tests__/v2/handlers/votes.test.js
@@ -1,10 +1,17 @@
 'use strict'
 
-require('../../__support__/setup')
-
+const app = require('../../__support__/setup')
 const utils = require('../utils')
 
 const voteId = 'ea294b610e51efb3ceb4229f27bf773e87f41d21b6bb1f3bf68629ffd652c2d3'
+
+beforeAll(async () => {
+  await app.setUp()
+})
+
+afterAll(async () => {
+  await app.tearDown()
+})
 
 describe('API 2.0 - Votes', () => {
   describe('GET /votes', () => {

--- a/packages/core-api/__tests__/v2/handlers/wallets.test.js
+++ b/packages/core-api/__tests__/v2/handlers/wallets.test.js
@@ -1,13 +1,20 @@
 'use strict'
 
-require('../../__support__/setup')
-
+const app = require('../../__support__/setup')
 const utils = require('../utils')
 
 const username = 'genesis_9'
 const address = 'AG8kwwk4TsYfA2HdwaWBVAJQBj6VhdcpMo'
 const publicKey = '0377f81a18d25d77b100cb17e829a72259f08334d064f6c887298917a04df8f647'
 const balance = 245098000000000
+
+beforeAll(async () => {
+  await app.setUp()
+})
+
+afterAll(async () => {
+  await app.tearDown()
+})
 
 describe('API 2.0 - Wallets', () => {
   describe('GET /wallets', () => {

--- a/packages/core-blockchain/__tests__/blockchain.test.js
+++ b/packages/core-blockchain/__tests__/blockchain.test.js
@@ -4,13 +4,17 @@ const { asValue } = require('awilix')
 const { slots } = require('@arkecosystem/crypto')
 
 const app = require('./__support__/setup')
-const genesisBlock = require('./__fixtures__/genesisBlock')
 
+let genesisBlock
 let container
 let blockchain
 
 beforeAll(async () => {
   container = await app.setUp()
+
+  // Create the genesis block after the setup has finished or else it uses a potentially
+  // wrong network config.
+  genesisBlock = require('./__fixtures__/genesisBlock')
 })
 
 afterAll(async () => {

--- a/packages/core-database-sequelize/__tests__/connection.test.js
+++ b/packages/core-database-sequelize/__tests__/connection.test.js
@@ -10,6 +10,9 @@ let connection
 
 beforeAll(async () => {
   await app.setUp()
+
+  // Wait for the setup to complete before creating the Genesis Block or else it uses a potentially
+  // wrong network config.
   genesisBlock = require('./__fixtures__/genesisBlock')
 })
 

--- a/packages/core-database-sequelize/__tests__/connection.test.js
+++ b/packages/core-database-sequelize/__tests__/connection.test.js
@@ -4,6 +4,7 @@ const app = require('./__support__/setup')
 const generateRound = require('./__support__/utils/generate-round')
 const createConnection = require('./__support__/utils/create-connection')
 const activeDelegates = require('./__fixtures__/delegates.json')
+const { Transaction } = require('@arkecosystem/crypto').models
 
 let genesisBlock
 let connection
@@ -436,10 +437,15 @@ describe('Sequelize Connection', () => {
         '3c39aca95ad807ce19c0325e3059d7b1cf967751c6929035214a4ef320fb8154'
       ])
 
-      expect(transactions).toBeObject()
-      expect(transactions[0].id).toBe('db1aa687737858cc9199bfa336f9b1c035915c30aaee60b1e0f8afadfdb946bd')
-      expect(transactions[1].id).toBe('0762007f825f02979a883396839d6f7425d5ab18f4b8c266bebe60212c793c6d')
-      expect(transactions[2].id).toBe('3c39aca95ad807ce19c0325e3059d7b1cf967751c6929035214a4ef320fb8154')
+      const transactionIds = transactions.map(transaction => {
+        return Transaction.deserialize(transaction.serialized.toString('hex')).id
+      })
+
+      expect(transactions).toBeArray()
+      expect(transactions).toHaveLength(3)
+      expect(transactionIds[0]).toBe('0762007f825f02979a883396839d6f7425d5ab18f4b8c266bebe60212c793c6d')
+      expect(transactionIds[1]).toBe('3c39aca95ad807ce19c0325e3059d7b1cf967751c6929035214a4ef320fb8154')
+      expect(transactionIds[2]).toBe('db1aa687737858cc9199bfa336f9b1c035915c30aaee60b1e0f8afadfdb946bd')
     })
   })
 

--- a/packages/core-database-sequelize/__tests__/connection.test.js
+++ b/packages/core-database-sequelize/__tests__/connection.test.js
@@ -11,7 +11,7 @@ let connection
 beforeAll(async () => {
   await app.setUp()
 
-  // Wait for the setup to complete before creating the Genesis Block or else it uses a potentially
+  // Create the genesis block after the setup has finished or else it uses a potentially
   // wrong network config.
   genesisBlock = require('./__fixtures__/genesisBlock')
 })

--- a/packages/core-database-sequelize/__tests__/connection.test.js
+++ b/packages/core-database-sequelize/__tests__/connection.test.js
@@ -4,12 +4,13 @@ const app = require('./__support__/setup')
 const generateRound = require('./__support__/utils/generate-round')
 const createConnection = require('./__support__/utils/create-connection')
 const activeDelegates = require('./__fixtures__/delegates.json')
-const genesisBlock = require('./__fixtures__/genesisBlock')
 
+let genesisBlock
 let connection
 
 beforeAll(async () => {
   await app.setUp()
+  genesisBlock = require('./__fixtures__/genesisBlock')
 })
 
 afterAll(async () => {

--- a/packages/core-database-sequelize/__tests__/repositories/blocks.test.js
+++ b/packages/core-database-sequelize/__tests__/repositories/blocks.test.js
@@ -5,15 +5,18 @@ expect.extend({ toBeBlockTableRow })
 
 const app = require('../__support__/setup')
 const createConnection = require('../__support__/utils/create-connection')
-const genesisBlock = require('../__fixtures__/genesisBlock')
 
 // TODO theses tests should use more than 1 block to be sure that they're correct
 
+let genesisBlock
 let connection
 let repository
 
-beforeAll(async () => {
+beforeAll(async (done) => {
   await app.setUp()
+  genesisBlock = require('../__fixtures__/genesisBlock')
+
+  done()
 })
 
 afterAll(async () => {

--- a/packages/core-database-sequelize/__tests__/repositories/blocks.test.js
+++ b/packages/core-database-sequelize/__tests__/repositories/blocks.test.js
@@ -15,7 +15,7 @@ let repository
 beforeAll(async () => {
   await app.setUp()
 
-  // Wait for the setup to complete before creating the Genesis Block or else it uses a potentially
+  // Create the genesis block after the setup has finished or else it uses a potentially
   // wrong network config.
   genesisBlock = require('../__fixtures__/genesisBlock')
 })

--- a/packages/core-database-sequelize/__tests__/repositories/blocks.test.js
+++ b/packages/core-database-sequelize/__tests__/repositories/blocks.test.js
@@ -12,11 +12,12 @@ let genesisBlock
 let connection
 let repository
 
-beforeAll(async (done) => {
+beforeAll(async () => {
   await app.setUp()
-  genesisBlock = require('../__fixtures__/genesisBlock')
 
-  done()
+  // Wait for the setup to complete before creating the Genesis Block or else it uses a potentially
+  // wrong network config.
+  genesisBlock = require('../__fixtures__/genesisBlock')
 })
 
 afterAll(async () => {

--- a/packages/core-database-sequelize/__tests__/repositories/transactions.test.js
+++ b/packages/core-database-sequelize/__tests__/repositories/transactions.test.js
@@ -9,9 +9,9 @@ const SPV = require('../../lib/spv')
 
 const app = require('../__support__/setup')
 const createConnection = require('../__support__/utils/create-connection')
-const genesisBlock = require('../__fixtures__/genesisBlock')
-const genesisTransaction = genesisBlock.transactions[0]
 
+let genesisBlock
+let genesisTransaction
 let connection
 let repository
 let spv
@@ -20,8 +20,12 @@ const getWallet = address => {
   return spv.walletManager.getWalletByAddress(address)
 }
 
-beforeAll(async () => {
+beforeAll(async (done) => {
   await app.setUp()
+  genesisBlock = require('../__fixtures__/genesisBlock')
+  genesisTransaction = genesisBlock.transactions[0]
+
+  done()
 })
 
 afterAll(async () => {
@@ -202,7 +206,7 @@ describe('Transaction Repository', () => {
 
       const receiverTransactions = await repository.findAllByWallet(receiver)
 
-      expect(receiverTransactions.count).toBe(1)
+      expect(receiverTransactions.count).toBe(2)
       expect(receiverTransactions.rows).toBeArray()
       expect(receiverTransactions.rows).not.toBeEmpty()
       receiverTransactions.rows.forEach(transaction => {
@@ -277,7 +281,7 @@ describe('Transaction Repository', () => {
 
       const transactions = await repository.findAllByRecipient('AU8hpb5QKJXBx6QhAzy3CJJR69pPfdvp5t')
 
-      expect(transactions.count).toBe(1)
+      expect(transactions.count).toBe(2)
       expect(transactions.rows).toBeArray()
       expect(transactions.rows).not.toBeEmpty()
       transactions.rows.forEach(transaction => {
@@ -442,7 +446,7 @@ describe('Transaction Repository', () => {
     it('should find the transaction fields', async () => {
       await connection.saveBlock(genesisBlock)
 
-      const id = '96fe3cac1ef331269fa0ecad5b56a805fad78fe7278608d4d44991b690282778'
+      const id = 'ea294b610e51efb3ceb4229f27bf773e87f41d21b6bb1f3bf68629ffd652c2d3'
       const type = 3
 
       const fields = await repository.findByTypeAndId(type, id)
@@ -495,16 +499,18 @@ describe('Transaction Repository', () => {
     // TODO when is not on the blockchain?
     // TODO when is not indexed?
     describe('when the wallet is indexed', () => {
-      const senderId = crypto.getAddress(genesisTransaction.senderPublicKey, 23)
+      const senderId = () => {
+        return crypto.getAddress(genesisTransaction.senderPublicKey, 23)
+      }
 
       beforeEach(() => {
-        const wallet = getWallet(senderId)
+        const wallet = getWallet(senderId())
         wallet.publicKey = genesisTransaction.senderPublicKey
         spv.walletManager.reindex(wallet)
       })
 
       it('should search transactions by the specified `senderId`', async () => {
-        await expectSearch({ senderId }, 51)
+        await expectSearch({ senderId: senderId() }, 51)
       })
     })
 
@@ -513,7 +519,7 @@ describe('Transaction Repository', () => {
     })
 
     it('should search transactions by the specified `recipientId`', async () => {
-      await expectSearch({ recipientId: genesisTransaction.recipientId }, 1)
+      await expectSearch({ recipientId: genesisTransaction.recipientId }, 2)
     })
 
     it('should search transactions by the specified `timestamp`', async () => {

--- a/packages/core-database-sequelize/__tests__/repositories/transactions.test.js
+++ b/packages/core-database-sequelize/__tests__/repositories/transactions.test.js
@@ -20,12 +20,13 @@ const getWallet = address => {
   return spv.walletManager.getWalletByAddress(address)
 }
 
-beforeAll(async (done) => {
+beforeAll(async () => {
   await app.setUp()
+
+  // Create the genesis block after the setup has finished or else it uses a potentially
+  // wrong network config.
   genesisBlock = require('../__fixtures__/genesisBlock')
   genesisTransaction = genesisBlock.transactions[0]
-
-  done()
 })
 
 afterAll(async () => {

--- a/packages/core-database-sequelize/__tests__/spv.test.js
+++ b/packages/core-database-sequelize/__tests__/spv.test.js
@@ -2,13 +2,17 @@
 
 const app = require('./__support__/setup')
 const createConnection = require('./__support__/utils/create-connection')
-const genesisBlock = require('./__fixtures__/genesisBlock')
 
+let genesisBlock
 let connection
 let spv
 
 beforeAll(async () => {
   await app.setUp()
+
+  // Create the genesis block after the setup has finished or else it uses a potentially
+  // wrong network config.
+  genesisBlock = require('./__fixtures__/genesisBlock')
 })
 
 afterAll(async () => {

--- a/packages/core-database/__tests__/repositories/delegates.test.js
+++ b/packages/core-database/__tests__/repositories/delegates.test.js
@@ -11,6 +11,9 @@ let calculateProductivity
 
 beforeAll(async (done) => {
   await app.setUp()
+
+  // Wait for the setup to complete before creating the Genesis Block or else it uses a potentially
+  // wrong network config.
   genesisBlock = require('../__fixtures__/genesisBlock')
 
   const delegateCalculator = require('../../lib/repositories/utils/delegate-calculator')

--- a/packages/core-database/__tests__/repositories/delegates.test.js
+++ b/packages/core-database/__tests__/repositories/delegates.test.js
@@ -12,7 +12,7 @@ let calculateProductivity
 beforeAll(async (done) => {
   await app.setUp()
 
-  // Wait for the setup to complete before creating the Genesis Block or else it uses a potentially
+  // Create the genesis block after the setup has finished or else it uses a potentially
   // wrong network config.
   genesisBlock = require('../__fixtures__/genesisBlock')
 

--- a/packages/core-database/__tests__/repositories/delegates.test.js
+++ b/packages/core-database/__tests__/repositories/delegates.test.js
@@ -1,10 +1,9 @@
 'use strict'
 
 const app = require('../__support__/setup')
-const genesisBlock = require('../__fixtures__/genesisBlock')
-
 const { crypto } = require('@arkecosystem/crypto')
 
+let genesisBlock
 let repository
 let walletManager
 let calculateApproval
@@ -12,6 +11,7 @@ let calculateProductivity
 
 beforeAll(async (done) => {
   await app.setUp()
+  genesisBlock = require('../__fixtures__/genesisBlock')
 
   const delegateCalculator = require('../../lib/repositories/utils/delegate-calculator')
   calculateApproval = delegateCalculator.calculateApproval

--- a/packages/core-database/__tests__/repositories/wallets.test.js
+++ b/packages/core-database/__tests__/repositories/wallets.test.js
@@ -2,15 +2,17 @@
 
 const _ = require('lodash')
 const app = require('../__support__/setup')
-const genesisBlock = require('../__fixtures__/genesisBlock')
-
 const { crypto } = require('@arkecosystem/crypto')
 
+let genesisBlock
+let genesisSenders
 let repository
 let walletManager
 
 beforeAll(async (done) => {
   await app.setUp()
+  genesisBlock = require('../__fixtures__/genesisBlock')
+  genesisSenders = _.uniq(_.compact(genesisBlock.transactions.map(tx => tx.senderPublicKey)))
 
   done()
 })
@@ -27,8 +29,6 @@ beforeEach(async (done) => {
 
   done()
 })
-
-const genesisSenders = _.uniq(_.compact(genesisBlock.transactions.map(tx => tx.senderPublicKey)))
 
 function generateWallets () {
   return genesisSenders.map(senderPublicKey => ({

--- a/packages/core-database/__tests__/repositories/wallets.test.js
+++ b/packages/core-database/__tests__/repositories/wallets.test.js
@@ -11,6 +11,9 @@ let walletManager
 
 beforeAll(async (done) => {
   await app.setUp()
+
+  // Wait for the setup to complete before creating the Genesis Block or else it uses a potentially
+  // wrong network config.
   genesisBlock = require('../__fixtures__/genesisBlock')
   genesisSenders = _.uniq(_.compact(genesisBlock.transactions.map(tx => tx.senderPublicKey)))
 

--- a/packages/core-database/__tests__/repositories/wallets.test.js
+++ b/packages/core-database/__tests__/repositories/wallets.test.js
@@ -12,7 +12,7 @@ let walletManager
 beforeAll(async (done) => {
   await app.setUp()
 
-  // Wait for the setup to complete before creating the Genesis Block or else it uses a potentially
+  // Create the genesis block after the setup has finished or else it uses a potentially
   // wrong network config.
   genesisBlock = require('../__fixtures__/genesisBlock')
   genesisSenders = _.uniq(_.compact(genesisBlock.transactions.map(tx => tx.senderPublicKey)))

--- a/packages/core-database/__tests__/wallet-manager.test.js
+++ b/packages/core-database/__tests__/wallet-manager.test.js
@@ -7,15 +7,19 @@ const { transactionBuilder } = require('@arkecosystem/crypto')
 const { TRANSACTION_TYPES } = require('@arkecosystem/crypto').constants
 
 const block = new Block(require('./__fixtures__/block.json')) // eslint-disable-line no-unused-vars
-const genesisBlock = require('./__fixtures__/genesisBlock') // eslint-disable-line no-unused-vars
 const walletData1 = require('./__fixtures__/wallets.json')[0]
 const walletData2 = require('./__fixtures__/wallets.json')[1]
 const walletDataFake = require('./__fixtures__/wallets.json')[2]
 
+let genesisBlock // eslint-disable-line no-unused-vars
 let walletManager
 
 beforeAll(async (done) => {
   await app.setUp()
+
+  // Create the genesis block after the setup has finished or else it uses a potentially
+  // wrong network config.
+  genesisBlock = require('./__fixtures__/genesisBlock')
 
   walletManager = new (require('../lib/wallet-manager'))()
 

--- a/packages/core-p2p/__tests__/peer.test.js
+++ b/packages/core-p2p/__tests__/peer.test.js
@@ -1,14 +1,21 @@
 'use strict'
 
 const app = require('./__support__/setup')
-const genesisBlock = require('./__fixtures__/genesisBlock')
-const genesisTransaction = require('./__fixtures__/genesisTransaction')
+
+let genesisBlock
+let genesisTransaction
 
 let Peer
 let peer
 
 beforeAll(async () => {
   await app.setUp()
+
+  // Create the genesis block after the setup has finished or else it uses a potentially
+  // wrong network config.
+  genesisBlock = require('./__fixtures__/genesisBlock')
+  genesisTransaction = require('./__fixtures__/genesisTransaction')
+
   Peer = require('../lib/peer')
 })
 

--- a/packages/core-p2p/__tests__/server/1.test.js
+++ b/packages/core-p2p/__tests__/server/1.test.js
@@ -7,12 +7,13 @@ const app = require('../__support__/setup')
 let genesisBlock
 let genesisTransaction
 
-beforeAll(async (done) => {
+beforeAll(async () => {
   await app.setUp()
+
+  // Wait for the setup to complete before creating the Genesis Block or else it uses a potentially
+  // wrong network config.
   genesisBlock = require('../__fixtures__/genesisBlock')
   genesisTransaction = require('../__fixtures__/genesisTransaction')
-
-  done()
 })
 
 afterAll(async () => {

--- a/packages/core-p2p/__tests__/server/1.test.js
+++ b/packages/core-p2p/__tests__/server/1.test.js
@@ -10,7 +10,7 @@ let genesisTransaction
 beforeAll(async () => {
   await app.setUp()
 
-  // Wait for the setup to complete before creating the Genesis Block or else it uses a potentially
+  // Create the genesis block after the setup has finished or else it uses a potentially
   // wrong network config.
   genesisBlock = require('../__fixtures__/genesisBlock')
   genesisTransaction = require('../__fixtures__/genesisTransaction')

--- a/packages/core-p2p/__tests__/server/1.test.js
+++ b/packages/core-p2p/__tests__/server/1.test.js
@@ -3,11 +3,16 @@
 const axios = require('axios')
 
 const app = require('../__support__/setup')
-const genesisBlock = require('../__fixtures__/genesisBlock')
-const genesisTransaction = require('../__fixtures__/genesisTransaction')
 
-beforeAll(async () => {
+let genesisBlock
+let genesisTransaction
+
+beforeAll(async (done) => {
   await app.setUp()
+  genesisBlock = require('../__fixtures__/genesisBlock')
+  genesisTransaction = require('../__fixtures__/genesisTransaction')
+
+  done()
 })
 
 afterAll(async () => {

--- a/packages/core-p2p/__tests__/server/internal.test.js
+++ b/packages/core-p2p/__tests__/server/internal.test.js
@@ -7,12 +7,13 @@ const app = require('../__support__/setup')
 let genesisBlock
 let genesisTransaction
 
-beforeAll(async (done) => {
+beforeAll(async () => {
   await app.setUp()
+
+  // Wait for the setup to complete before creating the Genesis Block or else it uses a potentially
+  // wrong network config.
   genesisBlock = require('../__fixtures__/genesisBlock')
   genesisTransaction = require('../__fixtures__/genesisTransaction')
-
-  done()
 })
 
 afterAll(async () => {

--- a/packages/core-p2p/__tests__/server/internal.test.js
+++ b/packages/core-p2p/__tests__/server/internal.test.js
@@ -10,7 +10,7 @@ let genesisTransaction
 beforeAll(async () => {
   await app.setUp()
 
-  // Wait for the setup to complete before creating the Genesis Block or else it uses a potentially
+  // Create the genesis block after the setup has finished or else it uses a potentially
   // wrong network config.
   genesisBlock = require('../__fixtures__/genesisBlock')
   genesisTransaction = require('../__fixtures__/genesisTransaction')

--- a/packages/core-p2p/__tests__/server/internal.test.js
+++ b/packages/core-p2p/__tests__/server/internal.test.js
@@ -3,11 +3,16 @@
 const axios = require('axios')
 
 const app = require('../__support__/setup')
-const genesisBlock = require('../__fixtures__/genesisBlock')
-const genesisTransaction = require('../__fixtures__/genesisTransaction')
 
-beforeAll(async () => {
+let genesisBlock
+let genesisTransaction
+
+beforeAll(async (done) => {
   await app.setUp()
+  genesisBlock = require('../__fixtures__/genesisBlock')
+  genesisTransaction = require('../__fixtures__/genesisTransaction')
+
+  done()
 })
 
 afterAll(async () => {


### PR DESCRIPTION
My original plan was to simply fix the tests  `should search transactions that includes all of them (AND)` and `should find all transactions that holds all the conditions (AND)` of  `core-database-sequelize`, but it turned out to be a fundamental issue.

### Why were the tests failing?
They both use the genesis transaction's recipientId to find a type-3 transaction. When the genesis block is created and serialized, the transactions are serialized with a **devnet** network version. Now when a transaction is deserialized a wrong recipientId is calculated and since all addresses in the genesis block start with `A`, it fails to find anything.

### Why devnet?
It is the default config. The creation of the genesis block happens **before** any test has the chance to run `app.setUp()`. This means all tests right now (except those using a devnet config) are using a genesis block with broken recipientIds, which kinda works except in those two cases.

### The fix
Delay the creation of the genesis block until `app.setUp()`has been called which loads the expected network config.

Due to the changes some tests suddenly failed, but they only required minor changes  to work with the now correct genesis block.  I also checked all other unit tests using a genesis block for regressions.

Now that all tests of `core-database-sequelize` pass, I re-enabled them in the jest config.