### PR TITLE
server error log & stop GRAPHQL

### DIFF
--- a/packages/core-graphql/lib/server.js
+++ b/packages/core-graphql/lib/server.js
@@ -47,8 +47,7 @@ module.exports = async (config) => {
 
     return server
   } catch (error) {
-    logger.error(error.stack)
-    // TODO no exit here?
-    process.exit(1)
+    logger.error(`Error starting GraphQL API Server, stopping in 5 seconds: ${error.stack}`)
+    await server.stop()
   }
 }


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
use Hapi native stop() function instead of process.exit on server.start() error in try{} at catch(error) {} block
use logger.error to display information
## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ x ] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [ ] Docs (documentation only changes)
- [ ] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [ x ] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [ x ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

Uses the same function as plugin.deregister (server.stop()); therefore I did not add any tests for this implementation.

[packages/core-graphql/lib/index.js#L24
](https://github.com/JeremiGendron/core/blob/bf35087c785b3507d10f29a0b39fc231cb35b30e/packages/core-graphql/lib/index.js#L24)
the resolvedPlugin returns an instance of require(server) -> the hapi.server created in server.js that we call stop on if the start fails.

[hapi documentation](https://hapijs.com/api#-await-serverinitialize), why it's important:

> If you must try to resume after an error, call server.stop() first to reset the server state.


#766 
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
