### PR TITLE
feat: criteria based peer suspensions

### DIFF
--- a/packages/core-p2p/__tests__/__support__/config/peers.json
+++ b/packages/core-p2p/__tests__/__support__/config/peers.json
@@ -22,7 +22,9 @@
       "port": 4002
     }
   ],
-  "blackList": [],
+  "blackList": [
+    "dummy-ip-addr"
+  ],
   "whiteList": [],
   "minimumVersion": ">=2.0.0",
   "sources": [

--- a/packages/core-p2p/__tests__/guard.test.js
+++ b/packages/core-p2p/__tests__/guard.test.js
@@ -77,7 +77,7 @@ describe('Guard', () => {
     })
 
     it('should return a 1 day suspension for "Blacklisted"', () => {
-      const actual = guard.__determineSuspensionTime({
+      const { until: actual } = guard.__determineSuspensionTime({
         ip: 'dummy-ip-addr'
       })
 
@@ -85,7 +85,7 @@ describe('Guard', () => {
     })
 
     it('should return a 6 hours suspension for "Invalid Version"', () => {
-      const actual = guard.__determineSuspensionTime({
+      const { until: actual } = guard.__determineSuspensionTime({
         version: '1.0.0'
       })
 
@@ -95,7 +95,7 @@ describe('Guard', () => {
     it('should return a 10 minutes suspension for "Node is not at height"', () => {
       guard.monitor.getNetworkHeight = jest.fn(() => 154)
 
-      const actual = guard.__determineSuspensionTime({
+      const { until: actual } = guard.__determineSuspensionTime({
         ...dummy,
         state: {
           height: 1
@@ -106,7 +106,7 @@ describe('Guard', () => {
     })
 
     it('should return a 5 minutes suspension for "Invalid Response Status"', () => {
-      const actual = guard.__determineSuspensionTime({
+      const { until: actual } = guard.__determineSuspensionTime({
         ...dummy,
         ...{ status: 201 }
       })
@@ -115,7 +115,7 @@ describe('Guard', () => {
     })
 
     it('should return a 2 minutes suspension for "Timeout"', () => {
-      const actual = guard.__determineSuspensionTime({
+      const { until: actual } = guard.__determineSuspensionTime({
         ...dummy,
         ...{ delay: -1 }
       })
@@ -124,7 +124,7 @@ describe('Guard', () => {
     })
 
     it('should return a 1 minutes suspension for "High Latency"', () => {
-      const actual = guard.__determineSuspensionTime({
+      const { until: actual } = guard.__determineSuspensionTime({
         ...dummy,
         ...{ delay: 3000 }
       })
@@ -133,7 +133,7 @@ describe('Guard', () => {
     })
 
     it('should return a 30 minutes suspension for "Unknown"', () => {
-      const actual = guard.__determineSuspensionTime(dummy)
+      const { until: actual } = guard.__determineSuspensionTime(dummy)
 
       expect(convertToMinutes(actual)).toBe(30)
     })

--- a/packages/core-p2p/__tests__/guard.test.js
+++ b/packages/core-p2p/__tests__/guard.test.js
@@ -63,7 +63,7 @@ describe('Guard', () => {
 
   describe('__determineSuspensionTime', () => {
     const convertToMinutes = actual => {
-      return Math.round(moment.duration(actual.diff(moment.now())).asMinutes())
+      return Math.ceil(moment.duration(actual.diff(moment.now())).asMinutes())
     }
 
     const dummy = {

--- a/packages/core-p2p/__tests__/guard.test.js
+++ b/packages/core-p2p/__tests__/guard.test.js
@@ -77,65 +77,72 @@ describe('Guard', () => {
     })
 
     it('should return a 1 day suspension for "Blacklisted"', () => {
-      const { until: actual } = guard.__determineSuspensionTime({
+      const { until, reason } = guard.__determineSuspensionTime({
         ip: 'dummy-ip-addr'
       })
 
-      expect(convertToMinutes(actual)).toBe(1440)
+      expect(convertToMinutes(until)).toBe(1440)
+      expect(reason).toBe('Blacklisted')
     })
 
     it('should return a 6 hours suspension for "Invalid Version"', () => {
-      const { until: actual } = guard.__determineSuspensionTime({
+      const { until, reason } = guard.__determineSuspensionTime({
         version: '1.0.0'
       })
 
-      expect(convertToMinutes(actual)).toBe(360)
+      expect(convertToMinutes(until)).toBe(360)
+      expect(reason).toBe('Invalid Version')
     })
 
     it('should return a 10 minutes suspension for "Node is not at height"', () => {
       guard.monitor.getNetworkHeight = jest.fn(() => 154)
 
-      const { until: actual } = guard.__determineSuspensionTime({
+      const { until, reason } = guard.__determineSuspensionTime({
         ...dummy,
         state: {
           height: 1
         }
       })
 
-      expect(convertToMinutes(actual)).toBe(10)
+      expect(convertToMinutes(until)).toBe(10)
+      expect(reason).toBe('Node is not at height')
     })
 
     it('should return a 5 minutes suspension for "Invalid Response Status"', () => {
-      const { until: actual } = guard.__determineSuspensionTime({
+      const { until, reason } = guard.__determineSuspensionTime({
         ...dummy,
         ...{ status: 201 }
       })
 
-      expect(convertToMinutes(actual)).toBe(5)
+      expect(convertToMinutes(until)).toBe(5)
+      expect(reason).toBe('Invalid Response Status')
     })
 
     it('should return a 2 minutes suspension for "Timeout"', () => {
-      const { until: actual } = guard.__determineSuspensionTime({
+      const { until, reason } = guard.__determineSuspensionTime({
         ...dummy,
         ...{ delay: -1 }
       })
 
-      expect(convertToMinutes(actual)).toBe(2)
+      expect(convertToMinutes(until)).toBe(2)
+      expect(reason).toBe('Timeout')
     })
 
     it('should return a 1 minutes suspension for "High Latency"', () => {
-      const { until: actual } = guard.__determineSuspensionTime({
+      const { until, reason } = guard.__determineSuspensionTime({
         ...dummy,
         ...{ delay: 3000 }
       })
 
-      expect(convertToMinutes(actual)).toBe(1)
+      expect(convertToMinutes(until)).toBe(1)
+      expect(reason).toBe('High Latency')
     })
 
     it('should return a 30 minutes suspension for "Unknown"', () => {
-      const { until: actual } = guard.__determineSuspensionTime(dummy)
+      const { until, reason } = guard.__determineSuspensionTime(dummy)
 
-      expect(convertToMinutes(actual)).toBe(30)
+      expect(convertToMinutes(until)).toBe(30)
+      expect(reason).toBe('Unknown')
     })
   })
 })

--- a/packages/core-p2p/lib/guard.js
+++ b/packages/core-p2p/lib/guard.js
@@ -158,11 +158,11 @@ class Guard {
    */
   __determineSuspensionTime (peer) {
     const createMoment = (number, period, message) => {
-      const duration = this.get(peer.ip).untilHuman
+      const duration = moment().add(number, period)
 
       logger.debug(`Suspended ${peer.ip} for ${duration} because of "${message}"`)
 
-      return moment().add(number, period)
+      return duration
     }
 
     // 1. Wrong version

--- a/packages/core-p2p/lib/guard.js
+++ b/packages/core-p2p/lib/guard.js
@@ -159,17 +159,22 @@ class Guard {
    * @return {Boolean}
    */
   __determineSuspensionTime (peer) {
-    // 1. High Latency / Timeout
+    // 1. High Latency
     if (peer.delay > 2000) {
+      return moment().add(1, 'minutes')
+    }
+
+    // 2. Timeout / Request Error
+    if (peer.delay === -1) {
       return moment().add(2, 'minutes')
     }
 
-    // 2. Faulty Response
+    // 3. Faulty Response
     if (peer.status !== 200) {
       return moment().add(5, 'minutes')
     }
 
-    // 3. Any cases we are unable to make a decision on
+    // Any cases we are unable to make a decision on
     return moment().add(30, 'minutes')
   }
 }

--- a/packages/core-p2p/lib/guard.js
+++ b/packages/core-p2p/lib/guard.js
@@ -158,12 +158,12 @@ class Guard {
    */
   __determineSuspensionTime (peer) {
     const createMoment = (number, period, message) => {
-      const duration = moment().add(number, period)
-      const durationHuman = duration.format('h [hrs], m [min]')
+      const until = moment().add(number, period)
+      const untilHuman = until.format('h [hrs], m [min]')
 
-      logger.debug(`Suspended ${peer.ip} for ${durationHuman} because of "${message}"`)
+      logger.debug(`Suspended ${peer.ip} until ${untilHuman} because of "${message}"`)
 
-      return duration
+      return until
     }
 
     // 1. Blacklisted

--- a/packages/core-p2p/lib/guard.js
+++ b/packages/core-p2p/lib/guard.js
@@ -159,9 +159,9 @@ class Guard {
   __determineSuspensionTime (peer) {
     const createMoment = (number, period, message) => {
       const until = moment().add(number, period)
-      const untilHuman = until.format('h [hrs], m [min]')
+      const untilDiff = moment.duration(until.diff(moment.now()))
 
-      logger.debug(`Suspended ${peer.ip} until ${untilHuman} because of "${message}"`)
+      logger.debug(`Suspended ${peer.ip} for ${untilDiff.asMinutes()} minutes because of "${message}"`)
 
       return until
     }

--- a/packages/core-p2p/lib/guard.js
+++ b/packages/core-p2p/lib/guard.js
@@ -176,6 +176,8 @@ class Guard {
     }
 
     // 3. Node is not at height
+    // NOTE: Suspending this peer only means that we no longer
+    // will download blocks from him but he can still download blocks from us.
     const heightDifference = Math.abs(this.monitor.getNetworkHeight() - peer.state.height)
 
     if (heightDifference >= 153) {

--- a/packages/core-p2p/lib/guard.js
+++ b/packages/core-p2p/lib/guard.js
@@ -156,7 +156,7 @@ class Guard {
   /**
    * Determine for how long the peer should be banned.
    * @param  {Peer}  peer
-   * @return {Boolean}
+   * @return {moment}
    */
   __determineSuspensionTime (peer) {
     // 1. High Latency

--- a/packages/core-p2p/lib/guard.js
+++ b/packages/core-p2p/lib/guard.js
@@ -176,6 +176,17 @@ class Guard {
       return moment().add(5, 'minutes')
     }
 
+    // 4. Node is not at height
+    const heightDifference = Math.abs(peer.state.height - this.getNetworkHeight())
+    if (heightDifference >= 153) {
+      return moment().add(30, 'minutes')
+    }
+
+    // 5. Wrong version
+    if (!this.isValidVersion(peer)) {
+      return moment().add(6, 'hours')
+    }
+
     // Any cases we are unable to make a decision on
     return moment().add(30, 'minutes')
   }

--- a/packages/core-p2p/lib/guard.js
+++ b/packages/core-p2p/lib/guard.js
@@ -159,14 +159,16 @@ class Guard {
    * @return {moment}
    */
   __determineSuspensionTime (peer) {
-    // 1. High Latency
-    if (peer.delay > 2000) {
-      return moment().add(1, 'minutes')
+    // 1. Wrong version
+    if (!this.isValidVersion(peer)) {
+      return moment().add(6, 'hours')
     }
 
-    // 2. Timeout / Request Error
-    if (peer.delay === -1) {
-      return moment().add(2, 'minutes')
+    // 2. Node is not at height
+    const heightDifference = Math.abs(this.getNetworkHeight() - peer.state.height)
+
+    if (heightDifference >= 153) {
+      return moment().add(30, 'minutes')
     }
 
     // 3. Faulty Response
@@ -176,16 +178,14 @@ class Guard {
       return moment().add(5, 'minutes')
     }
 
-    // 4. Node is not at height
-    const heightDifference = Math.abs(this.getNetworkHeight() - peer.state.height)
-
-    if (heightDifference >= 153) {
-      return moment().add(30, 'minutes')
+    // 4. Timeout or potentially a Request Error
+    if (peer.delay === -1) {
+      return moment().add(2, 'minutes')
     }
 
-    // 5. Wrong version
-    if (!this.isValidVersion(peer)) {
-      return moment().add(6, 'hours')
+    // 5. High Latency
+    if (peer.delay > 2000) {
+      return moment().add(1, 'minutes')
     }
 
     // Any cases we are unable to make a decision on

--- a/packages/core-p2p/lib/guard.js
+++ b/packages/core-p2p/lib/guard.js
@@ -166,31 +166,36 @@ class Guard {
       return duration
     }
 
-    // 1. Wrong version
+    // 1. Blacklisted
+    if (!this.isBlacklisted(peer)) {
+      return createMoment(1, 'day', 'Blacklisted')
+    }
+
+    // 2. Wrong version
     if (!this.isValidVersion(peer)) {
       return createMoment(6, 'hours', 'Invalid Version')
     }
 
-    // 2. Node is not at height
+    // 3. Node is not at height
     const heightDifference = Math.abs(this.monitor.getNetworkHeight() - peer.state.height)
 
     if (heightDifference >= 153) {
       return createMoment(30, 'minutes', 'Node is not at height')
     }
 
-    // 3. Faulty Response
+    // 4. Faulty Response
     // NOTE: We check this extra because a response can still succeed if
     // it returns any codes that are not 4xx or 5xx.
     if (peer.status !== 200) {
       return createMoment(5, 'minutes', 'Invalid Response Status')
     }
 
-    // 4. Timeout or potentially a Request Error
+    // 5. Timeout or potentially a Request Error
     if (peer.delay === -1) {
       return createMoment(2, 'minutes', 'Timeout')
     }
 
-    // 5. High Latency
+    // 6. High Latency
     if (peer.delay > 2000) {
       return createMoment(1, 'minutes', 'High Latency')
     }

--- a/packages/core-p2p/lib/guard.js
+++ b/packages/core-p2p/lib/guard.js
@@ -159,7 +159,7 @@ class Guard {
   __determineSuspensionTime (peer) {
     const createMoment = (number, period, message) => {
       const until = moment().add(number, period)
-      const untilDiff = moment.duration(until.diff(moment.now()))
+      const untilDiff = Math.round(moment.duration(until.diff(moment.now())))
 
       logger.debug(`Suspended ${peer.ip} for ${untilDiff.asMinutes()} minutes because of "${message}"`)
 

--- a/packages/core-p2p/lib/guard.js
+++ b/packages/core-p2p/lib/guard.js
@@ -176,12 +176,12 @@ class Guard {
       return createMoment(6, 'hours', 'Invalid Version')
     }
 
-    // // 3. Node is not at height
-    // const heightDifference = Math.abs(this.monitor.getNetworkHeight() - peer.state.height)
+    // 3. Node is not at height
+    const heightDifference = Math.abs(this.monitor.getNetworkHeight() - peer.state.height)
 
-    // if (heightDifference >= 153) {
-    //   return createMoment(30, 'minutes', 'Node is not at height')
-    // }
+    if (heightDifference >= 153) {
+      return createMoment(10, 'minutes', 'Node is not at height')
+    }
 
     // 4. Faulty Response
     // NOTE: We check this extra because a response can still succeed if

--- a/packages/core-p2p/lib/guard.js
+++ b/packages/core-p2p/lib/guard.js
@@ -50,7 +50,7 @@ class Guard {
       return
     }
 
-    const until = moment().add(this.monitor.config.suspendMinutes, 'minutes')
+    const until = this.__determineSuspensionTime(peer)
 
     this.suspensions[peer.ip] = {
       peer,
@@ -151,6 +151,26 @@ class Guard {
    */
   isMyself (peer) {
     return isMyself(peer.ip)
+  }
+
+  /**
+   * Determine for how long the peer should be banned.
+   * @param  {Peer}  peer
+   * @return {Boolean}
+   */
+  __determineSuspensionTime (peer) {
+    // 1. High Latency / Timeout
+    if (peer.delay > 2000) {
+      return moment().add(2, 'minutes')
+    }
+
+    // 2. Faulty Response
+    if (peer.status !== 200) {
+      return moment().add(5, 'minutes')
+    }
+
+    // 3. Any cases we are unable to make a decision on
+    return moment().add(30, 'minutes')
   }
 }
 

--- a/packages/core-p2p/lib/guard.js
+++ b/packages/core-p2p/lib/guard.js
@@ -159,9 +159,9 @@ class Guard {
   __determineSuspensionTime (peer) {
     const createMoment = (number, period, message) => {
       const until = moment().add(number, period)
-      const untilDiff = Math.ceil(moment.duration(until.diff(moment.now())))
+      const untilDiff = moment.duration(until.diff(moment.now()))
 
-      logger.debug(`Suspended ${peer.ip} for ${untilDiff.asMinutes()} minutes because of "${message}"`)
+      logger.debug(`Suspended ${peer.ip} for ${Math.ceil(untilDiff.asMinutes())} minutes because of "${message}"`)
 
       return until
     }

--- a/packages/core-p2p/lib/guard.js
+++ b/packages/core-p2p/lib/guard.js
@@ -158,7 +158,7 @@ class Guard {
    */
   __determineSuspensionTime (peer) {
     const createMoment = (number, period, message) => {
-      const until = moment().add(number, period)
+      const until = moment().utc().add(number, period)
       const untilDiff = moment.duration(until.diff(moment.now()))
 
       logger.debug(`Suspended ${peer.ip} for ${Math.ceil(untilDiff.asMinutes())} minutes because of "${message}"`)
@@ -176,12 +176,12 @@ class Guard {
       return createMoment(6, 'hours', 'Invalid Version')
     }
 
-    // 3. Node is not at height
-    const heightDifference = Math.abs(this.monitor.getNetworkHeight() - peer.state.height)
+    // // 3. Node is not at height
+    // const heightDifference = Math.abs(this.monitor.getNetworkHeight() - peer.state.height)
 
-    if (heightDifference >= 153) {
-      return createMoment(30, 'minutes', 'Node is not at height')
-    }
+    // if (heightDifference >= 153) {
+    //   return createMoment(30, 'minutes', 'Node is not at height')
+    // }
 
     // 4. Faulty Response
     // NOTE: We check this extra because a response can still succeed if

--- a/packages/core-p2p/lib/guard.js
+++ b/packages/core-p2p/lib/guard.js
@@ -167,7 +167,7 @@ class Guard {
     }
 
     // 1. Blacklisted
-    if (!this.isBlacklisted(peer)) {
+    if (this.isBlacklisted(peer)) {
       return createMoment(1, 'day', 'Blacklisted')
     }
 

--- a/packages/core-p2p/lib/guard.js
+++ b/packages/core-p2p/lib/guard.js
@@ -159,7 +159,7 @@ class Guard {
   __determineSuspensionTime (peer) {
     const createMoment = (number, period, message) => {
       const until = moment().add(number, period)
-      const untilDiff = Math.round(moment.duration(until.diff(moment.now())))
+      const untilDiff = Math.ceil(moment.duration(until.diff(moment.now())))
 
       logger.debug(`Suspended ${peer.ip} for ${untilDiff.asMinutes()} minutes because of "${message}"`)
 

--- a/packages/core-p2p/lib/guard.js
+++ b/packages/core-p2p/lib/guard.js
@@ -170,6 +170,8 @@ class Guard {
     }
 
     // 3. Faulty Response
+    // NOTE: We check this extra because a response can still succeed if
+    // it returns any codes that are not 4xx or 5xx.
     if (peer.status !== 200) {
       return moment().add(5, 'minutes')
     }

--- a/packages/core-p2p/lib/guard.js
+++ b/packages/core-p2p/lib/guard.js
@@ -159,8 +159,9 @@ class Guard {
   __determineSuspensionTime (peer) {
     const createMoment = (number, period, message) => {
       const duration = moment().add(number, period)
+      const durationHuman = duration.format('h [hrs], m [min]')
 
-      logger.debug(`Suspended ${peer.ip} for ${duration} because of "${message}"`)
+      logger.debug(`Suspended ${peer.ip} for ${durationHuman} because of "${message}"`)
 
       return duration
     }

--- a/packages/core-p2p/lib/guard.js
+++ b/packages/core-p2p/lib/guard.js
@@ -177,7 +177,8 @@ class Guard {
     }
 
     // 4. Node is not at height
-    const heightDifference = Math.abs(peer.state.height - this.getNetworkHeight())
+    const heightDifference = Math.abs(this.getNetworkHeight() - peer.state.height)
+
     if (heightDifference >= 153) {
       return moment().add(30, 'minutes')
     }

--- a/packages/core-p2p/lib/monitor.js
+++ b/packages/core-p2p/lib/monitor.js
@@ -175,15 +175,10 @@ class Monitor {
    * @return {void}
    */
   suspendPeer (ip) {
-    // TODO make a couple of tests on peer to understand the issue with this peer and decide how long to ban it
     const peer = this.peers[ip]
 
-    if (peer) {
-      if (this.guard.isSuspended(peer)) {
-        this.guard.suspensions[ip].until = moment(this.guard.suspensions[ip].until).add(1, 'day')
-      } else {
-        this.guard.suspend(peer)
-      }
+    if (peer && !this.guard.isSuspended(peer)) {
+      this.guard.suspend(peer)
     }
   }
 

--- a/packages/core-p2p/lib/peer.js
+++ b/packages/core-p2p/lib/peer.js
@@ -197,11 +197,13 @@ module.exports = class Peer {
       })
 
       this.delay = new Date().getTime() - temp
+      this.status = response.status
 
       this.__parseHeaders(response)
 
       return response.data
     } catch (error) {
+      this.delay = -1
       this.status = error.code
     }
   }


### PR DESCRIPTION
## Proposed changes

Right now we have a very harsh system for peer suspensions which doesn't care about the reason why a peer was identified as a troublemaker.

In order to make a better assessment about what a peer has done that deemed him as a problem I've implemented the `__determineSuspensionTime` method. This method will perform a few checks on the peer in question and determine a fair ban time for each cause of trouble instead of flat out banning for 5+ hours for everything.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
