### PR TITLE
fix: prevent feeMultiplier from being negative

### DIFF
--- a/packages/crypto/lib/managers/dynamic-fee.js
+++ b/packages/crypto/lib/managers/dynamic-fee.js
@@ -14,7 +14,7 @@ class DynamicFeeManager {
   * @returns {Number} Calculated dynamic fee in ARKTOSHI
   */
   calculateFee (feeMultiplier, transaction) {
-    if (feeMultiplier === 0) {
+    if (feeMultiplier <= 0) {
       feeMultiplier = 1
     }
 


### PR DESCRIPTION
## Proposed changes
If i set the feeMultiplier to a negative number, it allows me to accept all transactions. On the basis a feeMultiplier of 0 isn't allowed, I'm making this assumption for negative numbers also.

Edit: see screenshot below

![image](https://user-images.githubusercontent.com/8069294/44469921-6779cd00-a620-11e8-95ad-4131e670e9bd.png)

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
