### PR TITLE
misc: add retry delay when calling __chooseHost on forger startup

### DIFF
--- a/packages/core-forger/lib/client.js
+++ b/packages/core-forger/lib/client.js
@@ -1,6 +1,7 @@
 'use strict'
 const axios = require('axios')
 const sample = require('lodash/sample')
+const delay = require('delay')
 const container = require('@arkecosystem/core-container')
 const logger = container.resolvePlugin('logger')
 const config = container.resolvePlugin('config')
@@ -90,8 +91,8 @@ module.exports = class Client {
    * Get a list of all active delegate usernames.
    * @return {Object}
    */
-  async getUsernames () {
-    await this.__chooseHost()
+  async getUsernames (wait = 0) {
+    await this.__chooseHost(wait)
 
     try {
       const response = await this.__get(`${this.host}/internal/utils/usernames`)
@@ -134,7 +135,7 @@ module.exports = class Client {
    * Chose a responsive host.
    * @return {void}
    */
-  async __chooseHost () {
+  async __chooseHost (wait = 0) {
     const host = sample(this.hosts)
 
     try {
@@ -143,6 +144,10 @@ module.exports = class Client {
       this.host = host
     } catch (error) {
       logger.debug(`${host} didn't respond to the forger. Trying another host :sparkler:`)
+
+      if (wait > 0) {
+        await delay(wait)
+      }
 
       await this.__chooseHost()
     }

--- a/packages/core-forger/lib/manager.js
+++ b/packages/core-forger/lib/manager.js
@@ -41,7 +41,7 @@ module.exports = class ForgerManager {
       this.delegates.push(new Delegate(bip38, this.network, password))
     }
 
-    await this.__loadUsernames()
+    await this.__loadUsernames(2000)
 
     const delegates = this.delegates.map(delegate => {
       return `${this.usernames[delegate.publicKey]} (${delegate.publicKey})`
@@ -245,7 +245,7 @@ module.exports = class ForgerManager {
    * Get a list of all active delegate usernames.
    * @return {Object}
    */
-  async __loadUsernames () {
-    this.usernames = await this.client.getUsernames()
+  async __loadUsernames (wait = 0) {
+    this.usernames = await this.client.getUsernames(wait)
   }
 }


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
When starting a forger and relay simultaneously, the forger tries to connect to the relay immediately, even though it is not ready causing this:
![image](https://user-images.githubusercontent.com/1311798/46775202-820a2180-cd06-11e8-9761-14d729d9e106.png)

I added a small delay, so that calling `__chooseHost` during forger startup doesn't flood the poor relay with requests.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [X] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [ ] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [X] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
