### PR TITLE
fix: revert on wallets save in updatedelegate stats

### DIFF
--- a/packages/core-database/lib/interface.js
+++ b/packages/core-database/lib/interface.js
@@ -297,7 +297,7 @@ module.exports = class ConnectionInterface {
 
         try {
           this.updateDelegateStats(height, this.activedelegates)
-          await this.saveWallets(true) // save only modified wallets during the last round
+          await this.saveWallets(false) // save only modified wallets during the last round
 
           const delegates = await this.buildDelegates(maxDelegates, nextHeight) // active build delegate list from database state
           await this.saveRound(delegates) // save next round delegate list


### PR DESCRIPTION
## Proposed changes
Fix of saving only modified wallets. Back to old setting. 

## Types of changes
Fix

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [ ] Docs (documentation only changes)
- [ ] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
