### PR TITLE
feat: enable cors for p2p post transactions endpoint

### DIFF
--- a/packages/core-p2p/lib/server/versions/1/handlers.js
+++ b/packages/core-p2p/lib/server/versions/1/handlers.js
@@ -340,6 +340,9 @@ exports.postTransactions = {
     }
   },
   config: {
+    cors: {
+      additionalHeaders: ['nethash', 'port', 'version']
+    },
     plugins: {
       'hapi-ajv': {
         payloadSchema: schema.postTransactions


### PR DESCRIPTION
## Proposed changes
This is to match v1 transactions endpoint. Currently, the `/peer/transactions` endpoint is used in v1 to post transactions. We need that same functionality on core v2, for the same endpoint.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
