### PR TITLE
refactor: find peers timeout

### DIFF
--- a/packages/client/__tests__/client.test.js
+++ b/packages/client/__tests__/client.test.js
@@ -82,7 +82,7 @@ describe('API - Client', () => {
       }
 
       peers.forEach(peer => {
-        httpMock.onGet(/http.*\/api\/peers/).reply(200, { data })
+        httpMock.onGet(/http.*\/api\/peers/).reply(200, data)
       })
 
       const foundPeers = await Client.findPeers('devnet')
@@ -112,7 +112,7 @@ describe('API - Client', () => {
         }
 
         peers.forEach(peer => {
-          httpMock.onGet(/http.*\/api\/peers/).reply(200, { data })
+          httpMock.onGet(/http.*\/api\/peers/).reply(200, data)
         })
 
         const foundPeers = await Client.findPeers('devnet')
@@ -135,7 +135,7 @@ describe('API - Client', () => {
       }
 
       peers.forEach(peer => {
-        httpMock.onGet(/http.*\/api\/peers/).reply(200, { data })
+        httpMock.onGet(/http.*\/api\/peers/).reply(200, data)
       })
 
       const foundPeers = await Client.findPeers('devnet')
@@ -192,7 +192,7 @@ describe('API - Client', () => {
         peers
       }
       peers.forEach(peer => {
-        httpMock.onGet(/http.*\/api\/peers/).reply(200, { data })
+        httpMock.onGet(/http.*\/api\/peers/).reply(200, data)
       })
 
       const client = await Client.connect('devnet')

--- a/packages/client/lib/index.js
+++ b/packages/client/lib/index.js
@@ -27,14 +27,15 @@ module.exports = class ApiClient {
     let peers = null
 
     // Connect to each peer to get an updated list of peers until a success response
+    const client = new ApiClient('http://', version)
+    client.http.setTimeout(5000)
     for (const peer of networkPeers) {
       const peerUrl = `http://${peer.ip}:${peer.port}`
 
       // This method should not crash when a peer fails
       try {
-        const client = new ApiClient(peerUrl, version)
-        const response = await client.resource('peers').all()
-        const { data } = response.data
+        client.http.host = peerUrl
+        const { data } = await client.resource('peers').all()
 
         if (data.success && data.peers) {
           // Ignore local and unavailable peers


### PR DESCRIPTION
## Proposed changes
Fixes an issue when getting peer list response & also adds a timeout of 5 seconds to each request, in case the peer is not responsive.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
