### PR TITLE
fix: multisignature keysgroup serialization

### DIFF
--- a/packages/crypto/lib/models/transaction.js
+++ b/packages/crypto/lib/models/transaction.js
@@ -220,7 +220,7 @@ module.exports = class Transaction {
       let joined = null
 
       if (!transaction.version || transaction.version === 1) {
-        joined = transaction.asset.multisignature.keysgroup.map(k => k.slice(1)).join('') // eslint-disable-line max-len
+        joined = transaction.asset.multisignature.keysgroup.map(k => k[0] === '+' ? k.slice(1) : k).join('') // eslint-disable-line max-len
       } else {
         joined = transaction.asset.multisignature.keysgroup.join('')
       }


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

The following multi signature transaction `c7778b52f808b29d7f8de036a7686e2e4bf8cbeda360ed432a26c089efbeb31b` of block `4756553835950051038` from devnet fails signature verification.

Before this would fail with `Error: couldn't parse DER signature`
```javascript
await this.getBlock('4756553835950051038')
```

The keys in the keysgroup are not prefixed with a '+', but the serializer slices off the first byte nethertheless, messing up everything once it is missing.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [X] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->
- [X] Lint and unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
