### PR TITLE
fix: Suspending peer object

### DIFF
--- a/packages/core-p2p/lib/monitor.js
+++ b/packages/core-p2p/lib/monitor.js
@@ -86,10 +86,12 @@ class Monitor {
       return
     }
 
+    const newPeer = new Peer(peer.ip, peer.port)
+
     if (this.guard.isBlacklisted(peer.ip)) {
       logger.debug(`Rejected peer ${peer.ip} as it is blacklisted`)
 
-      this.guard.suspend(peer)
+      this.guard.suspend(newPeer)
 
       return
     }
@@ -97,7 +99,7 @@ class Monitor {
     if (!this.guard.isValidVersion(peer) && !this.guard.isWhitelisted(peer)) {
       logger.debug(`Rejected peer ${peer.ip} as it doesn't meet the minimum version requirements. Expected: ${config.peers.minimumVersion} - Received: ${peer.version}`)
 
-      this.guard.suspend(peer)
+      this.guard.suspend(newPeer)
 
       return
     }
@@ -109,8 +111,6 @@ class Monitor {
     if (peer.nethash !== config.network.nethash) {
       throw new Error('Request is made on the wrong network')
     }
-
-    const newPeer = new Peer(peer.ip, peer.port)
 
     try {
       await newPeer.ping(1500)


### PR DESCRIPTION
## Proposed changes
Suspend(peer) method was crashing as the peer sent to the method was not a `Peer` object, but just `peer` received from `accept-request`. Moved the object creation higher and passing `Peer` object to the suspend method.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [ ] Docs (documentation only changes)
- [ ] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:

## Checklist
- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)