### PR TITLE
fix: launch p2p server before pinging peers

### DIFF
--- a/packages/core-p2p/lib/index.js
+++ b/packages/core-p2p/lib/index.js
@@ -14,9 +14,9 @@ exports.plugin = {
   async register (container, options) {
     container.resolvePlugin('logger').info('Starting P2P Interface')
 
-    await monitor.start(options)
-
     monitor.server = await startServer(monitor, options)
+
+    await monitor.start(options)
 
     return monitor
   },


### PR DESCRIPTION
## Proposed changes
This swaps the order in which the p2p server is started. The current order means that the node tries to connect with peers, before its own server is online. This results in other peers trying to ping but the server is offline, resulting in it being suspended.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)=

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
