### PR TITLE
refactor: use p2p port for forger in plugins config

### DIFF
--- a/packages/core-forger/__tests__/client.test.js
+++ b/packages/core-forger/__tests__/client.test.js
@@ -5,7 +5,7 @@ const block = require('./__fixtures__/block')
 
 jest.setTimeout(30000)
 
-const host = 'http://127.0.0.1:4000'
+const host = `http://127.0.0.1:${process.env.ARK_P2P_PORT || 4000}`
 
 let Client
 let client

--- a/packages/core-forger/__tests__/manager.test.js
+++ b/packages/core-forger/__tests__/manager.test.js
@@ -20,7 +20,7 @@ afterAll(async () => {
 
 beforeEach(() => {
   const ForgeManager = require('../lib/manager')
-  defaultConfig.hosts = ['http://127.0.0.1:4000']
+  defaultConfig.hosts = [`http://127.0.0.1:${process.env.ARK_P2P_PORT || 4000}`]
   manager = new ForgeManager(defaultConfig)
 })
 

--- a/packages/core-forger/lib/defaults.js
+++ b/packages/core-forger/lib/defaults.js
@@ -1,3 +1,3 @@
 module.exports = {
-  hosts: ['http://127.0.0.1:4002']
+  hosts: [`http://127.0.0.1:${process.env.ARK_P2P_PORT || 4002}`]
 }

--- a/packages/core/lib/config/devnet/plugins.js
+++ b/packages/core/lib/config/devnet/plugins.js
@@ -86,7 +86,7 @@ module.exports = {
     graphiql: true
   },
   '@arkecosystem/core-forger': {
-    hosts: ['http://127.0.0.1:4002']
+    hosts: [`http://127.0.0.1:${process.env.ARK_P2P_PORT || 4002}`]
   },
   '@arkecosystem/core-json-rpc': {
     enabled: process.env.ARK_JSON_RPC_ENABLED,

--- a/packages/core/lib/config/mainnet/plugins.js
+++ b/packages/core/lib/config/mainnet/plugins.js
@@ -86,7 +86,7 @@ module.exports = {
     graphiql: true
   },
   '@arkecosystem/core-forger': {
-    hosts: ['http://127.0.0.1:4001']
+    hosts: [`http://127.0.0.1:${process.env.ARK_P2P_PORT || 4001}`]
   },
   '@arkecosystem/core-json-rpc': {
     enabled: process.env.ARK_JSON_RPC_ENABLED,

--- a/packages/core/lib/config/testnet.1/plugins.js
+++ b/packages/core/lib/config/testnet.1/plugins.js
@@ -86,7 +86,7 @@ module.exports = {
     graphiql: true
   },
   '@arkecosystem/core-forger': {
-    hosts: ['http://127.0.0.1:4102']
+    hosts: [`http://127.0.0.1:${process.env.ARK_P2P_PORT || 4102}`]
   },
   '@arkecosystem/core-json-rpc': {
     enabled: process.env.ARK_JSON_RPC_ENABLED,

--- a/packages/core/lib/config/testnet.2/plugins.js
+++ b/packages/core/lib/config/testnet.2/plugins.js
@@ -86,7 +86,7 @@ module.exports = {
     graphiql: true
   },
   '@arkecosystem/core-forger': {
-    hosts: ['http://127.0.0.1:4202']
+    hosts: [`http://127.0.0.1:${process.env.ARK_P2P_PORT || 4202}`]
   },
   '@arkecosystem/core-json-rpc': {
     enabled: process.env.ARK_JSON_RPC_ENABLED,

--- a/packages/core/lib/config/testnet.live/plugins.js
+++ b/packages/core/lib/config/testnet.live/plugins.js
@@ -86,7 +86,7 @@ module.exports = {
     graphiql: true
   },
   '@arkecosystem/core-forger': {
-    hosts: ['http://127.0.0.1:4000']
+    hosts: [`http://127.0.0.1:${process.env.ARK_P2P_PORT || 4000}`]
   },
   '@arkecosystem/core-json-rpc': {
     enabled: process.env.ARK_JSON_RPC_ENABLED,

--- a/packages/core/lib/config/testnet/plugins.js
+++ b/packages/core/lib/config/testnet/plugins.js
@@ -86,7 +86,7 @@ module.exports = {
     graphiql: true
   },
   '@arkecosystem/core-forger': {
-    hosts: ['http://127.0.0.1:4000']
+    hosts: [`http://127.0.0.1:${process.env.ARK_P2P_PORT || 4000}`]
   },
   '@arkecosystem/core-json-rpc': {
     enabled: process.env.ARK_JSON_RPC_ENABLED,


### PR DESCRIPTION
## Proposed changes

This PR will change the `plugins.js` to use the P2P port as default for the forger host.

## Types of changes

- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes