### PR TITLE
fix: missing transaction vendorfield

### DIFF
--- a/packages/core-api/__tests__/v1/handlers/transactions.test.js
+++ b/packages/core-api/__tests__/v1/handlers/transactions.test.js
@@ -217,6 +217,14 @@ describe('API 1.0 - Transactions', () => {
       if (response.data.success && response.data.transaction != null) {
         expect(response.data.transaction).toBeObject()
         expect(response.data.transaction).toHaveProperty('id', transaction.id)
+        expect(response.data.transaction).toHaveProperty('type', transaction.type)
+        expect(response.data.transaction).toHaveProperty('amount', transaction.amount)
+        expect(response.data.transaction).toHaveProperty('fee', transaction.fee)
+        expect(response.data.transaction).toHaveProperty('recipientId', transaction.recipientId)
+        expect(response.data.transaction).toHaveProperty('senderPublicKey', transaction.senderPublicKey)
+        expect(response.data.transaction).toHaveProperty('signature', transaction.signature)
+        expect(response.data.transaction).toHaveProperty('timestamp', transaction.timestamp)
+        expect(response.data.transaction).toHaveProperty('vendorField', transaction.vendorField)
       } else {
         expect(response.data.error).toBeString()
       }

--- a/packages/crypto/lib/models/transaction.js
+++ b/packages/crypto/lib/models/transaction.js
@@ -61,6 +61,7 @@ module.exports = class Transaction {
       'senderPublicKey',
       'recipientId',
       'type',
+      'vendorField',
       'vendorFieldHex',
       'amount',
       'fee',


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
This commit broke the vendorField https://github.com/ArkEcosystem/core/pull/956/files#diff-20020cdc4aa37467285162d1bf6da2e0 

Basically, it was applied in  `Transaction.deserialize` before, which was then extracted into `applyV1Compatibility` . The transaction constructor calls `applyV1Compatibility`, but what is missing is that `Transaction.deserialize` modified the actual tx object, while `applyV1Compatibility` modifies what is later assigned to `tx.data`. 

Now `vendorField` is correctly assigned to the transaction again. Also extended a unit test to make sure it doesn't go unnoticed anymore.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [X] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->
- [X] Lint and unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
