### PR TITLE
fix: delete ID query parameter to prevent faulty query for votes

### DIFF
--- a/packages/core-api/lib/versions/2/handlers/wallets.js
+++ b/packages/core-api/lib/versions/2/handlers/wallets.js
@@ -169,6 +169,9 @@ exports.votes = {
       return Boom.notFound('Wallet not found')
     }
 
+    // NOTE: We unset this value because it otherwise will produce a faulty SQL query
+    delete request.params.id
+
     const transactions = await database.transactions.allVotesBySender(
       wallet.publicKey, {
         ...request.params,


### PR DESCRIPTION
## Proposed changes

The ID parameter from the path was causing a wrong query to be generated when requesting http://localhost:4003/api/v2/wallets/AbgXLcnUo61JFsnFaAmoXE54wVc5L7Roa5/votes.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes