### PR TITLE
fix: failed to emit event in forger

### DIFF
--- a/packages/core-forger/__tests__/client.test.js
+++ b/packages/core-forger/__tests__/client.test.js
@@ -162,14 +162,14 @@ describe('Client', () => {
       jest.spyOn(axios, 'post')
       // const action = mockAxios.onPost(`${host}/internal/utils/events`), body => body.event === 'foo' && body.data === 'bar').reply(200)
       mockAxios.onPost(`${host}/internal/utils/events`).reply((c) => {
-        expect(JSON.parse(c.data)).toMatchObject({event: 'foo', data: 'bar'})
+        expect(JSON.parse(c.data)).toMatchObject({event: 'foo', body: 'bar'})
         return [200]
       })
 
       await client.__chooseHost()
       await client.emitEvent('foo', 'bar')
 
-      expect(axios.post).toHaveBeenCalledWith(`${host}/internal/utils/events`, {event: 'foo', data: 'bar'}, expect.any(Object))
+      expect(axios.post).toHaveBeenCalledWith(`${host}/internal/utils/events`, {event: 'foo', body: 'bar'}, expect.any(Object))
     })
   })
 })

--- a/packages/core-forger/lib/client.js
+++ b/packages/core-forger/lib/client.js
@@ -124,7 +124,7 @@ module.exports = class Client {
     }
 
     try {
-      await this.__post(`${host}/internal/utils/events`, {event, data: body})
+      await this.__post(`${host}/internal/utils/events`, {event, body})
     } catch (error) {
       logger.error(`Failed to emit "${event}" to "${host}"`)
     }


### PR DESCRIPTION
## Proposed changes

This was broken by https://github.com/ArkEcosystem/core/commit/3474e414714711dc9682529b96780b08cf3109cd which breaks any event emitting in the forger.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes