### PR TITLE
chore: increase transactions per block to 150

### DIFF
--- a/packages/core-api/__tests__/__support__/config/network.json
+++ b/packages/core-api/__tests__/__support__/config/network.json
@@ -20,7 +20,7 @@
     "blocktime": 8,
     "block": {
       "version": 0,
-      "maxTransactions": 50,
+      "maxTransactions": 150,
       "maxPayload": 2097152
     },
     "epoch": "2017-03-21T13:00:00.000Z",

--- a/packages/core-config/__tests__/__fixtures__/constants.json
+++ b/packages/core-config/__tests__/__fixtures__/constants.json
@@ -5,7 +5,7 @@
   "blocktime": 8,
   "block": {
     "version": 0,
-    "maxTransactions": 50,
+    "maxTransactions": 150,
     "maxPayload": 2097152
   },
   "epoch": "2017-03-21T13:00:00.000Z",
@@ -27,7 +27,7 @@
   "blocktime": 8,
   "block": {
     "version": 0,
-    "maxTransactions": 50,
+    "maxTransactions": 150,
     "maxPayload": 2097152
   },
   "epoch": "2017-03-21T13:00:00.000Z",

--- a/packages/core-config/__tests__/__stubs__/network.json
+++ b/packages/core-config/__tests__/__stubs__/network.json
@@ -20,7 +20,7 @@
     "blocktime": 8,
     "block": {
       "version": 0,
-      "maxTransactions": 50,
+      "maxTransactions": 150,
       "maxPayload": 2097152
     },
     "epoch": "2017-03-21T13:00:00.000Z",

--- a/packages/core-p2p/__tests__/__support__/config/network.json
+++ b/packages/core-p2p/__tests__/__support__/config/network.json
@@ -20,7 +20,7 @@
     "blocktime": 8,
     "block": {
       "version": 0,
-      "maxTransactions": 50,
+      "maxTransactions": 150,
       "maxPayload": 2097152
     },
     "epoch": "2017-03-21T13:00:00.000Z",

--- a/packages/crypto/lib/networks/ark/devnet.json
+++ b/packages/crypto/lib/networks/ark/devnet.json
@@ -20,7 +20,7 @@
     "blocktime": 8,
     "block": {
       "version": 0,
-      "maxTransactions": 50,
+      "maxTransactions": 150,
       "maxPayload": 2097152
     },
     "epoch": "2017-03-21T13:00:00.000Z",

--- a/packages/crypto/lib/networks/ark/mainnet.json
+++ b/packages/crypto/lib/networks/ark/mainnet.json
@@ -20,7 +20,7 @@
     "blocktime": 8,
     "block": {
       "version": 0,
-      "maxTransactions": 50,
+      "maxTransactions": 150,
       "maxPayload": 2097152
     },
     "epoch": "2017-03-21T13:00:00.000Z",

--- a/packages/crypto/lib/networks/ark/testnet.json
+++ b/packages/crypto/lib/networks/ark/testnet.json
@@ -20,7 +20,7 @@
     "blocktime": 8,
     "block": {
       "version": 0,
-      "maxTransactions": 50,
+      "maxTransactions": 150,
       "maxPayload": 2097152
     },
     "epoch": "2017-03-21T13:00:00.000Z",


### PR DESCRIPTION
## Proposed changes

Increasing the number of transactions a block can hold.

**DO NOT MERGE THIS YET.**

## Types of changes

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes