### PR TITLE
fix: reference modules directly in crypto

### DIFF
--- a/packages/crypto/lib/index.js
+++ b/packages/crypto/lib/index.js
@@ -14,7 +14,15 @@ module.exports = {
   transactionBuilder: require('./builder'),
 
   // Crypto...
-  ...require('./crypto'),
+  crypto: {
+    crypto: require('./crypto/crypto'),
+    ecdsa: require('./crypto/ecdsa'),
+    ECPair: require('./crypto/ecpair'),
+    ECSignature: require('./crypto/ecsignature'),
+    HDNode: require('./crypto/hdnode'),
+    slots: require('./crypto/slots'),
+    utils: require('./crypto/utils')
+  },
 
   // Managers...
   configManager: require('./managers/config'),


### PR DESCRIPTION
## Proposed changes

Using the spread syntax `...` could result in syntax errors together.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes