### PR TITLE
Update Travis to `forceExit` on tests and not conflict with `detectOpenHandles`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ before_script:
 
 script:
   # See https://jestjs.io/docs/en/troubleshooting.html#tests-are-extremely-slow-on-docker-and-or-continuous-integration-ci-server
-  - yarn test:coverage --ci --forceExit --maxWorkers 4
+  - yarn test:force-exit --ci --coverage
   - codecov
 
 jobs:

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "depcheck": "lerna run depcheck",
     "prepare": "lerna run prepare",
     "test": "cross-env ARK_ENV=test jest --runInBand --detectOpenHandles",
+    "test:force-exit": "cross-env ARK_ENV=test jest --runInBand --forceExit",
 		"test:coverage": "cross-env ARK_ENV=test jest --coverage --runInBand --detectOpenHandles"
   },
   "devDependencies": {


### PR DESCRIPTION
## Proposed changes
Added a new command `test:force-exit` command that uses `forceExit` instead of `detectOpenHandles` and update the Travis configuration to use it. Both options are exclusive, provoking that some Travis builds weren't working as expected. This should fix that

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Build (changes that affect the build system)