### PR TITLE
fix: P2P API requests before the monitor is ready

### DIFF
--- a/packages/core-p2p/lib/server/plugins/accept-request.js
+++ b/packages/core-p2p/lib/server/plugins/accept-request.js
@@ -23,6 +23,10 @@ const register = async (server, options) => {
         return h.continue
       }
 
+      if (!monitor.guard) {
+        return Boom.serverUnavailable('Peer Monitor not ready')
+      }
+
       if ((request.path.startsWith('/internal') || request.path.startsWith('/remote')) && !isWhitelist(options.whitelist, remoteAddress)) {
         return h.response({
           code: 'ResourceNotFound',


### PR DESCRIPTION
## Proposed changes

Sometimes if you run `pm2 restart all` the forger would be sending requests to the P2P API before the monitor itself was mounted which could result in exceptions in connection to `monitor.guard` not being available. This PR gracefully returns a 503 while the monitor is not ready.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes