### PR TITLE
fix: bad method call on suspended peers endpoint

### DIFF
--- a/packages/core-api/lib/versions/2/handlers/peers.js
+++ b/packages/core-api/lib/versions/2/handlers/peers.js
@@ -1,7 +1,8 @@
 'use strict'
 
 const Boom = require('boom')
-const blockchain = require('@arkecosystem/core-container').resolvePlugin('blockchain')
+const container = require('@arkecosystem/core-container')
+const blockchain = container.resolvePlugin('blockchain')
 const utils = require('../utils')
 const schema = require('../schema/peers')
 
@@ -75,7 +76,7 @@ exports.suspended = {
    * @return {Hapi.Response}
    */
   async handler (request, h) {
-    const peers = blockchain.p2p.getSuspendedPeers()
+    const peers = container.resolvePlugin('p2p').getSuspendedPeers()
 
     return utils.respondWithCollection(request, Object.values(peers).map(peer => peer.peer), 'peer')
   }

--- a/packages/core-p2p/lib/monitor.js
+++ b/packages/core-p2p/lib/monitor.js
@@ -196,6 +196,14 @@ class Monitor {
   }
 
   /**
+   * Get a list of all suspended peers.
+   * @return {void}
+   */
+  async getSuspendedPeers () {
+    return this.guard.all()
+  }
+
+  /**
    * Get all available peers.
    * @return {Peer[]}
    */


### PR DESCRIPTION
## Proposed changes

The suspended peers endpoint didn't work because it was calling non-existent methods

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes