### PR TITLE
fix: client cater for v2 peer list endpoint

### DIFF
--- a/packages/client/lib/index.js
+++ b/packages/client/lib/index.js
@@ -9,11 +9,11 @@ module.exports = class ApiClient {
    * Finds all the available peers, sorted by block height and delay
    *
    * @param {String}    network - Network name ('devnet' or 'mainnet')
-   * @param {Number}    version - API version
-   * @param {Object[]}  peersOverride - List of peers to use instead of initialPeers
+   * @param {Number}    [version=1] - API version
+   * @param {Object[]}  [peersOverride] - List of peers to use instead of initialPeers
    * @return {Object[]}
    */
-  static async findPeers (network, version, peersOverride) {
+  static async findPeers (network, version = 1, peersOverride) {
     if (peersOverride === undefined && !initialPeers.hasOwnProperty(network)) {
       throw new Error(`Network "${network}" is not supported`)
     }


### PR DESCRIPTION
## Proposed changes
Fixes findPeers method when accessing the v2 peer list endpoint (`/api/v2/peers`)

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
