### PR TITLE
Fix: Using correct constant name in block verify

### DIFF
--- a/packages/crypto/lib/models/block.js
+++ b/packages/crypto/lib/models/block.js
@@ -234,7 +234,7 @@ module.exports = class Block {
       //   }
       // }
 
-      if (block.payloadLength > constants.maxPayloadLength) {
+      if (block.payloadLength > constants.maxPayload) {
         result.errors.push('Payload length is too high')
       }
 


### PR DESCRIPTION
## Proposed changes
Using the correct value in the verify method. Found it yesterday with @vasild 
Currently the if block was like this
```
// wrong property name made this to constants.undefined which is false always in this case
if (block.payloadLength > constants.maxPayloadLength) {
     result.errors.push('Payload length is too high')
}
```

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes


