### PR TITLE
Add size-based log rolling in addition to daily rotation

### DIFF
--- a/packages/core/lib/config/devnet/plugins.js
+++ b/packages/core/lib/config/devnet/plugins.js
@@ -16,7 +16,9 @@ module.exports = {
           filename: process.env.ARK_LOG_FILE || `${process.env.ARK_PATH_DATA}/logs/core/${process.env.ARK_NETWORK_NAME}/%DATE%.log`,
           datePattern: 'YYYY-MM-DD',
           level: process.env.ARK_LOG_LEVEL || 'debug',
-          zippedArchive: true
+          zippedArchive: true,
+          maxSize: '100m',
+          maxFiles: '10'
         }
       }
     }

--- a/packages/core/lib/config/mainnet/plugins.js
+++ b/packages/core/lib/config/mainnet/plugins.js
@@ -16,7 +16,9 @@ module.exports = {
           filename: process.env.ARK_LOG_FILE || `${process.env.ARK_PATH_DATA}/logs/core/${process.env.ARK_NETWORK_NAME}/%DATE%.log`,
           datePattern: 'YYYY-MM-DD',
           level: process.env.ARK_LOG_LEVEL || 'debug',
-          zippedArchive: true
+          zippedArchive: true,
+          maxSize: '100m',
+          maxFiles: '10'
         }
       }
     }

--- a/packages/core/lib/config/testnet.1/plugins.js
+++ b/packages/core/lib/config/testnet.1/plugins.js
@@ -16,7 +16,9 @@ module.exports = {
           filename: process.env.ARK_LOG_FILE || `${process.env.ARK_PATH_DATA}/logs/core/${process.env.ARK_NETWORK_NAME}.1/%DATE%.log`,
           datePattern: 'YYYY-MM-DD',
           level: process.env.ARK_LOG_LEVEL || 'debug',
-          zippedArchive: true
+          zippedArchive: true,
+          maxSize: '100m',
+          maxFiles: '10'
         }
       }
     }

--- a/packages/core/lib/config/testnet.2/plugins.js
+++ b/packages/core/lib/config/testnet.2/plugins.js
@@ -16,7 +16,9 @@ module.exports = {
           filename: process.env.ARK_LOG_FILE || `${process.env.ARK_PATH_DATA}/logs/core/${process.env.ARK_NETWORK_NAME}.2/%DATE%.log`,
           datePattern: 'YYYY-MM-DD',
           level: process.env.ARK_LOG_LEVEL || 'debug',
-          zippedArchive: true
+          zippedArchive: true,
+          maxSize: '100m',
+          maxFiles: '10'
         }
       }
     }

--- a/packages/core/lib/config/testnet.live/plugins.js
+++ b/packages/core/lib/config/testnet.live/plugins.js
@@ -16,7 +16,9 @@ module.exports = {
           filename: process.env.ARK_LOG_FILE || `${process.env.ARK_PATH_DATA}/logs/core/${process.env.ARK_NETWORK_NAME}.live/%DATE%.log`,
           datePattern: 'YYYY-MM-DD',
           level: process.env.ARK_LOG_LEVEL || 'debug',
-          zippedArchive: true
+          zippedArchive: true,
+          maxSize: '100m',
+          maxFiles: '10'
         }
       }
     }

--- a/packages/core/lib/config/testnet/plugins.js
+++ b/packages/core/lib/config/testnet/plugins.js
@@ -16,7 +16,9 @@ module.exports = {
           filename: process.env.ARK_LOG_FILE || `${process.env.ARK_PATH_DATA}/logs/core/${process.env.ARK_NETWORK_NAME}/%DATE%.log`,
           datePattern: 'YYYY-MM-DD',
           level: process.env.ARK_LOG_LEVEL || 'debug',
-          zippedArchive: true
+          zippedArchive: true,
+          maxSize: '100m',
+          maxFiles: '10'
         }
       }
     }


### PR DESCRIPTION
## Proposed changes
We already rotate logs daily. This also adds a size-based rolling set to 100M

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)


## Further comments
This would partly address the "crazy logging" pointed in issue #1023 
