### PR TITLE
fix: changed logic in getRandomPeer > keys.filter, was too permissive

### DIFF
--- a/packages/core-p2p/__tests__/monitor.test.js
+++ b/packages/core-p2p/__tests__/monitor.test.js
@@ -29,7 +29,7 @@ beforeEach(async () => {
   const initialPeersMock = {};
   ['0.0.0.0', '0.0.0.1', '0.0.0.2', '0.0.0.3', '0.0.0.4'].forEach(ip => {
     const initialPeer = new Peer(ip, 4002)
-    initialPeersMock[ip] = Object.assign(initialPeer, initialPeer.headers, { ban: 0 })
+    initialPeersMock[ip] = Object.assign(initialPeer, initialPeer.headers, { downloadSize: 100 })
   });
   monitor.peers = initialPeersMock
 

--- a/packages/core-p2p/lib/monitor.js
+++ b/packages/core-p2p/lib/monitor.js
@@ -243,19 +243,19 @@ class Monitor {
     let keys = Object.keys(this.peers)
     keys = keys.filter((key) => {
         const peer = this.getPeer(key)
-        if (peer.ban < new Date().getTime()) {
-            return true
+        if (peer.ban > new Date().getTime()) {
+            return false
         }
 
-        if (acceptableDelay && peer.delay < acceptableDelay) {
-            return true
+        if (acceptableDelay && peer.delay > acceptableDelay) {
+            return false
         }
 
         if (downloadSize && peer.downloadSize !== downloadSize) {
-          return true
+          return false
         }
 
-        return false
+        return true
     })
 
     const random = keys[keys.length * Math.random() << 0]


### PR DESCRIPTION
Updated monitor.test.js to match the new logic, removed { ban: 0 } which is now not needed.

## Proposed changes
Changed logic in monitor.js : getRandomPeer > keys.filter, was too permissive. It returned true on any matching conditions.
Instead, here returning false on any unmatched condition, then returning true.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works