### PR TITLE
refactor: use immutable Map instead of object as storage

### DIFF
--- a/packages/core-storage/__tests__/creators.test.js
+++ b/packages/core-storage/__tests__/creators.test.js
@@ -1,0 +1,215 @@
+'use strict'
+
+const immutable = require('immutable')
+const Storage = require('../lib/storage')
+
+let testSubject
+beforeEach(() => {
+  testSubject = new Storage()
+})
+
+describe('Storage', () => {
+  describe('createList', () => {
+    it('should be a function', () => {
+      expect(testSubject.createList).toBeFunction()
+    })
+
+    it('should create a new immutable object', () => {
+      const actual = testSubject.createList([1, 2, 3, 4, 5])
+
+      expect(actual).toBeInstanceOf(immutable.List)
+    })
+  })
+
+  describe('createMap', () => {
+    it('should be a function', () => {
+      expect(testSubject.createMap).toBeFunction()
+    })
+
+    it('should create a new immutable object', () => {
+      const actual = testSubject.createMap({ key: 'value' })
+
+      expect(actual).toBeInstanceOf(immutable.Map)
+    })
+  })
+
+  describe('createOrderedMap', () => {
+    it('should be a function', () => {
+      expect(testSubject.createOrderedMap).toBeFunction()
+    })
+
+    it('should create a new immutable object', () => {
+      const actual = testSubject.createOrderedMap({ key: 'value' })
+
+      expect(actual).toBeInstanceOf(immutable.OrderedMap)
+    })
+  })
+
+  describe('createSet', () => {
+    it('should be a function', () => {
+      expect(testSubject.createSet).toBeFunction()
+    })
+
+    it('should create a new immutable object', () => {
+      const actual = testSubject.createSet([1, 2, 3, 4, 5])
+
+      expect(actual).toBeInstanceOf(immutable.Set)
+    })
+  })
+
+  describe('createOrderedSet', () => {
+    it('should be a function', () => {
+      expect(testSubject.createOrderedSet).toBeFunction()
+    })
+
+    it('should create a new immutable object', () => {
+      const actual = testSubject.createOrderedSet([1, 2, 3, 4, 5])
+
+      expect(actual).toBeInstanceOf(immutable.OrderedSet)
+    })
+  })
+
+  describe('createStack', () => {
+    it('should be a function', () => {
+      expect(testSubject.createStack).toBeFunction()
+    })
+
+    it('should create a new immutable object', () => {
+      const actual = testSubject.createStack([1, 2, 3, 4, 5])
+
+      expect(actual).toBeInstanceOf(immutable.Stack)
+    })
+  })
+
+  describe('createRange', () => {
+    it('should be a function', () => {
+      expect(testSubject.createRange).toBeFunction()
+    })
+
+    it('should create a new immutable object', () => {
+      const actual = testSubject.createRange([1, 2, 3, 4, 5])
+
+      expect(actual).toBeInstanceOf(immutable.Range)
+    })
+  })
+
+  describe('createRepeat', () => {
+    it('should be a function', () => {
+      expect(testSubject.createRepeat).toBeFunction()
+    })
+
+    it('should create a new immutable object', () => {
+      const actual = testSubject.createRepeat([1, 2, 3, 4, 5])
+
+      expect(actual).toBeInstanceOf(immutable.Repeat)
+    })
+  })
+
+  describe('createRecord', () => {
+    it('should be a function', () => {
+      expect(testSubject.createRecord).toBeFunction()
+    })
+
+    it('should create a new immutable object', () => {
+      const actual = testSubject.createRecord([1, 2, 3, 4, 5])
+
+      expect(actual).toBeFunction()
+    })
+  })
+
+  describe('createSeq', () => {
+    it('should be a function', () => {
+      expect(testSubject.createSeq).toBeFunction()
+    })
+
+    it('should create a new immutable object', () => {
+      const actual = testSubject.createSeq([1, 2, 3, 4, 5])
+
+      expect(actual).toBeInstanceOf(immutable.Seq)
+    })
+  })
+
+  describe('createSeqKeyed', () => {
+    it('should be a function', () => {
+      expect(testSubject.createSeqKeyed).toBeFunction()
+    })
+
+    it('should create a new immutable object', () => {
+      const actual = testSubject.createSeqKeyed([1, 2, 3, 4, 5])
+
+      expect(actual).toBeInstanceOf(immutable.Seq.Keyed)
+    })
+  })
+
+  describe('createSeqIndexed', () => {
+    it('should be a function', () => {
+      expect(testSubject.createSeqIndexed).toBeFunction()
+    })
+
+    it('should create a new immutable object', () => {
+      const actual = testSubject.createSeqIndexed([1, 2, 3, 4, 5])
+
+      expect(actual).toBeInstanceOf(immutable.Seq.Indexed)
+    })
+  })
+
+  describe('createSeqSet', () => {
+    it('should be a function', () => {
+      expect(testSubject.createSeqSet).toBeFunction()
+    })
+
+    it('should create a new immutable object', () => {
+      const actual = testSubject.createSeqSet([1, 2, 3, 4, 5])
+
+      expect(actual).toBeInstanceOf(immutable.Seq.Set)
+    })
+  })
+
+  describe('createCollection', () => {
+    it('should be a function', () => {
+      expect(testSubject.createCollection).toBeFunction()
+    })
+
+    it('should create a new immutable object', () => {
+      const actual = testSubject.createCollection([1, 2, 3, 4, 5])
+
+      expect(actual).toBeInstanceOf(immutable.Collection)
+    })
+  })
+
+  describe('createCollectionKeyed', () => {
+    it('should be a function', () => {
+      expect(testSubject.createCollectionKeyed).toBeFunction()
+    })
+
+    it('should create a new immutable object', () => {
+      const actual = testSubject.createCollectionKeyed([1, 2, 3, 4, 5])
+
+      expect(actual).toBeInstanceOf(immutable.Seq)
+    })
+  })
+
+  describe('createCollectionIndexed', () => {
+    it('should be a function', () => {
+      expect(testSubject.createCollectionIndexed).toBeFunction()
+    })
+
+    it('should create a new immutable object', () => {
+      const actual = testSubject.createCollectionIndexed([1, 2, 3, 4, 5])
+
+      expect(actual).toBeInstanceOf(immutable.Seq)
+    })
+  })
+
+  describe('createCollectionSet', () => {
+    it('should be a function', () => {
+      expect(testSubject.createCollectionSet).toBeFunction()
+    })
+
+    it('should create a new immutable object', () => {
+      const actual = testSubject.createCollectionSet([1, 2, 3, 4, 5])
+
+      expect(actual).toBeInstanceOf(immutable.Seq)
+    })
+  })
+})

--- a/packages/core-storage/__tests__/setters.test.js
+++ b/packages/core-storage/__tests__/setters.test.js
@@ -1,0 +1,215 @@
+'use strict'
+
+const immutable = require('immutable')
+const Storage = require('../lib/storage')
+
+let testSubject
+beforeEach(() => {
+  testSubject = new Storage()
+})
+
+describe('Storage', () => {
+  describe('setList', () => {
+    it('should be a function', () => {
+      expect(testSubject.setList).toBeFunction()
+    })
+
+    it('should set a new immutable object', () => {
+      const actual = testSubject.setList('dummy', [1, 2, 3, 4, 5])
+
+      expect(actual).toBeInstanceOf(immutable.List)
+    })
+  })
+
+  describe('setMap', () => {
+    it('should be a function', () => {
+      expect(testSubject.setMap).toBeFunction()
+    })
+
+    it('should set a new immutable object', () => {
+      const actual = testSubject.setMap('dummy', { key: 'value' })
+
+      expect(actual).toBeInstanceOf(immutable.Map)
+    })
+  })
+
+  describe('setOrderedMap', () => {
+    it('should be a function', () => {
+      expect(testSubject.setOrderedMap).toBeFunction()
+    })
+
+    it('should set a new immutable object', () => {
+      const actual = testSubject.setOrderedMap('dummy', { key: 'value' })
+
+      expect(actual).toBeInstanceOf(immutable.OrderedMap)
+    })
+  })
+
+  describe('setSet', () => {
+    it('should be a function', () => {
+      expect(testSubject.setSet).toBeFunction()
+    })
+
+    it('should set a new immutable object', () => {
+      const actual = testSubject.setSet('dummy', [1, 2, 3, 4, 5])
+
+      expect(actual).toBeInstanceOf(immutable.Set)
+    })
+  })
+
+  describe('setOrderedSet', () => {
+    it('should be a function', () => {
+      expect(testSubject.setOrderedSet).toBeFunction()
+    })
+
+    it('should set a new immutable object', () => {
+      const actual = testSubject.setOrderedSet('dummy', [1, 2, 3, 4, 5])
+
+      expect(actual).toBeInstanceOf(immutable.OrderedSet)
+    })
+  })
+
+  describe('setStack', () => {
+    it('should be a function', () => {
+      expect(testSubject.setStack).toBeFunction()
+    })
+
+    it('should set a new immutable object', () => {
+      const actual = testSubject.setStack('dummy', [1, 2, 3, 4, 5])
+
+      expect(actual).toBeInstanceOf(immutable.Stack)
+    })
+  })
+
+  describe('setRange', () => {
+    it('should be a function', () => {
+      expect(testSubject.setRange).toBeFunction()
+    })
+
+    it('should set a new immutable object', () => {
+      const actual = testSubject.setRange('dummy', [1, 2, 3, 4, 5])
+
+      expect(actual).toBeInstanceOf(immutable.Range)
+    })
+  })
+
+  describe('setRepeat', () => {
+    it('should be a function', () => {
+      expect(testSubject.setRepeat).toBeFunction()
+    })
+
+    it('should set a new immutable object', () => {
+      const actual = testSubject.setRepeat('dummy', [1, 2, 3, 4, 5])
+
+      expect(actual).toBeInstanceOf(immutable.Repeat)
+    })
+  })
+
+  describe('setRecord', () => {
+    it('should be a function', () => {
+      expect(testSubject.setRecord).toBeFunction()
+    })
+
+    it('should set a new immutable object', () => {
+      const actual = testSubject.setRecord('dummy', [1, 2, 3, 4, 5])
+
+      expect(actual).toBeFunction()
+    })
+  })
+
+  describe('setSeq', () => {
+    it('should be a function', () => {
+      expect(testSubject.setSeq).toBeFunction()
+    })
+
+    it('should set a new immutable object', () => {
+      const actual = testSubject.setSeq('dummy', [1, 2, 3, 4, 5])
+
+      expect(actual).toBeInstanceOf(immutable.Seq)
+    })
+  })
+
+  describe('setSeqKeyed', () => {
+    it('should be a function', () => {
+      expect(testSubject.setSeqKeyed).toBeFunction()
+    })
+
+    it('should set a new immutable object', () => {
+      const actual = testSubject.setSeqKeyed('dummy', [1, 2, 3, 4, 5])
+
+      expect(actual).toBeInstanceOf(immutable.Seq.Keyed)
+    })
+  })
+
+  describe('setSeqIndexed', () => {
+    it('should be a function', () => {
+      expect(testSubject.setSeqIndexed).toBeFunction()
+    })
+
+    it('should set a new immutable object', () => {
+      const actual = testSubject.setSeqIndexed('dummy', [1, 2, 3, 4, 5])
+
+      expect(actual).toBeInstanceOf(immutable.Seq.Indexed)
+    })
+  })
+
+  describe('setSeqSet', () => {
+    it('should be a function', () => {
+      expect(testSubject.setSeqSet).toBeFunction()
+    })
+
+    it('should set a new immutable object', () => {
+      const actual = testSubject.setSeqSet('dummy', [1, 2, 3, 4, 5])
+
+      expect(actual).toBeInstanceOf(immutable.Seq.Set)
+    })
+  })
+
+  describe('setCollection', () => {
+    it('should be a function', () => {
+      expect(testSubject.setCollection).toBeFunction()
+    })
+
+    it('should set a new immutable object', () => {
+      const actual = testSubject.setCollection('dummy', [1, 2, 3, 4, 5])
+
+      expect(actual).toBeInstanceOf(immutable.Collection)
+    })
+  })
+
+  describe('setCollectionKeyed', () => {
+    it('should be a function', () => {
+      expect(testSubject.setCollectionKeyed).toBeFunction()
+    })
+
+    it('should set a new immutable object', () => {
+      const actual = testSubject.setCollectionKeyed('dummy', [1, 2, 3, 4, 5])
+
+      expect(actual).toBeInstanceOf(immutable.Seq)
+    })
+  })
+
+  describe('setCollectionIndexed', () => {
+    it('should be a function', () => {
+      expect(testSubject.setCollectionIndexed).toBeFunction()
+    })
+
+    it('should set a new immutable object', () => {
+      const actual = testSubject.setCollectionIndexed('dummy', [1, 2, 3, 4, 5])
+
+      expect(actual).toBeInstanceOf(immutable.Seq)
+    })
+  })
+
+  describe('setCollectionSet', () => {
+    it('should be a function', () => {
+      expect(testSubject.setCollectionSet).toBeFunction()
+    })
+
+    it('should set a new immutable object', () => {
+      const actual = testSubject.setCollectionSet('dummy', [1, 2, 3, 4, 5])
+
+      expect(actual).toBeInstanceOf(immutable.Seq)
+    })
+  })
+})

--- a/packages/core-storage/__tests__/storage.test.js
+++ b/packages/core-storage/__tests__/storage.test.js
@@ -9,6 +9,55 @@ beforeEach(() => {
 })
 
 describe('Storage', () => {
+  describe('all', () => {
+    it('should be a function', () => {
+      expect(testSubject.all).toBeFunction()
+    })
+
+    it('should get the storage', () => {
+      expect(testSubject.all()).toBeInstanceOf(Map)
+    })
+  })
+
+  describe('entries', () => {
+    it('should be a function', () => {
+      expect(testSubject.entries).toBeFunction()
+    })
+
+    it('should get all entries', () => {
+      testSubject.setList('dummy', [1, 2, 3, 4, 5])
+
+      expect(testSubject.entries()).toBeObject()
+      expect(testSubject.entries()).not.toBeEmpty()
+    })
+  })
+
+  describe('keys', () => {
+    it('should be a function', () => {
+      expect(testSubject.keys).toBeFunction()
+    })
+
+    it('should get all keys', () => {
+      testSubject.setList('dummy', [1, 2, 3, 4, 5])
+
+      expect(testSubject.keys()).toBeObject()
+      expect(testSubject.keys()).not.toBeEmpty()
+    })
+  })
+
+  describe('values', () => {
+    it('should be a function', () => {
+      expect(testSubject.values).toBeFunction()
+    })
+
+    it('should get all values', () => {
+      testSubject.setList('dummy', [1, 2, 3, 4, 5])
+
+      expect(testSubject.values()).toBeObject()
+      expect(testSubject.values()).not.toBeEmpty()
+    })
+  })
+
   describe('get', () => {
     it('should be a function', () => {
       expect(testSubject.get).toBeFunction()

--- a/packages/core-storage/__tests__/storage.test.js
+++ b/packages/core-storage/__tests__/storage.test.js
@@ -16,7 +16,7 @@ describe('Storage', () => {
 
     it('should get the item', () => {
       const value = [1, 2, 3, 4, 5]
-      testSubject.createList('dummy', value)
+      testSubject.setList('dummy', value)
 
       expect(testSubject.get('dummy')).toEqual(immutable.List(value))
     })
@@ -42,7 +42,7 @@ describe('Storage', () => {
     })
 
     it('should throw if an item exists', () => {
-      testSubject.createList('dummy', [1, 2, 3, 4, 5])
+      testSubject.setList('dummy', [1, 2, 3, 4, 5])
 
       expect(() => {
         testSubject.set('dummy')
@@ -56,7 +56,7 @@ describe('Storage', () => {
     })
 
     it('should be true if the item exists', () => {
-      testSubject.createList('dummy', [1, 2, 3, 4, 5])
+      testSubject.setList('dummy', [1, 2, 3, 4, 5])
 
       expect(testSubject.has('dummy')).toBeTrue()
     })
@@ -73,7 +73,7 @@ describe('Storage', () => {
 
     it('should forget the item', () => {
       const value = [1, 2, 3, 4, 5]
-      testSubject.createList('dummy', value)
+      testSubject.setList('dummy', value)
 
       expect(testSubject.get('dummy')).toEqual(immutable.List(value))
       expect(testSubject.size()).toBe(1)
@@ -90,17 +90,17 @@ describe('Storage', () => {
     })
   })
 
-  describe('flush', () => {
+  describe('clear', () => {
     it('should be a function', () => {
-      expect(testSubject.flush).toBeFunction()
+      expect(testSubject.clear).toBeFunction()
     })
 
     it('should empty the storage', () => {
-      testSubject.createList('dummy', [1, 2, 3, 4, 5])
+      testSubject.setList('dummy', [1, 2, 3, 4, 5])
 
       expect(testSubject.size()).toBe(1)
 
-      testSubject.flush()
+      testSubject.clear()
 
       expect(testSubject.size()).toBe(0)
     })
@@ -112,219 +112,9 @@ describe('Storage', () => {
     })
 
     it('should get the size of the whole storage', () => {
-      testSubject.createList('dummy', [1, 2, 3, 4, 5])
+      testSubject.setList('dummy', [1, 2, 3, 4, 5])
 
       expect(testSubject.size()).toBe(1)
-    })
-
-    it('should get the size of the whole storage', () => {
-      testSubject.createList('items.dummy', [1, 2, 3, 4, 5])
-
-      expect(testSubject.size('items')).toBe(1)
-    })
-  })
-
-  describe('createList', () => {
-    it('should be a function', () => {
-      expect(testSubject.createList).toBeFunction()
-    })
-
-    it('should create a new immutable object', () => {
-      const actual = testSubject.createList('dummy', [1, 2, 3, 4, 5])
-
-      expect(actual).toBeInstanceOf(immutable.List)
-    })
-  })
-
-  describe('createMap', () => {
-    it('should be a function', () => {
-      expect(testSubject.createMap).toBeFunction()
-    })
-
-    it('should create a new immutable object', () => {
-      const actual = testSubject.createMap('dummy', { key: 'value' })
-
-      expect(actual).toBeInstanceOf(immutable.Map)
-    })
-  })
-
-  describe('createOrderedMap', () => {
-    it('should be a function', () => {
-      expect(testSubject.createOrderedMap).toBeFunction()
-    })
-
-    it('should create a new immutable object', () => {
-      const actual = testSubject.createOrderedMap('dummy', { key: 'value' })
-
-      expect(actual).toBeInstanceOf(immutable.OrderedMap)
-    })
-  })
-
-  describe('createSet', () => {
-    it('should be a function', () => {
-      expect(testSubject.createSet).toBeFunction()
-    })
-
-    it('should create a new immutable object', () => {
-      const actual = testSubject.createSet('dummy', [1, 2, 3, 4, 5])
-
-      expect(actual).toBeInstanceOf(immutable.Set)
-    })
-  })
-
-  describe('createOrderedSet', () => {
-    it('should be a function', () => {
-      expect(testSubject.createOrderedSet).toBeFunction()
-    })
-
-    it('should create a new immutable object', () => {
-      const actual = testSubject.createOrderedSet('dummy', [1, 2, 3, 4, 5])
-
-      expect(actual).toBeInstanceOf(immutable.OrderedSet)
-    })
-  })
-
-  describe('createStack', () => {
-    it('should be a function', () => {
-      expect(testSubject.createStack).toBeFunction()
-    })
-
-    it('should create a new immutable object', () => {
-      const actual = testSubject.createStack('dummy', [1, 2, 3, 4, 5])
-
-      expect(actual).toBeInstanceOf(immutable.Stack)
-    })
-  })
-
-  describe('createRange', () => {
-    it('should be a function', () => {
-      expect(testSubject.createRange).toBeFunction()
-    })
-
-    it('should create a new immutable object', () => {
-      const actual = testSubject.createRange('dummy', [1, 2, 3, 4, 5])
-
-      expect(actual).toBeInstanceOf(immutable.Range)
-    })
-  })
-
-  describe('createRepeat', () => {
-    it('should be a function', () => {
-      expect(testSubject.createRepeat).toBeFunction()
-    })
-
-    it('should create a new immutable object', () => {
-      const actual = testSubject.createRepeat('dummy', [1, 2, 3, 4, 5])
-
-      expect(actual).toBeInstanceOf(immutable.Repeat)
-    })
-  })
-
-  describe('createRecord', () => {
-    it('should be a function', () => {
-      expect(testSubject.createRecord).toBeFunction()
-    })
-
-    it('should create a new immutable object', () => {
-      const actual = testSubject.createRecord('dummy', [1, 2, 3, 4, 5])
-
-      expect(actual).toBeFunction()
-    })
-  })
-
-  describe('createSeq', () => {
-    it('should be a function', () => {
-      expect(testSubject.createSeq).toBeFunction()
-    })
-
-    it('should create a new immutable object', () => {
-      const actual = testSubject.createSeq('dummy', [1, 2, 3, 4, 5])
-
-      expect(actual).toBeInstanceOf(immutable.Seq)
-    })
-  })
-
-  describe('createSeqKeyed', () => {
-    it('should be a function', () => {
-      expect(testSubject.createSeqKeyed).toBeFunction()
-    })
-
-    it('should create a new immutable object', () => {
-      const actual = testSubject.createSeqKeyed('dummy', [1, 2, 3, 4, 5])
-
-      expect(actual).toBeInstanceOf(immutable.Seq.Keyed)
-    })
-  })
-
-  describe('createSeqIndexed', () => {
-    it('should be a function', () => {
-      expect(testSubject.createSeqIndexed).toBeFunction()
-    })
-
-    it('should create a new immutable object', () => {
-      const actual = testSubject.createSeqIndexed('dummy', [1, 2, 3, 4, 5])
-
-      expect(actual).toBeInstanceOf(immutable.Seq.Indexed)
-    })
-  })
-
-  describe('createSeqSet', () => {
-    it('should be a function', () => {
-      expect(testSubject.createSeqSet).toBeFunction()
-    })
-
-    it('should create a new immutable object', () => {
-      const actual = testSubject.createSeqSet('dummy', [1, 2, 3, 4, 5])
-
-      expect(actual).toBeInstanceOf(immutable.Seq.Set)
-    })
-  })
-
-  describe('createCollection', () => {
-    it('should be a function', () => {
-      expect(testSubject.createCollection).toBeFunction()
-    })
-
-    it('should create a new immutable object', () => {
-      const actual = testSubject.createCollection('dummy', [1, 2, 3, 4, 5])
-
-      expect(actual).toBeInstanceOf(immutable.Collection)
-    })
-  })
-
-  describe('createCollectionKeyed', () => {
-    it('should be a function', () => {
-      expect(testSubject.createCollectionKeyed).toBeFunction()
-    })
-
-    it('should create a new immutable object', () => {
-      const actual = testSubject.createCollectionKeyed('dummy', [1, 2, 3, 4, 5])
-
-      expect(actual).toBeInstanceOf(immutable.Seq)
-    })
-  })
-
-  describe('createCollectionIndexed', () => {
-    it('should be a function', () => {
-      expect(testSubject.createCollectionIndexed).toBeFunction()
-    })
-
-    it('should create a new immutable object', () => {
-      const actual = testSubject.createCollectionIndexed('dummy', [1, 2, 3, 4, 5])
-
-      expect(actual).toBeInstanceOf(immutable.Seq)
-    })
-  })
-
-  describe('createCollectionSet', () => {
-    it('should be a function', () => {
-      expect(testSubject.createCollectionSet).toBeFunction()
-    })
-
-    it('should create a new immutable object', () => {
-      const actual = testSubject.createCollectionSet('dummy', [1, 2, 3, 4, 5])
-
-      expect(actual).toBeInstanceOf(immutable.Seq)
     })
   })
 })

--- a/packages/core-storage/__tests__/storage.test.js
+++ b/packages/core-storage/__tests__/storage.test.js
@@ -15,7 +15,7 @@ describe('Storage', () => {
     })
 
     it('should get the storage', () => {
-      expect(testSubject.all()).toBeInstanceOf(Map)
+      expect(testSubject.all()).toBeInstanceOf(immutable.Map)
     })
   })
 

--- a/packages/core-storage/lib/storage.js
+++ b/packages/core-storage/lib/storage.js
@@ -11,10 +11,18 @@ module.exports = class Storage {
   }
 
   /**
-   * Get all of the storage entries.
+   * Get the storage map.
    * @return {Object}
    */
   all () {
+    return this.storage
+  }
+
+  /**
+   * Get all of the storage entries.
+   * @return {Object}
+   */
+  entries () {
     return this.storage.entries()
   }
 

--- a/packages/core-storage/lib/storage.js
+++ b/packages/core-storage/lib/storage.js
@@ -7,7 +7,7 @@ module.exports = class Storage {
    * Create a new Storage instance.
    */
   constructor () {
-    this.storage = new Map()
+    this.storage = immutable.Map()
   }
 
   /**
@@ -66,7 +66,7 @@ module.exports = class Storage {
       throw new Error(`${key} already exists in storage.`)
     }
 
-    this.storage.set(key, value)
+    this.storage = this.storage.set(key, value)
 
     return value
   }
@@ -90,7 +90,7 @@ module.exports = class Storage {
       throw new Error(`${key} doesn't exists in storage.`)
     }
 
-    this.storage.delete(key)
+    this.storage = this.storage.delete(key)
   }
 
   /**
@@ -98,7 +98,7 @@ module.exports = class Storage {
    * @return {void}
    */
   clear () {
-    this.storage.clear()
+    this.storage = this.storage.clear()
   }
 
   /**

--- a/packages/core-storage/lib/storage.js
+++ b/packages/core-storage/lib/storage.js
@@ -1,22 +1,37 @@
 'use strict'
 
 const immutable = require('immutable')
-const { get, set, has, omit } = require('lodash')
 
 module.exports = class Storage {
   /**
    * Create a new Storage instance.
    */
   constructor () {
-    this.storage = {}
+    this.storage = new Map()
   }
 
   /**
-   * Get all of the storage data.
-   * @return {[type]}
+   * Get all of the storage entries.
+   * @return {Object}
    */
   all () {
-    return this.storage
+    return this.storage.entries()
+  }
+
+  /**
+   * Get all of the storage keys.
+   * @return {Object}
+   */
+  keys () {
+    return this.storage.keys()
+  }
+
+  /**
+   * Get all of the storage values.
+   * @return {Object}
+   */
+  values () {
+    return this.storage.values()
   }
 
   /**
@@ -29,7 +44,7 @@ module.exports = class Storage {
       throw new Error(`${key} doesn't exists in storage.`)
     }
 
-    return get(this.storage, key)
+    return this.storage.get(key)
   }
 
   /**
@@ -43,7 +58,7 @@ module.exports = class Storage {
       throw new Error(`${key} already exists in storage.`)
     }
 
-    set(this.storage, key, value)
+    this.storage.set(key, value)
 
     return value
   }
@@ -54,7 +69,7 @@ module.exports = class Storage {
    * @return {Boolean}
    */
   has (key) {
-    return has(this.storage, key)
+    return this.storage.has(key)
   }
 
   /**
@@ -67,24 +82,194 @@ module.exports = class Storage {
       throw new Error(`${key} doesn't exists in storage.`)
     }
 
-    this.storage = omit(this.storage, [key])
+    this.storage.delete(key)
   }
 
   /**
    * Remove all items from the storage.
    * @return {void}
    */
-  flush () {
-    this.storage = {}
+  clear () {
+    this.storage.clear()
   }
 
   /**
-   * [size description]
+   * Returns the number of items in the storage.
    * @param  {String} key
    * @return {Number}
    */
   size (key) {
-    return Object.entries(key ? this.get(key) : this.storage).length
+    return key ? this.get(key).length : this.storage.size
+  }
+
+  /**
+   * Set a new List instance.
+   * @param  {String} key
+   * @param  {Array|Object} value
+   * @return {Immutable.List}
+   */
+  setList (key, value) {
+    return this.set(key, this.createList(value))
+  }
+
+  /**
+   * Set a new Map instance.
+   * @param  {String} key
+   * @param  {Array|Object} value
+   * @return {Immutable.Map}
+   */
+  setMap (key, value) {
+    return this.set(key, this.createMap(value))
+  }
+
+  /**
+   * Set a new OrderedMap instance.
+   * @param  {String} key
+   * @param  {Array|Object} value
+   * @return {Immutable.OrderedMap}
+   */
+  setOrderedMap (key, value) {
+    return this.set(key, this.createOrderedMap(value))
+  }
+
+  /**
+   * Set a new Set instance.
+   * @param  {String} key
+   * @param  {Array|Object} value
+   * @return {Immutable.Set}
+   */
+  setSet (key, value) {
+    return this.set(key, this.createSet(value))
+  }
+
+  /**
+   * Set a new OrderedSet instance.
+   * @param  {String} key
+   * @param  {Array|Object} value
+   * @return {Immutable.OrderedSet}
+   */
+  setOrderedSet (key, value) {
+    return this.set(key, this.createOrderedSet(value))
+  }
+
+  /**
+   * Set a new Stack instance.
+   * @param  {String} key
+   * @param  {Array|Object} value
+   * @return {Immutable.Stack}
+   */
+  setStack (key, value) {
+    return this.set(key, this.createStack(value))
+  }
+
+  /**
+   * Set a new Range instance.
+   * @param  {String} key
+   * @param  {Array|Object} value
+   * @return {Immutable.Range}
+   */
+  setRange (key, value) {
+    return this.set(key, this.createRange(value))
+  }
+
+  /**
+   * Set a new Repeat instance.
+   * @param  {String} key
+   * @param  {Array|Object} value
+   * @return {Immutable.Repeat}
+   */
+  setRepeat (key, value) {
+    return this.set(key, this.createRepeat(value))
+  }
+
+  /**
+   * Set a new Record instance.
+   * @param  {String} key
+   * @param  {Array|Object} value
+   * @return {Immutable.Record}
+   */
+  setRecord (key, value) {
+    return this.set(key, this.createRecord(value))
+  }
+
+  /**
+   * Set a new Seq instance.
+   * @param  {String} key
+   * @param  {Array|Object} value
+   * @return {Immutable.Seq}
+   */
+  setSeq (key, value) {
+    return this.set(key, this.createSeq(value))
+  }
+
+  /**
+   * Set a new Seq.Keyed instance.
+   * @param  {String} key
+   * @param  {Array|Object} value
+   * @return {Immutable.Seq.Keyed}
+   */
+  setSeqKeyed (key, value) {
+    return this.set(key, this.createSeqKeyed(value))
+  }
+
+  /**
+   * Set a new Seq.Indexed instance.
+   * @param  {String} key
+   * @param  {Array|Object} value
+   * @return {Immutable.Seq.Indexed}
+   */
+  setSeqIndexed (key, value) {
+    return this.set(key, this.createSeqIndexed(value))
+  }
+
+  /**
+   * Set a new Seq.Set instance.
+   * @param  {String} key
+   * @param  {Array|Object} value
+   * @return {Immutable.Seq.Set}
+   */
+  setSeqSet (key, value) {
+    return this.set(key, this.createSeqSet(value))
+  }
+
+  /**
+   * Set a new Collection instance.
+   * @param  {String} key
+   * @param  {Array|Object} value
+   * @return {Immutable.Collection}
+   */
+  setCollection (key, value) {
+    return this.set(key, this.createCollection(value))
+  }
+
+  /**
+   * Set a new Collection.Keyed instance.
+   * @param  {String} key
+   * @param  {Array|Object} value
+   * @return {Immutable.Collection.Keyed}
+   */
+  setCollectionKeyed (key, value) {
+    return this.set(key, this.createCollectionKeyed(value))
+  }
+
+  /**
+   * Set a new Collection.Indexed instance.
+   * @param  {String} key
+   * @param  {Array|Object} value
+   * @return {Immutable.Collection.Indexed}
+   */
+  setCollectionIndexed (key, value) {
+    return this.set(key, this.createCollectionIndexed(value))
+  }
+
+  /**
+   * Set a new Collection.Set instance.
+   * @param  {String} key
+   * @param  {Array|Object} value
+   * @return {Immutable.Collection.Set}
+   */
+  setCollectionSet (key, value) {
+    return this.set(key, this.createCollectionSet(value))
   }
 
   /**
@@ -93,8 +278,8 @@ module.exports = class Storage {
    * @param  {Array|Object} value
    * @return {Immutable.List}
    */
-  createList (key, value) {
-    return this.set(key, immutable.List(value))
+  createList (value) {
+    return immutable.List(value)
   }
 
   /**
@@ -103,8 +288,8 @@ module.exports = class Storage {
    * @param  {Array|Object} value
    * @return {Immutable.Map}
    */
-  createMap (key, value) {
-    return this.set(key, immutable.Map(value))
+  createMap (value) {
+    return immutable.Map(value)
   }
 
   /**
@@ -113,8 +298,8 @@ module.exports = class Storage {
    * @param  {Array|Object} value
    * @return {Immutable.OrderedMap}
    */
-  createOrderedMap (key, value) {
-    return this.set(key, immutable.OrderedMap(value))
+  createOrderedMap (value) {
+    return immutable.OrderedMap(value)
   }
 
   /**
@@ -123,8 +308,8 @@ module.exports = class Storage {
    * @param  {Array|Object} value
    * @return {Immutable.Set}
    */
-  createSet (key, value) {
-    return this.set(key, immutable.Set(value))
+  createSet (value) {
+    return immutable.Set(value)
   }
 
   /**
@@ -133,8 +318,8 @@ module.exports = class Storage {
    * @param  {Array|Object} value
    * @return {Immutable.OrderedSet}
    */
-  createOrderedSet (key, value) {
-    return this.set(key, immutable.OrderedSet(value))
+  createOrderedSet (value) {
+    return immutable.OrderedSet(value)
   }
 
   /**
@@ -143,8 +328,8 @@ module.exports = class Storage {
    * @param  {Array|Object} value
    * @return {Immutable.Stack}
    */
-  createStack (key, value) {
-    return this.set(key, immutable.Stack(value))
+  createStack (value) {
+    return immutable.Stack(value)
   }
 
   /**
@@ -153,8 +338,8 @@ module.exports = class Storage {
    * @param  {Array|Object} value
    * @return {Immutable.Range}
    */
-  createRange (key, value) {
-    return this.set(key, immutable.Range(value))
+  createRange (value) {
+    return immutable.Range(value)
   }
 
   /**
@@ -163,8 +348,8 @@ module.exports = class Storage {
    * @param  {Array|Object} value
    * @return {Immutable.Repeat}
    */
-  createRepeat (key, value) {
-    return this.set(key, immutable.Repeat(value))
+  createRepeat (value) {
+    return immutable.Repeat(value)
   }
 
   /**
@@ -173,8 +358,8 @@ module.exports = class Storage {
    * @param  {Array|Object} value
    * @return {Immutable.Record}
    */
-  createRecord (key, value) {
-    return this.set(key, immutable.Record(value))
+  createRecord (value) {
+    return immutable.Record(value)
   }
 
   /**
@@ -183,8 +368,8 @@ module.exports = class Storage {
    * @param  {Array|Object} value
    * @return {Immutable.Seq}
    */
-  createSeq (key, value) {
-    return this.set(key, immutable.Seq(value))
+  createSeq (value) {
+    return immutable.Seq(value)
   }
 
   /**
@@ -193,8 +378,8 @@ module.exports = class Storage {
    * @param  {Array|Object} value
    * @return {Immutable.Seq.Keyed}
    */
-  createSeqKeyed (key, value) {
-    return this.set(key, immutable.Seq.Keyed(value))
+  createSeqKeyed (value) {
+    return immutable.Seq.Keyed(value)
   }
 
   /**
@@ -203,8 +388,8 @@ module.exports = class Storage {
    * @param  {Array|Object} value
    * @return {Immutable.Seq.Indexed}
    */
-  createSeqIndexed (key, value) {
-    return this.set(key, immutable.Seq.Indexed(value))
+  createSeqIndexed (value) {
+    return immutable.Seq.Indexed(value)
   }
 
   /**
@@ -213,8 +398,8 @@ module.exports = class Storage {
    * @param  {Array|Object} value
    * @return {Immutable.Seq.Set}
    */
-  createSeqSet (key, value) {
-    return this.set(key, immutable.Seq.Set(value))
+  createSeqSet (value) {
+    return immutable.Seq.Set(value)
   }
 
   /**
@@ -223,8 +408,8 @@ module.exports = class Storage {
    * @param  {Array|Object} value
    * @return {Immutable.Collection}
    */
-  createCollection (key, value) {
-    return this.set(key, immutable.Collection(value))
+  createCollection (value) {
+    return immutable.Collection(value)
   }
 
   /**
@@ -233,8 +418,8 @@ module.exports = class Storage {
    * @param  {Array|Object} value
    * @return {Immutable.Collection.Keyed}
    */
-  createCollectionKeyed (key, value) {
-    return this.set(key, immutable.Collection.Keyed(value))
+  createCollectionKeyed (value) {
+    return immutable.Collection.Keyed(value)
   }
 
   /**
@@ -243,8 +428,8 @@ module.exports = class Storage {
    * @param  {Array|Object} value
    * @return {Immutable.Collection.Indexed}
    */
-  createCollectionIndexed (key, value) {
-    return this.set(key, immutable.Collection.Indexed(value))
+  createCollectionIndexed (value) {
+    return immutable.Collection.Indexed(value)
   }
 
   /**
@@ -253,7 +438,7 @@ module.exports = class Storage {
    * @param  {Array|Object} value
    * @return {Immutable.Collection.Set}
    */
-  createCollectionSet (key, value) {
-    return this.set(key, immutable.Collection.Set(value))
+  createCollectionSet (value) {
+    return immutable.Collection.Set(value)
   }
 }

--- a/packages/core-storage/package.json
+++ b/packages/core-storage/package.json
@@ -21,7 +21,6 @@
     "access": "public"
   },
   "dependencies": {
-    "immutable": "4.0.0-rc.9",
-    "lodash": "^4.17.10"
+    "immutable": "4.0.0-rc.9"
   }
 }


### PR DESCRIPTION
## Proposed changes

_This PR refactors the `core-storage` package to use an immutable map to handle the storage instead of a plain object._

Maps have the same performance, sometimes are even faster, and have built-in methods to modify their state that make dependencies like `lodash` unnecessary. Also added some helper methods to create immutable objects without straight-away adding them to the storage.

## Types of changes

- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)