### PR TITLE
Rename the global `ArkClient` variable to `ArkEcosystemClient`

### DIFF
--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -8,7 +8,7 @@
 yarn add @arkecosystem/client
 ```
 
-If you want to use the CDN version, is avialable two bundles:
+If you want to use the CDN version, is available two bundles:
 
 - Without the [@arkecosystem/crypto](http://github.com/ArkEcosystem/ArkEcosystem/core/packages/crypto) package: (_You will need to import both_)
 
@@ -28,13 +28,13 @@ If you want to use the CDN version, is avialable two bundles:
 Import the library in node.js:
 
 ```
-import ArkClient from @arkecosystem/client
+import ArkEcosystemClient from @arkecosystem/client
 ```
 
 Use the library:
 
 ```
-const client = new ArkClient('<your host here>')
+const client = new ArkEcosystemClient('<your host here>')
 ```
 
 ## Security

--- a/packages/client/build/webpack.config.js
+++ b/packages/client/build/webpack.config.js
@@ -27,7 +27,7 @@ const browserConfig = {
   },
   output: {
     ...format(pkg.browser),
-    library: 'ArkClient',
+    library: 'ArkEcosystemClient',
     libraryTarget: 'umd',
     umdNamedDefine: true,
     globalObject: 'this'


### PR DESCRIPTION
To keep it consistent with other API clients.