### PR TITLE
Fix new delegate not updating

### DIFF
--- a/packages/core-database/lib/wallet-manager.js
+++ b/packages/core-database/lib/wallet-manager.js
@@ -240,6 +240,10 @@ module.exports = class WalletManager {
 
     sender.applyTransactionToSender(data)
 
+    if (type === TRANSACTION_TYPES.DELEGATE_REGISTRATION) {
+      this.reindex(sender)
+    }
+
     if (recipient && type === TRANSACTION_TYPES.TRANSFER) {
       recipient.applyTransactionToRecipient(data)
     }


### PR DESCRIPTION
## Proposed changes
When a wallet user registers a new delegate name, it's not indexed in the wallet manager. This means that when the vote weight is recalculated at the end of each round, that wallet is not included.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Test (adding missing tests or fixing existing tests)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
