### PR TITLE
fix: delegate voters endpoint 500 error

### DIFF
--- a/packages/core-api/lib/versions/1/handlers/delegates.js
+++ b/packages/core-api/lib/versions/1/handlers/delegates.js
@@ -123,6 +123,13 @@ exports.voters = {
    */
   async handler (request, h) {
     const delegate = await database.delegates.findById(request.query.publicKey)
+
+    if (!delegate) {
+      return utils.respondWith({
+        accounts: []
+      })
+    }
+
     const accounts = await database.wallets.findAllByVote(delegate.publicKey)
 
     return utils.respondWith({


### PR DESCRIPTION
## Proposed changes
If a delegate cannot be found on the v1 endpoint `/api/v1/delegates/voters`, it throws a 500 error. The changes here mean it now returns `success: true` and an empty array (which matches current mainnet - http://node1.arknet.cloud:4001/api/delegates/voters?publicKey=02de5a05e931d09f752811ea933d07461ff6937253a8a6e9f45a2385c9c0ef45d1)

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
