### PR TITLE
fix: cast port number in peer list to number

### DIFF
--- a/packages/core-api/lib/versions/2/transformers/peer.js
+++ b/packages/core-api/lib/versions/2/transformers/peer.js
@@ -8,7 +8,7 @@
 module.exports = (model) => {
   return {
     ip: model.ip,
-    port: model.port,
+    port: +model.port,
     version: model.version,
     height: model.state ? model.state.height : model.height,
     status: model.status,

--- a/packages/core-p2p/lib/peer.js
+++ b/packages/core-p2p/lib/peer.js
@@ -32,7 +32,7 @@ module.exports = class Peer {
   toBroadcastInfo () {
     return {
       ip: this.ip,
-      port: this.port,
+      port: +this.port,
       version: this.version,
       os: this.os,
       status: this.status,


### PR DESCRIPTION
## Proposed changes
The peer list has inconsistent JSON - all endpoints; `/peer/list`, `/api/peers` and `/api/v2/peers`. This causes issues for SDKs (e.g. C++) that require strict type mappings, but it's impossible if a value can be both a string or an integer.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
