### PR TITLE
fix: cast port number from peers when filtering

### DIFF
--- a/packages/core-api/lib/versions/1/handlers/peers.js
+++ b/packages/core-api/lib/versions/1/handlers/peers.js
@@ -68,7 +68,7 @@ exports.show = {
     }
 
     const peer = peers.find(elem => {
-      return elem.ip === request.query.ip && elem.port === +request.query.port
+      return elem.ip === request.query.ip && +elem.port === +request.query.port
     })
 
     if (!peer) {


### PR DESCRIPTION
## Proposed changes
Some peers in the peer list have the port stored as string. I've added a forced-cast when filtering a specific peer on the v1 endpoint (`/api/v1/peers/get`) just as a precaution.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
