### PR TITLE
feat: P2P Config API

### DIFF
--- a/packages/core-p2p/lib/server/index.js
+++ b/packages/core-p2p/lib/server/index.js
@@ -52,6 +52,16 @@ module.exports = async (p2p, config) => {
   })
 
   await server.register({
+    plugin: require('./versions/config'),
+    routes: { prefix: '/config' }
+  })
+
+  await server.register({
+    plugin: require('./versions/1'),
+    routes: { prefix: '/peer' }
+  })
+
+  await server.register({
     plugin: require('./versions/internal'),
     routes: { prefix: '/internal' }
   })
@@ -62,8 +72,6 @@ module.exports = async (p2p, config) => {
       routes: { prefix: '/remote' }
     })
   }
-
-  await server.register({ plugin: require('./versions/1') })
 
   try {
     await server.start()

--- a/packages/core-p2p/lib/server/plugins/accept-request.js
+++ b/packages/core-p2p/lib/server/plugins/accept-request.js
@@ -17,6 +17,10 @@ const register = async (server, options) => {
     async method (request, h) {
       const remoteAddress = requestIp.getClientIp(request)
 
+      if (request.path.startsWith('/config')) {
+        return h.continue
+      }
+
       if ((request.path.startsWith('/internal') || request.path.startsWith('/remote')) && !isWhitelist(options.whitelist, remoteAddress)) {
         return h.response({
           code: 'ResourceNotFound',

--- a/packages/core-p2p/lib/server/versions/1/index.js
+++ b/packages/core-p2p/lib/server/versions/1/index.js
@@ -10,15 +10,15 @@ const handlers = require('./handlers')
  */
 const register = async (server, options) => {
   server.route([
-    { method: 'GET', path: '/peer/list', ...handlers.getPeers },
-    { method: 'GET', path: '/peer/blocks', ...handlers.getBlocks },
-    { method: 'GET', path: '/peer/transactionsFromIds', ...handlers.getTransactionsFromIds },
-    { method: 'GET', path: '/peer/height', ...handlers.getHeight },
-    { method: 'GET', path: '/peer/transactions', ...handlers.getTransactions },
-    { method: 'GET', path: '/peer/blocks/common', ...handlers.getCommonBlock },
-    { method: 'GET', path: '/peer/status', ...handlers.getStatus },
-    { method: 'POST', path: '/peer/blocks', ...handlers.postBlock },
-    { method: 'POST', path: '/peer/transactions', ...handlers.postTransactions }
+    { method: 'GET', path: '/list', ...handlers.getPeers },
+    { method: 'GET', path: '/blocks', ...handlers.getBlocks },
+    { method: 'GET', path: '/transactionsFromIds', ...handlers.getTransactionsFromIds },
+    { method: 'GET', path: '/height', ...handlers.getHeight },
+    { method: 'GET', path: '/transactions', ...handlers.getTransactions },
+    { method: 'GET', path: '/blocks/common', ...handlers.getCommonBlock },
+    { method: 'GET', path: '/status', ...handlers.getStatus },
+    { method: 'POST', path: '/blocks', ...handlers.postBlock },
+    { method: 'POST', path: '/transactions', ...handlers.postTransactions }
   ])
 }
 

--- a/packages/core-p2p/lib/server/versions/config/handlers.js
+++ b/packages/core-p2p/lib/server/versions/config/handlers.js
@@ -20,11 +20,11 @@ exports.getConfig = {
         network: {
           version: config.network.pubKeyHash,
           nethash: config.network.nethash,
-          explorer: config.network.client.explorer
-        },
-        token: {
-          name: config.network.client.token,
-          symbol: config.network.client.symbol
+          explorer: config.network.client.explorer,
+          token: {
+            name: config.network.client.token,
+            symbol: config.network.client.symbol
+          }
         },
         plugins: transform(config)
       }

--- a/packages/core-p2p/lib/server/versions/config/handlers.js
+++ b/packages/core-p2p/lib/server/versions/config/handlers.js
@@ -20,7 +20,10 @@ exports.getConfig = {
         token: config.network.client.token,
         symbol: config.network.client.symbol,
         explorer: config.network.client.explorer,
-        version: config.network.pubKeyHash,
+        versions: {
+          network: config.network.pubKeyHash,
+          core: container.resolveOptions('blockchain').version
+        },
         plugins: transform(config)
       }
     }

--- a/packages/core-p2p/lib/server/versions/config/handlers.js
+++ b/packages/core-p2p/lib/server/versions/config/handlers.js
@@ -16,12 +16,16 @@ exports.getConfig = {
   async handler (request, h) {
     return {
       data: {
-        nethash: config.network.nethash,
-        token: config.network.client.token,
-        symbol: config.network.client.symbol,
-        explorer: config.network.client.explorer,
+        network: {
+          version: config.network.pubKeyHash,
+          nethash: config.network.nethash,
+          explorer: config.network.client.explorer,
+        },
+        token: {
+          name: config.network.client.token,
+          symbol: config.network.client.symbol
+        },
         versions: {
-          network: config.network.pubKeyHash,
           core: container.resolveOptions('blockchain').version
         },
         plugins: transform(config)

--- a/packages/core-p2p/lib/server/versions/config/handlers.js
+++ b/packages/core-p2p/lib/server/versions/config/handlers.js
@@ -16,17 +16,15 @@ exports.getConfig = {
   async handler (request, h) {
     return {
       data: {
+        version: container.resolveOptions('blockchain').version,
         network: {
           version: config.network.pubKeyHash,
           nethash: config.network.nethash,
-          explorer: config.network.client.explorer,
+          explorer: config.network.client.explorer
         },
         token: {
           name: config.network.client.token,
           symbol: config.network.client.symbol
-        },
-        versions: {
-          core: container.resolveOptions('blockchain').version
         },
         plugins: transform(config)
       }

--- a/packages/core-p2p/lib/server/versions/config/handlers.js
+++ b/packages/core-p2p/lib/server/versions/config/handlers.js
@@ -1,0 +1,28 @@
+'use strict'
+
+const container = require('@arkecosystem/core-container')
+const config = container.resolvePlugin('config')
+const transform = require('./transformers/plugins')
+
+/**
+ * @type {Object}
+ */
+exports.getConfig = {
+  /**
+   * @param  {Hapi.Request} request
+   * @param  {Hapi.Toolkit} h
+   * @return {Hapi.Response}
+   */
+  async handler (request, h) {
+    return {
+      data: {
+        nethash: config.network.nethash,
+        token: config.network.client.token,
+        symbol: config.network.client.symbol,
+        explorer: config.network.client.explorer,
+        version: config.network.pubKeyHash,
+        plugins: transform(config)
+      }
+    }
+  }
+}

--- a/packages/core-p2p/lib/server/versions/config/index.js
+++ b/packages/core-p2p/lib/server/versions/config/index.js
@@ -1,0 +1,25 @@
+'use strict'
+
+const handlers = require('./handlers')
+
+/**
+ * Register config routes.
+ * @param  {Hapi.Server} server
+ * @param  {Object} options
+ * @return {void}
+ */
+const register = async (server, options) => {
+  server.route([
+    { method: 'GET', path: '/', ...handlers.getConfig }
+  ])
+}
+
+/**
+ * The struct used by hapi.js.
+ * @type {Object}
+ */
+exports.plugin = {
+  name: 'ARK P2P API - Config',
+  version: '0.1.0',
+  register
+}

--- a/packages/core-p2p/lib/server/versions/config/transformers/plugins.js
+++ b/packages/core-p2p/lib/server/versions/config/transformers/plugins.js
@@ -14,7 +14,6 @@ module.exports = (config) => {
   ]
 
   let result = {}
-  result[allowed[0]] = config.plugins[allowed[0]].port
 
   for (const [name, options] of Object.entries(config.plugins)) {
     if (allowed.includes(name)) {

--- a/packages/core-p2p/lib/server/versions/config/transformers/plugins.js
+++ b/packages/core-p2p/lib/server/versions/config/transformers/plugins.js
@@ -1,0 +1,38 @@
+'use strict'
+
+/**
+ * Turns a "config" object into readable object.
+ * @param  {Object} model
+ * @return {Object}
+ */
+module.exports = (config) => {
+  const allowed = [
+    '@arkecosystem/core-api',
+    '@arkecosystem/core-graphql',
+    '@arkecosystem/core-json-rpc',
+    '@arkecosystem/core-webhooks'
+  ]
+
+  let result = {}
+  result[allowed[0]] = config.plugins[allowed[0]].port
+
+  for (const [name, options] of Object.entries(config.plugins)) {
+    if (allowed.includes(name)) {
+      if (options.server) {
+        result[name] = {
+          enabled: !!options.server.enabled,
+          port: +options.server.port
+        }
+
+        continue
+      }
+
+      result[name] = {
+        enabled: !!options.enabled,
+        port: +options.port
+      }
+    }
+  }
+
+  return result
+}

--- a/packages/core/lib/config/devnet/plugins.js
+++ b/packages/core/lib/config/devnet/plugins.js
@@ -69,10 +69,6 @@ module.exports = {
       storage: `${process.env.ARK_PATH_DATA}/database/${process.env.ARK_NETWORK_NAME}/webhooks.sqlite`,
       logging: process.env.ARK_DB_LOGGING
     },
-    redis: {
-      host: process.env.ARK_REDIS_HOST || 'localhost',
-      port: process.env.ARK_REDIS_PORT || 6379
-    },
     server: {
       enabled: process.env.ARK_WEBHOOKS_API_ENABLED,
       host: process.env.ARK_WEBHOOKS_HOST || '0.0.0.0',

--- a/packages/core/lib/config/mainnet/plugins.js
+++ b/packages/core/lib/config/mainnet/plugins.js
@@ -69,10 +69,6 @@ module.exports = {
       storage: `${process.env.ARK_PATH_DATA}/database/${process.env.ARK_NETWORK_NAME}/webhooks.sqlite`,
       logging: process.env.ARK_DB_LOGGING
     },
-    redis: {
-      host: process.env.ARK_REDIS_HOST || 'localhost',
-      port: process.env.ARK_REDIS_PORT || 6379
-    },
     server: {
       enabled: process.env.ARK_WEBHOOKS_API_ENABLED,
       host: process.env.ARK_WEBHOOKS_HOST || '0.0.0.0',

--- a/packages/core/lib/config/testnet.1/plugins.js
+++ b/packages/core/lib/config/testnet.1/plugins.js
@@ -69,10 +69,6 @@ module.exports = {
       storage: `${process.env.ARK_PATH_DATA}/database/${process.env.ARK_NETWORK_NAME}.1/webhooks.sqlite`,
       logging: process.env.ARK_DB_LOGGING
     },
-    redis: {
-      host: process.env.ARK_REDIS_HOST || 'localhost',
-      port: process.env.ARK_REDIS_PORT || 6379
-    },
     server: {
       enabled: process.env.ARK_WEBHOOKS_API_ENABLED,
       host: process.env.ARK_WEBHOOKS_HOST || '0.0.0.0',

--- a/packages/core/lib/config/testnet.2/plugins.js
+++ b/packages/core/lib/config/testnet.2/plugins.js
@@ -69,10 +69,6 @@ module.exports = {
       storage: `${process.env.ARK_PATH_DATA}/database/${process.env.ARK_NETWORK_NAME}.2/webhooks.sqlite`,
       logging: process.env.ARK_DB_LOGGING
     },
-    redis: {
-      host: process.env.ARK_REDIS_HOST || 'localhost',
-      port: process.env.ARK_REDIS_PORT || 6379
-    },
     server: {
       enabled: process.env.ARK_WEBHOOKS_API_ENABLED,
       host: process.env.ARK_WEBHOOKS_HOST || '0.0.0.0',

--- a/packages/core/lib/config/testnet.live/plugins.js
+++ b/packages/core/lib/config/testnet.live/plugins.js
@@ -69,10 +69,6 @@ module.exports = {
       storage: `${process.env.ARK_PATH_DATA}/database/${process.env.ARK_NETWORK_NAME}.live/webhooks.sqlite`,
       logging: process.env.ARK_DB_LOGGING
     },
-    redis: {
-      host: process.env.ARK_REDIS_HOST || 'localhost',
-      port: process.env.ARK_REDIS_PORT || 6379
-    },
     server: {
       enabled: process.env.ARK_WEBHOOKS_API_ENABLED,
       host: process.env.ARK_WEBHOOKS_HOST || '0.0.0.0',

--- a/packages/core/lib/config/testnet/plugins.js
+++ b/packages/core/lib/config/testnet/plugins.js
@@ -69,10 +69,6 @@ module.exports = {
       storage: `${process.env.ARK_PATH_DATA}/database/${process.env.ARK_NETWORK_NAME}/webhooks.sqlite`,
       logging: process.env.ARK_DB_LOGGING
     },
-    redis: {
-      host: process.env.ARK_REDIS_HOST || 'localhost',
-      port: process.env.ARK_REDIS_PORT || 6379
-    },
     server: {
       enabled: process.env.ARK_WEBHOOKS_API_ENABLED,
       host: process.env.ARK_WEBHOOKS_HOST || '0.0.0.0',


### PR DESCRIPTION
## Proposed changes

Resolves https://github.com/ArkEcosystem/core/issues/877, https://github.com/ArkEcosystem/core/issues/884 https://github.com/ArkEcosystem/core/issues/888.

This PR adds a new config endpoint under http://0.0.0.0:4000/config, where 4000 is the P2P port of the corresponding network, meaning it can vary between main, dev and testnet.

It exposes information like versions of core and the network, detailed information about plugins and their state and more.

```
{
    "data": {
        "version": "2.0.0",
        "network": {
            "version": 23,
            "nethash": "d9acd04bde4234a81addb8482333b4ac906bed7be5a9970ce8ada428bd083192",
            "explorer": "http://texplorer.ark.io"
        },
        "token": {
            "name": "TARK",
            "symbol": "TѦ"
        },
        "plugins": {
            "@arkecosystem/core-api": {
                "enabled": true,
                "port": 4003
            },
            "@arkecosystem/core-webhooks": {
                "enabled": false,
                "port": 4004
            },
            "@arkecosystem/core-graphql": {
                "enabled": false,
                "port": 4005
            },
            "@arkecosystem/core-json-rpc": {
                "enabled": false,
                "port": 8080
            }
        }
    }
}
```

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes