### PR TITLE
Fix handling of "boolean" environment variables

### DIFF
--- a/packages/core-database-sequelize/README.md
+++ b/packages/core-database-sequelize/README.md
@@ -16,7 +16,7 @@ yarn add @arkecosystem/core-database-sequelize
 module.exports = {
   dialect: 'sqlite',
   storage: `${process.env.ARK_PATH_DATA}/database/${process.env.ARK_NETWORK_NAME}.sqlite`,
-  logging: process.env.ARK_DB_LOGGING || false
+  logging: process.env.ARK_DB_LOGGING
 }
 ```
 

--- a/packages/core-database-sequelize/lib/defaults.js
+++ b/packages/core-database-sequelize/lib/defaults.js
@@ -3,7 +3,7 @@
 module.exports = {
   dialect: 'sqlite',
   storage: process.env.ARK_DB_STORAGE || `${process.env.ARK_PATH_DATA}/database/${process.env.ARK_NETWORK_NAME}.sqlite`,
-  logging: process.env.ARK_DB_LOGGING || false,
+  logging: process.env.ARK_DB_LOGGING,
   redis: {
     host: process.env.ARK_REDIS_HOST || 'localhost',
     port: process.env.ARK_REDIS_PORT || 6379

--- a/packages/core-json-rpc/lib/defaults.js
+++ b/packages/core-json-rpc/lib/defaults.js
@@ -1,7 +1,7 @@
 'use strict'
 
 module.exports = {
-  enabled: process.env.ARK_JSON_RPC_ENABLED || false,
+  enabled: process.env.ARK_JSON_RPC_ENABLED,
   host: process.env.ARK_JSON_RPC_HOST || '0.0.0.0',
   port: process.env.ARK_JSON_RPC_PORT || 8080,
   allowRemote: true,

--- a/packages/core-transaction-pool-redis/lib/defaults.js
+++ b/packages/core-transaction-pool-redis/lib/defaults.js
@@ -1,7 +1,7 @@
 'use strict'
 
 module.exports = {
-  enabled: process.env.ARK_TRANSACTION_POOL_ENABLED || true,
+  enabled: !process.env.ARK_TRANSACTION_POOL_DISABLED,
   key: 'ark',
   maxTransactionsPerSender: process.env.ARK_TRANSACTION_POOL_MAX_PER_SENDER || 100,
   allowedSenders: [],

--- a/packages/core-webhooks/README.md
+++ b/packages/core-webhooks/README.md
@@ -12,18 +12,18 @@ yarn add @arkecosystem/core-webhooks
 
 ```js
 module.exports = {
-  enabled: process.env.ARK_WEBHOOKS_ENABLED || false,
+  enabled: !process.env.ARK_WEBHOOKS_DISABLED,
   database: {
     dialect: 'sqlite',
     storage: `${process.env.ARK_PATH_DATA}/database/webhooks.sqlite`,
-    logging: process.env.ARK_DB_LOGGING || false
+    logging: process.env.ARK_DB_LOGGING
   },
   redis: {
     host: process.env.ARK_REDIS_HOST || 'localhost',
     port: process.env.ARK_REDIS_PORT || 6379
   },
   server: {
-    enabled: process.env.ARK_WEBHOOKS_API_ENABLED || false,
+    enabled: process.env.ARK_WEBHOOKS_API_ENABLED,
     host: process.env.ARK_WEBHOOKS_HOST || '0.0.0.0',
     port: process.env.ARK_WEBHOOKS_PORT || 4004,
     whitelist: ['127.0.0.1', '::ffff:127.0.0.1', '192.168.*'],

--- a/packages/core-webhooks/lib/defaults.js
+++ b/packages/core-webhooks/lib/defaults.js
@@ -1,18 +1,18 @@
 'use strict'
 
 module.exports = {
-  enabled: process.env.ARK_WEBHOOKS_ENABLED || false,
+  enabled: !process.env.ARK_WEBHOOKS_DISABLED,
   database: {
     dialect: 'sqlite',
     storage: `${process.env.ARK_PATH_DATA}/database/webhooks.sqlite`,
-    logging: process.env.ARK_DB_LOGGING || false
+    logging: process.env.ARK_DB_LOGGING
   },
   redis: {
     host: process.env.ARK_REDIS_HOST || 'localhost',
     port: process.env.ARK_REDIS_PORT || 6379
   },
   server: {
-    enabled: process.env.ARK_WEBHOOKS_API_ENABLED || false,
+    enabled: process.env.ARK_WEBHOOKS_API_ENABLED,
     host: process.env.ARK_WEBHOOKS_HOST || '0.0.0.0',
     port: process.env.ARK_WEBHOOKS_PORT || 4004,
     whitelist: ['127.0.0.1', '::ffff:127.0.0.1', '192.168.*'],

--- a/packages/core/lib/config/devnet/plugins.js
+++ b/packages/core/lib/config/devnet/plugins.js
@@ -31,7 +31,7 @@ module.exports = {
     username: process.env.ARK_DB_USERNAME || 'ark',
     password: process.env.ARK_DB_PASSWORD || 'password',
     database: process.env.ARK_DB_DATABASE || 'ark_devnet',
-    logging: process.env.ARK_DB_LOGGING || false,
+    logging: process.env.ARK_DB_LOGGING,
     redis: {
       host: process.env.ARK_REDIS_HOST || 'localhost',
       port: process.env.ARK_REDIS_PORT || 6379
@@ -39,7 +39,7 @@ module.exports = {
   },
   '@arkecosystem/core-transaction-pool': {},
   '@arkecosystem/core-transaction-pool-redis': {
-    enabled: process.env.ARK_TRANSACTION_POOL_ENABLED || true,
+    enabled: !process.env.ARK_TRANSACTION_POOL_DISABLED,
     key: 'ark',
     maxTransactionsPerSender: process.env.ARK_TRANSACTION_POOL_MAX_PER_SENDER || 100,
     whitelist: [],
@@ -57,31 +57,31 @@ module.exports = {
     fastRebuild: true
   },
   '@arkecosystem/core-api': {
-    enabled: process.env.ARK_API_ENABLED || true,
+    enabled: !process.env.ARK_API_DISABLED,
     host: process.env.ARK_API_HOST || '0.0.0.0',
     port: process.env.ARK_API_PORT || 4003,
     whitelist: ['*']
   },
   '@arkecosystem/core-webhooks': {
-    enabled: process.env.ARK_WEBHOOKS_ENABLED || false,
+    enabled: !process.env.ARK_WEBHOOKS_DISABLED,
     database: {
       dialect: 'sqlite',
       storage: `${process.env.ARK_PATH_DATA}/database/${process.env.ARK_NETWORK_NAME}/webhooks.sqlite`,
-      logging: process.env.ARK_DB_LOGGING || false
+      logging: process.env.ARK_DB_LOGGING
     },
     redis: {
       host: process.env.ARK_REDIS_HOST || 'localhost',
       port: process.env.ARK_REDIS_PORT || 6379
     },
     server: {
-      enabled: process.env.ARK_WEBHOOKS_API_ENABLED || false,
+      enabled: process.env.ARK_WEBHOOKS_API_ENABLED,
       host: process.env.ARK_WEBHOOKS_HOST || '0.0.0.0',
       port: process.env.ARK_WEBHOOKS_PORT || 4004,
       whitelist: ['127.0.0.1', '::ffff:127.0.0.1', '192.168.*']
     }
   },
   '@arkecosystem/core-graphql': {
-    enabled: process.env.ARK_GRAPHQL_ENABLED || false,
+    enabled: !process.env.ARK_GRAPHQL_DISABLED,
     host: process.env.ARK_GRAPHQL_HOST || '0.0.0.0',
     port: process.env.ARK_GRAPHQL_PORT || 4005,
     path: '/graphql',
@@ -91,7 +91,7 @@ module.exports = {
     hosts: ['http://127.0.0.1:4002']
   },
   '@arkecosystem/core-json-rpc': {
-    enabled: process.env.ARK_JSON_RPC_ENABLED || false,
+    enabled: process.env.ARK_JSON_RPC_ENABLED,
     host: process.env.ARK_JSON_RPC_HOST || '0.0.0.0',
     port: process.env.ARK_JSON_RPC_PORT || 8080,
     allowRemote: true,

--- a/packages/core/lib/config/mainnet/plugins.js
+++ b/packages/core/lib/config/mainnet/plugins.js
@@ -31,7 +31,7 @@ module.exports = {
     // username: process.env.ARK_DB_USERNAME || 'ark',
     // password: process.env.ARK_DB_PASSWORD || 'password',
     // database: process.env.ARK_DB_DATABASE || 'ark_mainnet',
-    logging: process.env.ARK_DB_LOGGING || false,
+    logging: process.env.ARK_DB_LOGGING,
     redis: {
       host: process.env.ARK_REDIS_HOST || 'localhost',
       port: process.env.ARK_REDIS_PORT || 6379
@@ -39,7 +39,7 @@ module.exports = {
   },
   '@arkecosystem/core-transaction-pool': {},
   '@arkecosystem/core-transaction-pool-redis': {
-    enabled: process.env.ARK_TRANSACTION_POOL_ENABLED || true,
+    enabled: !process.env.ARK_TRANSACTION_POOL_DISABLED,
     key: 'ark',
     maxTransactionsPerSender: process.env.ARK_TRANSACTION_POOL_MAX_PER_SENDER || 100,
     whitelist: [],
@@ -63,25 +63,25 @@ module.exports = {
     whitelist: ['*']
   },
   '@arkecosystem/core-webhooks': {
-    enabled: process.env.ARK_WEBHOOKS_ENABLED || false,
+    enabled: !process.env.ARK_WEBHOOKS_DISABLED,
     database: {
       dialect: 'sqlite',
       storage: `${process.env.ARK_PATH_DATA}/database/${process.env.ARK_NETWORK_NAME}/webhooks.sqlite`,
-      logging: process.env.ARK_DB_LOGGING || false
+      logging: process.env.ARK_DB_LOGGING
     },
     redis: {
       host: process.env.ARK_REDIS_HOST || 'localhost',
       port: process.env.ARK_REDIS_PORT || 6379
     },
     server: {
-      enabled: process.env.ARK_WEBHOOKS_API_ENABLED || false,
+      enabled: process.env.ARK_WEBHOOKS_API_ENABLED,
       host: process.env.ARK_WEBHOOKS_HOST || '0.0.0.0',
       port: process.env.ARK_WEBHOOKS_PORT || 4004,
       whitelist: ['127.0.0.1', '::ffff:127.0.0.1', '192.168.*']
     }
   },
   '@arkecosystem/core-graphql': {
-    enabled: process.env.ARK_GRAPHQL_ENABLED || false,
+    enabled: !process.env.ARK_GRAPHQL_DISABLED,
     host: process.env.ARK_GRAPHQL_HOST || '0.0.0.0',
     port: process.env.ARK_GRAPHQL_PORT || 4005,
     path: '/graphql',
@@ -91,7 +91,7 @@ module.exports = {
     hosts: ['http://127.0.0.1:4001']
   },
   '@arkecosystem/core-json-rpc': {
-    enabled: process.env.ARK_JSON_RPC_ENABLED || false,
+    enabled: process.env.ARK_JSON_RPC_ENABLED,
     host: process.env.ARK_JSON_RPC_HOST || '0.0.0.0',
     port: process.env.ARK_JSON_RPC_PORT || 8080,
     allowRemote: true,

--- a/packages/core/lib/config/testnet.1/plugins.js
+++ b/packages/core/lib/config/testnet.1/plugins.js
@@ -31,7 +31,7 @@ module.exports = {
     // username: process.env.ARK_DB_USERNAME || 'ark',
     // password: process.env.ARK_DB_PASSWORD || 'password',
     // database: process.env.ARK_DB_DATABASE || 'ark_testnet1',
-    logging: process.env.ARK_DB_LOGGING || false,
+    logging: process.env.ARK_DB_LOGGING,
     redis: {
       host: process.env.ARK_REDIS_HOST || 'localhost',
       port: process.env.ARK_REDIS_PORT || 6379
@@ -39,7 +39,7 @@ module.exports = {
   },
   '@arkecosystem/core-transaction-pool': {},
   '@arkecosystem/core-transaction-pool-redis': {
-    enabled: process.env.ARK_TRANSACTION_POOL_ENABLED || true,
+    enabled: !process.env.ARK_TRANSACTION_POOL_DISABLED,
     key: 'ark1',
     maxTransactionsPerSender: process.env.ARK_TRANSACTION_POOL_MAX_PER_SENDER || 100,
     whitelist: [],
@@ -57,31 +57,31 @@ module.exports = {
     fastRebuild: true
   },
   '@arkecosystem/core-api': {
-    enabled: process.env.ARK_API_ENABLED || true,
+    enabled: !process.env.ARK_API_DISABLED,
     host: process.env.ARK_API_HOST || '0.0.0.0',
     port: process.env.ARK_API_PORT || 4103,
     whitelist: ['*']
   },
   '@arkecosystem/core-webhooks': {
-    enabled: process.env.ARK_WEBHOOKS_ENABLED || false,
+    enabled: !process.env.ARK_WEBHOOKS_DISABLED,
     database: {
       dialect: 'sqlite',
       storage: `${process.env.ARK_PATH_DATA}/database/${process.env.ARK_NETWORK_NAME}.1/webhooks.sqlite`,
-      logging: process.env.ARK_DB_LOGGING || false
+      logging: process.env.ARK_DB_LOGGING
     },
     redis: {
       host: process.env.ARK_REDIS_HOST || 'localhost',
       port: process.env.ARK_REDIS_PORT || 6379
     },
     server: {
-      enabled: process.env.ARK_WEBHOOKS_API_ENABLED || false,
+      enabled: process.env.ARK_WEBHOOKS_API_ENABLED,
       host: process.env.ARK_WEBHOOKS_HOST || '0.0.0.0',
       port: process.env.ARK_WEBHOOKS_PORT || 4004,
       whitelist: ['127.0.0.1', '::ffff:127.0.0.1', '192.168.*']
     }
   },
   '@arkecosystem/core-graphql': {
-    enabled: process.env.ARK_GRAPHQL_ENABLED || false,
+    enabled: !process.env.ARK_GRAPHQL_DISABLED,
     host: process.env.ARK_GRAPHQL_HOST || '0.0.0.0',
     port: process.env.ARK_GRAPHQL_PORT || 4105,
     path: '/graphql',
@@ -91,7 +91,7 @@ module.exports = {
     hosts: ['http://127.0.0.1:4102']
   },
   '@arkecosystem/core-json-rpc': {
-    enabled: process.env.ARK_JSON_RPC_ENABLED || false,
+    enabled: process.env.ARK_JSON_RPC_ENABLED,
     host: process.env.ARK_JSON_RPC_HOST || '0.0.0.0',
     port: process.env.ARK_JSON_RPC_PORT || 8080,
     allowRemote: true,

--- a/packages/core/lib/config/testnet.2/plugins.js
+++ b/packages/core/lib/config/testnet.2/plugins.js
@@ -31,7 +31,7 @@ module.exports = {
     // username: process.env.ARK_DB_USERNAME || 'ark',
     // password: process.env.ARK_DB_PASSWORD || 'password',
     // database: process.env.ARK_DB_DATABASE || 'ark_testnet2',
-    logging: process.env.ARK_DB_LOGGING || false,
+    logging: process.env.ARK_DB_LOGGING,
     redis: {
       host: process.env.ARK_REDIS_HOST || 'localhost',
       port: process.env.ARK_REDIS_PORT || 6379
@@ -39,7 +39,7 @@ module.exports = {
   },
   '@arkecosystem/core-transaction-pool': {},
   '@arkecosystem/core-transaction-pool-redis': {
-    enabled: process.env.ARK_TRANSACTION_POOL_ENABLED || true,
+    enabled: !process.env.ARK_TRANSACTION_POOL_DISABLED,
     key: 'ark2',
     maxTransactionsPerSender: process.env.ARK_TRANSACTION_POOL_MAX_PER_SENDER || 100,
     whitelist: [],
@@ -57,31 +57,31 @@ module.exports = {
     fastRebuild: true
   },
   '@arkecosystem/core-api': {
-    enabled: process.env.ARK_API_ENABLED || true,
+    enabled: !process.env.ARK_API_DISABLED,
     host: process.env.ARK_API_HOST || '0.0.0.0',
     port: process.env.ARK_API_PORT || 4203,
     whitelist: ['*']
   },
   '@arkecosystem/core-webhooks': {
-    enabled: process.env.ARK_WEBHOOKS_ENABLED || false,
+    enabled: !process.env.ARK_WEBHOOKS_DISABLED,
     database: {
       dialect: 'sqlite',
       storage: `${process.env.ARK_PATH_DATA}/database/${process.env.ARK_NETWORK_NAME}.2/webhooks.sqlite`,
-      logging: process.env.ARK_DB_LOGGING || false
+      logging: process.env.ARK_DB_LOGGING
     },
     redis: {
       host: process.env.ARK_REDIS_HOST || 'localhost',
       port: process.env.ARK_REDIS_PORT || 6379
     },
     server: {
-      enabled: process.env.ARK_WEBHOOKS_API_ENABLED || false,
+      enabled: process.env.ARK_WEBHOOKS_API_ENABLED,
       host: process.env.ARK_WEBHOOKS_HOST || '0.0.0.0',
       port: process.env.ARK_WEBHOOKS_PORT || 4004,
       whitelist: ['127.0.0.1', '::ffff:127.0.0.1', '192.168.*']
     }
   },
   '@arkecosystem/core-graphql': {
-    enabled: process.env.ARK_GRAPHQL_ENABLED || false,
+    enabled: !process.env.ARK_GRAPHQL_DISABLED,
     host: process.env.ARK_GRAPHQL_HOST || '0.0.0.0',
     port: process.env.ARK_GRAPHQL_PORT || 4205,
     path: '/graphql',
@@ -91,7 +91,7 @@ module.exports = {
     hosts: ['http://127.0.0.1:4202']
   },
   '@arkecosystem/core-json-rpc': {
-    enabled: process.env.ARK_JSON_RPC_ENABLED || false,
+    enabled: process.env.ARK_JSON_RPC_ENABLED,
     host: process.env.ARK_JSON_RPC_HOST || '0.0.0.0',
     port: process.env.ARK_JSON_RPC_PORT || 8080,
     allowRemote: true,

--- a/packages/core/lib/config/testnet.live/plugins.js
+++ b/packages/core/lib/config/testnet.live/plugins.js
@@ -31,7 +31,7 @@ module.exports = {
     // username: process.env.ARK_DB_USERNAME || 'ark',
     // password: process.env.ARK_DB_PASSWORD || 'password',
     // database: process.env.ARK_DB_DATABASE || 'ark_testnet1',
-    logging: process.env.ARK_DB_LOGGING || false,
+    logging: process.env.ARK_DB_LOGGING,
     redis: {
       host: process.env.ARK_REDIS_HOST || 'localhost',
       port: process.env.ARK_REDIS_PORT || 6379
@@ -39,7 +39,7 @@ module.exports = {
   },
   '@arkecosystem/core-transaction-pool': {},
   '@arkecosystem/core-transaction-pool-redis': {
-    enabled: process.env.ARK_TRANSACTION_POOL_ENABLED || true,
+    enabled: !process.env.ARK_TRANSACTION_POOL_DISABLED,
     key: 'ark1',
     maxTransactionsPerSender: process.env.ARK_TRANSACTION_POOL_MAX_PER_SENDER || 100,
     whitelist: ['127.0.0.1', '::ffff:127.0.0.1', '192.168.*'],
@@ -63,25 +63,25 @@ module.exports = {
     whitelist: ['*']
   },
   '@arkecosystem/core-webhooks': {
-    enabled: process.env.ARK_WEBHOOKS_ENABLED || false,
+    enabled: !process.env.ARK_WEBHOOKS_DISABLED,
     database: {
       dialect: 'sqlite',
       storage: `${process.env.ARK_PATH_DATA}/database/${process.env.ARK_NETWORK_NAME}.live/webhooks.sqlite`,
-      logging: process.env.ARK_DB_LOGGING || false
+      logging: process.env.ARK_DB_LOGGING
     },
     redis: {
       host: process.env.ARK_REDIS_HOST || 'localhost',
       port: process.env.ARK_REDIS_PORT || 6379
     },
     server: {
-      enabled: process.env.ARK_WEBHOOKS_API_ENABLED || false,
+      enabled: process.env.ARK_WEBHOOKS_API_ENABLED,
       host: process.env.ARK_WEBHOOKS_HOST || '0.0.0.0',
       port: process.env.ARK_WEBHOOKS_PORT || 4004,
       whitelist: ['127.0.0.1', '::ffff:127.0.0.1', '192.168.*']
     }
   },
   '@arkecosystem/core-graphql': {
-    enabled: process.env.ARK_GRAPHQL_ENABLED || false,
+    enabled: !process.env.ARK_GRAPHQL_DISABLED,
     host: process.env.ARK_GRAPHQL_HOST || '0.0.0.0',
     port: process.env.ARK_GRAPHQL_PORT || 4105,
     path: '/graphql',
@@ -91,7 +91,7 @@ module.exports = {
     hosts: ['http://127.0.0.1:4000']
   },
   '@arkecosystem/core-json-rpc': {
-    enabled: process.env.ARK_JSON_RPC_ENABLED || false,
+    enabled: process.env.ARK_JSON_RPC_ENABLED,
     host: process.env.ARK_JSON_RPC_HOST || '0.0.0.0',
     port: process.env.ARK_JSON_RPC_PORT || 8080,
     allowRemote: true,

--- a/packages/core/lib/config/testnet/plugins.js
+++ b/packages/core/lib/config/testnet/plugins.js
@@ -31,7 +31,7 @@ module.exports = {
     // username: process.env.ARK_DB_USERNAME || 'ark',
     // password: process.env.ARK_DB_PASSWORD || 'password',
     // database: process.env.ARK_DB_DATABASE || 'ark_testnet',
-    logging: process.env.ARK_DB_LOGGING || false,
+    logging: process.env.ARK_DB_LOGGING,
     redis: {
       host: process.env.ARK_REDIS_HOST || 'localhost',
       port: process.env.ARK_REDIS_PORT || 6379
@@ -39,7 +39,7 @@ module.exports = {
   },
   '@arkecosystem/core-transaction-pool': {},
   '@arkecosystem/core-transaction-pool-redis': {
-    enabled: process.env.ARK_TRANSACTION_POOL_ENABLED || true,
+    enabled: !process.env.ARK_TRANSACTION_POOL_DISABLED,
     key: 'ark-testnet',
     maxTransactionsPerSender: process.env.ARK_TRANSACTION_POOL_MAX_PER_SENDER || 100,
     whitelist: [],
@@ -57,31 +57,31 @@ module.exports = {
     fastRebuild: true
   },
   '@arkecosystem/core-api': {
-    enabled: process.env.ARK_API_ENABLED || true,
+    enabled: !process.env.ARK_API_DISABLED,
     host: process.env.ARK_API_HOST || '0.0.0.0',
     port: process.env.ARK_API_PORT || 4003,
     whitelist: ['*']
   },
   '@arkecosystem/core-webhooks': {
-    enabled: process.env.ARK_WEBHOOKS_ENABLED || true,
+    enabled: !process.env.ARK_WEBHOOKS_DISABLED,
     database: {
       dialect: 'sqlite',
       storage: `${process.env.ARK_PATH_DATA}/database/${process.env.ARK_NETWORK_NAME}/webhooks.sqlite`,
-      logging: process.env.ARK_DB_LOGGING || false
+      logging: process.env.ARK_DB_LOGGING
     },
     redis: {
       host: process.env.ARK_REDIS_HOST || 'localhost',
       port: process.env.ARK_REDIS_PORT || 6379
     },
     server: {
-      enabled: process.env.ARK_WEBHOOKS_API_ENABLED || false,
+      enabled: process.env.ARK_WEBHOOKS_API_ENABLED,
       host: process.env.ARK_WEBHOOKS_HOST || '0.0.0.0',
       port: process.env.ARK_WEBHOOKS_PORT || 4004,
       whitelist: ['127.0.0.1', '::ffff:127.0.0.1', '192.168.*']
     }
   },
   '@arkecosystem/core-graphql': {
-    enabled: process.env.ARK_GRAPHQL_ENABLED || true,
+    enabled: !process.env.ARK_GRAPHQL_DISABLED,
     host: process.env.ARK_GRAPHQL_HOST || '0.0.0.0',
     port: process.env.ARK_GRAPHQL_PORT || 4005,
     path: '/graphql',
@@ -91,7 +91,7 @@ module.exports = {
     hosts: ['http://127.0.0.1:4000']
   },
   '@arkecosystem/core-json-rpc': {
-    enabled: process.env.ARK_JSON_RPC_ENABLED || false,
+    enabled: process.env.ARK_JSON_RPC_ENABLED,
     host: process.env.ARK_JSON_RPC_HOST || '0.0.0.0',
     port: process.env.ARK_JSON_RPC_PORT || 8080,
     allowRemote: true,


### PR DESCRIPTION
`expression || true` always evaluates to `true`.
`expression || false` always evaluates to `expression`.

So, while it makes perfect sense to have something like
`process.env.ARK_JSON_RPC_PORT || 8080`, constructs like
`process.env.ARK_TRANSACTION_POOL_ENABLED || true` mean that it is not
possible to disable (the transaction pool).

`process.env.ARK_DB_LOGGING || false` is just clutter and is the same as
`process.env.ARK_DB_LOGGING`.

After this change it is possible to disable
ARK_API_ENABLED
ARK_GRAPHQL_ENABLED
ARK_TRANSACTION_POOL_ENABLED
ARK_WEBHOOKS_ENABLED
by not setting the relevant variable in the environment (or setting it
to an empty string).

This is a behavioral change - users that did not had e.g.
ARK_TRANSACTION_POOL_ENABLED set in the environment before this change
would have it enabled, whereas after this change it will be disabled for
them and in order to enable it they must define
ARK_TRANSACTION_POOL_ENABLED in the environment (to some value).

## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [ ] Docs (documentation only changes)
- [ ] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [ ] I have read the [CONTRIBUTING](https://docs.ark.io/docs/contributing) documentation
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
