### PR TITLE
fix: delegate registration

### DIFF
--- a/packages/core-forger/__tests__/client.test.js
+++ b/packages/core-forger/__tests__/client.test.js
@@ -64,7 +64,7 @@ describe('Client', () => {
 
         await client.__chooseHost()
 
-        const wasBroadcasted = await client.broadcast(block.toRawJson())
+        const wasBroadcasted = await client.broadcast(block.toJson())
         expect(wasBroadcasted).toBeTruthy()
       })
     })

--- a/packages/core-forger/lib/manager.js
+++ b/packages/core-forger/lib/manager.js
@@ -177,7 +177,7 @@ module.exports = class ForgerManager {
     const username = this.usernames[delegate.publicKey]
     logger.info(`Forged new block ${block.data.id} by delegate ${username} (${delegate.publicKey}) :trident:`)
 
-    await this.client.broadcast(block.toRawJson())
+    await this.client.broadcast(block.toJson())
 
     this.client.emitEvent('block.forged', block.data)
     transactions.forEach(transaction => this.client.emitEvent('transaction.forged', transaction.data))

--- a/packages/core-p2p/__tests__/monitor.test.js
+++ b/packages/core-p2p/__tests__/monitor.test.js
@@ -217,7 +217,7 @@ describe('Monitor', () => {
     it('should be ok', () => {
       expect(monitor.broadcastTransactions).toBeFunction()
 
-      expect(monitor.toBroadcastV1)
+      expect(monitor.toJson)
     })
   })
 

--- a/packages/core-p2p/__tests__/peer.test.js
+++ b/packages/core-p2p/__tests__/peer.test.js
@@ -64,7 +64,7 @@ describe('Peer', () => {
     })
 
     it('should be ok', async () => {
-      const response = await peerMock.postBlock(genesisBlock.toBroadcastV1())
+      const response = await peerMock.postBlock(genesisBlock.toJson())
 
       expect(response).toBeObject()
       expect(response).toHaveProperty('success')
@@ -78,7 +78,7 @@ describe('Peer', () => {
     })
 
     it('should be ok', async () => {
-      const response = await peerMock.postTransactions([genesisTransaction.toBroadcastV1()])
+      const response = await peerMock.postTransactions([genesisTransaction.toJson()])
 
       expect(response).toBeObject()
       expect(response).toHaveProperty('success')

--- a/packages/core-p2p/__tests__/server/1.test.js
+++ b/packages/core-p2p/__tests__/server/1.test.js
@@ -158,7 +158,7 @@ describe('API - Version 1', () => {
   describe('POST /peer/blocks', () => {
     it('should be ok', async () => {
       const response = await utils.POST('peer/blocks', {
-        block: genesisBlock.toBroadcastV1()
+        block: genesisBlock.toJson()
       })
 
       expect(response.status).toBe(200)
@@ -173,7 +173,7 @@ describe('API - Version 1', () => {
   describe('POST /peer/transactions', () => {
     it('should be ok', async () => {
       const response = await utils.POST('peer/transactions', {
-        transactions: [genesisTransaction.toBroadcastV1()]
+        transactions: [genesisTransaction.toJson()]
       })
 
       expect(response.status).toBe(200)

--- a/packages/core-p2p/__tests__/server/internal.test.js
+++ b/packages/core-p2p/__tests__/server/internal.test.js
@@ -36,7 +36,7 @@ describe('API - Internal', () => {
   describe('POST /blocks', () => {
     it('should be ok', async () => {
       const response = await utils.POST('internal/blocks', {
-        block: genesisBlock.toBroadcastV1()
+        block: genesisBlock.toJson()
       })
 
       expect(response.status).toBe(204)

--- a/packages/core-p2p/__tests__/server/peer.test.js
+++ b/packages/core-p2p/__tests__/server/peer.test.js
@@ -153,7 +153,7 @@ describe('API P2P - Version 2', () => {
   describe('POST /peer/blocks', () => {
     it('should fail with status code 202 when posting existing block', async () => {
       const response = await utils.POST('peer/blocks', {
-        block: genesisBlock.toBroadcastV1()
+        block: genesisBlock.toJson()
       })
 
       expect(response).toHaveProperty('status')

--- a/packages/core-p2p/lib/monitor.js
+++ b/packages/core-p2p/lib/monitor.js
@@ -432,7 +432,7 @@ class Monitor {
 
     logger.info(`Broadcasting block ${block.data.height.toLocaleString()} to ${peers.length} peers`)
 
-    await Promise.all(peers.map(peer => peer.postBlock(block.toBroadcastV1())))
+    await Promise.all(peers.map(peer => peer.postBlock(block.toJson())))
   }
 
   /**
@@ -444,7 +444,7 @@ class Monitor {
     logger.debug(`Broadcasting ${transactions.length} transactions to ${peers.length} peers`)
 
     const transactionsV1 = []
-    transactions.forEach(transaction => transactionsV1.push(transaction.toBroadcastV1()))
+    transactions.forEach(transaction => transactionsV1.push(transaction.toJson()))
 
     return Promise.all(peers.map(peer => peer.postTransactions(transactionsV1)))
   }

--- a/packages/crypto/__tests__/models/transaction.test.js
+++ b/packages/crypto/__tests__/models/transaction.test.js
@@ -88,8 +88,8 @@ describe('Models - Transaction', () => {
       expect(transaction).toBeInstanceOf(Transaction)
 
       // We can't compare the data directly, since the created instance uses Bignums.
-      // ... call toBroadcastV1() which casts the Bignums to numbers beforehand.
-      expect(transaction.toBroadcastV1()).toEqual(transactionData)
+      // ... call toJson() which casts the Bignums to numbers beforehand.
+      expect(transaction.toJson()).toEqual(transactionData)
     })
   })
 

--- a/packages/crypto/lib/models/block.js
+++ b/packages/crypto/lib/models/block.js
@@ -152,14 +152,6 @@ module.exports = class Block {
   }
 
   /*
-   * Return block data for v1.
-   * @return {Object}
-   */
-  toBroadcastV1 () {
-    return this.toRawJson()
-  }
-
-  /*
    * Get block id
    * @param  {Object} data
    * @return {String}
@@ -506,7 +498,7 @@ module.exports = class Block {
     return b
   }
 
-  toRawJson () {
+  toJson () {
     // Convert Bignums
     let blockData = cloneDeepWith(this.data, (value, key) => {
       if (['reward', 'totalAmount', 'totalFee'].indexOf(key) !== -1) {
@@ -515,7 +507,7 @@ module.exports = class Block {
     })
 
     return Object.assign(blockData, {
-      transactions: this.transactions.map(transaction => transaction.toBroadcastV1())
+      transactions: this.transactions.map(transaction => transaction.toJson())
     })
   }
 }

--- a/packages/crypto/lib/models/transaction.js
+++ b/packages/crypto/lib/models/transaction.js
@@ -135,25 +135,6 @@ module.exports = class Transaction {
    * @return {Object}
    */
   toBroadcastV1 () {
-    if (this.type === TRANSACTION_TYPES.DELEGATE_REGISTRATION) {
-      return {
-        id: this.id,
-        type: this.type,
-        amount: 0,
-        fee: this.fee.toNumber(),
-        recipientId: null,
-        senderPublicKey: this.senderPublicKey,
-        timestamp: this.timestamp,
-        asset: {
-          delegate: {
-            username: this.asset.delegate.username,
-            publicKey: this.senderPublicKey
-          }
-        },
-        signature: this.signature
-      }
-    }
-
     // Convert Bignums
     return cloneDeepWith(this.data, (value, key) => {
       if (['amount', 'fee'].indexOf(key) !== -1) {

--- a/packages/crypto/lib/models/transaction.js
+++ b/packages/crypto/lib/models/transaction.js
@@ -131,10 +131,10 @@ module.exports = class Transaction {
   }
 
   /*
-   * Return transaction data for v1.
+   * Return transaction data.
    * @return {Object}
    */
-  toBroadcastV1 () {
+  toJson () {
     // Convert Bignums
     return cloneDeepWith(this.data, (value, key) => {
       if (['amount', 'fee'].indexOf(key) !== -1) {
@@ -224,7 +224,7 @@ module.exports = class Transaction {
     }
 
     else if (transaction.type === TRANSACTION_TYPES.DELEGATE_RESIGNATION) {
-       // delegate resignation - empty payload 
+       // delegate resignation - empty payload
     }
 
     if (transaction.signature) {


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
When `Block.toRawJson`  started using `Transaction#toBroadcastV1`  the delegate registration stopped working. The latter treats delegate registrations slightly different, in that it creates an object using `this.timestamp` instead of `this.data.timestamp` as is the case for all other tx types. The former timestamp is the modified timestamp by the Block and explains why delegate registrations cannot be verified anymore.

Since the code was [introduced](https://github.com/ArkEcosystem/core/pull/355/files#diff-7db79b34868931dce067b5ca7e46ca9f) in may and that there have been a lot of changes all over the place, it's probably safe to remove it as it doesn't appear to have any side effects besides that delegate registrations work again. In worst case we learn what is was meant to prevent from happening. :man_shrugging: 

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [X] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [ ] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
