### PR TITLE
refactor: plugin extensions

### DIFF
--- a/packages/core-container/lib/registrars/plugin.js
+++ b/packages/core-container/lib/registrars/plugin.js
@@ -95,6 +95,10 @@ module.exports = class PluginRegistrars {
       return
     }
 
+    if (item.plugin.extends) {
+      await this.__registerWithContainer(item.plugin.extends)
+    }
+
     const name = item.plugin.name || item.plugin.pkg.name
     const version = item.plugin.version || item.plugin.pkg.version
     const defaults = item.plugin.defaults || item.plugin.pkg.defaults

--- a/packages/core-database-postgres/lib/index.js
+++ b/packages/core-database-postgres/lib/index.js
@@ -10,6 +10,7 @@ exports.plugin = {
   pkg: require('../package.json'),
   defaults: require('./defaults'),
   alias: 'database',
+  extends: '@arkecosystem/core-database',
   async register (container, options) {
     container.resolvePlugin('logger').info('Establishing Database Connection')
 

--- a/packages/core-logger-winston/README.md
+++ b/packages/core-logger-winston/README.md
@@ -18,20 +18,20 @@ module.exports = {
     console: {
       constructor: 'Console',
       options: {
-        colorize: true,
         level: process.env.ARK_LOG_LEVEL || 'debug',
-        timestamp: () => Date.now(),
-        formatter: (info) => require('./formatter')(info)
+        format: require('./formatter')
       }
     },
     dailyRotate: {
       package: 'winston-daily-rotate-file',
       constructor: 'DailyRotateFile',
       options: {
-        filename: `${process.env.ARK_PATH_DATA}/logs/core/${process.env.ARK_NETWORK_NAME}/%DATE%.log`,
+        filename: process.env.ARK_LOG_FILE || `${process.env.ARK_PATH_DATA}/logs/core/${process.env.ARK_NETWORK_NAME}/%DATE%.log`,
         datePattern: 'YYYY-MM-DD',
         level: process.env.ARK_LOG_LEVEL || 'debug',
-        zippedArchive: true
+        zippedArchive: true,
+        maxSize: '100m',
+        maxFiles: '10'
       }
     }
   }

--- a/packages/core-logger-winston/lib/defaults.js
+++ b/packages/core-logger-winston/lib/defaults.js
@@ -13,9 +13,9 @@ module.exports = {
       package: 'winston-daily-rotate-file',
       constructor: 'DailyRotateFile',
       options: {
+        level: process.env.ARK_LOG_LEVEL || 'debug',
         filename: process.env.ARK_LOG_FILE || `${process.env.ARK_PATH_DATA}/logs/core/${process.env.ARK_NETWORK_NAME}/%DATE%.log`,
         datePattern: 'YYYY-MM-DD',
-        level: process.env.ARK_LOG_LEVEL || 'debug',
         zippedArchive: true,
         maxSize: '100m',
         maxFiles: '10'

--- a/packages/core-logger-winston/lib/defaults.js
+++ b/packages/core-logger-winston/lib/defaults.js
@@ -5,7 +5,6 @@ module.exports = {
     console: {
       constructor: 'Console',
       options: {
-        colorize: true,
         level: process.env.ARK_LOG_LEVEL || 'debug',
         format: require('./formatter')
       }

--- a/packages/core-logger-winston/lib/index.js
+++ b/packages/core-logger-winston/lib/index.js
@@ -10,6 +10,7 @@ exports.plugin = {
   pkg: require('../package.json'),
   defaults: require('./defaults'),
   alias: 'logger',
+  extends: '@arkecosystem/core-logger',
   async register (container, options) {
     const logManager = container.resolvePlugin('logManager')
     await logManager.makeDriver(new WinstonDriver(options))

--- a/packages/core-test-utils/config/testnet/plugins.js
+++ b/packages/core-test-utils/config/testnet/plugins.js
@@ -5,16 +5,13 @@ module.exports = {
     transports: {
       console: {
         options: {
-          level: process.env.ARK_LOG_LEVEL || 'debug',
-          format: require('@arkecosystem/core-logger-winston/lib/formatter')
+          level: process.env.ARK_LOG_LEVEL || 'debug'
         }
       },
       dailyRotate: {
         options: {
-          filename: process.env.ARK_LOG_FILE || `${process.env.ARK_PATH_DATA}/logs/core/${process.env.ARK_NETWORK_NAME}/%DATE%.log`,
-          datePattern: 'YYYY-MM-DD',
           level: process.env.ARK_LOG_LEVEL || 'debug',
-          zippedArchive: true
+          filename: process.env.ARK_LOG_FILE || `${process.env.ARK_PATH_DATA}/logs/core/${process.env.ARK_NETWORK_NAME}/%DATE%.log`
         }
       }
     }

--- a/packages/core-test-utils/config/testnet/plugins.js
+++ b/packages/core-test-utils/config/testnet/plugins.js
@@ -1,12 +1,10 @@
 module.exports = {
   '@arkecosystem/core-event-emitter': {},
   '@arkecosystem/core-config': {},
-  '@arkecosystem/core-logger': {},
   '@arkecosystem/core-logger-winston': {
     transports: {
       console: {
         options: {
-          colorize: true,
           level: process.env.ARK_LOG_LEVEL || 'debug',
           format: require('@arkecosystem/core-logger-winston/lib/formatter')
         }
@@ -21,9 +19,6 @@ module.exports = {
       }
     }
   },
-  '@arkecosystem/core-database': {
-    snapshots: `${process.env.ARK_PATH_DATA}/snapshots/${process.env.ARK_NETWORK_NAME}`
-  },
   '@arkecosystem/core-database-postgres': {
     connection: {
       host: process.env.ARK_DB_HOST || 'localhost',
@@ -37,7 +32,6 @@ module.exports = {
       port: process.env.ARK_REDIS_PORT || 6379
     }
   },
-  '@arkecosystem/core-transaction-pool': {},
   '@arkecosystem/core-transaction-pool-redis': {
     enabled: !process.env.ARK_TRANSACTION_POOL_DISABLED,
     key: 'ark-testnet',

--- a/packages/core-test-utils/package.json
+++ b/packages/core-test-utils/package.json
@@ -18,7 +18,6 @@
   },
   "dependencies": {
     "@arkecosystem/core-container": "^0.1.1",
-    "@arkecosystem/core-logger-winston": "^0.1.1",
     "@arkecosystem/crypto": "^0.2.0",
     "bip39": "^2.5.0",
     "lodash": "^4.17.10",

--- a/packages/core-transaction-pool-mem/lib/defaults.js
+++ b/packages/core-transaction-pool-mem/lib/defaults.js
@@ -1,11 +1,7 @@
 'use strict'
 
 module.exports = {
-  enabled: true,
-  // How often to save/sync the transaction pool to a persistent storage.
-  // The number designates count of added or deleted transactions that are not in
-  // the persistent storage. When that number is reached a new sync of the pool is
-  // triggered.
+  enabled: !process.env.ARK_TRANSACTION_POOL_DISABLED,
   syncInterval: 512,
   storage: `${process.env.ARK_PATH_DATA}/database/transaction-pool-${process.env.ARK_NETWORK_NAME}.sqlite`,
   maxTransactionsPerSender: process.env.ARK_TRANSACTION_POOL_MAX_PER_SENDER || 300,

--- a/packages/core-transaction-pool-mem/lib/index.js
+++ b/packages/core-transaction-pool-mem/lib/index.js
@@ -10,6 +10,7 @@ exports.plugin = {
   pkg: require('../package.json'),
   defaults: require('./defaults'),
   alias: 'transactionPool',
+  extends: '@arkecosystem/core-transaction-pool',
   async register (container, options) {
     container.resolvePlugin('logger').info('Connecting to transaction pool')
 

--- a/packages/core-transaction-pool-redis/lib/index.js
+++ b/packages/core-transaction-pool-redis/lib/index.js
@@ -10,6 +10,7 @@ exports.plugin = {
   pkg: require('../package.json'),
   defaults: require('./defaults'),
   alias: 'transactionPool',
+  extends: '@arkecosystem/core-transaction-pool',
   async register (container, options) {
     container.resolvePlugin('logger').info('Connecting to transaction pool')
 

--- a/packages/core/lib/config/devnet/plugins.js
+++ b/packages/core/lib/config/devnet/plugins.js
@@ -1,12 +1,10 @@
 module.exports = {
   '@arkecosystem/core-event-emitter': {},
   '@arkecosystem/core-config': {},
-  '@arkecosystem/core-logger': {},
   '@arkecosystem/core-logger-winston': {
     transports: {
       console: {
         options: {
-          colorize: true,
           level: process.env.ARK_LOG_LEVEL || 'debug',
           format: require('@arkecosystem/core-logger-winston/lib/formatter')
         }
@@ -16,15 +14,10 @@ module.exports = {
           filename: process.env.ARK_LOG_FILE || `${process.env.ARK_PATH_DATA}/logs/core/${process.env.ARK_NETWORK_NAME}/%DATE%.log`,
           datePattern: 'YYYY-MM-DD',
           level: process.env.ARK_LOG_LEVEL || 'debug',
-          zippedArchive: true,
-          maxSize: '100m',
-          maxFiles: '10'
+          zippedArchive: true
         }
       }
     }
-  },
-  '@arkecosystem/core-database': {
-    snapshots: `${process.env.ARK_PATH_DATA}/snapshots/${process.env.ARK_NETWORK_NAME}`
   },
   '@arkecosystem/core-database-postgres': {
     connection: {
@@ -39,7 +32,6 @@ module.exports = {
       port: process.env.ARK_REDIS_PORT || 6379
     }
   },
-  '@arkecosystem/core-transaction-pool': {},
   '@arkecosystem/core-transaction-pool-mem': {
     enabled: true,
     storage: `${process.env.ARK_PATH_DATA}/database/transaction-pool-${process.env.ARK_NETWORK_NAME}.sqlite`,

--- a/packages/core/lib/config/devnet/plugins.js
+++ b/packages/core/lib/config/devnet/plugins.js
@@ -5,16 +5,13 @@ module.exports = {
     transports: {
       console: {
         options: {
-          level: process.env.ARK_LOG_LEVEL || 'debug',
-          format: require('@arkecosystem/core-logger-winston/lib/formatter')
+          level: process.env.ARK_LOG_LEVEL || 'debug'
         }
       },
       dailyRotate: {
         options: {
-          filename: process.env.ARK_LOG_FILE || `${process.env.ARK_PATH_DATA}/logs/core/${process.env.ARK_NETWORK_NAME}/%DATE%.log`,
-          datePattern: 'YYYY-MM-DD',
           level: process.env.ARK_LOG_LEVEL || 'debug',
-          zippedArchive: true
+          filename: process.env.ARK_LOG_FILE || `${process.env.ARK_PATH_DATA}/logs/core/${process.env.ARK_NETWORK_NAME}/%DATE%.log`
         }
       }
     }
@@ -33,7 +30,7 @@ module.exports = {
     }
   },
   '@arkecosystem/core-transaction-pool-mem': {
-    enabled: true,
+    enabled: !process.env.ARK_TRANSACTION_POOL_DISABLED,
     storage: `${process.env.ARK_PATH_DATA}/database/transaction-pool-${process.env.ARK_NETWORK_NAME}.sqlite`,
     maxTransactionsPerSender: process.env.ARK_TRANSACTION_POOL_MAX_PER_SENDER || 300,
     whitelist: [],

--- a/packages/core/lib/config/mainnet/plugins.js
+++ b/packages/core/lib/config/mainnet/plugins.js
@@ -5,16 +5,13 @@ module.exports = {
     transports: {
       console: {
         options: {
-          level: process.env.ARK_LOG_LEVEL || 'debug',
-          format: require('@arkecosystem/core-logger-winston/lib/formatter')
+          level: process.env.ARK_LOG_LEVEL || 'debug'
         }
       },
       dailyRotate: {
         options: {
-          filename: process.env.ARK_LOG_FILE || `${process.env.ARK_PATH_DATA}/logs/core/${process.env.ARK_NETWORK_NAME}/%DATE%.log`,
-          datePattern: 'YYYY-MM-DD',
           level: process.env.ARK_LOG_LEVEL || 'debug',
-          zippedArchive: true
+          filename: process.env.ARK_LOG_FILE || `${process.env.ARK_PATH_DATA}/logs/core/${process.env.ARK_NETWORK_NAME}/%DATE%.log`
         }
       }
     }
@@ -33,7 +30,7 @@ module.exports = {
     }
   },
   '@arkecosystem/core-transaction-pool-mem': {
-    enabled: true,
+    enabled: !process.env.ARK_TRANSACTION_POOL_DISABLED,
     storage: `${process.env.ARK_PATH_DATA}/database/transaction-pool-${process.env.ARK_NETWORK_NAME}.sqlite`,
     maxTransactionsPerSender: process.env.ARK_TRANSACTION_POOL_MAX_PER_SENDER || 300,
     whitelist: [],

--- a/packages/core/lib/config/mainnet/plugins.js
+++ b/packages/core/lib/config/mainnet/plugins.js
@@ -1,12 +1,10 @@
 module.exports = {
   '@arkecosystem/core-event-emitter': {},
   '@arkecosystem/core-config': {},
-  '@arkecosystem/core-logger': {},
   '@arkecosystem/core-logger-winston': {
     transports: {
       console: {
         options: {
-          colorize: true,
           level: process.env.ARK_LOG_LEVEL || 'debug',
           format: require('@arkecosystem/core-logger-winston/lib/formatter')
         }
@@ -16,30 +14,11 @@ module.exports = {
           filename: process.env.ARK_LOG_FILE || `${process.env.ARK_PATH_DATA}/logs/core/${process.env.ARK_NETWORK_NAME}/%DATE%.log`,
           datePattern: 'YYYY-MM-DD',
           level: process.env.ARK_LOG_LEVEL || 'debug',
-          zippedArchive: true,
-          maxSize: '100m',
-          maxFiles: '10'
+          zippedArchive: true
         }
       }
     }
   },
-  '@arkecosystem/core-database': {
-    snapshots: `${process.env.ARK_PATH_DATA}/snapshots/${process.env.ARK_NETWORK_NAME}`
-  },
-  // '@arkecosystem/core-database-sequelize': {
-  //   dialect: 'sqlite',
-  //   storage: process.env.ARK_DB_STORAGE || `${process.env.ARK_PATH_DATA}/database/${process.env.ARK_NETWORK_NAME}_sequence2.sqlite`,
-  //   // host: process.env.ARK_DB_HOST || 'localhost',
-  //   // dialect: process.env.ARK_DB_DIALECT || 'postgres',
-  //   // username: process.env.ARK_DB_USERNAME || 'ark',
-  //   // password: process.env.ARK_DB_PASSWORD || 'password',
-  //   // database: process.env.ARK_DB_DATABASE || 'ark_mainnet',
-  //   logging: process.env.ARK_DB_LOGGING,
-  //   redis: {
-  //     host: process.env.ARK_REDIS_HOST || 'localhost',
-  //     port: process.env.ARK_REDIS_PORT || 6379
-  //   }
-  // },
   '@arkecosystem/core-database-postgres': {
     connection: {
       host: process.env.ARK_DB_HOST || 'localhost',
@@ -53,7 +32,6 @@ module.exports = {
       port: process.env.ARK_REDIS_PORT || 6379
     }
   },
-  '@arkecosystem/core-transaction-pool': {},
   '@arkecosystem/core-transaction-pool-mem': {
     enabled: true,
     storage: `${process.env.ARK_PATH_DATA}/database/transaction-pool-${process.env.ARK_NETWORK_NAME}.sqlite`,

--- a/packages/core/lib/config/testnet.1/plugins.js
+++ b/packages/core/lib/config/testnet.1/plugins.js
@@ -5,16 +5,13 @@ module.exports = {
     transports: {
       console: {
         options: {
-          level: process.env.ARK_LOG_LEVEL || 'debug',
-          format: require('@arkecosystem/core-logger-winston/lib/formatter')
+          level: process.env.ARK_LOG_LEVEL || 'debug'
         }
       },
       dailyRotate: {
         options: {
-          filename: process.env.ARK_LOG_FILE || `${process.env.ARK_PATH_DATA}/logs/core/${process.env.ARK_NETWORK_NAME}.1/%DATE%.log`,
-          datePattern: 'YYYY-MM-DD',
           level: process.env.ARK_LOG_LEVEL || 'debug',
-          zippedArchive: true
+          filename: process.env.ARK_LOG_FILE || `${process.env.ARK_PATH_DATA}/logs/core/${process.env.ARK_NETWORK_NAME}.1/%DATE%.log`
         }
       }
     }

--- a/packages/core/lib/config/testnet.1/plugins.js
+++ b/packages/core/lib/config/testnet.1/plugins.js
@@ -1,12 +1,10 @@
 module.exports = {
   '@arkecosystem/core-event-emitter': {},
   '@arkecosystem/core-config': {},
-  '@arkecosystem/core-logger': {},
   '@arkecosystem/core-logger-winston': {
     transports: {
       console: {
         options: {
-          colorize: true,
           level: process.env.ARK_LOG_LEVEL || 'debug',
           format: require('@arkecosystem/core-logger-winston/lib/formatter')
         }
@@ -16,15 +14,10 @@ module.exports = {
           filename: process.env.ARK_LOG_FILE || `${process.env.ARK_PATH_DATA}/logs/core/${process.env.ARK_NETWORK_NAME}.1/%DATE%.log`,
           datePattern: 'YYYY-MM-DD',
           level: process.env.ARK_LOG_LEVEL || 'debug',
-          zippedArchive: true,
-          maxSize: '100m',
-          maxFiles: '10'
+          zippedArchive: true
         }
       }
     }
-  },
-  '@arkecosystem/core-database': {
-    snapshots: `${process.env.ARK_PATH_DATA}/${process.env.ARK_NETWORK_NAME}.1/snapshots`
   },
   '@arkecosystem/core-database-postgres': {
     connection: {
@@ -39,7 +32,6 @@ module.exports = {
       port: process.env.ARK_REDIS_PORT || 6379
     }
   },
-  '@arkecosystem/core-transaction-pool': {},
   '@arkecosystem/core-transaction-pool-mem': {
     enabled: true,
     storage: `${process.env.ARK_PATH_DATA}/database/transaction-pool-${process.env.ARK_NETWORK_NAME}.sqlite`,

--- a/packages/core/lib/config/testnet.2/plugins.js
+++ b/packages/core/lib/config/testnet.2/plugins.js
@@ -1,12 +1,10 @@
 module.exports = {
   '@arkecosystem/core-event-emitter': {},
   '@arkecosystem/core-config': {},
-  '@arkecosystem/core-logger': {},
   '@arkecosystem/core-logger-winston': {
     transports: {
       console: {
         options: {
-          colorize: true,
           level: process.env.ARK_LOG_LEVEL || 'debug',
           format: require('@arkecosystem/core-logger-winston/lib/formatter')
         }
@@ -16,15 +14,10 @@ module.exports = {
           filename: process.env.ARK_LOG_FILE || `${process.env.ARK_PATH_DATA}/logs/core/${process.env.ARK_NETWORK_NAME}.2/%DATE%.log`,
           datePattern: 'YYYY-MM-DD',
           level: process.env.ARK_LOG_LEVEL || 'debug',
-          zippedArchive: true,
-          maxSize: '100m',
-          maxFiles: '10'
+          zippedArchive: true
         }
       }
     }
-  },
-  '@arkecosystem/core-database': {
-    snapshots: `${process.env.ARK_PATH_DATA}/${process.env.ARK_NETWORK_NAME}.2/snapshots`
   },
   '@arkecosystem/core-database-postgres': {
     connection: {
@@ -39,7 +32,6 @@ module.exports = {
       port: process.env.ARK_REDIS_PORT || 6379
     }
   },
-  '@arkecosystem/core-transaction-pool': {},
   '@arkecosystem/core-transaction-pool-mem': {
     enabled: true,
     storage: `${process.env.ARK_PATH_DATA}/database/transaction-pool-${process.env.ARK_NETWORK_NAME}.sqlite`,

--- a/packages/core/lib/config/testnet.2/plugins.js
+++ b/packages/core/lib/config/testnet.2/plugins.js
@@ -5,16 +5,13 @@ module.exports = {
     transports: {
       console: {
         options: {
-          level: process.env.ARK_LOG_LEVEL || 'debug',
-          format: require('@arkecosystem/core-logger-winston/lib/formatter')
+          level: process.env.ARK_LOG_LEVEL || 'debug'
         }
       },
       dailyRotate: {
         options: {
-          filename: process.env.ARK_LOG_FILE || `${process.env.ARK_PATH_DATA}/logs/core/${process.env.ARK_NETWORK_NAME}.2/%DATE%.log`,
-          datePattern: 'YYYY-MM-DD',
           level: process.env.ARK_LOG_LEVEL || 'debug',
-          zippedArchive: true
+          filename: process.env.ARK_LOG_FILE || `${process.env.ARK_PATH_DATA}/logs/core/${process.env.ARK_NETWORK_NAME}.2/%DATE%.log`
         }
       }
     }

--- a/packages/core/lib/config/testnet.live/plugins.js
+++ b/packages/core/lib/config/testnet.live/plugins.js
@@ -1,12 +1,10 @@
 module.exports = {
   '@arkecosystem/core-event-emitter': {},
   '@arkecosystem/core-config': {},
-  '@arkecosystem/core-logger': {},
   '@arkecosystem/core-logger-winston': {
     transports: {
       console: {
         options: {
-          colorize: true,
           level: process.env.ARK_LOG_LEVEL || 'debug',
           format: require('@arkecosystem/core-logger-winston/lib/formatter')
         }
@@ -16,15 +14,10 @@ module.exports = {
           filename: process.env.ARK_LOG_FILE || `${process.env.ARK_PATH_DATA}/logs/core/${process.env.ARK_NETWORK_NAME}.live/%DATE%.log`,
           datePattern: 'YYYY-MM-DD',
           level: process.env.ARK_LOG_LEVEL || 'debug',
-          zippedArchive: true,
-          maxSize: '100m',
-          maxFiles: '10'
+          zippedArchive: true
         }
       }
     }
-  },
-  '@arkecosystem/core-database': {
-    snapshots: `${process.env.ARK_PATH_DATA}/${process.env.ARK_NETWORK_NAME}.live/snapshots`
   },
   '@arkecosystem/core-database-postgres': {
     connection: {
@@ -39,7 +32,6 @@ module.exports = {
       port: process.env.ARK_REDIS_PORT || 6379
     }
   },
-  '@arkecosystem/core-transaction-pool': {},
   '@arkecosystem/core-transaction-pool-mem': {
     enabled: true,
     storage: `${process.env.ARK_PATH_DATA}/database/transaction-pool-${process.env.ARK_NETWORK_NAME}.sqlite`,

--- a/packages/core/lib/config/testnet.live/plugins.js
+++ b/packages/core/lib/config/testnet.live/plugins.js
@@ -5,16 +5,13 @@ module.exports = {
     transports: {
       console: {
         options: {
-          level: process.env.ARK_LOG_LEVEL || 'debug',
-          format: require('@arkecosystem/core-logger-winston/lib/formatter')
+          level: process.env.ARK_LOG_LEVEL || 'debug'
         }
       },
       dailyRotate: {
         options: {
-          filename: process.env.ARK_LOG_FILE || `${process.env.ARK_PATH_DATA}/logs/core/${process.env.ARK_NETWORK_NAME}.live/%DATE%.log`,
-          datePattern: 'YYYY-MM-DD',
           level: process.env.ARK_LOG_LEVEL || 'debug',
-          zippedArchive: true
+          filename: process.env.ARK_LOG_FILE || `${process.env.ARK_PATH_DATA}/logs/core/${process.env.ARK_NETWORK_NAME}.live/%DATE%.log`
         }
       }
     }

--- a/packages/core/lib/config/testnet/plugins.js
+++ b/packages/core/lib/config/testnet/plugins.js
@@ -1,12 +1,10 @@
 module.exports = {
   '@arkecosystem/core-event-emitter': {},
   '@arkecosystem/core-config': {},
-  '@arkecosystem/core-logger': {},
   '@arkecosystem/core-logger-winston': {
     transports: {
       console: {
         options: {
-          colorize: true,
           level: process.env.ARK_LOG_LEVEL || 'debug',
           format: require('@arkecosystem/core-logger-winston/lib/formatter')
         }
@@ -16,15 +14,10 @@ module.exports = {
           filename: process.env.ARK_LOG_FILE || `${process.env.ARK_PATH_DATA}/logs/core/${process.env.ARK_NETWORK_NAME}/%DATE%.log`,
           datePattern: 'YYYY-MM-DD',
           level: process.env.ARK_LOG_LEVEL || 'debug',
-          zippedArchive: true,
-          maxSize: '100m',
-          maxFiles: '10'
+          zippedArchive: true
         }
       }
     }
-  },
-  '@arkecosystem/core-database': {
-    snapshots: `${process.env.ARK_PATH_DATA}/snapshots/${process.env.ARK_NETWORK_NAME}`
   },
   '@arkecosystem/core-database-postgres': {
     connection: {
@@ -39,7 +32,6 @@ module.exports = {
       port: process.env.ARK_REDIS_PORT || 6379
     }
   },
-  '@arkecosystem/core-transaction-pool': {},
   '@arkecosystem/core-transaction-pool-mem': {
     enabled: true,
     storage: `${process.env.ARK_PATH_DATA}/database/transaction-pool-${process.env.ARK_NETWORK_NAME}.sqlite`,

--- a/packages/core/lib/config/testnet/plugins.js
+++ b/packages/core/lib/config/testnet/plugins.js
@@ -5,16 +5,13 @@ module.exports = {
     transports: {
       console: {
         options: {
-          level: process.env.ARK_LOG_LEVEL || 'debug',
-          format: require('@arkecosystem/core-logger-winston/lib/formatter')
+          level: process.env.ARK_LOG_LEVEL || 'debug'
         }
       },
       dailyRotate: {
         options: {
-          filename: process.env.ARK_LOG_FILE || `${process.env.ARK_PATH_DATA}/logs/core/${process.env.ARK_NETWORK_NAME}/%DATE%.log`,
-          datePattern: 'YYYY-MM-DD',
           level: process.env.ARK_LOG_LEVEL || 'debug',
-          zippedArchive: true
+          filename: process.env.ARK_LOG_FILE || `${process.env.ARK_PATH_DATA}/logs/core/${process.env.ARK_NETWORK_NAME}/%DATE%.log`
         }
       }
     }


### PR DESCRIPTION
## Proposed changes

This adds an `extends` prop for plugins which can be used to extend interfaces like the database and transaction pool packages as it was kind of pointless to register them via configuration without them accepting a configuration.

## Types of changes

- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes