### PR TITLE
Add cross-env to support Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "lint": "lerna run lint",
     "depcheck": "lerna run depcheck",
     "prepare": "lerna run prepare",
-    "test": "ARK_ENV=test jest --forceExit",
-    "test:coverage": "ARK_ENV=test jest --coverage --forceExit"
+    "test": "cross-env ARK_ENV=test jest --forceExit",
+    "test:coverage": "cross-env ARK_ENV=test jest --coverage --forceExit"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-beta.51",
@@ -17,6 +17,7 @@
     "axios": "^0.18.0",
     "babel-loader": "^8.0.0-beta",
     "body-parser": "^1.18.3",
+    "cross-env": "^5.2.0",
     "depcheck": "^0.6.9",
     "docdash": "^0.4.0",
     "eslint": "^4.19.1",


### PR DESCRIPTION
## Proposed changes
Add support for running the core tests under Windows.  The current issue is that the script syntax assumes a *nix enviroment variable format and does not work with Windows.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [ ] Docs (documentation only changes)
- [ ] Test (adding missing tests or fixing existing tests)
- [x] Other... Please describe: build / devops infrastructure

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

Fixes: #822