### PR TITLE
[WIP] Revert peer fixes

### DIFF
--- a/packages/core-blockchain/lib/blockchain.js
+++ b/packages/core-blockchain/lib/blockchain.js
@@ -391,6 +391,10 @@ module.exports = class Blockchain {
    * @return {Boolean}
    */
   isSynced (block) {
+    if (!this.p2p.hasPeers()) {
+      return true
+    }
+
     block = block || this.getLastBlock()
 
     return slots.getTime() - block.data.timestamp < 3 * config.getConstants(block.height).blocktime
@@ -402,6 +406,10 @@ module.exports = class Blockchain {
    * @return {Boolean}
    */
   isRebuildSynced (block) {
+    if (!this.p2p.hasPeers()) {
+      return true
+    }
+
     block = block || this.getLastBlock()
 
     const remaining = slots.getTime() - block.data.timestamp

--- a/packages/core-blockchain/lib/state-machine.js
+++ b/packages/core-blockchain/lib/state-machine.js
@@ -333,6 +333,8 @@ blockchainMachine.actionMap = blockchain => {
 
       logger.info(`Removed ${random} blocks :wastebasket:`)
 
+      await blockchain.p2p.resetSuspendedPeers()
+
       blockchain.dispatch('SUCCESS')
     }
   }

--- a/packages/core-blockchain/lib/state-machine.js
+++ b/packages/core-blockchain/lib/state-machine.js
@@ -306,7 +306,7 @@ blockchainMachine.actionMap = blockchain => {
           logger.warn('Downloaded block not accepted: ' + JSON.stringify(blocks[0]))
           logger.warn('Last block: ' + JSON.stringify(lastBlock.data))
 
-          blockchain.p2p.banPeer(blocks[0].ip)
+          blockchain.p2p.suspendPeer(blocks[0].ip)
 
           // disregard the whole block list
           blockchain.dispatch('FORK')

--- a/packages/core-p2p/lib/guard.js
+++ b/packages/core-p2p/lib/guard.js
@@ -64,6 +64,32 @@ class Guard {
   }
 
   /**
+   * Suspends a peer unless whitelisted.
+   * @param {Peer} peer
+   * @return {void}
+   */
+  async unsuspend (peer) {
+    if (!this.suspensions[peer.ip]) {
+      return
+    }
+
+    delete this.suspensions[peer.ip]
+
+    await this.monitor.acceptNewPeer(peer)
+  }
+
+  /**
+   * Reset suspended peer list.
+   * @return {void}
+   */
+  async resetSuspendedPeers () {
+    logger.info('Clearing suspended peers')
+    for (const ip of Object.keys(this.suspensions)) {
+      await this.unsuspend(this.get(ip).peer)
+    }
+  }
+
+  /**
    * Determine if peer is suspended or not.
    * @param  {Peer} peer
    * @return {Boolean}

--- a/packages/core-p2p/lib/guard.js
+++ b/packages/core-p2p/lib/guard.js
@@ -64,7 +64,7 @@ class Guard {
   }
 
   /**
-   * Suspends a peer unless whitelisted.
+   * Remove a suspended peer.
    * @param {Peer} peer
    * @return {void}
    */

--- a/packages/core-p2p/lib/manager.js
+++ b/packages/core-p2p/lib/manager.js
@@ -52,8 +52,14 @@ module.exports = class PeerManager {
    * @param  {Number}   fromBlockHeight
    * @return {Object[]}
    */
-  downloadBlocks (fromBlockHeight) {
-    return this.monitor.downloadBlocks(fromBlockHeight)
+  async downloadBlocks (fromBlockHeight) {
+    try {
+      return await this.monitor.downloadBlocks(fromBlockHeight)
+    } catch (error) {
+      logger.error(`Could not download blocks: ${error.message}`)
+    }
+
+    return []
   }
 
   /**

--- a/packages/core-p2p/lib/manager.js
+++ b/packages/core-p2p/lib/manager.js
@@ -97,6 +97,14 @@ module.exports = class PeerManager {
   }
 
   /**
+   * Check if we have any peers.
+   * @return {bool}
+   */
+  hasPeers () {
+    return !!this.monitor.getPeers().length
+  }
+
+  /**
    * Get peers.
    * @return {Peer[]}
    */

--- a/packages/core-p2p/lib/manager.js
+++ b/packages/core-p2p/lib/manager.js
@@ -82,12 +82,12 @@ module.exports = class PeerManager {
   }
 
   /**
-   * ban an existing peer.
+   * Suspend an existing peer.
    * @param  {Peer}    peer
-   * @return {Promise}
+   * @return {void}
    */
-  banPeer (ip) {
-    return this.monitor.banPeer(ip)
+  suspendPeer (ip) {
+    return this.monitor.suspendPeer(ip)
   }
 
   /**

--- a/packages/core-p2p/lib/monitor.js
+++ b/packages/core-p2p/lib/monitor.js
@@ -162,11 +162,11 @@ module.exports = class Monitor {
   }
 
   /**
-   * ban an existing peer.
+   * Suspend an existing peer.
    * @param  {Peer} peer
-   * @return {Promise}
+   * @return {void}
    */
-  banPeer (ip) {
+  suspendPeer (ip) {
     // TODO make a couple of tests on peer to understand the issue with this peer and decide how long to ban it
     const peer = this.peers[ip]
 

--- a/packages/core-p2p/lib/monitor.js
+++ b/packages/core-p2p/lib/monitor.js
@@ -176,8 +176,6 @@ module.exports = class Monitor {
       } else {
          this.guard.suspend(peer)
       }
-
-      logger.debug(`Banned peer ${ip} for ${this.guard.get(ip).untilHuman}`)
     }
   }
 

--- a/packages/core-p2p/lib/monitor.js
+++ b/packages/core-p2p/lib/monitor.js
@@ -182,6 +182,14 @@ module.exports = class Monitor {
   }
 
   /**
+   * Reset banned peer list.
+   * @return {void}
+   */
+  async resetSuspendedPeers () {
+    return this.guard.resetSuspendedPeers()
+  }
+
+  /**
    * Get all available peers.
    * @return {Peer[]}
    */


### PR DESCRIPTION
## Proposed changes
Currently there's no great way of running a single node without it completely crashing (I don't consider `ARK_ENV=test` as suitable way unless testing). While these changes don't allow for forging due to 0 quorum, it prevents the crash in the first place due to 0 peers, meaning it's possible to then setup other peers to connect to it.

Also, it didn't feel right that if there was 0 peers, it thought it wasn't synced. That caused an intense amount of spam in the logs, constantly looping through the download blocks process. As a result, i change it so the node thinks it's in sync if there are no other peers. May need input from others on this point (@faustbrian @fix).

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works

