### PR TITLE
fix: limit decimals to 0

### DIFF
--- a/packages/core-forger/lib/client.js
+++ b/packages/core-forger/lib/client.js
@@ -149,7 +149,7 @@ module.exports = class Client {
         await delay(wait)
       }
 
-      await this.__chooseHost()
+      await this.__chooseHost(wait)
     }
   }
 

--- a/packages/crypto/lib/utils/bignum.js
+++ b/packages/crypto/lib/utils/bignum.js
@@ -1,6 +1,11 @@
-const Bignum = require('bignumber.js')
+const BigNumber = require('bignumber.js')
 
-Bignum.ZERO = new Bignum(0)
-Bignum.ONE = new Bignum(1)
+BigNumber.ZERO = new BigNumber(0)
+BigNumber.ONE = new BigNumber(1)
 
-module.exports = Bignum
+BigNumber.config({
+    DECIMAL_PLACES: 0,
+    EXPONENTIAL_AT: 1e9
+})
+
+module.exports = BigNumber


### PR DESCRIPTION
## Proposed changes

Limits the decimals to 0 for any bignumber.js objects.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes