### PR TITLE
Don't load .env in test environment

### DIFF
--- a/packages/core-container/lib/environment.js
+++ b/packages/core-container/lib/environment.js
@@ -69,6 +69,12 @@ module.exports = class Environment {
    * @return {void}
    */
   __exportVariables () {
+    // Don't pollute the test environment, which is more in line with how
+    // travis runs the tests.
+    if (process.env.NODE_ENV === 'test') {
+      return
+    }
+
     const envPath = expandHomeDir(`${process.env.ARK_PATH_DATA}/.env`)
 
     if (fs.existsSync(envPath)) {


### PR DESCRIPTION
## Proposed changes
The `~/.ark/.env` doesn't exist on Travis, so it makes sense to not even attempt to load it 
when `ARK_ENV=test` is true. 

This fixes an issue I ran into when running tests (core-forger) locally:
![screenshot_20180824_175318](https://user-images.githubusercontent.com/1311798/44601583-3d213e80-a7dd-11e8-9371-0ecaf6ae3293.png)

Since the container loaded my `.env` and thus set `ARK_P2P_PORT` to `4002`, which caused `process.env.ARK_P2P_PORT || 4000` from `core/lib/config/testnet/plugins.js` to return the wrong port.

## Checklist
- [X] Lint and unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works