### PR TITLE
refactor: improve wallet manager method names

### DIFF
--- a/packages/core-api/lib/versions/1/handlers/delegates.js
+++ b/packages/core-api/lib/versions/1/handlers/delegates.js
@@ -171,7 +171,7 @@ exports.forged = {
    * @return {Hapi.Response}
    */
   async handler (request, h) {
-    const wallet = database.walletManager.getWalletByPublicKey(request.query.generatorPublicKey)
+    const wallet = database.walletManager.findByPublicKey(request.query.generatorPublicKey)
 
     return utils.respondWith({
       fees: Number(wallet.forgedFees),

--- a/packages/core-api/lib/versions/2/transformers/block.js
+++ b/packages/core-api/lib/versions/2/transformers/block.js
@@ -9,7 +9,7 @@ const formatTimestamp = require('./utils/format-timestamp')
  * @return {Object}
  */
 module.exports = (model) => {
-  const generator = database.walletManager.getWalletByPublicKey(model.generatorPublicKey)
+  const generator = database.walletManager.findByPublicKey(model.generatorPublicKey)
 
   return {
     id: model.id,

--- a/packages/core-database-sequelize/__tests__/connection.test.js
+++ b/packages/core-database-sequelize/__tests__/connection.test.js
@@ -297,7 +297,7 @@ describe('Sequelize Connection', () => {
 
       const delegates = await connection.buildDelegates(51, 1)
 
-      const wallet = connection.walletManager.getWalletByPublicKey('03e59140fde881ac437ec3dc3e372bf25f7c19f0b471a5b35cc30f783e8a7b811b')
+      const wallet = connection.walletManager.findByPublicKey('03e59140fde881ac437ec3dc3e372bf25f7c19f0b471a5b35cc30f783e8a7b811b')
       expect(wallet.missedBlocks).toBe(0)
 
       const { height } = genesisBlock.data

--- a/packages/core-database-sequelize/__tests__/repositories/transactions.test.js
+++ b/packages/core-database-sequelize/__tests__/repositories/transactions.test.js
@@ -17,7 +17,7 @@ let repository
 let spv
 
 const getWallet = address => {
-  return spv.walletManager.getWalletByAddress(address)
+  return spv.walletManager.findByAddress(address)
 }
 
 beforeAll(async () => {
@@ -106,7 +106,7 @@ describe('Transaction Repository', () => {
 
     it('should find the same transactions with parameter senderId and corresponding senderPublicKey', async () => {
       await connection.saveBlock(genesisBlock)
-      const senderWallet = await spv.walletManager.getWalletByPublicKey('034776bd6080a504b0f84f8d66b16af292dc253aa5f4be8b807746a82aa383bd3c')
+      const senderWallet = await spv.walletManager.findByPublicKey('034776bd6080a504b0f84f8d66b16af292dc253aa5f4be8b807746a82aa383bd3c')
 
       const transactionsSenderPublicKey = await repository.findAll({ senderPublicKey: senderWallet.publicKey })
       const transactionsSenderId = await repository.findAll({ senderId: senderWallet.address })
@@ -204,7 +204,7 @@ describe('Transaction Repository', () => {
 
     it('should find the same transactions with parameter senderId and corresponding senderPublicKey', async () => {
       await connection.saveBlock(genesisBlock)
-      const senderWallet = await spv.walletManager.getWalletByPublicKey('034776bd6080a504b0f84f8d66b16af292dc253aa5f4be8b807746a82aa383bd3c')
+      const senderWallet = await spv.walletManager.findByPublicKey('034776bd6080a504b0f84f8d66b16af292dc253aa5f4be8b807746a82aa383bd3c')
 
       const transactionsSenderPublicKey = await repository.findAllLegacy({ senderPublicKey: senderWallet.publicKey })
       const transactionsSenderId = await repository.findAllLegacy({ senderId: senderWallet.address })

--- a/packages/core-database-sequelize/__tests__/repositories/transactions.test.js
+++ b/packages/core-database-sequelize/__tests__/repositories/transactions.test.js
@@ -42,11 +42,6 @@ beforeEach(async () => {
   const cache = {}
   repository.cache.get = jest.fn(key => cache[key])
   repository.cache.set = jest.fn((key, value) => (cache[key] = value))
-
-  // Disable event listeners on 'wallet:cold:created' for these tests
-  const container = require('@arkecosystem/core-container')
-  const emitter = container.resolvePlugin('event-emitter')
-  emitter.off('wallet:cold:created')
 })
 
 afterEach(async () => {

--- a/packages/core-database-sequelize/__tests__/repositories/transactions.test.js
+++ b/packages/core-database-sequelize/__tests__/repositories/transactions.test.js
@@ -42,6 +42,11 @@ beforeEach(async () => {
   const cache = {}
   repository.cache.get = jest.fn(key => cache[key])
   repository.cache.set = jest.fn((key, value) => (cache[key] = value))
+
+  // Disable event listeners on 'wallet:cold:created' for these tests
+  const container = require('@arkecosystem/core-container')
+  const emitter = container.resolvePlugin('event-emitter')
+  emitter.off('wallet:cold:created')
 })
 
 afterEach(async () => {

--- a/packages/core-database-sequelize/__tests__/spv.test.js
+++ b/packages/core-database-sequelize/__tests__/spv.test.js
@@ -29,11 +29,11 @@ afterEach(async () => {
 })
 
 const getWallet = address => {
-  return spv.walletManager.getWalletByAddress(address)
+  return spv.walletManager.findByAddress(address)
 }
 
-const getWalletByPublicKey = publicKey => {
-  return spv.walletManager.getWalletByPublicKey(publicKey)
+const findByPublicKey = publicKey => {
+  return spv.walletManager.findByPublicKey(publicKey)
 }
 
 describe('SPV', () => {
@@ -74,15 +74,15 @@ describe('SPV', () => {
       const publicKey = '03b47f6b6719c76bad46a302d9cff7be9b1c2b2a20602a0d880f139b5b8901f068'
 
       spv.__buildBlockRewards = jest.fn(pass => {
-        const wallet = spv.walletManager.getWalletByPublicKey(pass)
+        const wallet = spv.walletManager.findByPublicKey(pass)
         wallet.balance += 10
       })
 
-      expect(getWalletByPublicKey(publicKey).balance).toBe(0)
+      expect(findByPublicKey(publicKey).balance).toBe(0)
 
       await spv.__buildBlockRewards(publicKey)
 
-      expect(getWalletByPublicKey(publicKey).balance).toBe(10)
+      expect(findByPublicKey(publicKey).balance).toBe(10)
     })
   })
 
@@ -98,11 +98,11 @@ describe('SPV', () => {
 
       const publicKey = '03b47f6b6719c76bad46a302d9cff7be9b1c2b2a20602a0d880f139b5b8901f068'
 
-      expect(getWalletByPublicKey(publicKey).lastBlock).toBeNull()
+      expect(findByPublicKey(publicKey).lastBlock).toBeNull()
 
       await spv.__buildLastForgedBlocks()
 
-      expect(getWalletByPublicKey(publicKey).lastBlock.id).toBe('17184958558311101492')
+      expect(findByPublicKey(publicKey).lastBlock.id).toBe('17184958558311101492')
     })
   })
 
@@ -132,16 +132,16 @@ describe('SPV', () => {
 
       const publicKey = '03b47f6b6719c76bad46a302d9cff7be9b1c2b2a20602a0d880f139b5b8901f068'
 
-      expect(getWalletByPublicKey(publicKey).secondPublicKey).toBeNull()
+      expect(findByPublicKey(publicKey).secondPublicKey).toBeNull()
 
       spv.__buildSecondSignatures = jest.fn(pass => {
-        const wallet = spv.walletManager.getWalletByPublicKey(pass)
+        const wallet = spv.walletManager.findByPublicKey(pass)
         wallet.secondPublicKey = 'fake-key'
       })
 
       await spv.__buildSecondSignatures(publicKey)
 
-      expect(getWalletByPublicKey(publicKey).secondPublicKey).toBe('fake-key')
+      expect(findByPublicKey(publicKey).secondPublicKey).toBe('fake-key')
     })
   })
 
@@ -187,16 +187,16 @@ describe('SPV', () => {
 
       const publicKey = '03b47f6b6719c76bad46a302d9cff7be9b1c2b2a20602a0d880f139b5b8901f068'
 
-      expect(getWalletByPublicKey(publicKey).multisignature).toBeNull()
+      expect(findByPublicKey(publicKey).multisignature).toBeNull()
 
       spv.__buildMultisignatures = jest.fn(pass => {
-        const wallet = spv.walletManager.getWalletByPublicKey(pass)
+        const wallet = spv.walletManager.findByPublicKey(pass)
         wallet.multisignature = 'fake-multi-signature'
       })
 
       await spv.__buildMultisignatures(publicKey)
 
-      expect(getWalletByPublicKey(publicKey).multisignature).toBe('fake-multi-signature')
+      expect(findByPublicKey(publicKey).multisignature).toBe('fake-multi-signature')
     })
   })
 })

--- a/packages/core-database-sequelize/lib/repositories/transactions.js
+++ b/packages/core-database-sequelize/lib/repositories/transactions.js
@@ -469,7 +469,7 @@ module.exports = class TransactionsRepository extends Repository {
    * @return {String}
    */
   __publicKeyfromSenderId (senderId) {
-    return this.connection.walletManager.getWalletByAddress(senderId).publicKey
+    return this.connection.walletManager.findByAddress(senderId).publicKey
   }
 
   __orderBy (params) {

--- a/packages/core-database-sequelize/lib/spv.js
+++ b/packages/core-database-sequelize/lib/spv.js
@@ -68,7 +68,7 @@ module.exports = class SPV {
       .all()
 
     data.forEach(row => {
-      const wallet = this.walletManager.getWalletByAddress(row.recipientId)
+      const wallet = this.walletManager.findByAddress(row.recipientId)
 
       wallet
         ? wallet.balance = parseInt(row.amount)
@@ -89,7 +89,7 @@ module.exports = class SPV {
       .all()
 
     data.forEach(row => {
-      const wallet = this.walletManager.getWalletByPublicKey(row.generatorPublicKey)
+      const wallet = this.walletManager.findByPublicKey(row.generatorPublicKey)
       wallet.balance += parseInt(row.reward)
     })
   }
@@ -107,7 +107,7 @@ module.exports = class SPV {
       .all()
 
     data.forEach(row => {
-      const wallet = this.walletManager.getWalletByPublicKey(row.generatorPublicKey)
+      const wallet = this.walletManager.findByPublicKey(row.generatorPublicKey)
       wallet.lastBlock = row
     })
   }
@@ -126,7 +126,7 @@ module.exports = class SPV {
       .all()
 
     data.forEach(row => {
-      let wallet = this.walletManager.getWalletByPublicKey(row.senderPublicKey)
+      let wallet = this.walletManager.findByPublicKey(row.senderPublicKey)
       wallet.balance -= parseInt(row.amount) + parseInt(row.fee)
 
       if (wallet.balance < 0 && !this.walletManager.isGenesis(wallet)) {
@@ -147,7 +147,7 @@ module.exports = class SPV {
       .all()
 
     data.forEach(row => {
-      const wallet = this.walletManager.getWalletByPublicKey(row.senderPublicKey)
+      const wallet = this.walletManager.findByPublicKey(row.senderPublicKey)
       wallet.secondPublicKey = Transaction.deserialize(row.serialized.toString('hex')).asset.signature.publicKey
     })
   }
@@ -165,7 +165,7 @@ module.exports = class SPV {
       .all()
 
     for (let i = 0; i < transactions.length; i++) {
-      const wallet = this.walletManager.getWalletByPublicKey(transactions[i].senderPublicKey)
+      const wallet = this.walletManager.findByPublicKey(transactions[i].senderPublicKey)
       wallet.username = Transaction.deserialize(transactions[i].serialized.toString('hex')).asset.delegate.username
 
       this.walletManager.reindex(wallet)
@@ -198,7 +198,7 @@ module.exports = class SPV {
         return block.generatorPublicKey === delegates[i].publicKey
       })[0]
 
-      const wallet = this.walletManager.getWalletByPublicKey(delegates[i].publicKey)
+      const wallet = this.walletManager.findByPublicKey(delegates[i].publicKey)
       wallet.votebalance = delegates[i].votebalance
       wallet.missedBlocks = parseInt(delegates[i].missedBlocks)
 
@@ -225,7 +225,7 @@ module.exports = class SPV {
       .all()
 
     data.forEach(row => {
-      const wallet = this.walletManager.getWalletByPublicKey(row.senderPublicKey)
+      const wallet = this.walletManager.findByPublicKey(row.senderPublicKey)
 
       if (!wallet.voted) {
         const vote = Transaction.deserialize(row.serialized.toString('hex')).asset.votes[0]
@@ -252,7 +252,7 @@ module.exports = class SPV {
       .all()
 
     data.forEach(row => {
-      const wallet = this.walletManager.getWalletByPublicKey(row.senderPublicKey)
+      const wallet = this.walletManager.findByPublicKey(row.senderPublicKey)
 
       if (!wallet.multisignature) {
         wallet.multisignature = Transaction.deserialize(row.serialized.toString('hex')).asset.multisignature

--- a/packages/core-database/__tests__/wallet-manager.test.js
+++ b/packages/core-database/__tests__/wallet-manager.test.js
@@ -89,7 +89,7 @@ describe('Wallet Manager', () => {
 
     beforeEach(() => {
       delegateMock = { applyBlock: jest.fn(), publicKey: delegatePublicKey }
-      walletManager.getWalletByPublicKey = jest.fn(() => delegateMock)
+      walletManager.findByPublicKey = jest.fn(() => delegateMock)
       walletManager.applyTransaction = jest.fn()
       walletManager.revertTransaction = jest.fn()
 
@@ -290,7 +290,7 @@ describe('Wallet Manager', () => {
 
         expect(sender.balance).toBe(balance - transaction.fee)
         expect(sender.username).toBe(username)
-        expect(walletManager.getWalletByUsername(username)).toBe(sender)
+        expect(walletManager.findByUsername(username)).toBe(sender)
       })
 
       it('should fail if the transaction cannot be applied', async () => {
@@ -334,8 +334,8 @@ describe('Wallet Manager', () => {
         senderId: 'APnhwwyTbMiykJwYbGhYjNgtHiVJDSEhSn'
       })
 
-      const sender = walletManager.getWalletByPublicKey(transaction.data.senderPublicKey)
-      const recipient = walletManager.getWalletByAddress(transaction.data.recipientId)
+      const sender = walletManager.findByPublicKey(transaction.data.senderPublicKey)
+      const recipient = walletManager.findByAddress(transaction.data.recipientId)
       recipient.balance = transaction.data.amount
 
       expect(sender.balance).toBe(0)
@@ -348,9 +348,9 @@ describe('Wallet Manager', () => {
     })
   })
 
-  describe('getWalletByAddress', () => {
+  describe('findByAddress', () => {
     it('should be a function', () => {
-      expect(walletManager.getWalletByAddress).toBeFunction()
+      expect(walletManager.findByAddress).toBeFunction()
     })
 
     it('should index it by address', () => {
@@ -364,13 +364,13 @@ describe('Wallet Manager', () => {
       const wallet = new Wallet(walletData1.address)
 
       walletManager.reindex(wallet)
-      expect(walletManager.getWalletByAddress(wallet.address).address).toBe(wallet.address)
+      expect(walletManager.findByAddress(wallet.address).address).toBe(wallet.address)
     })
   })
 
-  describe('getWalletByPublicKey', () => {
+  describe('findByPublicKey', () => {
     it('should be a function', () => {
-      expect(walletManager.getWalletByPublicKey).toBeFunction()
+      expect(walletManager.findByPublicKey).toBeFunction()
     })
 
     it('should index it by publicKey', () => {
@@ -386,13 +386,13 @@ describe('Wallet Manager', () => {
       wallet.publicKey = 'dummy-public-key'
 
       walletManager.reindex(wallet)
-      expect(walletManager.getWalletByPublicKey(wallet.publicKey).publicKey).toBe(wallet.publicKey)
+      expect(walletManager.findByPublicKey(wallet.publicKey).publicKey).toBe(wallet.publicKey)
     })
   })
 
-  describe('getWalletByUsername', () => {
+  describe('findByUsername', () => {
     it('should be a function', () => {
-      expect(walletManager.getWalletByUsername).toBeFunction()
+      expect(walletManager.findByUsername).toBeFunction()
     })
 
     it('should index it by username', () => {
@@ -408,7 +408,7 @@ describe('Wallet Manager', () => {
       wallet.username = 'dummy-username'
 
       walletManager.reindex(wallet)
-      expect(walletManager.getWalletByUsername(wallet.username).username).toBe(wallet.username)
+      expect(walletManager.findByUsername(wallet.username).username).toBe(wallet.username)
     })
   })
 

--- a/packages/core-database/lib/interface.js
+++ b/packages/core-database/lib/interface.js
@@ -241,7 +241,7 @@ module.exports = class ConnectionInterface {
     try {
       delegates.forEach(delegate => {
         let producedBlocks = this.blocksInCurrentRound.filter(blockGenerator => blockGenerator.data.generatorPublicKey === delegate.publicKey)
-        let wallet = this.walletManager.getWalletByPublicKey(delegate.publicKey)
+        let wallet = this.walletManager.findByPublicKey(delegate.publicKey)
 
         if (producedBlocks.length === 0) {
           wallet.missedBlocks++
@@ -351,12 +351,12 @@ module.exports = class ConnectionInterface {
     const slot = slots.getSlotNumber(block.data.timestamp)
     const forgingDelegate = delegates[slot % delegates.length]
 
-    const generatorUsername = this.walletManager.getWalletByPublicKey(block.data.generatorPublicKey).username
+    const generatorUsername = this.walletManager.findByPublicKey(block.data.generatorPublicKey).username
 
     if (!forgingDelegate) {
       logger.debug(`Could not decide if delegate ${generatorUsername} (${block.data.generatorPublicKey}) is allowed to forge block ${block.data.height.toLocaleString()} :grey_question:`)
     } else if (forgingDelegate.publicKey !== block.data.generatorPublicKey) {
-      const forgingUsername = this.walletManager.getWalletByPublicKey(forgingDelegate.publicKey).username
+      const forgingUsername = this.walletManager.findByPublicKey(forgingDelegate.publicKey).username
 
       throw new Error(`Delegate ${generatorUsername} (${block.data.generatorPublicKey}) not allowed to forge, should be ${forgingUsername} (${forgingDelegate.publicKey}) :-1:`)
     } else {
@@ -418,7 +418,7 @@ module.exports = class ConnectionInterface {
   async verifyTransaction (transaction) {
     const senderId = crypto.getAddress(transaction.data.senderPublicKey, config.network.pubKeyHash)
 
-    let sender = this.walletManager.getWalletByAddress[senderId] // should exist
+    let sender = this.walletManager.findByAddress[senderId] // should exist
 
     if (!sender.publicKey) {
       sender.publicKey = transaction.data.senderPublicKey

--- a/packages/core-database/lib/wallet-manager.js
+++ b/packages/core-database/lib/wallet-manager.js
@@ -285,7 +285,9 @@ module.exports = class WalletManager {
     if (!this.walletsByAddress[address]) {
       this.walletsByAddress[address] = new Wallet(address)
 
-      this.__emitEvent('wallet:cold:created', this.walletsByAddress[address])
+      if (process.env.NODE_ENV !== 'test') {
+        this.__emitEvent('wallet:cold:created', this.walletsByAddress[address])
+      }
     }
 
     return this.walletsByAddress[address]

--- a/packages/core-database/lib/wallet-manager.js
+++ b/packages/core-database/lib/wallet-manager.js
@@ -118,7 +118,7 @@ module.exports = class WalletManager {
   applyBlock (block) {
     const generatorPublicKey = block.data.generatorPublicKey
 
-    let delegate = this.getWalletByPublicKey(block.data.generatorPublicKey)
+    let delegate = this.findByPublicKey(block.data.generatorPublicKey)
 
     if (!delegate) {
       const generator = crypto.getAddress(generatorPublicKey, config.network.pubKeyHash)
@@ -169,7 +169,7 @@ module.exports = class WalletManager {
    * @return {void}
    */
   async revertBlock (block) {
-    let delegate = this.getWalletByPublicKey(block.data.generatorPublicKey)
+    let delegate = this.findByPublicKey(block.data.generatorPublicKey)
 
     if (!delegate) {
       const generator = crypto.getAddress(block.data.generatorPublicKey, config.network.pubKeyHash)
@@ -208,9 +208,8 @@ module.exports = class WalletManager {
     const { data } = transaction
     const { type, asset, recipientId, senderPublicKey } = data
 
-    const sender = this.getWalletByPublicKey(senderPublicKey)
-    
-    const recipient = this.findOrCreate(recipientId)
+    const sender = this.findByPublicKey(senderPublicKey)
+    const recipient = this.findByAddress(recipientId)
 
     if (type === TRANSACTION_TYPES.DELEGATE_REGISTRATION && this.walletsByUsername[asset.delegate.username.toLowerCase()]) {
 
@@ -258,8 +257,8 @@ module.exports = class WalletManager {
    * @return {Transaction}
    */
   revertTransaction ({ type, data }) {
-    const sender = this.getWalletByPublicKey(data.senderPublicKey) // Should exist
-    const recipient = this.getWalletByAddress(data.recipientId)
+    const sender = this.findByPublicKey(data.senderPublicKey) // Should exist
+    const recipient = this.findByAddress(data.recipientId)
 
     sender.revertTransactionForSender(data)
 
@@ -278,45 +277,30 @@ module.exports = class WalletManager {
   }
 
   /**
-   * Find or create a wallet for the given address.
-   * @param  {String} address
-   * @return {Wallet}
-   */
-  findOrCreate (address) {
-   let wallet = this.getWalletByAddress(address)
-    
-   if (!wallet) { // cold wallet
-     this.walletsByAddress[address] = new Wallet(address) 
-
-     this.__emitEvent('wallet:cold:created', this.walletsByAddress[address]) 
-   }
-
-   return this.walletsByAddress[address]
-  }
-
-  /**
-   * Get a wallet by the given address.
+   * Find a wallet by the given address.
    * @param  {String} address
    * @return {(Wallet|null)}
    */
-  getWalletByAddress (address) {
+  findByAddress (address) {
     if (!this.walletsByAddress[address]) {
       this.walletsByAddress[address] = new Wallet(address)
+
+      this.__emitEvent('wallet:cold:created', this.walletsByAddress[address])
     }
 
     return this.walletsByAddress[address]
   }
 
   /**
-   * Get a wallet by the given public key.
+   * Find a wallet by the given public key.
    * @param  {String} publicKey
    * @return {Wallet}
    */
-  getWalletByPublicKey (publicKey) {
+  findByPublicKey (publicKey) {
     if (!this.walletsByPublicKey[publicKey]) {
       const address = crypto.getAddress(publicKey, config.network.pubKeyHash)
 
-      this.walletsByPublicKey[publicKey] = this.getWalletByAddress(address)
+      this.walletsByPublicKey[publicKey] = this.findByAddress(address)
       this.walletsByPublicKey[publicKey].publicKey = publicKey
     }
 
@@ -324,11 +308,11 @@ module.exports = class WalletManager {
   }
 
   /**
-   * Get a wallet by the given username.
+   * Find a wallet by the given username.
    * @param  {String} publicKey
    * @return {Wallet}
    */
-  getWalletByUsername (username) {
+  findByUsername (username) {
     return this.walletsByUsername[username]
   }
 

--- a/packages/core-p2p/lib/server/versions/internal/handlers/utils.js
+++ b/packages/core-p2p/lib/server/versions/internal/handlers/utils.js
@@ -23,7 +23,7 @@ exports.usernames = {
 
     const data = {}
     for (const delegate of delegates) {
-      data[delegate.publicKey] = walletManager.getWalletByPublicKey(delegate.publicKey).username
+      data[delegate.publicKey] = walletManager.findByPublicKey(delegate.publicKey).username
     }
 
     return { data }

--- a/packages/core-transaction-pool/lib/interface.js
+++ b/packages/core-transaction-pool/lib/interface.js
@@ -271,7 +271,7 @@ module.exports = class TransactionPoolInterface {
     for (const transaction of block.transactions) {
       const exists = await this.transactionExists(transaction.id)
       if (!exists) {
-        const senderWallet = this.walletManager.exists(transaction.senderPublicKey) ? this.walletManager.getWalletByPublicKey(transaction.senderPublicKey) : false
+        const senderWallet = this.walletManager.exists(transaction.senderPublicKey) ? this.walletManager.findByPublicKey(transaction.senderPublicKey) : false
         // if wallet in pool we try to apply transaction
         if (senderWallet || this.walletManager.exists(transaction.recipientId)) {
           try {

--- a/packages/core-transaction-pool/lib/pool-wallet-manager.js
+++ b/packages/core-transaction-pool/lib/pool-wallet-manager.js
@@ -27,9 +27,9 @@ module.exports = class PoolWalletManager extends WalletManager {
    * @param  {String} address
    * @return {(Wallet|null)}
    */
-  getWalletByAddress (address) {
+  findByAddress (address) {
     if (!this.walletsByAddress[address]) {
-      const blockchainWallet = database.walletManager.getWalletByAddress(address)
+      const blockchainWallet = database.walletManager.findByAddress(address)
       const wallet = Object.assign(new Wallet(address), blockchainWallet) // do not modify
 
       this.reindex(wallet)
@@ -88,8 +88,8 @@ module.exports = class PoolWalletManager extends WalletManager {
     const { data } = transaction
     const { type, asset, recipientId, senderPublicKey } = data
 
-    const sender = this.getWalletByPublicKey(senderPublicKey)
-    let recipient = recipientId ? this.getWalletByAddress(recipientId) : null
+    const sender = this.findByPublicKey(senderPublicKey)
+    let recipient = recipientId ? this.findByAddress(recipientId) : null
 
     if (!recipient && recipientId) { // cold wallet
       recipient = new Wallet(recipientId)
@@ -136,7 +136,7 @@ module.exports = class PoolWalletManager extends WalletManager {
   applyPoolBlock (block) {
     // if delegate in poll wallet manager - apply rewards
     if (this.exists(block.data.generatorPublicKey)) {
-      const delegateWallet = this.getWalletByPublicKey(block.data.generatorPublicKey)
+      const delegateWallet = this.findByPublicKey(block.data.generatorPublicKey)
       delegateWallet.applyBlock(block.data)
     }
   }

--- a/packages/core-transaction-pool/lib/utils/validation-helpers.js
+++ b/packages/core-transaction-pool/lib/utils/validation-helpers.js
@@ -14,7 +14,7 @@ module.exports = {
   canApplyToBlockchain: transaction => {
     return database
       .walletManager
-      .getWalletByPublicKey(transaction.senderPublicKey)
+      .findByPublicKey(transaction.senderPublicKey)
       .canApply(transaction)
   },
 


### PR DESCRIPTION
## Proposed changes

Renaming some methods as having the prefix `getWallet` is redundant if the methods are inside the `WalletManager`. Also includes a small refactor for more consistent behaviour of trigger the `wallet:cold:created` event as a method was rendered useless after some renaming and looking at the logic.

## Types of changes

- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes