### PR TITLE
Use container to retrieve 'p2p' ref in api handlers

### DIFF
--- a/packages/core-p2p/lib/monitor.js
+++ b/packages/core-p2p/lib/monitor.js
@@ -313,7 +313,7 @@ class Monitor {
 
   /**
    * Check if we have any peers.
-   * @return {bool}
+   * @return {boolean}
    */
   hasPeers () {
     return !!this.getPeers().length


### PR DESCRIPTION
## Proposed changes
Some minor changes to the p2p handlers to retrieve the p2p reference from the container. This makes it easier to write tests for them since we're simplifying the dependency.
(i.e. We'd only need to mock the container's resolvePlugin call as opposed to mimicking a request.server.app object)

I realize @faustbrian  will overhaul the implementation of p2p API at some point, however, there's some salvageable code in there so this won't entirely be deprecated

## Types of changes
- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
<!--