### PR TITLE
chore: run tests first

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,9 +34,9 @@ before_install:
 install: yarn
 
 stages:
+  - test
   - lint
   - depcheck
-  - test
 
 before_script:
   - 'if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export DISPLAY=:99.0; fi'


### PR DESCRIPTION
## Proposed changes

Tests are more important then linting or depchecks, there is no point in waiting 10 minutes for tests to run just because of those.

## Types of changes

- [x] Build (changes that affect the build system)
- [x] Test (adding missing tests or fixing existing tests)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
