### PR TITLE
arkjs removal follow-up fixes

### DIFF
--- a/packages/crypto/__tests__/builder/transactions/__shared__/transaction.js
+++ b/packages/crypto/__tests__/builder/transactions/__shared__/transaction.js
@@ -109,11 +109,8 @@ module.exports = () => {
 
   describe('sign', () => {
     it('signs this transaction with the keys of the passphrase', () => {
-      let keys
-      crypto.getKeys = jest.fn(pass => {
-        keys = { publicKey: `${pass} public key` }
-        return keys
-      })
+      let keys = { publicKey: '02d0d835266297f15c192be2636eb3fbc30b39b87fc583ff112062ef8ae1a1f2af' }
+      crypto.getKeys = jest.fn(() => keys)
       crypto.sign = jest.fn()
       const signingObject = builder.__getSigningObject()
 
@@ -124,10 +121,11 @@ module.exports = () => {
     })
 
     it('establishes the public key of the sender', () => {
-      crypto.getKeys = jest.fn(pass => ({ publicKey: `${pass} public key` }))
+      let keys = { publicKey: '02d0d835266297f15c192be2636eb3fbc30b39b87fc583ff112062ef8ae1a1f2af' }
+      crypto.getKeys = jest.fn(() => keys)
       crypto.sign = jest.fn()
       builder.sign('my real pass')
-      expect(builder.data.senderPublicKey).toBe('my real pass public key')
+      expect(builder.data.senderPublicKey).toBe(keys.publicKey)
     })
   })
 

--- a/packages/crypto/__tests__/builder/transactions/multi-signature.test.js
+++ b/packages/crypto/__tests__/builder/transactions/multi-signature.test.js
@@ -48,11 +48,11 @@ describe('Multi Signature Transaction', () => {
     it('establishes the recipient id', () => {
       const pass = 'dummy pass'
 
-      crypto.getKeys = jest.fn(pass => ({ publicKey: `${pass} public key` }))
+      crypto.getKeys = jest.fn(() => ({ publicKey: '02d0d835266297f15c192be2636eb3fbc30b39b87fc583ff112062ef8ae1a1f2af' }))
       crypto.sign = jest.fn()
 
       builder.sign(pass)
-      expect(builder.data.recipientId).toBe('DKNJwdxrPQg6xXbrpaQLfgi6kC2ndaz8N5')
+      expect(builder.data.recipientId).toBe('D5q7YfEFDky1JJVQQEy4MGyiUhr5cGg47F')
     })
   })
 

--- a/packages/crypto/__tests__/builder/transactions/vote.test.js
+++ b/packages/crypto/__tests__/builder/transactions/vote.test.js
@@ -37,11 +37,11 @@ describe('Vote Transaction', () => {
     it('establishes the recipient id', () => {
       const pass = 'dummy pass'
 
-      crypto.getKeys = jest.fn(pass => ({ publicKey: `${pass} public key` }))
+      crypto.getKeys = jest.fn(() => ({ publicKey: '02d0d835266297f15c192be2636eb3fbc30b39b87fc583ff112062ef8ae1a1f2af' }))
       crypto.sign = jest.fn()
 
       builder.sign(pass)
-      expect(builder.data.recipientId).toBe('DKNJwdxrPQg6xXbrpaQLfgi6kC2ndaz8N5')
+      expect(builder.data.recipientId).toBe('D5q7YfEFDky1JJVQQEy4MGyiUhr5cGg47F')
     })
   })
 })

--- a/packages/crypto/__tests__/crypto/crypto.test.js
+++ b/packages/crypto/__tests__/crypto/crypto.test.js
@@ -230,6 +230,24 @@ describe('crypto.js', () => {
 
       expect(address).toBe(keyPair.getAddress())
     })
+
+    it('should not throw an error if the publicKey is valid', () => {
+      try {
+        const validKeys = ['02d0d835266297f15c192be2636eb3fbc30b39b87fc583ff112062ef8ae1a1f2af', 'a'.repeat(66)]
+        for (const validKey of validKeys) {
+          crypto.getAddress(validKey)
+        }
+      } catch (error) {
+        expect().fail('Should not have failed to call getAddress with a valid publicKey')
+      }
+    })
+
+    it('should throw an error if the publicKey is invalid', () => {
+      const invalidKeys = ['invalid', 'a'.repeat(65), 'a'.repeat(67), 'z'.repeat(66)]
+      for (const invalidKey of invalidKeys) {
+        expect(() => crypto.getAddress(invalidKey)).toThrowError(new Error(`publicKey '${invalidKey}' is invalid`))
+      }
+    })
   })
 
   describe('verify', () => {

--- a/packages/crypto/__tests__/handlers/transactions/handler.test.js
+++ b/packages/crypto/__tests__/handlers/transactions/handler.test.js
@@ -45,7 +45,7 @@ describe('Handler', () => {
     })
 
     it('should be falsy', () => {
-      transaction.senderPublicKey = 'p'.repeat(66)
+      transaction.senderPublicKey = 'a'.repeat(66)
 
       expect(handler.canApply(wallet, transaction)).toBeFalsy()
     })
@@ -70,7 +70,7 @@ describe('Handler', () => {
     it('should not be ok', () => {
       handler.apply = jest.fn()
 
-      transaction.senderPublicKey = 'p'.repeat(66)
+      transaction.senderPublicKey = 'a'.repeat(66)
 
       const initialBalance = 1000 * ARKTOSHI
       wallet.balance = initialBalance
@@ -100,7 +100,7 @@ describe('Handler', () => {
     it('should not be ok', () => {
       handler.revert = jest.fn()
 
-      transaction.senderPublicKey = 'p'.repeat(66)
+      transaction.senderPublicKey = 'a'.repeat(66)
 
       const initialBalance = 1000 * ARKTOSHI
       wallet.balance = initialBalance

--- a/packages/crypto/__tests__/handlers/transactions/ipfs.test.js
+++ b/packages/crypto/__tests__/handlers/transactions/ipfs.test.js
@@ -23,7 +23,7 @@ describe('IpfsHandler', () => {
     })
 
     it('should not be ok', () => {
-      transaction.senderPublicKey = 'p'.repeat(66)
+      transaction.senderPublicKey = 'a'.repeat(66)
 
       expect(handler.canApply(wallet, transaction)).toBeFalsy()
     })

--- a/packages/crypto/__tests__/handlers/transactions/timelock-transfer.test.js
+++ b/packages/crypto/__tests__/handlers/transactions/timelock-transfer.test.js
@@ -23,7 +23,7 @@ describe('TimelockTransferHandler', () => {
     })
 
     it('should not be ok', () => {
-      transaction.senderPublicKey = 'p'.repeat(66)
+      transaction.senderPublicKey = 'a'.repeat(66)
 
       expect(handler.canApply(wallet, transaction)).toBeFalsy()
     })

--- a/packages/crypto/__tests__/handlers/transactions/transfer.test.js
+++ b/packages/crypto/__tests__/handlers/transactions/transfer.test.js
@@ -23,7 +23,7 @@ describe('TransferHandler', () => {
     })
 
     it('should not be ok', () => {
-      transaction.senderPublicKey = 'p'.repeat(66)
+      transaction.senderPublicKey = 'a'.repeat(66)
 
       expect(handler.canApply(wallet, transaction)).toBeFalsy()
     })

--- a/packages/crypto/__tests__/models/wallet.test.js
+++ b/packages/crypto/__tests__/models/wallet.test.js
@@ -86,7 +86,7 @@ describe('Models - Wallet', () => {
     })
 
     it('should not apply incorrect block', () => {
-      block.generatorPublicKey = 'wrong'
+      block.generatorPublicKey = 'a'.repeat(66)
       const originalWallet = Object.assign({}, testWallet)
       testWallet.applyBlock(block)
       expect(testWallet.balance).toBe(originalWallet.balance)

--- a/packages/crypto/lib/crypto/crypto.js
+++ b/packages/crypto/lib/crypto/crypto.js
@@ -237,7 +237,7 @@ class Crypto {
   /**
    * Verify transaction on the network.
    * @param  {Transaction}        transaction
-   * @param  {(Number|undefined)} network
+   * @param  {(Object|undefined)} network
    * @return {Boolean}
    */
   verify (transaction, network) {
@@ -263,7 +263,7 @@ class Crypto {
    * Verify second signature for transaction.
    * @param  {Transaction}        transaction
    * @param  {String}             publicKey
-   * @param  {(Number|undefined)} networkVersion
+   * @param  {(Object|undefined)} network
    * @return {Boolean}
    */
   verifySecondSignature (transaction, publicKey, network) {
@@ -271,14 +271,20 @@ class Crypto {
       network = configManager.config
     }
 
+    let hash
     let secondSignature
     if (transaction.version && transaction.version !== 1) {
+      hash = this.getHash(transaction)
       secondSignature = transaction.secondSignature
     } else {
+      hash = this.getHash(transaction, false, true)
       secondSignature = transaction.signSignature
     }
 
-    const hash = this.getHash(transaction, false, true)
+    if (!secondSignature) {
+      return false
+    }
+
     const secondSignatureBuffer = Buffer.from(secondSignature, 'hex')
     const publicKeyBuffer = Buffer.from(publicKey, 'hex')
     const ecpair = ECPair.fromPublicKeyBuffer(publicKeyBuffer, network)

--- a/packages/crypto/lib/crypto/crypto.js
+++ b/packages/crypto/lib/crypto/crypto.js
@@ -308,6 +308,11 @@ class Crypto {
    * @return {String}
    */
   getAddress (publicKey, networkVersion) {
+    var pubKeyRegex = /^[0-9A-Fa-f]{66}$/;
+    if (!pubKeyRegex.test(publicKey)) {
+      throw new Error(`publicKey '${publicKey}' is invalid`)
+    }
+
     if (!networkVersion) {
       networkVersion = configManager.get('pubKeyHash')
     }

--- a/packages/crypto/lib/crypto/crypto.js
+++ b/packages/crypto/lib/crypto/crypto.js
@@ -47,7 +47,7 @@ class Crypto {
 
         bb.flip()
 
-        assetBytes = new Uint8Array(bb.toArrayBuffer()).length
+        assetBytes = new Uint8Array(bb.toArrayBuffer())
         assetSize = assetBytes.length
         break
       }


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
A follow-up to the arkjs removal, where a few regressions slipped in.

This [check](https://github.com/ArkEcosystem/ark-js/blob/master/lib/transactions/crypto.js#L460) somehow didn't made it, so I added it back. Some unit tests were adjusted, since they can't just pass anything to `getAddress` anymore.

A bug in `getBytes` resulted in wrong bytes for type 1 transactions which caused block 9887 on devnet to fail verification.
 
Lastly, return early in `verifySecondSignature` if no second signature is set.



## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [ ] Docs (documentation only changes)
- [ ] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [ ] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [X] Lint and unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!--
