### PR TITLE
test: double spend tests on api, p2p, transaction-pool-redis

### DIFF
--- a/packages/core-api/__tests__/__support__/setup.js
+++ b/packages/core-api/__tests__/__support__/setup.js
@@ -5,7 +5,7 @@ const containerHelper = require('@arkecosystem/core-test-utils/lib/helpers/conta
 
 const generateRound = require('./utils/generate-round')
 const activeDelegates = require('@arkecosystem/core-test-utils/fixtures/testnet/delegates')
-const round = generateRound(activeDelegates.publicKeys, 1)
+const round = generateRound(activeDelegates.map(delegate => delegate.publicKey), 1)
 
 exports.setUp = async () => {
   jest.setTimeout(60000)

--- a/packages/core-test-utils/fixtures/testnet/delegates.js
+++ b/packages/core-test-utils/fixtures/testnet/delegates.js
@@ -1,11 +1,24 @@
 'use strict'
 
-const { crypto } = require('@arkecosystem/crypto')
+const { client, crypto } = require('@arkecosystem/crypto')
 
 module.exports = getDelegates()
 
+/**
+ * Get the testnet genesis delegates information
+ * @return {Array} array of objects like { secret, publicKey, address }
+ */
 function getDelegates () {
-    const delegates = require('../../config/testnet/delegates.json')
-    delegates.publicKeys = delegates.secrets.map(secret => crypto.getKeys(secret).publicKey)
-    return delegates
+    client.getConfigManager().setFromPreset('ark', 'testnet')
+
+    const delegatesConfig = require('../../config/testnet/delegates.json')
+
+    return delegatesConfig.secrets.map(secret => {
+        const publicKey = crypto.getKeys(secret).publicKey
+        return {
+          secret,
+          publicKey,
+          address: crypto.getAddress(publicKey)
+        }
+    })
 }

--- a/packages/core-transaction-pool-redis/__tests__/guard.test.js
+++ b/packages/core-transaction-pool-redis/__tests__/guard.test.js
@@ -1,0 +1,55 @@
+'use strict'
+
+const generateTransfers = require('@arkecosystem/core-test-utils/lib/generators/transactions/transfer')
+const delegates = require('@arkecosystem/core-test-utils/fixtures/testnet/delegates')
+const app = require('./__support__/setup')
+const defaultConfig = require('../lib/defaults')
+
+let TransactionGuard
+let connection
+let guard
+
+beforeAll(async () => {
+  await app.setUp()
+
+  TransactionGuard = require('@arkecosystem/core-transaction-pool/lib/guard')
+
+  const RedisConnection = require('../lib/connection.js')
+  connection = new RedisConnection(defaultConfig)
+  connection = await connection.make()
+  guard = new TransactionGuard(connection)
+})
+
+afterAll(async () => {
+  await connection.disconnect()
+  await app.tearDown()
+})
+
+beforeEach(async () => {
+  await connection.flush()
+})
+
+afterEach(async () => {
+  await connection.flush()
+})
+
+describe('Transaction Guard', () => {
+  it('should be an object', () => {
+    expect(guard).toBeObject()
+  })
+
+  describe('validate', () => {
+    it('should be a function', () => {
+      expect(guard.validate).toBeFunction()
+    })
+
+    it('should not validate 2 double spending transactions', async () => {
+      const amount = 245098000000000 - 5098000000000 // a bit less than the delegates' balance
+      const transactions = generateTransfers('testnet', delegates[0].secret, delegates[1].address, amount, 2, true)
+
+      await guard.validate(transactions)
+
+      expect(guard.errors[transactions[1].id]).toEqual([`Error: PoolWalletManager: Can't apply transaction ${transactions[1].id}`])
+    })
+  })
+})


### PR DESCRIPTION
## Proposed changes

Double spend tests on api, p2p, transaction-pool-redis. (+ minor refactor on core-test-utils)

Please review and tell me if this needs to be improved or have some more complex test case.

## Types of changes

- [x] Test (adding missing tests or fixing existing tests)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works