### PR TITLE
peer/blocks should at least return the last block, if the blockHeight…

### DIFF
--- a/packages/core-p2p/__tests__/server/1.test.js
+++ b/packages/core-p2p/__tests__/server/1.test.js
@@ -59,6 +59,20 @@ describe('API - Version 1', () => {
       expect(response.data).toHaveProperty('blocks')
       expect(response.data.blocks).toBeArray()
     })
+
+    it('should retrieve lastBlock if no "lastBlockHeight" specified', async () => {
+      const response = await sendGET('peer/blocks');
+
+      expect(response.status).toBe(200);
+      expect(response.data).toBeObject()
+
+      expect(response.data).toHaveProperty('success')
+      expect(response.data.success).toBeTruthy()
+
+      expect(response.data).toHaveProperty('blocks')
+      expect(response.data.blocks).toBeArray()
+      expect(response.data.blocks).toHaveLength(1)
+    })
   })
 
   describe('GET /peer/transactionsFromIds', () => {

--- a/packages/core-p2p/lib/server/versions/1/handlers.js
+++ b/packages/core-p2p/lib/server/versions/1/handlers.js
@@ -359,12 +359,12 @@ exports.getBlocks = {
    */
   async handler (request, h) {
     try {
-      let database = container.resolvePlugin('database')
+      const database = container.resolvePlugin('database')
+      const blockchain = container.resolvePlugin('blockchain')
       let reqBlockHeight = parseInt(request.query.lastBlockHeight)
       let blocks = []
       if (!request.query.lastBlockHeight || Number.isNaN(reqBlockHeight)) {
-        blocks.push(await database.getLastBlock())
-
+        blocks.push(blockchain.getLastBlock())
       } else {
         blocks = await database.getBlocks(parseInt(reqBlockHeight) + 1, 400)
       }

--- a/packages/core-p2p/lib/server/versions/1/handlers.js
+++ b/packages/core-p2p/lib/server/versions/1/handlers.js
@@ -245,28 +245,28 @@ exports.postBlock = {
         //   missingIds = block.transactionIds.slice(0)
         // }
         // if (missingIds.length > 0) {
-          let peer = await request.server.app.p2p.getPeer(requestIp.getClientIp(request))
-          // only for test because it can be used for DDOS attack
-          if (!peer && process.env.NODE_ENV === 'test_p2p') {
-            peer = await request.server.app.p2p.getRandomPeer()
-          }
-
-          if (!peer) {
-            return { success: false }
-          }
-
-          transactions = await peer.getTransactionsFromIds(block.transactionIds)
-          // issue on v1, using /api/ instead of /peer/
-          if (transactions.length < block.transactionIds.length) transactions = await peer.getTransactionsFromBlock(block.id)
-
-          // reorder them correctly
-          block.transactions = block.transactionIds.map(id => transactions.find(tx => tx.id === id))
-          logger.debug(`Found missing transactions: ${block.transactions.map(tx => tx.id)}`)
-
-          if (block.transactions.length !== block.numberOfTransactions) {
-            return { success: false }
-          }
+        let peer = await request.server.app.p2p.getPeer(requestIp.getClientIp(request))
+        // only for test because it can be used for DDOS attack
+        if (!peer && process.env.NODE_ENV === 'test_p2p') {
+          peer = await request.server.app.p2p.getRandomPeer()
         }
+
+        if (!peer) {
+          return {success: false}
+        }
+
+        transactions = await peer.getTransactionsFromIds(block.transactionIds)
+        // issue on v1, using /api/ instead of /peer/
+        if (transactions.length < block.transactionIds.length) transactions = await peer.getTransactionsFromBlock(block.id)
+
+        // reorder them correctly
+        block.transactions = block.transactionIds.map(id => transactions.find(tx => tx.id === id))
+        logger.debug(`Found missing transactions: ${block.transactions.map(tx => tx.id)}`)
+
+        if (block.transactions.length !== block.numberOfTransactions) {
+          return {success: false}
+        }
+      }
       // } else return { success: false }
 
       block.ip = requestIp.getClientIp(request)
@@ -359,7 +359,15 @@ exports.getBlocks = {
    */
   async handler (request, h) {
     try {
-      const blocks = await container.resolvePlugin('database').getBlocks(parseInt(request.query.lastBlockHeight) + 1, 400)
+      let database = container.resolvePlugin('database')
+      let reqBlockHeight = parseInt(request.query.lastBlockHeight)
+      let blocks = []
+      if (!request.query.lastBlockHeight || Number.isNaN(reqBlockHeight)) {
+        blocks.push(await database.getLastBlock())
+
+      } else {
+        blocks = await database.getBlocks(parseInt(reqBlockHeight) + 1, 400)
+      }
 
       logger.info(`${requestIp.getClientIp(request)} has downloaded ${blocks.length} blocks from height ${request.query.lastBlockHeight}`)
 


### PR DESCRIPTION
## Fixes #912 
In an effort to increase the robustness of the API, I've modified /peer/blocks to return the last block if its called w/o a 'lastBlockHeight' parameter.

The other alternative would be have it fail w/ a validation error saying 'lastBlockHeight' param is required. However, that's a high fidelity change(other endpoints are also affected if we implement a validation middleware)  w/ little value.

## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Test (adding missing tests or fixing existing tests)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] I have added tests that prove my fix is effective or that my feature works
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->