### PR TITLE
Test (p2p package) : use Hapi inject instead of axios for server requests

### DIFF
--- a/packages/core-p2p/__tests__/__support__/utils.js
+++ b/packages/core-p2p/__tests__/__support__/utils.js
@@ -1,0 +1,37 @@
+'use strict'
+
+class Helpers {
+  async GET (endpoint, params = {}) {
+    return this.request('GET', endpoint, params)
+  }
+
+  async POST (endpoint, params) {
+    return this.request('POST', endpoint, params)
+  }
+
+  async request (method, path, params = {}) {
+    const url = `http://localhost:4002/${path}`
+
+    const server = require('@arkecosystem/core-container').resolvePlugin('p2p').server
+
+    // Build URL params from _params_ object for GET / DELETE requests
+    const getParams = Object.entries(params).map(([key, val]) => `${key}=${val}`).join('&')
+
+    // Injecting the request into Hapi server instead of using axios
+    const injectOptions = {
+      method,
+      url: ['GET', 'DELETE'].includes(method) ? `${url}?${getParams}` : url,
+      headers: {},
+      payload: ['GET', 'DELETE'].includes(method) ? {} : params
+    }
+
+    const response = await server.inject(injectOptions)
+    Object.assign(response, { data: response.result, status: response.statusCode })
+    return response
+  }
+}
+
+/**
+ * @type {Helpers}
+ */
+module.exports = new Helpers()

--- a/packages/core-p2p/__tests__/server/1.test.js
+++ b/packages/core-p2p/__tests__/server/1.test.js
@@ -1,8 +1,7 @@
 'use strict'
 
-const axios = require('axios')
-
 const app = require('../__support__/setup')
+const utils = require('../__support__/utils')
 
 let genesisBlock
 let genesisTransaction
@@ -20,18 +19,10 @@ afterAll(async () => {
   await app.tearDown()
 })
 
-const sendGET = async (endpoint, params = {}) => {
-  return axios.get(`http://127.0.0.1:4002/${endpoint}`, { params })
-}
-
-const sendPOST = async (endpoint, params) => {
-  return axios.post(`http://127.0.0.1:4002/${endpoint}`, params)
-}
-
 describe('API - Version 1', () => {
   describe('GET /peer/list', () => {
     it('should be ok', async () => {
-      const response = await sendGET('peer/list')
+      const response = await utils.GET('peer/list')
 
       expect(response.status).toBe(200)
 
@@ -47,7 +38,7 @@ describe('API - Version 1', () => {
 
   describe('GET /peer/blocks', () => {
     it('should be ok', async () => {
-      const response = await sendGET('peer/blocks', { lastBlockHeight: 1 })
+      const response = await utils.GET('peer/blocks', { lastBlockHeight: 1 })
 
       expect(response.status).toBe(200)
 
@@ -61,7 +52,7 @@ describe('API - Version 1', () => {
     })
 
     it('should retrieve lastBlock if no "lastBlockHeight" specified', async () => {
-      const response = await sendGET('peer/blocks');
+      const response = await utils.GET('peer/blocks');
 
       expect(response.status).toBe(200);
       expect(response.data).toBeObject()
@@ -77,7 +68,7 @@ describe('API - Version 1', () => {
 
   describe('GET /peer/transactionsFromIds', () => {
     it('should be ok', async () => {
-      const response = await sendGET('peer/transactionsFromIds', {
+      const response = await utils.GET('peer/transactionsFromIds', {
         ids: 'e40ce11cab82736da1cc91191716f3c1f446ca7b6a9f4f93b7120ef105ba06e8'
       })
 
@@ -95,7 +86,7 @@ describe('API - Version 1', () => {
 
   describe('GET /peer/height', () => {
     it('should be ok', async () => {
-      const response = await sendGET('peer/height')
+      const response = await utils.GET('peer/height')
 
       expect(response.status).toBe(200)
 
@@ -114,7 +105,7 @@ describe('API - Version 1', () => {
 
   describe('GET /peer/transactions', () => {
     it('should be ok', async () => {
-      const response = await sendGET('peer/transactions')
+      const response = await utils.GET('peer/transactions')
 
       expect(response.status).toBe(200)
 
@@ -130,7 +121,7 @@ describe('API - Version 1', () => {
 
   describe('GET /peer/blocks/common', () => {
     it('should be ok', async () => {
-      const response = await sendGET('peer/blocks/common', {
+      const response = await utils.GET('peer/blocks/common', {
         ids: '13149578060728881902'
       })
 
@@ -153,7 +144,7 @@ describe('API - Version 1', () => {
 
   describe('GET /peer/status', () => {
     it('should be ok', async () => {
-      const response = await sendGET('peer/status')
+      const response = await utils.GET('peer/status')
 
       expect(response.status).toBe(200)
 
@@ -166,7 +157,7 @@ describe('API - Version 1', () => {
 
   describe('POST /peer/blocks', () => {
     it('should be ok', async () => {
-      const response = await sendPOST('peer/blocks', {
+      const response = await utils.POST('peer/blocks', {
         block: genesisBlock.toBroadcastV1()
       })
 
@@ -181,7 +172,7 @@ describe('API - Version 1', () => {
 
   describe('POST /peer/transactions', () => {
     it('should be ok', async () => {
-      const response = await sendPOST('peer/transactions', {
+      const response = await utils.POST('peer/transactions', {
         transactions: [genesisTransaction.toBroadcastV1()]
       })
 

--- a/packages/core-p2p/__tests__/server/internal.test.js
+++ b/packages/core-p2p/__tests__/server/internal.test.js
@@ -1,8 +1,7 @@
 'use strict'
 
-const axios = require('axios')
-
 const app = require('../__support__/setup')
+const utils = require('../__support__/utils')
 
 let genesisBlock
 let genesisTransaction
@@ -20,18 +19,10 @@ afterAll(async () => {
   await app.tearDown()
 })
 
-const sendGET = async (endpoint, params = {}) => {
-  return axios.get(`http://127.0.0.1:4002/internal/${endpoint}`, { params })
-}
-
-const sendPOST = async (endpoint, params) => {
-  return axios.post(`http://127.0.0.1:4002/internal/${endpoint}`, params)
-}
-
 describe('API - Internal', () => {
   describe('GET /rounds/current', () => {
     it('should be ok', async () => {
-      const response = await sendGET('rounds/current')
+      const response = await utils.GET('internal/rounds/current')
 
       expect(response.status).toBe(200)
 
@@ -43,7 +34,7 @@ describe('API - Internal', () => {
 
   describe('POST /blocks', () => {
     it('should be ok', async () => {
-      const response = await sendPOST('blocks', {
+      const response = await utils.POST('internal/blocks', {
         block: genesisBlock.toBroadcastV1()
       })
 
@@ -53,7 +44,7 @@ describe('API - Internal', () => {
 
   describe.skip('POST /transactions/verify', () => {
     it('should be ok', async () => {
-      const response = await sendPOST('transactions/verify', {
+      const response = await utils.POST('internal/transactions/verify', {
         transaction: genesisTransaction
       })
 
@@ -67,7 +58,7 @@ describe('API - Internal', () => {
 
   describe('GET /transactions/forging', () => {
     it('should be ok', async () => {
-      const response = await sendGET('transactions/forging')
+      const response = await utils.GET('internal/transactions/forging')
 
       expect(response.status).toBe(200)
 
@@ -79,7 +70,7 @@ describe('API - Internal', () => {
 
   describe('GET /network/state', () => {
     it('should be ok', async () => {
-      const response = await sendGET('network/state')
+      const response = await utils.GET('internal/network/state')
 
       expect(response.status).toBe(200)
 


### PR DESCRIPTION
## Proposed changes
For tests in core-p2p package, use Hapi inject instead of axios for server requests.

## Types of changes

- [x] Test (adding missing tests or fixing existing tests)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
