### PR TITLE
fix: expect many or no results from heightRange

### DIFF
--- a/packages/core-database-postgres/lib/repositories/blocks.js
+++ b/packages/core-database-postgres/lib/repositories/blocks.js
@@ -46,7 +46,7 @@ module.exports = class BlocksRepository extends Repository {
    * @return {Promise}
    */
   async heightRange (start, end) {
-    return this.db.many(sql.heightRange, { start, end })
+    return this.db.manyOrNone(sql.heightRange, { start, end })
   }
 
   /**


### PR DESCRIPTION
## Proposed changes

If a node is not yet synced this could result in no results so we need to use `heightRange`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes