### PR TITLE
feat: minimum peer version

### DIFF
--- a/packages/core-deployer/bin/deployer
+++ b/packages/core-deployer/bin/deployer
@@ -140,6 +140,7 @@ const requestNodeIp = options.nodeIp === '0.0.0.0' ? '127.0.0.1' : options.nodeI
 
 updateConfig('network.json', networkConfig, options.configPath)
 updateConfig('peers.json', {
+  minimumVersion: '>=1.1.1',
   minimumNetworkReach: 1,
   list: [{
     ip: requestNodeIp,

--- a/packages/core-p2p/lib/monitor.js
+++ b/packages/core-p2p/lib/monitor.js
@@ -427,7 +427,10 @@ module.exports = class Monitor {
       peer,
       until: moment().add(this.manager.config.suspendMinutes, 'minutes')
     }
+
     delete this.peers[peer.ip]
+
+    logger.error(`Suspended ${peer.ip}:${peer.port} until ` + this.suspendedPeers[peer.ip].until.humanize())
   }
 
   /**

--- a/packages/core-p2p/lib/monitor.js
+++ b/packages/core-p2p/lib/monitor.js
@@ -141,7 +141,7 @@ module.exports = class Monitor {
    * @throws {Error} If invalid peer
    */
   async acceptNewPeer (peer) {
-    if (!mm.isMatch(peer.version, this.config.peers.minimumVersion)) {
+    if (!mm.isMatch(peer.version, this.config.peers.minimumVersion) && !this.config.peers.whiteList.includes(peer.ip)) {
       logger.debug(`Rejected peer ${peer.ip}:${peer.port} as it doesn't meet the minimum version requirements. Expected: ${this.config.peers.minimumVersion} - Received: ${peer.version}`)
 
       return

--- a/packages/core-p2p/lib/monitor.js
+++ b/packages/core-p2p/lib/monitor.js
@@ -142,13 +142,13 @@ module.exports = class Monitor {
    */
   async acceptNewPeer (peer) {
     if (!mm.isMatch(peer.version, this.config.peers.minimumVersion) && !this.config.peers.whiteList.includes(peer.ip)) {
-      logger.debug(`Rejected peer ${peer.ip}:${peer.port} as it doesn't meet the minimum version requirements. Expected: ${this.config.peers.minimumVersion} - Received: ${peer.version}`)
+      logger.debug(`Rejected peer ${peer.ip} as it doesn't meet the minimum version requirements. Expected: ${this.config.peers.minimumVersion} - Received: ${peer.version}`)
 
       return
     }
 
     if (this.config.peers.blackList.includes(peer.ip)) {
-      logger.debug(`Rejected peer ${peer.ip}:${peer.port} as it is blacklisted`)
+      logger.debug(`Rejected peer ${peer.ip} as it is blacklisted`)
 
       return
     }
@@ -430,7 +430,7 @@ module.exports = class Monitor {
 
     delete this.peers[peer.ip]
 
-    logger.debug(`Suspended ${peer.ip}:${peer.port} until ` + this.suspendedPeers[peer.ip].until.humanize())
+    logger.debug(`Suspended ${peer.ip} until ` + this.suspendedPeers[peer.ip].until.format("h [hrs], m [min]"))
   }
 
   /**

--- a/packages/core-p2p/lib/monitor.js
+++ b/packages/core-p2p/lib/monitor.js
@@ -430,7 +430,7 @@ module.exports = class Monitor {
 
     delete this.peers[peer.ip]
 
-    logger.debug(`Suspended ${peer.ip} until ` + this.suspendedPeers[peer.ip].until.format("h [hrs], m [min]"))
+    logger.debug(`Suspended ${peer.ip} until ` + this.suspendedPeers[peer.ip].until.format('h [hrs], m [min]'))
   }
 
   /**
@@ -450,6 +450,8 @@ module.exports = class Monitor {
     const suspendedPeer = this.suspendedPeers[peer.ip]
 
     if (suspendedPeer && moment().isBefore(suspendedPeer.until)) {
+      logger.debug(`${peer.ip} still suspended until ` + suspendedPeer.until.format('h [hrs], m [min]'))
+
       return true
     } else if (suspendedPeer) {
       delete this.suspendedPeers[peer.ip]

--- a/packages/core-p2p/lib/monitor.js
+++ b/packages/core-p2p/lib/monitor.js
@@ -430,7 +430,7 @@ module.exports = class Monitor {
 
     delete this.peers[peer.ip]
 
-    logger.error(`Suspended ${peer.ip}:${peer.port} until ` + this.suspendedPeers[peer.ip].until.humanize())
+    logger.debug(`Suspended ${peer.ip}:${peer.port} until ` + this.suspendedPeers[peer.ip].until.humanize())
   }
 
   /**

--- a/packages/core-p2p/lib/monitor.js
+++ b/packages/core-p2p/lib/monitor.js
@@ -144,11 +144,15 @@ module.exports = class Monitor {
     if (!semver.satisfies(peer.version, this.config.peers.minimumVersion) && !this.config.peers.whiteList.includes(peer.ip)) {
       logger.debug(`Rejected peer ${peer.ip} as it doesn't meet the minimum version requirements. Expected: ${this.config.peers.minimumVersion} - Received: ${peer.version}`)
 
+      this.__suspendPeer(peer)
+
       return
     }
 
     if (this.config.peers.blackList.includes(peer.ip)) {
       logger.debug(`Rejected peer ${peer.ip} as it is blacklisted`)
+
+      this.__suspendPeer(peer)
 
       return
     }

--- a/packages/core-p2p/lib/monitor.js
+++ b/packages/core-p2p/lib/monitor.js
@@ -3,7 +3,7 @@
 const prettyMs = require('pretty-ms')
 const moment = require('moment')
 const delay = require('delay')
-const mm = require('micromatch')
+const semver = require('semver')
 
 const { slots } = require('@arkecosystem/crypto')
 
@@ -141,7 +141,7 @@ module.exports = class Monitor {
    * @throws {Error} If invalid peer
    */
   async acceptNewPeer (peer) {
-    if (!mm.isMatch(peer.version, this.config.peers.minimumVersion) && !this.config.peers.whiteList.includes(peer.ip)) {
+    if (!semver.satisfies(peer.version, this.config.peers.minimumVersion) && !this.config.peers.whiteList.includes(peer.ip)) {
       logger.debug(`Rejected peer ${peer.ip} as it doesn't meet the minimum version requirements. Expected: ${this.config.peers.minimumVersion} - Received: ${peer.version}`)
 
       return

--- a/packages/core-p2p/lib/monitor.js
+++ b/packages/core-p2p/lib/monitor.js
@@ -3,6 +3,7 @@
 const prettyMs = require('pretty-ms')
 const moment = require('moment')
 const delay = require('delay')
+const mm = require('micromatch')
 
 const { slots } = require('@arkecosystem/crypto')
 
@@ -140,6 +141,12 @@ module.exports = class Monitor {
    * @throws {Error} If invalid peer
    */
   async acceptNewPeer (peer) {
+    if (!mm.isMatch(peer.version, this.config.peers.minimumVersion)) {
+      logger.debug(`Rejected peer ${peer.ip}:${peer.port} as it doesn't meet the minimum version requirements. Expected: ${this.config.peers.minimumVersion} - Received: ${peer.version}`)
+
+      return
+    }
+
     if (this.config.peers.blackList.includes(peer.ip)) {
       logger.debug(`Rejected peer ${peer.ip}:${peer.port} as it is blacklisted`)
 

--- a/packages/core-p2p/lib/server/plugins/throttle/bucket.js
+++ b/packages/core-p2p/lib/server/plugins/throttle/bucket.js
@@ -18,6 +18,7 @@ class Bucket {
    */
   add (ip, limit) {
     this.limiters[ip] = new RateLimiter(limit, 'minute', true)
+    this.limits[ip] = limit
   }
 
   /**

--- a/packages/core-p2p/lib/server/plugins/throttle/index.js
+++ b/packages/core-p2p/lib/server/plugins/throttle/index.js
@@ -33,10 +33,7 @@ const register = async (server, options) => {
 
       bucket.decrement(remoteAddress)
 
-      const remaining = bucket.remaining(remoteAddress)
-      logger.verbose(`${remoteAddress} has ${remaining} requests left.`)
-
-      if (remaining <= 0) {
+      if (bucket.remaining(remoteAddress) <= 0) {
         logger.debug(`${remoteAddress} has exceeded the maximum number of requests per minute.`)
 
         return h.response({

--- a/packages/core-p2p/lib/server/plugins/throttle/index.js
+++ b/packages/core-p2p/lib/server/plugins/throttle/index.js
@@ -33,7 +33,10 @@ const register = async (server, options) => {
 
       bucket.decrement(remoteAddress)
 
-      if (bucket.remaining(remoteAddress) <= 0) {
+      const remaining = bucket.remaining(remoteAddress)
+      logger.verbose(`${remoteAddress} has ${remaining} requests left.`)
+
+      if (remaining <= 0) {
         logger.debug(`${remoteAddress} has exceeded the maximum number of requests per minute.`)
 
         return h.response({

--- a/packages/core-p2p/package.json
+++ b/packages/core-p2p/package.json
@@ -32,6 +32,7 @@
     "moment": "^2.22.2",
     "pretty-ms": "^3.2.0",
     "request-ip": "^2.0.2",
+    "semver": "^5.5.0",
     "sntp": "^3.0.1",
     "threads": "^0.11.0"
   },

--- a/packages/core/lib/config/devnet/peers.json
+++ b/packages/core/lib/config/devnet/peers.json
@@ -1,5 +1,5 @@
 {
-  "minimumVersion": "2.*",
+  "minimumVersion": ">=1.1.1",
   "minimumNetworkReach": 5,
   "globalTimeout": 5000,
   "coldStart": 5,

--- a/packages/core/lib/config/devnet/peers.json
+++ b/packages/core/lib/config/devnet/peers.json
@@ -1,4 +1,5 @@
 {
+  "minimumVersion": "2.*",
   "minimumNetworkReach": 5,
   "globalTimeout": 5000,
   "coldStart": 5,

--- a/packages/core/lib/config/mainnet/peers.json
+++ b/packages/core/lib/config/mainnet/peers.json
@@ -1,4 +1,5 @@
 {
+  "minimumVersion": ">=1.1.1",
   "minimumNetworkReach": 20,
   "globalTimeout": 5000,
   "coldStart": 30,

--- a/packages/core/lib/config/testnet.1/peers.json
+++ b/packages/core/lib/config/testnet.1/peers.json
@@ -1,4 +1,5 @@
 {
+  "minimumVersion": ">=1.1.1",
   "minimumNetworkReach": 20,
   "globalTimeout": 5000,
   "coldStart": 30,

--- a/packages/core/lib/config/testnet.2/peers.json
+++ b/packages/core/lib/config/testnet.2/peers.json
@@ -1,4 +1,5 @@
 {
+  "minimumVersion": ">=1.1.1",
   "minimumNetworkReach": 20,
   "globalTimeout": 5000,
   "coldStart": 30,

--- a/packages/core/lib/config/testnet.live/peers.json
+++ b/packages/core/lib/config/testnet.live/peers.json
@@ -1,4 +1,5 @@
 {
+  "minimumVersion": ">=1.1.1",
   "minimumNetworkReach": 10,
   "blackList": [],
   "globalTimeout": 3000,

--- a/packages/core/lib/config/testnet/peers.json
+++ b/packages/core/lib/config/testnet/peers.json
@@ -1,4 +1,5 @@
 {
+  "minimumVersion": ">=1.1.1",
   "minimumNetworkReach": 5,
   "globalTimeout": 5000,
   "coldStart": 30,


### PR DESCRIPTION
## Proposed changes

Allows to set version constraints for peers by using https://github.com/npm/node-semver. This makes it easy to exclude certain peers, for example all v1 nodes while allowing v2 nodes to join. Whitelisted IPs will go around the version constraints and still be accepted.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes