### PR TITLE
feat: log usernames in forger (via P2P API)

### DIFF
--- a/packages/core-forger/lib/client.js
+++ b/packages/core-forger/lib/client.js
@@ -86,6 +86,18 @@ module.exports = class Client {
   }
 
   /**
+   * Get a list of all active delegate usernames.
+   * @return {Object}
+   */
+  async getUsernames () {
+    await this.__chooseHost()
+
+    const response = await this.__get(`${this.host}/internal/usernames`)
+
+    return response.data.data || {}
+  }
+
+  /**
    * Chose a responsive host.
    * @return {void}
    */

--- a/packages/core-p2p/lib/server/versions/internal/handlers.js
+++ b/packages/core-p2p/lib/server/versions/internal/handlers.js
@@ -176,3 +176,28 @@ exports.checkBlockchainSynced = {
     }
   }
 }
+
+/**
+ * @type {Object}
+ */
+exports.getUsernames = {
+  /**
+   * @param  {Hapi.Request} request
+   * @param  {Hapi.Toolkit} h
+   * @return {Hapi.Response}
+   */
+  async handler (request, h) {
+    const blockchain = container.resolvePlugin('blockchain')
+    const walletManager = container.resolvePlugin('database').walletManager
+
+    const lastBlock = blockchain.getLastBlock()
+    const delegates = await blockchain.database.getActiveDelegates(lastBlock.data.height + 1)
+
+    const data = {}
+    for (const delegate of delegates) {
+      data[delegate.publicKey] = walletManager.getWalletByPublicKey(delegate.publicKey).username
+    }
+
+    return { success: true, data }
+  }
+}

--- a/packages/core-p2p/lib/server/versions/internal/index.js
+++ b/packages/core-p2p/lib/server/versions/internal/index.js
@@ -15,7 +15,8 @@ const register = async (server, options) => {
     { method: 'POST', path: '/verifyTransaction', ...handlers.postVerifyTransaction },
     { method: 'GET', path: '/forgingTransactions', ...handlers.getTransactionsForForging },
     { method: 'GET', path: '/networkState', ...handlers.getNetworkState },
-    { method: 'GET', path: '/syncCheck', ...handlers.checkBlockchainSynced }
+    { method: 'GET', path: '/syncCheck', ...handlers.checkBlockchainSynced },
+    { method: 'GET', path: '/usernames', ...handlers.getUsernames }
   ])
 }
 


### PR DESCRIPTION
## Proposed changes

Adds the ability to log usernames in the forger as it usually doesn't have access to that kind of data. Currently the forger only logs public keys which makes testing really tedious unless you want to remember every public key in existence.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes