### PR TITLE
Test: ignore package core-tester-cli in test coverage reports

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "packages/core-tester-cli/**/*"


### PR DESCRIPTION
## Proposed changes
Ignore package core-tester-cli in test coverage reports (codecov.io).

## Types of changes

- [x] Test (adding missing tests or fixing existing tests)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes