### PR TITLE
Fix how the client connects to endpoints depending on the API version

### DIFF
--- a/packages/client/__tests__/client.test.js
+++ b/packages/client/__tests__/client.test.js
@@ -5,7 +5,7 @@ const { arrayContaining } = expect
 
 const Client = require('../lib')
 const HttpClient = require('../lib/http')
-const ApiResource = require('../lib/resources/v1/transactions')
+const TransactionsResource = require('../lib/resources/v2/transactions')
 const initialPeers = require('../lib/peers')
 
 // https://github.com/facebook/jest/issues/3601
@@ -17,7 +17,7 @@ const { peers, peersOverride } = require('./fixtures/peers')
 let client
 
 beforeEach(() => {
-  client = (new Client(host))
+  client = (new Client(host, 2))
 })
 
 describe('API - Client', () => {
@@ -31,10 +31,11 @@ describe('API - Client', () => {
     })
 
     it('should return an API resource', () => {
-      expect(client.resource('transactions')).toBeInstanceOf(ApiResource)
+      expect(client.resource('transactions')).toBeInstanceOf(TransactionsResource)
     })
 
     it('should use 1 as the default API version', () => {
+      client = (new Client(host))
       expect(client.version).toBe(1)
     })
 
@@ -51,15 +52,15 @@ describe('API - Client', () => {
 
   describe('setVersion', () => {
     it('should set the API version', () => {
-      client.setVersion(2)
+      client.setVersion(1)
 
-      expect(client.version).toBe(2)
+      expect(client.version).toBe(1)
     })
 
     it('should set the API version of the HTTP client too', () => {
-      client.setVersion(2)
+      client.setVersion(1)
 
-      expect(client.http.version).toBe(2)
+      expect(client.http.version).toBe(1)
     })
 
     it('should throw an Error if the API version is falsy', async () => {
@@ -82,10 +83,10 @@ describe('API - Client', () => {
       }
 
       peers.forEach(peer => {
-        httpMock.onGet(/http.*\/api\/peers/).reply(200, { data })
+        httpMock.onGet(/http.*\/api\/v2\/peers/).reply(200, { data })
       })
 
-      const foundPeers = await Client.findPeers('devnet')
+      const foundPeers = await Client.findPeers('devnet', 2)
       expect(foundPeers).toEqual([
         peers[1],
         peers[3],
@@ -112,10 +113,10 @@ describe('API - Client', () => {
         }
 
         peers.forEach(peer => {
-          httpMock.onGet(/http.*\/api\/peers/).reply(200, { data })
+          httpMock.onGet(/http.*\/api\/v2\/peers/).reply(200, { data })
         })
 
-        const foundPeers = await Client.findPeers('devnet')
+        const foundPeers = await Client.findPeers('devnet', 2)
         expect(foundPeers).toEqual(arrayContaining(peers))
         expect(foundPeers).not.toContainEqual(localPeer)
       }
@@ -135,10 +136,10 @@ describe('API - Client', () => {
       }
 
       peers.forEach(peer => {
-        httpMock.onGet(/http.*\/api\/peers/).reply(200, { data })
+        httpMock.onGet(/http.*\/api\/v2\/peers/).reply(200, { data })
       })
 
-      const foundPeers = await Client.findPeers('devnet')
+      const foundPeers = await Client.findPeers('devnet', 2)
       expect(foundPeers).toEqual(arrayContaining(peers))
       expect(foundPeers).not.toContainEqual(notOkPeer)
     })
@@ -151,12 +152,12 @@ describe('API - Client', () => {
     describe('when the request to find peers fails', () => {
       beforeEach(() => {
         peers.forEach(peer => {
-          httpMock.onGet(/http.*\/api\/peers/).reply(500)
+          httpMock.onGet(/http.*\/api\/v2\/peers/).reply(500)
         })
       })
 
       it('returns the list of initial (hardcoded) peers', async () => {
-        const foundPeers = await Client.findPeers('devnet')
+        const foundPeers = await Client.findPeers('devnet', 2)
         expect(foundPeers).not.toEqual(arrayContaining(peers))
         expect(foundPeers).toEqual(arrayContaining(initialPeers.devnet))
       })
@@ -192,10 +193,10 @@ describe('API - Client', () => {
         peers
       }
       peers.forEach(peer => {
-        httpMock.onGet(/http.*\/api\/peers/).reply(200, { data })
+        httpMock.onGet(/http.*\/api\/v2\/peers/).reply(200, { data })
       })
 
-      const client = await Client.connect('devnet')
+      const client = await Client.connect('devnet', 2)
       expect(client.getConnection().host).toEqual(`http://${peers[1].ip}:${peers[1].port}`)
     })
   })

--- a/packages/client/__tests__/http.test.js
+++ b/packages/client/__tests__/http.test.js
@@ -2,9 +2,6 @@ const axios = require('axios')
 const MockAdapter = require('axios-mock-adapter')
 const mock = new MockAdapter(axios)
 
-const toHaveAtLeastHeaders = require('./matchers/http/headers')
-expect.extend({ toHaveAtLeastHeaders })
-
 const HttpClient = require('../lib/http')
 
 const host = 'http://example.net'
@@ -15,14 +12,6 @@ beforeEach(() => {
 })
 
 describe('API - HTTP Client', () => {
-  let headers
-
-  beforeEach(() => {
-    headers = {
-      'API-Version': client.version
-    }
-  })
-
   describe('constructor', () => {
     it('should be instantiated', () => {
       expect(client).toBeInstanceOf(HttpClient)
@@ -77,9 +66,25 @@ describe('API - HTTP Client', () => {
     })
   })
 
+  describe('sendRequest', () => {
+    it('should infer the API URL from the version', async () => {
+      client.setVersion(1)
+      mock.onGet(`${host}/api/ENDPOINT`).reply(200, { data: [] })
+
+      let response = await client.sendRequest('get', 'ENDPOINT')
+      expect(response.status).toBe(200)
+
+      client.setVersion(2)
+      mock.onGet(`${host}/api/v2/ENDPOINT`).reply(200, { data: [] })
+
+      response = await client.sendRequest('get', 'ENDPOINT')
+      expect(response.status).toBe(200)
+    })
+  })
+
   describe('get', () => {
     beforeEach(() => {
-      mock.onGet(`${host}/api/ENDPOINT`).reply(200, { data: [] })
+      mock.onGet(`${host}/api/v2/ENDPOINT`).reply(200, { data: [] })
     })
 
     it('should send GET requests to the API', async () => {
@@ -88,17 +93,11 @@ describe('API - HTTP Client', () => {
       expect(response.status).toBe(200)
     })
 
-    it('should use the necessary request headers', async () => {
-      const response = await client.get('ENDPOINT')
-
-      expect(response.config).toHaveAtLeastHeaders(headers)
-    })
-
     it('should send the request params', async () => {
       const params = { param1: 'value1', param2: 'value2' }
 
       mock.reset()
-      mock.onGet(`${host}/api/ENDPOINT`, { params }).reply(200, { data: [] })
+      mock.onGet(`${host}/api/v2/ENDPOINT`, { params }).reply(200, { data: [] })
 
       const response = await client.get('ENDPOINT', params)
 
@@ -108,7 +107,7 @@ describe('API - HTTP Client', () => {
 
   describe('post', () => {
     beforeEach(() => {
-      mock.onPost(`${host}/api/ENDPOINT`).reply(200, { data: [] })
+      mock.onPost(`${host}/api/v2/ENDPOINT`).reply(200, { data: [] })
     })
 
     it('should send POST requests to the API', async () => {
@@ -116,17 +115,11 @@ describe('API - HTTP Client', () => {
 
       expect(response.status).toBe(200)
     })
-
-    it('should use the necessary request headers', async () => {
-      const response = await client.post('ENDPOINT')
-
-      expect(response.config).toHaveAtLeastHeaders(headers)
-    })
   })
 
   describe('put', () => {
     beforeEach(() => {
-      mock.onPut(`${host}/api/ENDPOINT`).reply(200, { data: [] })
+      mock.onPut(`${host}/api/v2/ENDPOINT`).reply(200, { data: [] })
     })
 
     it('should send PUT requests to the API', async () => {
@@ -134,17 +127,11 @@ describe('API - HTTP Client', () => {
 
       expect(response.status).toBe(200)
     })
-
-    it('should use the necessary request headers', async () => {
-      const response = await client.put('ENDPOINT')
-
-      expect(response.config).toHaveAtLeastHeaders(headers)
-    })
   })
 
   describe('patch', () => {
     beforeEach(() => {
-      mock.onPatch(`${host}/api/ENDPOINT`).reply(200, { data: [] })
+      mock.onPatch(`${host}/api/v2/ENDPOINT`).reply(200, { data: [] })
     })
 
     it('should send PATCH requests to the API', async () => {
@@ -152,17 +139,11 @@ describe('API - HTTP Client', () => {
 
       expect(response.status).toBe(200)
     })
-
-    it('should use the necessary request headers', async () => {
-      const response = await client.patch('ENDPOINT')
-
-      expect(response.config).toHaveAtLeastHeaders(headers)
-    })
   })
 
   describe('delete', () => {
     beforeEach(() => {
-      mock.onDelete(`${host}/api/ENDPOINT`).reply(200, { data: [] })
+      mock.onDelete(`${host}/api/v2/ENDPOINT`).reply(200, { data: [] })
     })
 
     it('should send DELETE requests to the API', async () => {
@@ -171,17 +152,11 @@ describe('API - HTTP Client', () => {
       expect(response.status).toBe(200)
     })
 
-    it('should use the necessary request headers', async () => {
-      const response = await client.delete('ENDPOINT')
-
-      expect(response.config).toHaveAtLeastHeaders(headers)
-    })
-
     it('should send the request params', async () => {
       const params = { param1: 'value1', param2: 'value2' }
 
       mock.reset()
-      mock.onDelete(`${host}/api/ENDPOINT`, { params }).reply(200, { data: [] })
+      mock.onDelete(`${host}/api/v2/ENDPOINT`, { params }).reply(200, { data: [] })
 
       const response = await client.delete('ENDPOINT', params)
 

--- a/packages/client/__tests__/mocks/v2/blocks.js
+++ b/packages/client/__tests__/mocks/v2/blocks.js
@@ -1,6 +1,6 @@
 module.exports = (mock, host) => {
-  mock.onGet(`${host}/api/blocks`).reply(200, { data: [] })
-  mock.onGet(`${host}/api/blocks/123`).reply(200, { data: [] })
-  mock.onGet(`${host}/api/blocks/123/transactions`).reply(200, { data: [] })
-  mock.onPost(`${host}/api/blocks/search`).reply(200, { data: [] })
+  mock.onGet(`${host}/api/v2/blocks`).reply(200, { data: [] })
+  mock.onGet(`${host}/api/v2/blocks/123`).reply(200, { data: [] })
+  mock.onGet(`${host}/api/v2/blocks/123/transactions`).reply(200, { data: [] })
+  mock.onPost(`${host}/api/v2/blocks/search`).reply(200, { data: [] })
 }

--- a/packages/client/__tests__/mocks/v2/delegates.js
+++ b/packages/client/__tests__/mocks/v2/delegates.js
@@ -1,6 +1,6 @@
 module.exports = (mock, host) => {
-  mock.onGet(`${host}/api/delegates`).reply(200, { data: [] })
-  mock.onGet(`${host}/api/delegates/123`).reply(200, { data: [] })
-  mock.onGet(`${host}/api/delegates/123/blocks`).reply(200, { data: [] })
-  mock.onGet(`${host}/api/delegates/123/voters`).reply(200, { data: [] })
+  mock.onGet(`${host}/api/v2/delegates`).reply(200, { data: [] })
+  mock.onGet(`${host}/api/v2/delegates/123`).reply(200, { data: [] })
+  mock.onGet(`${host}/api/v2/delegates/123/blocks`).reply(200, { data: [] })
+  mock.onGet(`${host}/api/v2/delegates/123/voters`).reply(200, { data: [] })
 }

--- a/packages/client/__tests__/mocks/v2/multisignatures.js
+++ b/packages/client/__tests__/mocks/v2/multisignatures.js
@@ -1,5 +1,5 @@
 module.exports = (mock, host) => {
-  mock.onGet(`${host}/api/multisignatures`).reply(200, { data: [] })
-  mock.onGet(`${host}/api/multisignatures/pending`).reply(200, { data: [] })
-  mock.onGet(`${host}/api/multisignatures/wallets`).reply(200, { data: [] })
+  mock.onGet(`${host}/api/v2/multisignatures`).reply(200, { data: [] })
+  mock.onGet(`${host}/api/v2/multisignatures/pending`).reply(200, { data: [] })
+  mock.onGet(`${host}/api/v2/multisignatures/wallets`).reply(200, { data: [] })
 }

--- a/packages/client/__tests__/mocks/v2/node.js
+++ b/packages/client/__tests__/mocks/v2/node.js
@@ -1,5 +1,5 @@
 module.exports = (mock, host) => {
-  mock.onGet(`${host}/api/node/status`).reply(200, { data: [] })
-  mock.onGet(`${host}/api/node/syncing`).reply(200, { data: [] })
-  mock.onGet(`${host}/api/node/configuration`).reply(200, { data: [] })
+  mock.onGet(`${host}/api/v2/node/status`).reply(200, { data: [] })
+  mock.onGet(`${host}/api/v2/node/syncing`).reply(200, { data: [] })
+  mock.onGet(`${host}/api/v2/node/configuration`).reply(200, { data: [] })
 }

--- a/packages/client/__tests__/mocks/v2/peers.js
+++ b/packages/client/__tests__/mocks/v2/peers.js
@@ -1,4 +1,4 @@
 module.exports = (mock, host) => {
-  mock.onGet(`${host}/api/peers`).reply(200, { data: [] })
-  mock.onGet(`${host}/api/peers/123`).reply(200, { data: [] })
+  mock.onGet(`${host}/api/v2/peers`).reply(200, { data: [] })
+  mock.onGet(`${host}/api/v2/peers/123`).reply(200, { data: [] })
 }

--- a/packages/client/__tests__/mocks/v2/signatures.js
+++ b/packages/client/__tests__/mocks/v2/signatures.js
@@ -1,3 +1,3 @@
 module.exports = (mock, host) => {
-  mock.onGet(`${host}/api/signatures`).reply(200, { data: [] })
+  mock.onGet(`${host}/api/v2/signatures`).reply(200, { data: [] })
 }

--- a/packages/client/__tests__/mocks/v2/statistics.js
+++ b/packages/client/__tests__/mocks/v2/statistics.js
@@ -1,7 +1,7 @@
 module.exports = (mock, host) => {
-  mock.onGet(`${host}/api/statistics/blockchain`).reply(200, { data: [] })
-  mock.onGet(`${host}/api/statistics/transactions`).reply(200, { data: [] })
-  mock.onGet(`${host}/api/statistics/blocks`).reply(200, { data: [] })
-  mock.onGet(`${host}/api/statistics/votes`).reply(200, { data: [] })
-  mock.onGet(`${host}/api/statistics/unvotes`).reply(200, { data: [] })
+  mock.onGet(`${host}/api/v2/statistics/blockchain`).reply(200, { data: [] })
+  mock.onGet(`${host}/api/v2/statistics/transactions`).reply(200, { data: [] })
+  mock.onGet(`${host}/api/v2/statistics/blocks`).reply(200, { data: [] })
+  mock.onGet(`${host}/api/v2/statistics/votes`).reply(200, { data: [] })
+  mock.onGet(`${host}/api/v2/statistics/unvotes`).reply(200, { data: [] })
 }

--- a/packages/client/__tests__/mocks/v2/transactions.js
+++ b/packages/client/__tests__/mocks/v2/transactions.js
@@ -1,9 +1,9 @@
 module.exports = (mock, host) => {
-  mock.onGet(`${host}/api/transactions`).reply(200, { data: [] })
-  mock.onPost(`${host}/api/transactions`).reply(200, { data: [] })
-  mock.onGet(`${host}/api/transactions/123`).reply(200, { data: [] })
-  mock.onGet(`${host}/api/transactions/unconfirmed`).reply(200, { data: [] })
-  mock.onGet(`${host}/api/transactions/unconfirmed/123`).reply(200, { data: [] })
-  mock.onPost(`${host}/api/transactions/search`).reply(200, { data: [] })
-  mock.onGet(`${host}/api/transactions/types`).reply(200, { data: [] })
+  mock.onGet(`${host}/api/v2/transactions`).reply(200, { data: [] })
+  mock.onPost(`${host}/api/v2/transactions`).reply(200, { data: [] })
+  mock.onGet(`${host}/api/v2/transactions/123`).reply(200, { data: [] })
+  mock.onGet(`${host}/api/v2/transactions/unconfirmed`).reply(200, { data: [] })
+  mock.onGet(`${host}/api/v2/transactions/unconfirmed/123`).reply(200, { data: [] })
+  mock.onPost(`${host}/api/v2/transactions/search`).reply(200, { data: [] })
+  mock.onGet(`${host}/api/v2/transactions/types`).reply(200, { data: [] })
 }

--- a/packages/client/__tests__/mocks/v2/votes.js
+++ b/packages/client/__tests__/mocks/v2/votes.js
@@ -1,4 +1,4 @@
 module.exports = (mock, host) => {
-  mock.onGet(`${host}/api/votes`).reply(200, { data: [] })
-  mock.onGet(`${host}/api/votes/123`).reply(200, { data: [] })
+  mock.onGet(`${host}/api/v2/votes`).reply(200, { data: [] })
+  mock.onGet(`${host}/api/v2/votes/123`).reply(200, { data: [] })
 }

--- a/packages/client/__tests__/mocks/v2/wallets.js
+++ b/packages/client/__tests__/mocks/v2/wallets.js
@@ -1,10 +1,10 @@
 module.exports = (mock, host) => {
-  mock.onGet(`${host}/api/wallets`).reply(200, { data: [] })
-  mock.onGet(`${host}/api/wallets/top`).reply(200, { data: [] })
-  mock.onGet(`${host}/api/wallets/123`).reply(200, { data: [] })
-  mock.onGet(`${host}/api/wallets/123/transactions`).reply(200, { data: [] })
-  mock.onGet(`${host}/api/wallets/123/transactions/sent`).reply(200, { data: [] })
-  mock.onGet(`${host}/api/wallets/123/transactions/received`).reply(200, { data: [] })
-  mock.onGet(`${host}/api/wallets/123/votes`).reply(200, { data: [] })
-  mock.onPost(`${host}/api/wallets/search`).reply(200, { data: [] })
+  mock.onGet(`${host}/api/v2/wallets`).reply(200, { data: [] })
+  mock.onGet(`${host}/api/v2/wallets/top`).reply(200, { data: [] })
+  mock.onGet(`${host}/api/v2/wallets/123`).reply(200, { data: [] })
+  mock.onGet(`${host}/api/v2/wallets/123/transactions`).reply(200, { data: [] })
+  mock.onGet(`${host}/api/v2/wallets/123/transactions/sent`).reply(200, { data: [] })
+  mock.onGet(`${host}/api/v2/wallets/123/transactions/received`).reply(200, { data: [] })
+  mock.onGet(`${host}/api/v2/wallets/123/votes`).reply(200, { data: [] })
+  mock.onPost(`${host}/api/v2/wallets/search`).reply(200, { data: [] })
 }

--- a/packages/client/__tests__/mocks/v2/webhooks.js
+++ b/packages/client/__tests__/mocks/v2/webhooks.js
@@ -1,8 +1,8 @@
 module.exports = (mock, host) => {
-  mock.onGet(`${host}/api/webhooks`).reply(200, { data: [] })
-  mock.onPost(`${host}/api/webhooks`).reply(200, { data: [] })
-  mock.onGet(`${host}/api/webhooks/123`).reply(200, { data: [] })
-  mock.onPut(`${host}/api/webhooks/123`).reply(200, { data: [] })
-  mock.onDelete(`${host}/api/webhooks/123`).reply(200, { data: [] })
-  mock.onGet(`${host}/api/webhooks/events`).reply(200, { data: [] })
+  mock.onGet(`${host}/api/v2/webhooks`).reply(200, { data: [] })
+  mock.onPost(`${host}/api/v2/webhooks`).reply(200, { data: [] })
+  mock.onGet(`${host}/api/v2/webhooks/123`).reply(200, { data: [] })
+  mock.onPut(`${host}/api/v2/webhooks/123`).reply(200, { data: [] })
+  mock.onDelete(`${host}/api/v2/webhooks/123`).reply(200, { data: [] })
+  mock.onGet(`${host}/api/v2/webhooks/events`).reply(200, { data: [] })
 }

--- a/packages/client/examples/README.md
+++ b/packages/client/examples/README.md
@@ -3,10 +3,9 @@
 ### `send-to-random-wallet`
 This example sends 1 DARK to a random wallet if you've enough balance.
 
- * To use this example, it's necessary having a devnet wallet with at least 1.1 DARK.
+ * To use this example, it's necessary having a `devnet` wallet with at least 1.1 DARK.
 
-To run it:
+To run it, execute from here:
 ```
-cd packages/client/examples
-ARK_CLIENT_EXAMPLE_SENDER="devnet wallet address" ARK_CLIENT_EXAMPLE_PASS="the twelve words that forms the password of the wallet" ./post-transaction.js
+ARK_CLIENT_EXAMPLE_SENDER="devnet wallet address" ARK_CLIENT_EXAMPLE_PASS="the twelve words that forms the password of the wallet" ./send-to-random-wallet.js
 ```

--- a/packages/client/lib/http.js
+++ b/packages/client/lib/http.js
@@ -101,12 +101,16 @@ module.exports = class HttpClient {
    * @throws Will throw an error if the HTTP request fails.
    */
   sendRequest (method, path, payload) {
-    if (!this.headers['API-Version']) {
-      this.headers['API-Version'] = this.version
+    let baseURL
+
+    if (this.version === 1) {
+      baseURL = `${this.host}/api/`
+    } else {
+      baseURL = `${this.host}/api/v${this.version}`
     }
 
     const client = axios.create({
-      baseURL: `${this.host}/api/`,
+      baseURL,
       headers: this.headers,
       timeout: this.timeout
     })


### PR DESCRIPTION
## Proposed changes

https://github.com/p-meier/hapi-api-version checks the `api-version` header and then it rewrites the URL to the versioned version (`/api/blocks` to `/api/v2/blocks`). Since during the `OPTIONS` request, `axios` doesn't include custom headers (such as the necessary `api-version`), those API client requests were always resolved to a V1 endpoint.

When the endpoint was existing on V1 and V2 (like `/api/delegates`) the behaviour was successful, but on V2-only endpoints, this was provoking a problem, because the pre-flight `OPTIONS` request was redirected to an nonexistent endpoint.

This PR removes the usage of the `api-version` header, but adds the version to the API endpoint URL.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Docs (documentation only changes)
- [x] Test (adding missing tests or fixing existing tests)

## Further comments

Other option is using an [`Accept` header](https://github.com/p-meier/hapi-api-version#accept-header), but it wouldn't work unless renaming the current `vendorName` (https://github.com/ArkEcosystem/core/blob/46e550628f421539e50caaab97ba5fea44e9f176/packages/core-api/lib/server.js#L51) to remove the "-" or sending a PR request to https://github.com/p-meier/hapi-api-version to accept them.