### PR TITLE
fix: sort peers by latency, not random

### DIFF
--- a/packages/core-api/lib/versions/1/handlers/peers.js
+++ b/packages/core-api/lib/versions/1/handlers/peers.js
@@ -22,14 +22,12 @@ exports.index = {
       return utils.respondWith('No peers found', true)
     }
 
-    let peers = allPeers.sort(() => 0.5 - Math.random())
+    let peers = allPeers.sort((a, b) => a.delay - b.delay)
     peers = request.query.os ? allPeers.filter(peer => peer.os === request.query.os) : peers
     peers = request.query.status ? allPeers.filter(peer => peer.status === request.query.status) : peers
     peers = request.query.port ? allPeers.filter(peer => peer.port === request.query.port) : peers
     peers = request.query.version ? allPeers.filter(peer => peer.version === request.query.version) : peers
     peers = peers.slice(0, (request.query.limit || 100))
-
-    peers = peers.sort((a, b) => a.delay - b.delay)
 
     if (request.query.orderBy) {
       const order = request.query.orderBy.split(':')

--- a/packages/core-api/lib/versions/2/handlers/peers.js
+++ b/packages/core-api/lib/versions/2/handlers/peers.js
@@ -16,7 +16,7 @@ exports.index = {
   async handler (request, h) {
     const allPeers = await blockchain.p2p.getPeers()
 
-    let result = allPeers.sort(() => 0.5 - Math.random())
+    let result = allPeers.sort((a, b) => a.delay - b.delay)
     result = request.query.os ? result.filter(peer => peer.os === request.query.os) : result
     result = request.query.status ? result.filter(peer => peer.status === request.query.status) : result
     result = request.query.port ? result.filter(peer => peer.port === request.query.port) : result

--- a/packages/core-p2p/lib/server/versions/1/handlers.js
+++ b/packages/core-p2p/lib/server/versions/1/handlers.js
@@ -24,7 +24,7 @@ exports.getPeers = {
     try {
       const peers = request.server.app.p2p.getPeers()
         .map(peer => peer.toBroadcastInfo())
-        .sort(() => Math.random() - 0.5)
+        .sort((a, b) => a.delay - b.delay)
 
       return {
         success: true,


### PR DESCRIPTION
## Proposed changes
It's currently fairly useless to sort peers randomly. Due to the pagination used, peers are randomly sorted and then cropped at the page limit. This could result in getting the X amount of bad peers, and never a peer with a low latency, because every page request (e.g. page 2 of the peer list) will result in a new completely random set of peers. 

I understand this is likely to prevent some sort of attack, but I can think of 3 easy ways to get round this and no easy solution for any of them:

1. send necessary headers and access the p2p endpoint `:4002/peer/list` which has the full list
2. spam the public peer endpoint `:4003/api/v2/peers` a few hundred times until i've got a good chunk of the list
3. run my own node and have access to them all in any way i want

I don't see the benefit of randomising the peer list here. @fix	i'd like your input

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
