### PR TITLE
perf: optimize Transaction.fromBytes

### DIFF
--- a/packages/crypto/lib/models/transaction.js
+++ b/packages/crypto/lib/models/transaction.js
@@ -127,12 +127,10 @@ module.exports = class Transaction {
 
   /*
    * Return a clean transaction data from the serialized form.
-   * @return {Object}
+   * @return {Transaction}
    */
   static fromBytes (hexString) {
-    const deserialized = Transaction.deserialize(hexString)
-    Transaction.applyV1Compatibility(deserialized)
-    return new Transaction(deserialized)
+    return new Transaction(hexString)
   }
 
   verify () {


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Currently, a call to `Transaction.fromBytes` goes like:
> fromBytes(hex) -> Transaction.deserialize -> applyV1Compatibility -> verify -> new Transaction -> Transaction.deserialize -> applyV1Compatibility -> verify

For no apparent reason, everything that happens in the `Transaction` constructor is duplicated.
(Everything up to the last `applyV1Compatiblity` would also be applied to V2 transactions...)

It can be reduced to:
> fromBytes(hex) -> new Transaction -> Transaction.deserialize -> applyV1Compatibility -> verify

which speeds it up by 2x.

Parsing all transactions (150k) from devnet:
```json
Before:
52601.147ms
After:
25641.869ms
```

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->
- [X] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->
- [X] Lint and unit tests pass locally with my changes
