### PR TITLE
feat: immutable storage

### DIFF
--- a/packages/core-storage/.gitattributes
+++ b/packages/core-storage/.gitattributes
@@ -1,0 +1,11 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+/.editorconfig    export-ignore
+/.gitattributes   export-ignore
+/.gitignore       export-ignore
+/.travis.yml      export-ignore
+/__tests__        export-ignore
+/docs             export-ignore
+/README.md        export-ignore

--- a/packages/core-storage/CHANGELOG.md
+++ b/packages/core-storage/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## Unreleased

--- a/packages/core-storage/LICENSE
+++ b/packages/core-storage/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) Ark Ecosystem <info@ark.io>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/core-storage/README.md
+++ b/packages/core-storage/README.md
@@ -1,0 +1,22 @@
+![ARK Core](https://i.imgur.com/1aP6F2o.png)
+
+# ARK Core - Storage
+
+## Installation
+
+```bash
+yarn add @arkecosystem/core-storage
+```
+
+## Security
+
+If you discover a security vulnerability within this package, please send an e-mail to security@ark.io. All security vulnerabilities will be promptly addressed.
+
+## Credits
+
+- [Brian Faust](https://github.com/faustbrian)
+- [All Contributors](../../../../contributors)
+
+## License
+
+[MIT](LICENSE) © [ArkEcosystem](https://ark.io)

--- a/packages/core-storage/__tests__/storage.test.js
+++ b/packages/core-storage/__tests__/storage.test.js
@@ -129,7 +129,7 @@ describe('Storage', () => {
       expect(testSubject.createList).toBeFunction()
     })
 
-    it('should create a new list', () => {
+    it('should create a new immutable object', () => {
       const actual = testSubject.createList('dummy', [1, 2, 3, 4, 5])
 
       expect(actual).toBeInstanceOf(immutable.List)
@@ -141,7 +141,7 @@ describe('Storage', () => {
       expect(testSubject.createMap).toBeFunction()
     })
 
-    it('should create a new list', () => {
+    it('should create a new immutable object', () => {
       const actual = testSubject.createMap('dummy', { key: 'value' })
 
       expect(actual).toBeInstanceOf(immutable.Map)
@@ -153,7 +153,7 @@ describe('Storage', () => {
       expect(testSubject.createOrderedMap).toBeFunction()
     })
 
-    it('should create a new list', () => {
+    it('should create a new immutable object', () => {
       const actual = testSubject.createOrderedMap('dummy', { key: 'value' })
 
       expect(actual).toBeInstanceOf(immutable.OrderedMap)
@@ -165,7 +165,7 @@ describe('Storage', () => {
       expect(testSubject.createSet).toBeFunction()
     })
 
-    it('should create a new list', () => {
+    it('should create a new immutable object', () => {
       const actual = testSubject.createSet('dummy', [1, 2, 3, 4, 5])
 
       expect(actual).toBeInstanceOf(immutable.Set)
@@ -177,7 +177,7 @@ describe('Storage', () => {
       expect(testSubject.createOrderedSet).toBeFunction()
     })
 
-    it('should create a new list', () => {
+    it('should create a new immutable object', () => {
       const actual = testSubject.createOrderedSet('dummy', [1, 2, 3, 4, 5])
 
       expect(actual).toBeInstanceOf(immutable.OrderedSet)
@@ -189,7 +189,7 @@ describe('Storage', () => {
       expect(testSubject.createStack).toBeFunction()
     })
 
-    it('should create a new list', () => {
+    it('should create a new immutable object', () => {
       const actual = testSubject.createStack('dummy', [1, 2, 3, 4, 5])
 
       expect(actual).toBeInstanceOf(immutable.Stack)
@@ -201,7 +201,7 @@ describe('Storage', () => {
       expect(testSubject.createRange).toBeFunction()
     })
 
-    it('should create a new list', () => {
+    it('should create a new immutable object', () => {
       const actual = testSubject.createRange('dummy', [1, 2, 3, 4, 5])
 
       expect(actual).toBeInstanceOf(immutable.Range)
@@ -213,7 +213,7 @@ describe('Storage', () => {
       expect(testSubject.createRepeat).toBeFunction()
     })
 
-    it('should create a new list', () => {
+    it('should create a new immutable object', () => {
       const actual = testSubject.createRepeat('dummy', [1, 2, 3, 4, 5])
 
       expect(actual).toBeInstanceOf(immutable.Repeat)
@@ -225,7 +225,7 @@ describe('Storage', () => {
       expect(testSubject.createRecord).toBeFunction()
     })
 
-    it('should create a new list', () => {
+    it('should create a new immutable object', () => {
       const actual = testSubject.createRecord('dummy', [1, 2, 3, 4, 5])
 
       expect(actual).toBeFunction()
@@ -237,7 +237,7 @@ describe('Storage', () => {
       expect(testSubject.createSeq).toBeFunction()
     })
 
-    it('should create a new list', () => {
+    it('should create a new immutable object', () => {
       const actual = testSubject.createSeq('dummy', [1, 2, 3, 4, 5])
 
       expect(actual).toBeInstanceOf(immutable.Seq)
@@ -249,7 +249,7 @@ describe('Storage', () => {
       expect(testSubject.createSeqKeyed).toBeFunction()
     })
 
-    it('should create a new list', () => {
+    it('should create a new immutable object', () => {
       const actual = testSubject.createSeqKeyed('dummy', [1, 2, 3, 4, 5])
 
       expect(actual).toBeInstanceOf(immutable.Seq.Keyed)
@@ -261,7 +261,7 @@ describe('Storage', () => {
       expect(testSubject.createSeqIndexed).toBeFunction()
     })
 
-    it('should create a new list', () => {
+    it('should create a new immutable object', () => {
       const actual = testSubject.createSeqIndexed('dummy', [1, 2, 3, 4, 5])
 
       expect(actual).toBeInstanceOf(immutable.Seq.Indexed)
@@ -273,7 +273,7 @@ describe('Storage', () => {
       expect(testSubject.createSeqSet).toBeFunction()
     })
 
-    it('should create a new list', () => {
+    it('should create a new immutable object', () => {
       const actual = testSubject.createSeqSet('dummy', [1, 2, 3, 4, 5])
 
       expect(actual).toBeInstanceOf(immutable.Seq.Set)
@@ -285,7 +285,7 @@ describe('Storage', () => {
       expect(testSubject.createCollection).toBeFunction()
     })
 
-    it('should create a new list', () => {
+    it('should create a new immutable object', () => {
       const actual = testSubject.createCollection('dummy', [1, 2, 3, 4, 5])
 
       expect(actual).toBeInstanceOf(immutable.Collection)
@@ -297,7 +297,7 @@ describe('Storage', () => {
       expect(testSubject.createCollectionKeyed).toBeFunction()
     })
 
-    it('should create a new list', () => {
+    it('should create a new immutable object', () => {
       const actual = testSubject.createCollectionKeyed('dummy', [1, 2, 3, 4, 5])
 
       expect(actual).toBeInstanceOf(immutable.Seq)
@@ -309,7 +309,7 @@ describe('Storage', () => {
       expect(testSubject.createCollectionIndexed).toBeFunction()
     })
 
-    it('should create a new list', () => {
+    it('should create a new immutable object', () => {
       const actual = testSubject.createCollectionIndexed('dummy', [1, 2, 3, 4, 5])
 
       expect(actual).toBeInstanceOf(immutable.Seq)
@@ -321,7 +321,7 @@ describe('Storage', () => {
       expect(testSubject.createCollectionSet).toBeFunction()
     })
 
-    it('should create a new list', () => {
+    it('should create a new immutable object', () => {
       const actual = testSubject.createCollectionSet('dummy', [1, 2, 3, 4, 5])
 
       expect(actual).toBeInstanceOf(immutable.Seq)

--- a/packages/core-storage/__tests__/storage.test.js
+++ b/packages/core-storage/__tests__/storage.test.js
@@ -1,0 +1,330 @@
+'use strict'
+
+const immutable = require('immutable')
+const Storage = require('../lib/storage')
+
+let testSubject
+beforeEach(() => {
+  testSubject = new Storage()
+})
+
+describe('Storage', () => {
+  describe('get', () => {
+    it('should be a function', () => {
+      expect(testSubject.get).toBeFunction()
+    })
+
+    it('should get the item', () => {
+      const value = [1, 2, 3, 4, 5]
+      testSubject.createList('dummy', value)
+
+      expect(testSubject.get('dummy')).toEqual(immutable.List(value))
+    })
+
+    it('should throw if an item does not exist', () => {
+      expect(() => {
+        testSubject.get('dummy')
+      }).toThrow()
+    })
+  })
+
+  describe('set', () => {
+    it('should be a function', () => {
+      expect(testSubject.set).toBeFunction()
+    })
+
+    it('should set the item', () => {
+      expect(testSubject.size()).toBe(0)
+
+      testSubject.set('dummy', immutable.List([1, 2, 3, 4, 5]))
+
+      expect(testSubject.size()).toBe(1)
+    })
+
+    it('should throw if an item exists', () => {
+      testSubject.createList('dummy', [1, 2, 3, 4, 5])
+
+      expect(() => {
+        testSubject.set('dummy')
+      }).toThrow()
+    })
+  })
+
+  describe('has', () => {
+    it('should be a function', () => {
+      expect(testSubject.has).toBeFunction()
+    })
+
+    it('should be true if the item exists', () => {
+      testSubject.createList('dummy', [1, 2, 3, 4, 5])
+
+      expect(testSubject.has('dummy')).toBeTrue()
+    })
+
+    it('should be false if the item does not exist', () => {
+      expect(testSubject.has('dummy')).toBeFalse()
+    })
+  })
+
+  describe('forget', () => {
+    it('should be a function', () => {
+      expect(testSubject.forget).toBeFunction()
+    })
+
+    it('should forget the item', () => {
+      const value = [1, 2, 3, 4, 5]
+      testSubject.createList('dummy', value)
+
+      expect(testSubject.get('dummy')).toEqual(immutable.List(value))
+      expect(testSubject.size()).toBe(1)
+
+      testSubject.forget('dummy')
+
+      expect(testSubject.size()).toBe(0)
+    })
+
+    it('should throw if an item does not exist', () => {
+      expect(() => {
+        testSubject.get('dummy')
+      }).toThrow()
+    })
+  })
+
+  describe('flush', () => {
+    it('should be a function', () => {
+      expect(testSubject.flush).toBeFunction()
+    })
+
+    it('should empty the storage', () => {
+      testSubject.createList('dummy', [1, 2, 3, 4, 5])
+
+      expect(testSubject.size()).toBe(1)
+
+      testSubject.flush()
+
+      expect(testSubject.size()).toBe(0)
+    })
+  })
+
+  describe('size', () => {
+    it('should be a function', () => {
+      expect(testSubject.size).toBeFunction()
+    })
+
+    it('should get the size of the whole storage', () => {
+      testSubject.createList('dummy', [1, 2, 3, 4, 5])
+
+      expect(testSubject.size()).toBe(1)
+    })
+
+    it('should get the size of the whole storage', () => {
+      testSubject.createList('items.dummy', [1, 2, 3, 4, 5])
+
+      expect(testSubject.size('items')).toBe(1)
+    })
+  })
+
+  describe('createList', () => {
+    it('should be a function', () => {
+      expect(testSubject.createList).toBeFunction()
+    })
+
+    it('should create a new list', () => {
+      const actual = testSubject.createList('dummy', [1, 2, 3, 4, 5])
+
+      expect(actual).toBeInstanceOf(immutable.List)
+    })
+  })
+
+  describe('createMap', () => {
+    it('should be a function', () => {
+      expect(testSubject.createMap).toBeFunction()
+    })
+
+    it('should create a new list', () => {
+      const actual = testSubject.createMap('dummy', { key: 'value' })
+
+      expect(actual).toBeInstanceOf(immutable.Map)
+    })
+  })
+
+  describe('createOrderedMap', () => {
+    it('should be a function', () => {
+      expect(testSubject.createOrderedMap).toBeFunction()
+    })
+
+    it('should create a new list', () => {
+      const actual = testSubject.createOrderedMap('dummy', { key: 'value' })
+
+      expect(actual).toBeInstanceOf(immutable.OrderedMap)
+    })
+  })
+
+  describe('createSet', () => {
+    it('should be a function', () => {
+      expect(testSubject.createSet).toBeFunction()
+    })
+
+    it('should create a new list', () => {
+      const actual = testSubject.createSet('dummy', [1, 2, 3, 4, 5])
+
+      expect(actual).toBeInstanceOf(immutable.Set)
+    })
+  })
+
+  describe('createOrderedSet', () => {
+    it('should be a function', () => {
+      expect(testSubject.createOrderedSet).toBeFunction()
+    })
+
+    it('should create a new list', () => {
+      const actual = testSubject.createOrderedSet('dummy', [1, 2, 3, 4, 5])
+
+      expect(actual).toBeInstanceOf(immutable.OrderedSet)
+    })
+  })
+
+  describe('createStack', () => {
+    it('should be a function', () => {
+      expect(testSubject.createStack).toBeFunction()
+    })
+
+    it('should create a new list', () => {
+      const actual = testSubject.createStack('dummy', [1, 2, 3, 4, 5])
+
+      expect(actual).toBeInstanceOf(immutable.Stack)
+    })
+  })
+
+  describe('createRange', () => {
+    it('should be a function', () => {
+      expect(testSubject.createRange).toBeFunction()
+    })
+
+    it('should create a new list', () => {
+      const actual = testSubject.createRange('dummy', [1, 2, 3, 4, 5])
+
+      expect(actual).toBeInstanceOf(immutable.Range)
+    })
+  })
+
+  describe('createRepeat', () => {
+    it('should be a function', () => {
+      expect(testSubject.createRepeat).toBeFunction()
+    })
+
+    it('should create a new list', () => {
+      const actual = testSubject.createRepeat('dummy', [1, 2, 3, 4, 5])
+
+      expect(actual).toBeInstanceOf(immutable.Repeat)
+    })
+  })
+
+  describe('createRecord', () => {
+    it('should be a function', () => {
+      expect(testSubject.createRecord).toBeFunction()
+    })
+
+    it('should create a new list', () => {
+      const actual = testSubject.createRecord('dummy', [1, 2, 3, 4, 5])
+
+      expect(actual).toBeFunction()
+    })
+  })
+
+  describe('createSeq', () => {
+    it('should be a function', () => {
+      expect(testSubject.createSeq).toBeFunction()
+    })
+
+    it('should create a new list', () => {
+      const actual = testSubject.createSeq('dummy', [1, 2, 3, 4, 5])
+
+      expect(actual).toBeInstanceOf(immutable.Seq)
+    })
+  })
+
+  describe('createSeqKeyed', () => {
+    it('should be a function', () => {
+      expect(testSubject.createSeqKeyed).toBeFunction()
+    })
+
+    it('should create a new list', () => {
+      const actual = testSubject.createSeqKeyed('dummy', [1, 2, 3, 4, 5])
+
+      expect(actual).toBeInstanceOf(immutable.Seq.Keyed)
+    })
+  })
+
+  describe('createSeqIndexed', () => {
+    it('should be a function', () => {
+      expect(testSubject.createSeqIndexed).toBeFunction()
+    })
+
+    it('should create a new list', () => {
+      const actual = testSubject.createSeqIndexed('dummy', [1, 2, 3, 4, 5])
+
+      expect(actual).toBeInstanceOf(immutable.Seq.Indexed)
+    })
+  })
+
+  describe('createSeqSet', () => {
+    it('should be a function', () => {
+      expect(testSubject.createSeqSet).toBeFunction()
+    })
+
+    it('should create a new list', () => {
+      const actual = testSubject.createSeqSet('dummy', [1, 2, 3, 4, 5])
+
+      expect(actual).toBeInstanceOf(immutable.Seq.Set)
+    })
+  })
+
+  describe('createCollection', () => {
+    it('should be a function', () => {
+      expect(testSubject.createCollection).toBeFunction()
+    })
+
+    it('should create a new list', () => {
+      const actual = testSubject.createCollection('dummy', [1, 2, 3, 4, 5])
+
+      expect(actual).toBeInstanceOf(immutable.Collection)
+    })
+  })
+
+  describe('createCollectionKeyed', () => {
+    it('should be a function', () => {
+      expect(testSubject.createCollectionKeyed).toBeFunction()
+    })
+
+    it('should create a new list', () => {
+      const actual = testSubject.createCollectionKeyed('dummy', [1, 2, 3, 4, 5])
+
+      expect(actual).toBeInstanceOf(immutable.Seq)
+    })
+  })
+
+  describe('createCollectionIndexed', () => {
+    it('should be a function', () => {
+      expect(testSubject.createCollectionIndexed).toBeFunction()
+    })
+
+    it('should create a new list', () => {
+      const actual = testSubject.createCollectionIndexed('dummy', [1, 2, 3, 4, 5])
+
+      expect(actual).toBeInstanceOf(immutable.Seq)
+    })
+  })
+
+  describe('createCollectionSet', () => {
+    it('should be a function', () => {
+      expect(testSubject.createCollectionSet).toBeFunction()
+    })
+
+    it('should create a new list', () => {
+      const actual = testSubject.createCollectionSet('dummy', [1, 2, 3, 4, 5])
+
+      expect(actual).toBeInstanceOf(immutable.Seq)
+    })
+  })
+})

--- a/packages/core-storage/jest.config.js
+++ b/packages/core-storage/jest.config.js
@@ -1,0 +1,22 @@
+'use strict'
+
+module.exports = {
+  testEnvironment: 'node',
+  bail: false,
+  verbose: true,
+  testMatch: [
+    '**/__tests__/**/*.test.js'
+  ],
+  moduleFileExtensions: [
+    'js',
+    'json'
+  ],
+  collectCoverage: false,
+  coverageDirectory: '<rootDir>/.coverage',
+  collectCoverageFrom: [
+    'lib/**/*.js',
+    '!**/node_modules/**'
+  ],
+  watchman: false,
+  setupTestFrameworkScriptFile: 'jest-extended'
+}

--- a/packages/core-storage/jsdoc.json
+++ b/packages/core-storage/jsdoc.json
@@ -1,0 +1,24 @@
+{
+  "tags": {
+    "allowUnknownTags": false
+  },
+  "source": {
+    "include": "./lib",
+    "includePattern": ".js$",
+    "excludePattern": "(node_modules/|docs)"
+  },
+  "plugins": [
+    "plugins/markdown"
+  ],
+  "opts": {
+    "template": "../../node_modules/docdash",
+    "encoding": "utf8",
+    "destination": "docs/",
+    "recurse": true,
+    "verbose": true
+  },
+  "templates": {
+    "cleverLinks": false,
+    "monospaceLinks": false
+  }
+}

--- a/packages/core-storage/lib/index.js
+++ b/packages/core-storage/lib/index.js
@@ -1,0 +1,15 @@
+'use strict'
+
+const Storage = require('./storage')
+
+/**
+ * The struct used by the plugin container.
+ * @type {Object}
+ */
+exports.plugin = {
+  pkg: require('../package.json'),
+  alias: 'storage',
+  async register (container, options) {
+    return new Storage()
+  }
+}

--- a/packages/core-storage/lib/storage.js
+++ b/packages/core-storage/lib/storage.js
@@ -1,0 +1,259 @@
+'use strict'
+
+const immutable = require('immutable')
+const { get, set, has, omit } = require('lodash')
+
+module.exports = class Storage {
+  /**
+   * Create a new Storage instance.
+   */
+  constructor () {
+    this.storage = {}
+  }
+
+  /**
+   * Get all of the storage data.
+   * @return {[type]}
+   */
+  all () {
+    return this.storage
+  }
+
+  /**
+   * Retrieve an item from the storage by key.
+   * @param  {String} key
+   * @return {Immutable.*}
+   */
+  get (key) {
+    if (!this.has(key)) {
+      throw new Error(`${key} doesn't exists in storage.`)
+    }
+
+    return get(this.storage, key)
+  }
+
+  /**
+   * Store an item in the storage.
+   * @param {String} key
+   * @param {Array|Object} value
+   * @return {Immutable.*}
+   */
+  set (key, value) {
+    if (this.has(key)) {
+      throw new Error(`${key} already exists in storage.`)
+    }
+
+    set(this.storage, key, value)
+
+    return value
+  }
+
+  /**
+   * Determine if an item exists in the storage.
+   * @param  {String}  key
+   * @return {Boolean}
+   */
+  has (key) {
+    return has(this.storage, key)
+  }
+
+  /**
+   * Remove an item from the storage.
+   * @param  {String} key
+   * @return {void}
+   */
+  forget (key) {
+    if (!this.has(key)) {
+      throw new Error(`${key} doesn't exists in storage.`)
+    }
+
+    this.storage = omit(this.storage, [key])
+  }
+
+  /**
+   * Remove all items from the storage.
+   * @return {void}
+   */
+  flush () {
+    this.storage = {}
+  }
+
+  /**
+   * [size description]
+   * @param  {String} key
+   * @return {Number}
+   */
+  size (key) {
+    return Object.entries(key ? this.get(key) : this.storage).length
+  }
+
+  /**
+   * Create a new List instance.
+   * @param  {String} key
+   * @param  {Array|Object} value
+   * @return {Immutable.List}
+   */
+  createList (key, value) {
+    return this.set(key, immutable.List(value))
+  }
+
+  /**
+   * Create a new Map instance.
+   * @param  {String} key
+   * @param  {Array|Object} value
+   * @return {Immutable.Map}
+   */
+  createMap (key, value) {
+    return this.set(key, immutable.Map(value))
+  }
+
+  /**
+   * Create a new OrderedMap instance.
+   * @param  {String} key
+   * @param  {Array|Object} value
+   * @return {Immutable.OrderedMap}
+   */
+  createOrderedMap (key, value) {
+    return this.set(key, immutable.OrderedMap(value))
+  }
+
+  /**
+   * Create a new Set instance.
+   * @param  {String} key
+   * @param  {Array|Object} value
+   * @return {Immutable.Set}
+   */
+  createSet (key, value) {
+    return this.set(key, immutable.Set(value))
+  }
+
+  /**
+   * Create a new OrderedSet instance.
+   * @param  {String} key
+   * @param  {Array|Object} value
+   * @return {Immutable.OrderedSet}
+   */
+  createOrderedSet (key, value) {
+    return this.set(key, immutable.OrderedSet(value))
+  }
+
+  /**
+   * Create a new Stack instance.
+   * @param  {String} key
+   * @param  {Array|Object} value
+   * @return {Immutable.Stack}
+   */
+  createStack (key, value) {
+    return this.set(key, immutable.Stack(value))
+  }
+
+  /**
+   * Create a new Range instance.
+   * @param  {String} key
+   * @param  {Array|Object} value
+   * @return {Immutable.Range}
+   */
+  createRange (key, value) {
+    return this.set(key, immutable.Range(value))
+  }
+
+  /**
+   * Create a new Repeat instance.
+   * @param  {String} key
+   * @param  {Array|Object} value
+   * @return {Immutable.Repeat}
+   */
+  createRepeat (key, value) {
+    return this.set(key, immutable.Repeat(value))
+  }
+
+  /**
+   * Create a new Record instance.
+   * @param  {String} key
+   * @param  {Array|Object} value
+   * @return {Immutable.Record}
+   */
+  createRecord (key, value) {
+    return this.set(key, immutable.Record(value))
+  }
+
+  /**
+   * Create a new Seq instance.
+   * @param  {String} key
+   * @param  {Array|Object} value
+   * @return {Immutable.Seq}
+   */
+  createSeq (key, value) {
+    return this.set(key, immutable.Seq(value))
+  }
+
+  /**
+   * Create a new Seq.Keyed instance.
+   * @param  {String} key
+   * @param  {Array|Object} value
+   * @return {Immutable.Seq.Keyed}
+   */
+  createSeqKeyed (key, value) {
+    return this.set(key, immutable.Seq.Keyed(value))
+  }
+
+  /**
+   * Create a new Seq.Indexed instance.
+   * @param  {String} key
+   * @param  {Array|Object} value
+   * @return {Immutable.Seq.Indexed}
+   */
+  createSeqIndexed (key, value) {
+    return this.set(key, immutable.Seq.Indexed(value))
+  }
+
+  /**
+   * Create a new Seq.Set instance.
+   * @param  {String} key
+   * @param  {Array|Object} value
+   * @return {Immutable.Seq.Set}
+   */
+  createSeqSet (key, value) {
+    return this.set(key, immutable.Seq.Set(value))
+  }
+
+  /**
+   * Create a new Collection instance.
+   * @param  {String} key
+   * @param  {Array|Object} value
+   * @return {Immutable.Collection}
+   */
+  createCollection (key, value) {
+    return this.set(key, immutable.Collection(value))
+  }
+
+  /**
+   * Create a new Collection.Keyed instance.
+   * @param  {String} key
+   * @param  {Array|Object} value
+   * @return {Immutable.Collection.Keyed}
+   */
+  createCollectionKeyed (key, value) {
+    return this.set(key, immutable.Collection.Keyed(value))
+  }
+
+  /**
+   * Create a new Collection.Indexed instance.
+   * @param  {String} key
+   * @param  {Array|Object} value
+   * @return {Immutable.Collection.Indexed}
+   */
+  createCollectionIndexed (key, value) {
+    return this.set(key, immutable.Collection.Indexed(value))
+  }
+
+  /**
+   * Create a new Collection.Set instance.
+   * @param  {String} key
+   * @param  {Array|Object} value
+   * @return {Immutable.Collection.Set}
+   */
+  createCollectionSet (key, value) {
+    return this.set(key, immutable.Collection.Set(value))
+  }
+}

--- a/packages/core-storage/package.json
+++ b/packages/core-storage/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@arkecosystem/core-storage",
   "description": "Immutable in-memory storage for ARK Core",
-  "version": "0.1.1",
+  "version": "0.1.0",
   "contributors": [
     "Brian Faust <brian@ark.io>"
   ],

--- a/packages/core-storage/package.json
+++ b/packages/core-storage/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@arkecosystem/core-storage",
+  "description": "Immutable in-memory storage for ARK Core",
+  "version": "0.1.1",
+  "contributors": [
+    "Brian Faust <brian@ark.io>"
+  ],
+  "license": "MIT",
+  "main": "lib/index.js",
+  "scripts": {
+    "build:docs": "../../node_modules/.bin/jsdoc -c jsdoc.json",
+    "test": "cross-env ARK_ENV=test jest --runInBand --detectOpenHandles",
+    "test:coverage": "cross-env ARK_ENV=test jest --coverage --runInBand --detectOpenHandles",
+    "test:debug": "cross-env ARK_ENV=test node --inspect-brk ../../node_modules/.bin/jest --runInBand --watch",
+    "test:watch": "cross-env ARK_ENV=test jest --runInBand --watch",
+    "test:watch:all": "cross-env ARK_ENV=test jest --runInBand --watchAll",
+    "lint": "eslint ./ --fix",
+    "depcheck": "depcheck ./"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "immutable": "4.0.0-rc.9",
+    "lodash": "^4.17.10"
+  }
+}


### PR DESCRIPTION
## Proposed changes

This PR provides an immutable storage in the form of the new package `core-storage`. This package makes use of https://facebook.github.io/immutable-js/ under the hood so everything that can be done by immutable.js can be done with core-storage.

`core-storage` only is a wrapper around immutable.js in order to make it possible to have a shared instance for in-memory information that all plugins and core itself can access at any time without having to worry about the data in it getting modified without being told to do so.

We could use this storage for peers, wallets, blockchain state, blocks and many more things were we need the certainty that the data stays how it was stored.

The usage is pretty simple, an example would be the wallet manager. Below example demonstrates how we replace POJOs with the immutable storage provided by `core-storage`.

```js
const container = require('@arkecosystem/core-container')
const storage = container.resolvePlugin('storage')

// Old way
this.walletsByAddress = {}
this.walletsByAddress[address] = address

// New way
this.walletsByAddress = storage.createMap('wallets.byUsername', {})
this.walletsByAddress.set(address, wallet)
```

Lays the groundwork to work on https://github.com/ArkEcosystem/core/issues/818, https://github.com/ArkEcosystem/core/issues/851, https://github.com/ArkEcosystem/core/issues/850.

**This PR only provides the storage. Integration into core plugins will be done after this is merged.**

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
