### PR TITLE
test: fix TIMELOCK_TRANSFER usage

### DIFF
--- a/packages/core-test-utils/__tests__/matchers/transactions/types/timelock-transfer.test.js
+++ b/packages/core-test-utils/__tests__/matchers/transactions/types/timelock-transfer.test.js
@@ -1,10 +1,10 @@
-const { TIMELOCK_TRANSFER } = require('@arkecosystem/crypto').constants
+const { TRANSACTION_TYPES } = require('@arkecosystem/crypto').constants
 
 require('../../../../lib/matchers/transactions/types/timelock-transfer')
 
 describe('.toBeTimelockTransferType', () => {
   test('passes when given a valid transaction', () => {
-    expect({ type: TIMELOCK_TRANSFER }).toBeTimelockTransferType()
+    expect({ type: TRANSACTION_TYPES.TIMELOCK_TRANSFER }).toBeTimelockTransferType()
   })
 
   test('fails when given an invalid transaction', () => {

--- a/packages/core-test-utils/lib/matchers/transactions/types/timelock-transfer.js
+++ b/packages/core-test-utils/lib/matchers/transactions/types/timelock-transfer.js
@@ -1,11 +1,11 @@
 'use strict'
 
-const { TIMELOCK_TRANSFER } = require('@arkecosystem/crypto').constants
+const { TRANSACTION_TYPES } = require('@arkecosystem/crypto').constants
 
 const toBeTimelockTransferType = (received) => {
   return {
     message: () => 'Expected value to be a valid TIMELOCK_TRANSFER transaction.',
-    pass: received.type === TIMELOCK_TRANSFER
+    pass: received.type === TRANSACTION_TYPES.TIMELOCK_TRANSFER
   }
 }
 


### PR DESCRIPTION
The code before this patch used

const { TIMELOCK_TRANSFER } = require('@arkecosystem/crypto').constants

but packages/crypto/lib/constants.js contains:

exports.TRANSACTION_TYPES = Object.freeze({
  ...
  TIMELOCK_TRANSFER: 6,
  ...
})

So TIMELOCK_TRANSFER ends up being undefined. The test ended up comparing
undefined with undefined instead of 6 with 6.

## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [ ] Docs (documentation only changes)
- [ ] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [ ] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
