### PR TITLE
Fix graphql queries which were not working after postgres migration + re-enable tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -12,7 +12,7 @@ module.exports = {
     '**/packages/core-deployer/**/__tests__/**/*.test.js',
     '**/packages/core-event-emitter/**/__tests__/**/*.test.js',
     '**/packages/core-forger/**/__tests__/**/*.test.js',
-    // '**/packages/core-graphql/**/__tests__/**/*.test.js',
+    '**/packages/core-graphql/**/__tests__/**/*.test.js',
     '**/packages/core-json-rpc/**/__tests__/**/*.test.js',
     '**/packages/core-logger-winston/**/__tests__/**/*.test.js',
     '**/packages/core-logger/**/__tests__/**/*.test.js',

--- a/packages/core-graphql/lib/repositories/blocks.js
+++ b/packages/core-graphql/lib/repositories/blocks.js
@@ -1,0 +1,132 @@
+'use strict'
+
+const container = require('@arkecosystem/core-container')
+const database = container.resolvePlugin('database')
+
+const buildFilterQuery = require('./utils/filter-query')
+const Repository = require('./repository')
+
+class BlocksRepository extends Repository {
+  /**
+   * Get all blocks for the given parameters.
+   * @param  {Object}  parameters
+   * @return {Object}
+   */
+  async findAll (parameters = {}) {
+    const selectQuery = this.query.select().from(this.query)
+    const countQuery = this._makeEstimateQuery()
+
+    const applyConditions = queries => {
+      const conditions = Object.entries(this._formatConditions(parameters))
+
+      if (conditions.length) {
+        const first = conditions.shift()
+
+        for (const item of queries) {
+          item.where(this.query[first[0]].equals(first[1]))
+
+          for (const condition of conditions) {
+            item.and(this.query[condition[0]].equals(condition[1]))
+          }
+        }
+      }
+    }
+
+    applyConditions([selectQuery, countQuery])
+
+    return this._findManyWithCount(selectQuery, countQuery, {
+      limit: parameters.limit || 100,
+      offset: parameters.offset || 0,
+      orderBy: this.__orderBy(parameters)
+    })
+  }
+
+  /**
+   * Get all blocks for the given generator.
+   * @param  {String} generatorPublicKey
+   * @param  {Object} paginator
+   * @return {Object}
+   */
+  async findAllByGenerator (generatorPublicKey, paginator) {
+    return this.findAll({...{ generatorPublicKey }, ...paginator})
+  }
+
+  /**
+   * Get a block.
+   * @param  {Number} id
+   * @return {Object}
+   */
+  async findById (id) {
+    const query = this.query
+      .select()
+      .from(this.query)
+      .where(this.query.id.equals(id))
+
+    return this._find(query)
+  }
+
+  /**
+   * Get the last block for the given generator.
+   * TODO is this right?
+   * @param  {String} generatorPublicKey
+   * @return {Object}
+   */
+  async findLastByPublicKey (generatorPublicKey) {
+    const query = this.query
+      .select(this.query.id, this.query.timestamp)
+      .from(this.query)
+      .where(this.query.generator_public_key.equals(generatorPublicKey))
+      .order(this.query.created_at.desc)
+
+    return this._find(query)
+  }
+
+  /**
+   * Search all blocks.
+   * @param  {Object} parameters
+   * @return {Object}
+   */
+  async search (parameters) {
+    const selectQuery = this.query.select().from(this.query)
+    const countQuery = this._makeEstimateQuery()
+
+    const applyConditions = queries => {
+      const conditions = buildFilterQuery(this._formatConditions(parameters), {
+        exact: ['id', 'version', 'previous_block', 'payload_hash', 'generator_public_key', 'block_signature'],
+        between: ['timestamp', 'height', 'number_of_transactions', 'total_amount', 'total_fee', 'reward', 'payload_length']
+      })
+
+      if (conditions.length) {
+        const first = conditions.shift()
+
+        for (const item of queries) {
+          item.where(this.query[first.column][first.method](first.value))
+
+          for (const condition of conditions) {
+            item.and(this.query[condition.column][condition.method](condition.value))
+          }
+        }
+      }
+    }
+
+    applyConditions([selectQuery, countQuery])
+
+    return this._findManyWithCount(selectQuery, countQuery, {
+      limit: parameters.limit,
+      offset: parameters.offset,
+      orderBy: this.__orderBy(parameters)
+    })
+  }
+
+  getModel () {
+    return database.models.block
+  }
+
+  __orderBy (parameters) {
+    return parameters.orderBy
+      ? parameters.orderBy.split(':')
+      : ['height', 'desc']
+  }
+}
+
+module.exports = new BlocksRepository()

--- a/packages/core-graphql/lib/repositories/index.js
+++ b/packages/core-graphql/lib/repositories/index.js
@@ -1,0 +1,4 @@
+module.exports = {
+  blocks: require('./blocks'),
+  transactions: require('./transactions')
+}

--- a/packages/core-graphql/lib/repositories/repository.js
+++ b/packages/core-graphql/lib/repositories/repository.js
@@ -1,0 +1,71 @@
+'use strict'
+
+const container = require('@arkecosystem/core-container')
+const database = container.resolvePlugin('database')
+
+module.exports = class Repository {
+  constructor () {
+    this.cache = database.getCache()
+    this.model = this.getModel()
+    this.query = this.model.query()
+  }
+
+  async _find (query) {
+    return database.query.oneOrNone(query.toQuery())
+  }
+
+  async _findMany (query) {
+    return database.query.manyOrNone(query.toQuery())
+  }
+
+  async _findManyWithCount (selectQuery, countQuery, { limit, offset, orderBy }) {
+    const { count } = await this._find(countQuery)
+
+    selectQuery
+      .order(this.query[orderBy[0]][orderBy[1]])
+      .offset(offset)
+      .limit(limit)
+
+      limit = 100
+      offset = 0
+      const rows = await this._findMany(selectQuery)
+    return {
+      rows: rows,
+      count: +count
+    }
+  }
+
+  _makeCountQuery () {
+    return this.query
+      .select('count(*) AS count')
+      .from(this.query)
+  }
+
+  _makeEstimateQuery () {
+    return this.query
+      .select('count(*) AS count')
+      .from(`${this.model.getTable()} TABLESAMPLE SYSTEM (100)`)
+  }
+
+  _formatConditions (parameters) {
+    const columns = this.model.getColumnSet().columns.map(column => ({
+      name: column.name,
+      prop: column.prop || column.name
+    }))
+
+    const columnNames = columns.map(column => column.name)
+    const columnProps = columns.map(column => column.prop)
+
+    const filter = args => args.filter(arg => {
+      return columnNames.includes(arg) || columnProps.includes(arg)
+    })
+
+    return filter(Object.keys(parameters)).reduce((items, item) => {
+      const columnName = columns.find(column => (column.prop === item)).name
+
+      items[columnName] = parameters[item]
+
+      return items
+    }, {})
+  }
+}

--- a/packages/core-graphql/lib/repositories/transactions.js
+++ b/packages/core-graphql/lib/repositories/transactions.js
@@ -1,0 +1,432 @@
+'use strict'
+
+const container = require('@arkecosystem/core-container')
+const database = container.resolvePlugin('database')
+
+const moment = require('moment')
+const { slots } = require('@arkecosystem/crypto')
+const { TRANSACTION_TYPES } = require('@arkecosystem/crypto').constants
+const buildFilterQuery = require('./utils/filter-query')
+const Repository = require('./repository')
+
+class TransactionsRepository extends Repository {
+  /**
+   * Get all transactions.
+   * @param  {Object}  params
+   * @return {Object}
+   */
+  async findAll (parameters = {}) {
+    const selectQuery = this.query.select().from(this.query)
+    const countQuery = this._makeEstimateQuery()
+
+    if (parameters.senderId) {
+      const senderPublicKey = this.__publicKeyFromSenderId(parameters.senderId)
+
+      if (!senderPublicKey) {
+        return { rows: [], count: 0 }
+      }
+
+      parameters.senderPublicKey = senderPublicKey
+    }
+
+    const applyConditions = queries => {
+      const conditions = Object.entries(this._formatConditions(parameters))
+
+      if (conditions.length) {
+        const first = conditions.shift()
+
+        for (const item of queries) {
+          item.where(this.query[first[0]].equals(first[1]))
+
+          for (const condition of conditions) {
+            item.and(this.query[condition[0]].equals(condition[1]))
+          }
+        }
+      }
+    }
+
+    applyConditions([selectQuery, countQuery])
+
+    const results = await this._findManyWithCount(selectQuery, countQuery, {
+      limit: parameters.limit || 100,
+      offset: parameters.offset || 0,
+      orderBy: this.__orderBy(parameters)
+    })
+
+    results.rows = await this.__mapBlocksToTransactions(results.rows)
+    return results
+  }
+
+  /**
+   * Get all transactions (LEGACY, for V1 only).
+   * @param  {Object}  params
+   * @return {Object}
+   */
+  async findAllLegacy (parameters = {}) {
+    const selectQuery = this.query
+      .select(this.query.block_id, this.query.serialized)
+      .from(this.query)
+    const countQuery = this._makeEstimateQuery()
+
+    if (parameters.senderId) {
+      parameters.senderPublicKey = this.__publicKeyFromSenderId(parameters.senderId)
+    }
+
+    const applyConditions = queries => {
+      const conditions = Object.entries(this._formatConditions(parameters))
+
+      if (conditions.length) {
+        const first = conditions.shift()
+
+        for (const item of queries) {
+          item.where(this.query[first[0]].equals(first[1]))
+
+          for (const [key, value] of conditions) {
+            item.or(this.query[key].equals(value))
+          }
+        }
+      }
+    }
+
+    applyConditions([selectQuery, countQuery])
+
+    const results = await this._findManyWithCount(selectQuery, countQuery, {
+      limit: parameters.limit,
+      offset: parameters.offset,
+      orderBy: this.__orderBy(parameters)
+    })
+
+    results.rows = await this.__mapBlocksToTransactions(results.rows)
+
+    return results
+  }
+
+  /**
+   * Get all transactions for the given Wallet object.
+   * @param  {Wallet} wallet
+   * @param  {Object} parameters
+   * @return {Object}
+   */
+  async findAllByWallet (wallet, parameters = {}) {
+    const selectQuery = this.query
+      .select(this.query.block_id, this.query.serialized)
+      .from(this.query)
+    const countQuery = this._makeEstimateQuery()
+
+    const applyConditions = queries => {
+      for (const item of queries) {
+        item
+          .where(this.query.sender_public_key.equals(wallet.publicKey))
+          .or(this.query.recipient_id.equals(wallet.address))
+      }
+    }
+
+    applyConditions([selectQuery, countQuery])
+
+    const results = await this._findManyWithCount(selectQuery, countQuery, {
+      limit: parameters.limit,
+      offset: parameters.offset,
+      orderBy: this.__orderBy(parameters)
+    })
+
+    results.rows = await this.__mapBlocksToTransactions(results.rows)
+
+    return results
+  }
+
+  /**
+   * Get all transactions for the given sender public key.
+   * @param  {String} senderPublicKey
+   * @param  {Object} parameters
+   * @return {Object}
+   */
+  async findAllBySender (senderPublicKey, parameters = {}) {
+    return this.findAll({...{senderPublicKey}, ...parameters})
+  }
+
+  /**
+   * Get all transactions for the given recipient address.
+   * @param  {String} recipientId
+   * @param  {Object} parameters
+   * @return {Object}
+   */
+  async findAllByRecipient (recipientId, parameters = {}) {
+    return this.findAll({...{recipientId}, ...parameters})
+  }
+
+  /**
+   * Get all vote transactions for the given sender public key.
+   * TODO rename to findAllVotesBySender or not?
+   * @param  {String} senderPublicKey
+   * @param  {Object} parameters
+   * @return {Object}
+   */
+  async allVotesBySender (senderPublicKey, parameters = {}) {
+    return this.findAll({...{senderPublicKey, type: TRANSACTION_TYPES.VOTE}, ...parameters})
+  }
+
+  /**
+   * Get all transactions for the given block.
+   * @param  {Number} blockId
+   * @param  {Object} parameters
+   * @return {Object}
+   */
+  async findAllByBlock (blockId, parameters = {}) {
+    return this.findAll({...{blockId}, ...parameters})
+  }
+
+  /**
+   * Get all transactions for the given type.
+   * @param  {Number} type
+   * @param  {Object} parameters
+   * @return {Object}
+   */
+  async findAllByType (type, parameters = {}) {
+    return this.findAll({...{type}, ...parameters})
+  }
+
+  /**
+   * Get a transaction.
+   * @param  {Number} id
+   * @return {Object}
+   */
+  async findById (id) {
+    const query = this.query
+      .select(this.query.block_id, this.query.serialized)
+      .from(this.query)
+      .where(this.query.id.equals(id))
+
+    const transaction = await this._find(query)
+
+    return this.__mapBlocksToTransactions(transaction)
+  }
+
+  /**
+   * Get a transactions for the given type and id.
+   * @param  {Number} type
+   * @param  {Number} id
+   * @return {Object}
+   */
+  async findByTypeAndId (type, id) {
+    const query = this.query
+      .select(this.query.block_id, this.query.serialized)
+      .from(this.query)
+      .where(this.query.id.equals(id).and(this.query.type.equals(type)))
+
+    const transaction = await this._find(query)
+
+    return this.__mapBlocksToTransactions(transaction)
+  }
+
+  /**
+   * Get transactions for the given ids.
+   * @param  {Array} ids
+   * @return {Object}
+   */
+  async findByIds (ids) {
+    const query = this.query
+      .select(this.query.block_id, this.query.serialized)
+      .from(this.query)
+      .where(this.query.id.in(ids))
+
+    return this._findMany(query)
+  }
+
+  /**
+   * Get all transactions that have a vendor field.
+   * @return {Object}
+   */
+  async findWithVendorField () {
+    const query = this.query
+      .select(this.query.block_id, this.query.serialized)
+      .from(this.query)
+      .where(this.query.vendor_field_hex.isNotNull())
+
+    const transactions = await this._findMany(query)
+
+    return this.__mapBlocksToTransactions(transactions)
+  }
+
+  /**
+   * Calculates min, max and average fee statistics based on transactions table
+   * @return {Object}
+   */
+  async getFeeStatistics () {
+    const query = this.query
+      .select(
+        this.query.type,
+        this.query.fee.min('minFee'),
+        this.query.fee.max('maxFee'),
+        this.query.fee.avg('avgFee'),
+        this.query.timestamp.max('timestamp')
+      )
+      .from(this.query)
+      .where(this.query.timestamp.gte(slots.getTime(moment().subtract(30, 'days'))))
+      .group(this.query.type)
+      .order('"timestamp" DESC')
+
+    return this._findMany(query)
+  }
+
+  /**
+   * Search all transactions.
+   *
+   * @param  {Object} params
+   * @return {Object}
+   */
+  async search (parameters) {
+    const selectQuery = this.query.select().from(this.query)
+    const countQuery = this._makeEstimateQuery()
+
+    if (parameters.senderId) {
+      const senderPublicKey = this.__publicKeyFromSenderId(parameters.senderId)
+
+      if (senderPublicKey) {
+        parameters.senderPublicKey = senderPublicKey
+      }
+    }
+
+    const applyConditions = queries => {
+      const conditions = buildFilterQuery(this._formatConditions(parameters), {
+        exact: ['id', 'block_id', 'type', 'version', 'sender_public_key', 'recipient_id'],
+        between: ['timestamp', 'amount', 'fee'],
+        wildcard: ['vendor_field_hex']
+      })
+
+      if (conditions.length) {
+        const first = conditions.shift()
+
+        for (const item of queries) {
+          item.where(this.query[first.column][first.method](first.value))
+
+          for (const condition of conditions) {
+            item.and(this.query[condition.column][condition.method](condition.value))
+          }
+        }
+      }
+    }
+
+    applyConditions([selectQuery, countQuery])
+
+    const results = await this._findManyWithCount(selectQuery, countQuery, {
+      limit: parameters.limit,
+      offset: parameters.offset,
+      orderBy: this.__orderBy(parameters)
+    })
+
+    results.rows = await this.__mapBlocksToTransactions(results.rows)
+
+    return results
+  }
+
+  getModel () {
+    return database.models.transaction
+  }
+
+  /**
+   * [__mapBlocksToTransactions description]
+   * @param  {Array|Object} data
+   * @return {Object}
+   */
+  async __mapBlocksToTransactions (data) {
+    const blockQuery = database.models.block.query()
+
+    // Array...
+    if (Array.isArray(data)) {
+      // 1. get heights from cache
+      const missingFromCache = []
+
+      for (let i = 0; i < data.length; i++) {
+        const cachedBlock = await this.__getBlockCache(data[i].blockId)
+
+        if (cachedBlock) {
+          data[i].block = cachedBlock
+        } else {
+          missingFromCache.push({
+            index: i,
+            blockId: data[i].blockId
+          })
+        }
+      }
+
+      // 2. get missing heights from database
+      if (missingFromCache.length) {
+        const query = blockQuery
+          .select(blockQuery.id, blockQuery.height)
+          .from(blockQuery)
+          .where(blockQuery.id.in(missingFromCache.map(d => d.blockId)))
+          .group(blockQuery.id)
+
+        const blocks = await this._findMany(query)
+
+        for (const missing of missingFromCache) {
+          const block = blocks.find(block => (block.id === missing.blockId))
+          if (block) {
+            data[missing.index].block = block
+            this.__setBlockCache(block)
+          }
+        }
+      }
+
+      return data
+    }
+
+    // Object...
+    if (data) {
+      const cachedBlock = await this.__getBlockCache(data.blockId)
+
+      if (cachedBlock) {
+        data.block = cachedBlock
+      } else {
+        const query = blockQuery
+          .select(blockQuery.id, blockQuery.height)
+          .from(blockQuery)
+          .where(blockQuery.id.equals(data.blockId))
+
+        data.block = await this._find(query)
+
+        this.__setBlockCache(data.block)
+      }
+    }
+
+    return data
+  }
+
+  /**
+   * Tries to retrieve the height of the block from the cache
+   * @param  {String} blockId
+   * @return {Object|null}
+   */
+  async __getBlockCache (blockId) {
+    const height = await this.cache.get(`heights:${blockId}`)
+
+    return height ? ({ height, id: blockId }) : null
+  }
+
+  /**
+   * Stores the height of the block on the cache
+   * @param  {Object} block
+   * @param  {String} block.id
+   * @param  {Number} block.height
+   */
+  __setBlockCache ({ id, height }) {
+    this.cache.set(`heights:${id}`, height)
+  }
+
+  /**
+   * Retrieves the publicKey of the address from the WalletManager in-memory data
+   * @param {String} senderId
+   * @return {String}
+   */
+  __publicKeyFromSenderId (senderId) {
+    return database.walletManager.findByAddress(senderId).publicKey
+  }
+
+  __orderBy (parameters) {
+    return parameters.orderBy
+      ? parameters.orderBy.split(':')
+      : ['timestamp', 'desc']
+  }
+}
+
+module.exports = new TransactionsRepository()

--- a/packages/core-graphql/lib/repositories/utils/filter-query.js
+++ b/packages/core-graphql/lib/repositories/utils/filter-query.js
@@ -1,0 +1,73 @@
+'use strict'
+
+/**
+ * Create a "where" object for a sql query.
+ * @param  {Object} parameters
+ * @param  {Object} filters
+ * @return {Object}
+ */
+module.exports = (parameters, filters) => {
+  let where = []
+
+  if (filters.hasOwnProperty('exact')) {
+    for (const elem of filters['exact']) {
+      if (typeof parameters[elem] !== 'undefined') {
+        where.push({
+          column: elem,
+          method: 'equals',
+          value: parameters[elem]
+        })
+      }
+    }
+  }
+
+  if (filters.hasOwnProperty('between')) {
+    for (const elem of filters['between']) {
+      if (!parameters[elem]) {
+        continue
+      }
+
+      if (!parameters[elem].hasOwnProperty('from') && !parameters[elem].hasOwnProperty('to')) {
+        where.push({
+          column: elem,
+          method: 'equals',
+          value: parameters[elem]
+        })
+      }
+
+      if (parameters[elem].hasOwnProperty('from') || parameters[elem].hasOwnProperty('to')) {
+        where[elem] = {}
+
+        if (parameters[elem].hasOwnProperty('from')) {
+          where.push({
+            column: elem,
+            method: 'gte',
+            value: parameters[elem].from
+          })
+        }
+
+        if (parameters[elem].hasOwnProperty('to')) {
+          where.push({
+            column: elem,
+            method: 'lte',
+            value: parameters[elem].to
+          })
+        }
+      }
+    }
+  }
+
+  if (filters.hasOwnProperty('wildcard')) {
+    for (const elem of filters['wildcard']) {
+      if (parameters[elem]) {
+        where.push({
+          column: elem,
+          method: 'like',
+          value: `%${parameters[elem]}%`
+        })
+      }
+    }
+  }
+
+  return where
+}

--- a/packages/core-graphql/lib/resolvers/queries/block/block.js
+++ b/packages/core-graphql/lib/resolvers/queries/block/block.js
@@ -6,4 +6,4 @@ const database = require('@arkecosystem/core-container').resolvePlugin('database
  * Get a single block from the database
  * @return {Block}
  */
-module.exports = (_, { id }) => database.blocks.findById(id)
+module.exports = (_, { id }) => database.db.blocks.findById(id)

--- a/packages/core-graphql/lib/resolvers/queries/block/blocks.js
+++ b/packages/core-graphql/lib/resolvers/queries/block/blocks.js
@@ -1,18 +1,18 @@
 'use strict';
 
-const database = require('@arkecosystem/core-container').resolvePlugin('database')
 const { formatOrderBy } = require('../../../helpers')
+const { blocks: repository } = require('../../../repositories')
 
 /**
  * Get multiple blocks from the database
  * @return {Block[]}
  */
 module.exports = async (_, args) => {
-  const { orderBy, filter, ...params } = args
+  const { orderBy, filter } = args
 
-  const order = formatOrderBy(orderBy, 'height:DESC')
+  const order = formatOrderBy(orderBy, 'height:desc')
 
-  const result = await database.blocks.findAll({ ...filter, orderBy: order, ...params }, false)
+  const result = await repository.findAll({ ...filter, orderBy: order })
 
   return result ? result.rows : []
 }

--- a/packages/core-graphql/lib/resolvers/queries/transaction/transaction.js
+++ b/packages/core-graphql/lib/resolvers/queries/transaction/transaction.js
@@ -1,15 +1,9 @@
 'use strict';
 
 const database = require('@arkecosystem/core-container').resolvePlugin('database')
-const { unserializeTransactions } = require('../../../helpers')
 
 /**
  * Get a single transaction from the database
  * @return {Transaction}
  */
-module.exports = async (_, { id }) => {
-  const result = await database.transactions.findById(id)
-  const transaction = unserializeTransactions(result.serialized)
-
-  return transaction
-}
+module.exports = async (_, { id }) => database.db.transactions.findById(id)

--- a/packages/core-graphql/lib/resolvers/queries/transaction/transactions.js
+++ b/packages/core-graphql/lib/resolvers/queries/transaction/transactions.js
@@ -1,23 +1,18 @@
 'use strict';
 
-const database = require('@arkecosystem/core-container').resolvePlugin('database')
-const { constants } = require('@arkecosystem/crypto')
-const { formatOrderBy, unserializeTransactions } = require('../../../helpers')
+const { formatOrderBy } = require('../../../helpers')
+const { transactions: repository } = require('../../../repositories')
 
 /**
  * Get multiple transactions from the database
  * @return {Transaction[]}
  */
 module.exports = async (root, args) => {
-  const { orderBy, filter, ...params } = args
+  const { orderBy, filter } = args
 
-  const order = formatOrderBy(orderBy, 'timestamp:DESC')
+  const order = formatOrderBy(orderBy, 'timestamp:desc')
 
-  if (params.type) {
-    params.type = constants.TRANSACTION_TYPES[params.type]
-  }
-
-  const result = await database.transactions.findAll({ ...filter, orderBy: order, ...params }, false)
+  const result = await repository.findAll({ ...filter, orderBy: order })
   const transactions = result ? result.rows : []
-  return unserializeTransactions(transactions)
+  return transactions
 }

--- a/packages/core-graphql/package.json
+++ b/packages/core-graphql/package.json
@@ -25,7 +25,8 @@
     "hapi": "^17.5.0",
     "inert": "^5.1.0",
     "lout": "^11.0.1",
-    "vision": "^5.3.2"
+    "vision": "^5.3.2",
+    "moment": "^2.22.1"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Proposed changes

Fix graphql queries which were not working after postgres migration + re-enable tests.

Added a `repositories` folder where queries are built (copy-pasted from core-api). This might need some rework to keep only what is needed.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Test (adding missing tests or fixing existing tests)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes