### PR TITLE
Fix transfer, undefined passphrase when overridingPassphrase

### DIFF
--- a/packages/core-tester-cli/lib/commands/multi-signature.js
+++ b/packages/core-tester-cli/lib/commands/multi-signature.js
@@ -98,8 +98,8 @@ module.exports = class MultiSignatureCommand extends Command {
         .network(this.config.network.version)
         .sign(wallet.passphrase)
 
-      if (wallet.secondPassphrase || this.options.secondPassphrase) {
-        builder.secondSign(wallet.secondPassphrase || this.options.secondPassphrase)
+      if (wallet.secondPassphrase || this.config.secondPassphrase) {
+        builder.secondSign(wallet.secondPassphrase || this.config.secondPassphrase)
       }
 
       if (approvalWallets) {

--- a/packages/core-tester-cli/lib/commands/transfer.js
+++ b/packages/core-tester-cli/lib/commands/transfer.js
@@ -109,10 +109,10 @@ module.exports = class TransferCommand extends Command {
         .network(this.config.network.version)
         .amount(transactionAmount)
         .vendorField(vendorField === undefined ? `Transaction ${i + 1}` : vendorField)
-        .sign(overridePassphrase ? this.options.passphrase : wallet.passphrase)
+        .sign(overridePassphrase ? this.config.passphrase : wallet.passphrase)
 
-      if (wallet.secondPassphrase || this.options.secondPassphrase) {
-        builder.secondSign(wallet.secondPassphrase || this.options.secondPassphrase)
+      if (wallet.secondPassphrase || this.config.secondPassphrase) {
+        builder.secondSign(wallet.secondPassphrase || this.config.secondPassphrase)
       }
 
       if (approvalWallets) {


### PR DESCRIPTION
## Proposed changes
transfer command was blowing chunks being we're referencing the incorrect object to read passphrase/2nd passphrase

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)