### PR TITLE
fix: return false instead of throwing

### DIFF
--- a/packages/core-p2p/lib/server/versions/1/handlers.js
+++ b/packages/core-p2p/lib/server/versions/1/handlers.js
@@ -189,7 +189,7 @@ exports.postBlock = {
       const b = new Block(block)
 
       if (!b.verification.verified) {
-        throw new Error('invalid block received')
+        return {success: false}
       }
 
       blockchain.pushPingBlock(b.data)


### PR DESCRIPTION
## Proposed changes

This replaces the thrown error with a response as this is the v1 P2P API and errors are handled as `success: false`. Because this error was unhandled it would get caught as an unhandled exception.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes