### PR TITLE
fix: wrong docs link

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-Please see [CONTRIBUTING](https://docs.ark.io/docs/contributing) for details before opening your pull request.
+Please see [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) for details before opening your pull request.


### PR DESCRIPTION
## Proposed changes

Fixing an invalid link to the docs.

## Types of changes

- [x] Docs (documentation only changes)