### PR TITLE
core-tester-cli: improve transaction to clipboard

### DIFF
--- a/packages/core-tester-cli/__tests__/utils/copy-to-clipboard.test.js
+++ b/packages/core-tester-cli/__tests__/utils/copy-to-clipboard.test.js
@@ -10,11 +10,13 @@ describe('Utils - Copy to Clipboard', () => {
 
   it('should contain the copied content', () => {
     copyToClipboard([{
-      key: 'value'
+      key: 'value',
+      serialized: Buffer.from('00', 'hex')
     }])
 
     expect(JSON.parse(clipboardy.readSync())).toEqual([{
-      key: 'value'
+      key: 'value',
+      serialized: '00'
     }])
   })
 })

--- a/packages/core-tester-cli/bin/tester
+++ b/packages/core-tester-cli/bin/tester
@@ -52,7 +52,10 @@ app
   .command('*')
   .action(env => {
     app.help()
-    process.exit(0)
   })
 
 app.parse(process.argv)
+
+if (app.args.length === 0) {
+  app.help()
+}

--- a/packages/core-tester-cli/lib/utils/copy-to-clipboard.js
+++ b/packages/core-tester-cli/lib/utils/copy-to-clipboard.js
@@ -2,7 +2,10 @@ const clipboardy = require('clipboardy')
 const logger = require('./logger')
 
 module.exports = (transactions) => {
-  clipboardy.writeSync(JSON.stringify(transactions))
+  transactions.forEach(transaction => {
+    transaction.serialized = transaction.serialized.toString('hex')
+  })
 
+  clipboardy.writeSync(JSON.stringify(transactions))
   logger.info(`Copied ${transactions.length} transactions`)
 }


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
The tester allows to copy transacitons to the clipboard, which can be useful especially if you want the serialized data. Unfortunately the Buffer object is not turned into a hex string before it is copied, which is a bit useless.

Before:
```json
"serialized":{"type":"Buffer","data":[255,1,30,0,232,19,219,2,3,215,223,228,78,119,16,57,51,79,71,18,251,149,173,53,82,84,246,116,200,245,210,134,80,49,153,21,123,123,247,195,87,128,150,152,0,0,0,0,0,6,84,73,68,58,32,48,0,242,5,42,1,0,0,0,15,0,0,0,30,2,29,129,190,6,43,194,100,182,140,88,192,222,2,251,160,147,25,146,120,48,68,2,32,37,122,108,207,148,185,247,92,59,147,60,125,206,12,103,239,76,162,251,24,197,197,142,124,239,143,188,187,108,73,48,113,2,32,96,210,114,207,31,13,188,255,195,130,69,244,202,132,223,206,214,216,129,247,223,254,179,226,170,229,245,140,185,31,21,232]}
```
After:
```json
"serialized": "ff011e003614db0203d7dfe44e771039334f4712fb95ad355254f674c8f5d286503199157b7bf7c3578096980000000000065449443a203000f2052a010000000f0000001e31102d3d56a1bec7f00c225625a9ae4a6c654bb1304402203f05a9423f4d24ff20d822ec40fffd741cbb5c97ea39046fb1d367553f303231022059788382452514c5d56795863c48041faad2b05bc203b6af6127aca9c3bcde4e"
```


## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [X] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->
- [X] Lint and unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)


## Further comments
I don't know if it's widely used and would break workflows, but it would probably be even better
if the result of `transaction.toBroadcastV1()` would be copied instead of `JSON.stringify`.