### PR TITLE
fix: add back delegate ranks

### DIFF
--- a/packages/core-database/lib/wallet-manager.js
+++ b/packages/core-database/lib/wallet-manager.js
@@ -196,6 +196,9 @@ module.exports = class WalletManager {
         const delegate = this.byPublicKey[voter.vote]
         delegate.voteBalance = delegate.voteBalance.plus(voter.balance)
       })
+    Object.values(this.byUsername)
+      .sort((a, b) => (b.voteBalance - a.voteBalance))
+      .forEach((delegate, index) => (delegate.rate = index + 1))
   }
 
   /**


### PR DESCRIPTION
## Proposed changes

The ranks were removed by https://github.com/ArkEcosystem/core/commit/ffe27042236a3ab6ae9f4a336f5ea0e8acdf16ed which results in wrong API output

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes