### PR TITLE
fix: sending too many requests to relays in forger

### DIFF
--- a/packages/core-forger/lib/client.js
+++ b/packages/core-forger/lib/client.js
@@ -48,8 +48,8 @@ module.exports = class Client {
 
     try {
       await this.__get(`${this.host}/internal/syncCheck`)
-    } catch (e) {
-      logger.error(e.message)
+    } catch (error) {
+      logger.error(`Could not sync check: ${error.message}`)
     }
   }
 

--- a/packages/core-forger/lib/client.js
+++ b/packages/core-forger/lib/client.js
@@ -43,15 +43,15 @@ module.exports = class Client {
    * Sends the WAKEUP signal to the to relay hosts to check if synced and sync if necesarry
    */
   async syncCheck () {
-    await Promise.each(this.hosts, async (host) => {
-      logger.debug(`Sending wake-up check to relay node(s) ${host}`)
+    await this.__chooseHost()
 
-      try {
-        await this.__get(`${this.host}/internal/syncCheck`)
-      } catch (e) {
-        //
-      }
-    })
+    logger.debug(`Sending wake-up check to relay node ${this.host}`)
+
+    try {
+      await this.__get(`${this.host}/internal/syncCheck`)
+    } catch (e) {
+      logger.error(e.message)
+    }
   }
 
   /**

--- a/packages/core-forger/lib/client.js
+++ b/packages/core-forger/lib/client.js
@@ -1,5 +1,4 @@
 'use strict'
-const Promise = require('bluebird')
 const axios = require('axios')
 const sample = require('lodash/sample')
 const container = require('@arkecosystem/core-container')

--- a/packages/core-forger/package.json
+++ b/packages/core-forger/package.json
@@ -23,7 +23,6 @@
     "@arkecosystem/core-container": "^0.1.1",
     "@arkecosystem/crypto": "^0.1.1",
     "axios": "^0.18.0",
-    "bluebird": "^3.5.1",
     "delay": "^2.0.0",
     "lodash": "^4.17.10"
   },


### PR DESCRIPTION
## Proposed changes

The forger was sending wake-up signals to all relays instead of choosing one which could result in a lot of requests and missing blocks in certain cases. Resolves https://github.com/ArkEcosystem/core/issues/886

## Types of changes

- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes