### PR TITLE
fix: properly set crypto config on launch

### DIFF
--- a/packages/core-config/lib/loader.js
+++ b/packages/core-config/lib/loader.js
@@ -21,7 +21,7 @@ class ConfigLoader {
 
     this._validateConfig()
 
-    this.buildConstants()
+    this.configureCrypto()
 
     return this
   }
@@ -36,11 +36,11 @@ class ConfigLoader {
   }
 
   /**
-   * Build constants from the config.
+   * Configure the crypto package.
    * @return {void}
    */
-  buildConstants () {
-    configManager.buildConstants()
+  configureCrypto () {
+    configManager.setConfig(this.network)
   }
 
   /**


### PR DESCRIPTION
## Proposed changes

Crypto was using the default configuration which is `devnet`. This will set the configuration for the crypto package on launch of core.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes