### PR TITLE
Fix API client HTTP params (query string)

### DIFF
--- a/packages/client/__tests__/http.test.js
+++ b/packages/client/__tests__/http.test.js
@@ -176,5 +176,16 @@ describe('API - HTTP Client', () => {
 
       expect(response.config).toHaveAtLeastHeaders(headers)
     })
+
+    it('should send the request params', async () => {
+      const params = { param1: 'value1', param2: 'value2' }
+
+      mock.reset()
+      mock.onDelete(`${host}/api/ENDPOINT`, { params }).reply(200, { data: [] })
+
+      const response = await client.delete('ENDPOINT', params)
+
+      expect(response.status).toBe(200)
+    })
   })
 })

--- a/packages/client/__tests__/http.test.js
+++ b/packages/client/__tests__/http.test.js
@@ -93,6 +93,17 @@ describe('API - HTTP Client', () => {
 
       expect(response.config).toHaveAtLeastHeaders(headers)
     })
+
+    it('should send the request params', async () => {
+      const params = { param1: 'value1', param2: 'value2' }
+
+      mock.reset()
+      mock.onGet(`${host}/api/ENDPOINT`, { params }).reply(200, { data: [] })
+
+      const response = await client.get('ENDPOINT', params)
+
+      expect(response.status).toBe(200)
+    })
   })
 
   describe('post', () => {

--- a/packages/client/lib/http.js
+++ b/packages/client/lib/http.js
@@ -89,7 +89,7 @@ module.exports = class HttpClient {
    * @return {Promise}
    */
   delete (path, params = {}) {
-    return this.sendRequest('delete', path, params)
+    return this.sendRequest('delete', path, { params })
   }
 
   /**

--- a/packages/client/lib/http.js
+++ b/packages/client/lib/http.js
@@ -49,7 +49,7 @@ module.exports = class HttpClient {
    * @return {Promise}
    */
   get (path, params = {}) {
-    return this.sendRequest('get', path, params)
+    return this.sendRequest('get', path, { params })
   }
 
   /**


### PR DESCRIPTION
## Proposed changes
The API client wasn't sending the GET and DELETE query string parameters.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Test (adding missing tests or fixing existing tests)
