### PR TITLE
Remove the usage of the `core/crypto` package on `core/client`

### DIFF
--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -8,16 +8,7 @@
 yarn add @arkecosystem/client
 ```
 
-If you want to use the CDN version, is available two bundles:
-
-- Without the [@arkecosystem/crypto](http://github.com/ArkEcosystem/ArkEcosystem/core/packages/crypto) package: (_You will need to import both_)
-
-```html
-<script src="https://unpkg.com/@arkecosystem/crypto/dist/index.umd.js"></script>
-<script src="https://unpkg.com/@arkecosystem/client/dist/index.umd.js"></script>
-```
-
-- And a standalone file:
+If you want to use the CDN version:
 
 ```html
 <script src="https://unpkg.com/@arkecosystem/client/dist/bundle.umd.js"></script>

--- a/packages/client/__tests__/http.test.js
+++ b/packages/client/__tests__/http.test.js
@@ -1,5 +1,5 @@
-const toHaveHeaders = require('./matchers/http/headers')
-expect.extend({ toHaveHeaders })
+const toHaveAtLeastHeaders = require('./matchers/http/headers')
+expect.extend({ toHaveAtLeastHeaders })
 
 const HttpClient = require('../lib/http')
 
@@ -10,23 +10,11 @@ beforeEach(() => {
 })
 
 describe('API - HTTP Client', () => {
-  const headers = {
-    'API-version': 2,
-    Nethash: 'test nethash',
-    Port: '1',
-    Version: 'test version (pubKeyHash)'
-  }
+  let headers
 
   beforeEach(() => {
-    const { configManager } = require('@arkecosystem/crypto')
-    configManager.get = option => {
-      if (option === 'nethash') {
-        return headers.Nethash
-      } else if (option === 'pubKeyHash') {
-        return headers.Version
-      }
-
-      throw new Error(`Wrong option "${option}" to mock`)
+    headers = {
+      'API-Version': client.version
     }
   })
 
@@ -64,6 +52,26 @@ describe('API - HTTP Client', () => {
     })
   })
 
+  describe('setTimeout', () => {
+    it('should set the timeout', () => {
+      expect(client.timeout).toBe(60000)
+      client.setTimeout(5000)
+      expect(client.timeout).toBe(5000)
+    })
+  })
+
+  describe('setHeaders', () => {
+    it('should set the headers', () => {
+      const newHeaders = {
+        'API-Version': 30,
+        other: 'value'
+      }
+      client.setHeaders(newHeaders)
+
+      expect(client.headers).toEqual(newHeaders)
+    })
+  })
+
   describe('get', () => {
     it('should send GET requests', async () => {
       const response = await client.get('get')
@@ -74,7 +82,7 @@ describe('API - HTTP Client', () => {
     it('should use the necessary request headers', async () => {
       const response = await client.get('get')
 
-      expect(response).toHaveHeaders(headers)
+      expect(response.config).toHaveAtLeastHeaders(headers)
     })
   })
 
@@ -88,7 +96,7 @@ describe('API - HTTP Client', () => {
     it('should use the necessary request headers', async () => {
       const response = await client.get('get')
 
-      expect(response).toHaveHeaders(headers)
+      expect(response.config).toHaveAtLeastHeaders(headers)
     })
   })
 
@@ -102,7 +110,7 @@ describe('API - HTTP Client', () => {
     it('should use the necessary request headers', async () => {
       const response = await client.get('get')
 
-      expect(response).toHaveHeaders(headers)
+      expect(response.config).toHaveAtLeastHeaders(headers)
     })
   })
 
@@ -116,7 +124,7 @@ describe('API - HTTP Client', () => {
     it('should use the necessary request headers', async () => {
       const response = await client.get('get')
 
-      expect(response).toHaveHeaders(headers)
+      expect(response.config).toHaveAtLeastHeaders(headers)
     })
   })
 
@@ -130,7 +138,7 @@ describe('API - HTTP Client', () => {
     it('should use the necessary request headers', async () => {
       const response = await client.get('get')
 
-      expect(response).toHaveHeaders(headers)
+      expect(response.config).toHaveAtLeastHeaders(headers)
     })
   })
 })

--- a/packages/client/__tests__/matchers/http/headers.js
+++ b/packages/client/__tests__/matchers/http/headers.js
@@ -1,20 +1,29 @@
 'use strict'
 
+/**
+ * Check that the request configuration includes some headers with the expected
+ * values. The assertion is case insensitive.
+ */
 module.exports = (actual, expected) => {
-  // These headers should be added to the request
-  const additional = ['API-Version', 'Nethash', 'Port', 'Version']
+  const requestNormalizedHeaders = Object.keys(actual.headers).map(header => header.toLowerCase())
+
+  let found = 0
+  for (const header in expected) {
+    const normalizedHeader = header.toLowerCase()
+
+    if (requestNormalizedHeaders.indexOf(normalizedHeader) !== -1) {
+      const expectedValue = expected[header]
+
+      if (expectedValue === actual.headers[header]) {
+        found++
+      } else {
+        break
+      }
+    }
+  }
 
   return {
-    message: () => {
-      const actualHeaders = additional.reduce((all, header) => {
-        if (header in additional) {
-          all[header] = actual.data.headers[header]
-        }
-        return all
-      }, {})
-
-      return `Expected actual headers to match expected: ${JSON.stringify(actualHeaders)} vs. ${JSON.stringify(expected)}`
-    },
-    pass: additional.every(header => actual.data.headers[header] === expected[header])
+    message: () => `Expected actual headers to include and match expected: ${JSON.stringify(actual)} vs. ${JSON.stringify(expected)}`,
+    pass: found === Object.keys(expected).length
   }
 }

--- a/packages/client/build/webpack.config.js
+++ b/packages/client/build/webpack.config.js
@@ -31,11 +31,6 @@ const browserConfig = {
   }
 }
 
-// bundle with crypto package
-const bundleConfig = {...browserConfig}
-bundleConfig.externals = {}
-bundleConfig.output = {...browserConfig.output, filename: browserConfig.output.filename.replace('index', 'bundle')}
-
 const moduleConfig = {
   target: 'node',
   babel: {
@@ -58,4 +53,4 @@ const moduleConfig = {
   }
 }
 
-module.exports = [bundleConfig, browserConfig, moduleConfig].map(({ babel, ...entry }) => merge(base(babel), entry));
+module.exports = [browserConfig, moduleConfig].map(({ babel, ...entry }) => merge(base(babel), entry));

--- a/packages/client/build/webpack.config.js
+++ b/packages/client/build/webpack.config.js
@@ -22,9 +22,6 @@ const browserConfig = {
       browsers: 'defaults'
     }
   },
-  externals: {
-    '@arkecosystem/crypto': 'ArkCrypto'
-  },
   output: {
     ...format(pkg.browser),
     library: 'ArkEcosystemClient',

--- a/packages/client/lib/http.js
+++ b/packages/client/lib/http.js
@@ -14,6 +14,7 @@ module.exports = class HttpClient {
     }
 
     this.version = apiVersion
+    this.headers = {}
   }
 
   /**
@@ -22,6 +23,14 @@ module.exports = class HttpClient {
    */
   setVersion (version) {
     this.version = version
+  }
+
+  /**
+   * Establish the headers of the requests.
+   * @param {Object} headers
+   */
+  setHeaders (headers = {}) {
+    this.headers = headers
   }
 
   /**
@@ -83,12 +92,13 @@ module.exports = class HttpClient {
    * @throws Will throw an error if the HTTP request fails.
    */
   sendRequest (method, path, payload) {
+    if (!this.headers['API-Version']) {
+      this.headers['API-Version'] = this.version
+    }
+
     const client = axios.create({
       baseURL: this.host,
-      headers: {
-        port: '1',
-        'API-Version': this.version
-      }
+      headers: this.headers,
     })
 
     try {

--- a/packages/client/lib/http.js
+++ b/packages/client/lib/http.js
@@ -1,4 +1,3 @@
-const { configManager } = require('@arkecosystem/crypto')
 const axios = require('axios')
 
 module.exports = class HttpClient {
@@ -87,8 +86,6 @@ module.exports = class HttpClient {
     const client = axios.create({
       baseURL: this.host,
       headers: {
-        nethash: configManager.get('nethash'),
-        version: configManager.get('pubKeyHash'),
         port: '1',
         'API-Version': this.version
       }

--- a/packages/client/lib/http.js
+++ b/packages/client/lib/http.js
@@ -14,6 +14,7 @@ module.exports = class HttpClient {
     }
 
     this.version = apiVersion
+    this.timeout = 60000
     this.headers = {}
   }
 
@@ -31,6 +32,14 @@ module.exports = class HttpClient {
    */
   setHeaders (headers = {}) {
     this.headers = headers
+  }
+
+  /**
+   * Establish the timeout of the requests.
+   * @param {Number} timeout
+   */
+  setTimeout (timeout) {
+    this.timeout = timeout
   }
 
   /**
@@ -99,6 +108,7 @@ module.exports = class HttpClient {
     const client = axios.create({
       baseURL: this.host,
       headers: this.headers,
+      timeout: this.timeout
     })
 
     try {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -29,7 +29,6 @@
     "depcheck": "depcheck ./"
   },
   "dependencies": {
-    "@arkecosystem/crypto": "^0.1.1",
     "axios": "^0.18.0",
     "lodash.orderby": "^4.6.0",
     "lodash.shuffle": "^4.2.0"


### PR DESCRIPTION
## Proposed changes
The  `crypto` dependency is almost useless currently but it increase the size of the browser bundle a lot.