### PR TITLE
chore: travis config use postgres 9.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,13 +23,6 @@ before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash
   - export PATH="$HOME/.yarn/bin:$PATH"
   - yarn config set cache-folder $HOME/.cache/yarn
-  - sudo service postgresql stop
-  - sudo apt-get remove -q 'postgresql-*'
-  - sudo apt-get update -q
-  - sudo apt-get install -q postgresql-10 postgresql-client-10
-  - sudo sed -i -e '/local.*peer/s/postgres/all/' -e 's/peer\|md5/trust/g' /etc/postgresql/*/main/pg_hba.conf
-  - sudo sed -i 's/port = 5433/port = 5432/' /etc/postgresql/10/main/postgresql.conf
-  - sudo service postgresql restart
 
 install: yarn
 


### PR DESCRIPTION
## Proposed changes

Use "standard" travis postgres 9.6, so remove custom postgres 10 steps from travis config (was only useful before for sequelize).

## Types of changes

- [x] Build (changes that affect the build system)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes