### PR TITLE
fix: errors in transaction guard

### DIFF
--- a/packages/core-transaction-pool/lib/guard.js
+++ b/packages/core-transaction-pool/lib/guard.js
@@ -50,7 +50,7 @@ module.exports = class TransactionGuard {
       accept: this.accept.map(transaction => transaction.id),
       excess: this.excess.map(transaction => transaction.id),
       invalid: this.invalid.map(transaction => transaction.id),
-      broadcast: this.invalid.map(transaction => transaction.id)
+      broadcast: this.broadcast.map(transaction => transaction.id)
     }
   }
 
@@ -140,7 +140,7 @@ module.exports = class TransactionGuard {
         return true
       }
 
-      this.invalid.push(this.transactions)
+      this.invalid.push(this.transaction)
 
       return false
     })


### PR DESCRIPTION
I found two little bugs in the `TransactionGuard` while looking over https://github.com/ArkEcosystem/core/pull/785 but they are not directly related to that PR since they are already on master.

The first seems to be a copy paste mistake and the second a typo.