### PR TITLE
fix: blockchain not ready for usernames

### DIFF
--- a/packages/core-p2p/lib/server/versions/internal/handlers.js
+++ b/packages/core-p2p/lib/server/versions/internal/handlers.js
@@ -188,6 +188,11 @@ exports.getUsernames = {
    */
   async handler (request, h) {
     const blockchain = container.resolvePlugin('blockchain')
+
+    if (!blockchain) {
+      return { success: true, error: 'Blockchain not ready' }
+    }
+
     const walletManager = container.resolvePlugin('database').walletManager
 
     const lastBlock = blockchain.getLastBlock()

--- a/packages/core-p2p/lib/server/versions/internal/handlers.js
+++ b/packages/core-p2p/lib/server/versions/internal/handlers.js
@@ -190,7 +190,7 @@ exports.getUsernames = {
     const blockchain = container.resolvePlugin('blockchain')
 
     if (!blockchain) {
-      return { success: true, error: 'Blockchain not ready' }
+      return { success: false, error: 'Blockchain not ready' }
     }
 
     const walletManager = container.resolvePlugin('database').walletManager


### PR DESCRIPTION
## Proposed changes

If a request would be send to the P2P API to get usernames before the node is synced it would throw a 500. This handles it by returning a response with a message.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes