### PR TITLE
fix: remove username logging in forger (no access to wallets)

### DIFF
--- a/packages/core-forger/lib/manager.js
+++ b/packages/core-forger/lib/manager.js
@@ -5,7 +5,6 @@ const delay = require('delay')
 const container = require('@arkecosystem/core-container')
 const logger = container.resolvePlugin('logger')
 const config = container.resolvePlugin('config')
-const database = container.resolvePlugin('database')
 const emitter = container.resolvePlugin('event-emitter')
 
 const { slots } = require('@arkecosystem/crypto')
@@ -43,11 +42,7 @@ module.exports = class ForgerManager {
       this.delegates.push(new Delegate(bip38, this.network, password))
     }
 
-    const delegates = this.delegates.map(delegate => {
-      const wallet = database.walletManager.getWalletByPublicKey(delegate.publicKey)
-
-      return `${wallet.username} (${wallet.publicKey})`
-    })
+    const delegates = this.delegates.map(delegate => delegate.publicKey).join(',')
 
     logger.debug(`Loaded ${delegates} delegates.`)
 
@@ -90,8 +85,7 @@ module.exports = class ForgerManager {
         // logger.debug(`Current forging delegate ${round.currentForger.publicKey} is not configured on this node.`)
 
         if (this.__isDelegateActivated(round.nextForger.publicKey)) {
-          const username = database.walletManager.getWalletByPublicKey(round.nextForger.publicKey).username
-          logger.info(`Next forging delegate ${username} (${round.nextForger.publicKey}) is active on this node.`)
+          logger.info(`Next forging delegate ${round.nextForger.publicKey} is active on this node.`)
           await this.client.syncCheck()
         }
 
@@ -138,8 +132,7 @@ module.exports = class ForgerManager {
       blockOptions.reward = round.reward
 
       const block = await delegate.forge(transactions, blockOptions)
-      const username = database.walletManager.getWalletByPublicKey(delegate.publicKey).username
-      logger.info(`Forged new block ${block.data.id} by delegate ${username} (${delegate.publicKey}) :trident:`)
+      logger.info(`Forged new block ${block.data.id} by delegate ${delegate.publicKey} :trident:`)
 
       emitter.emit('block.forged', block.data)
       transactions.forEach(transaction => emitter.emit('transaction.forged', transaction.data))
@@ -186,8 +179,7 @@ module.exports = class ForgerManager {
     }
 
     if (networkState.overHeightBlockHeader && networkState.overHeightBlockHeader.generatorPublicKey === currentForger.publicKey) {
-      const username = database.walletManager.getWalletByPublicKey(currentForger.publicKey).username
-      logger.info(`Possible double forging for delegate: ${username} (${currentForger.publicKey}).`)
+      logger.info(`Possible double forging for delegate: ${currentForger.publicKey}.`)
       logger.debug(`Network State: ${JSON.stringify(networkState)}`)
       return false
     }


### PR DESCRIPTION
## Proposed changes

The forger couldn't start because it made use of the database dependency for logging usernames. The forger runs split from the relay so it has no access to the database or wallet manager.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes