### PR TITLE
test: replace toBeTruthy / Falsy by toBeTrue / False when appropriate

### DIFF
--- a/packages/core-api/__tests__/v1/handlers/blocks.test.js
+++ b/packages/core-api/__tests__/v1/handlers/blocks.test.js
@@ -49,7 +49,7 @@ describe('API 1.0 - Blocks', () => {
       const response = await utils.request('GET', 'blocks', { limit: 500 })
       utils.expectError(response)
 
-      expect(response.data.success).toBeFalsy()
+      expect(response.data.success).toBeFalse()
       expect(response.data.error).toContain('should be <= 100')
     })
   })

--- a/packages/core-blockchain/__tests__/blockchain.test.js
+++ b/packages/core-blockchain/__tests__/blockchain.test.js
@@ -82,7 +82,7 @@ describe('Blockchain', () => {
 
       const started = await blockchain.start(true)
 
-      expect(started).toBeTruthy()
+      expect(started).toBeTrue()
     })
   })
 
@@ -326,7 +326,7 @@ describe('Blockchain', () => {
         expect(blockchain.isSynced({ data: {
           timestamp: slots.getTime(),
           height: genesisBlock.height
-        } })).toBeTruthy()
+        } })).toBeTrue()
       })
     })
 
@@ -336,7 +336,7 @@ describe('Blockchain', () => {
           timestamp: slots.getTime() - genesisBlock.timestamp,
           height: genesisBlock.height
         }))
-        expect(blockchain.isSynced()).toBeTruthy()
+        expect(blockchain.isSynced()).toBeTrue()
         expect(blockchain.getLastBlock()).toHaveBeenCalledWith(true)
       })
     })
@@ -352,7 +352,7 @@ describe('Blockchain', () => {
         expect(blockchain.isRebuildSynced({ data: {
           timestamp: slots.getTime() - 3600 * 24 * 6,
           height: blocks101to155[52].height
-        } })).toBeTruthy()
+        } })).toBeTrue()
       })
     })
 
@@ -362,7 +362,7 @@ describe('Blockchain', () => {
           timestamp: slots.getTime() - genesisBlock.timestamp,
           height: genesisBlock.height
         }))
-        expect(blockchain.isRebuildSynced()).toBeTruthy()
+        expect(blockchain.isRebuildSynced()).toBeTrue()
         expect(blockchain.getLastBlock()).toHaveBeenCalledWith(true)
       })
     })
@@ -403,7 +403,7 @@ describe('Blockchain', () => {
         }
       }
 
-      expect(blockchain.__isChained(previousBlock, nextBlock)).toBeTruthy()
+      expect(blockchain.__isChained(previousBlock, nextBlock)).toBeTrue()
     })
 
     it('should not be ok', () => {
@@ -424,7 +424,7 @@ describe('Blockchain', () => {
         }
       }
 
-      expect(blockchain.__isChained(previousBlock, nextBlock)).toBeFalsy()
+      expect(blockchain.__isChained(previousBlock, nextBlock)).toBeFalse()
     })
   })
 

--- a/packages/core-container/__tests__/container.test.js
+++ b/packages/core-container/__tests__/container.test.js
@@ -37,7 +37,7 @@ describe('Container', () => {
   it('should determine if a registration exists', () => {
     container.register('fake', asValue('value'))
 
-    expect(container.has('fake')).toBeTruthy()
+    expect(container.has('fake')).toBeTrue()
   })
 
   it('should resolve and export paths', () => {

--- a/packages/core-database/__tests__/wallet-manager.test.js
+++ b/packages/core-database/__tests__/wallet-manager.test.js
@@ -432,7 +432,7 @@ describe('Wallet Manager', () => {
     it('should be removed if all criteria are satisfied', async () => {
       const wallet = new Wallet(walletData1.address)
 
-      expect(walletManager.__canBePurged(wallet)).toBeTruthy()
+      expect(walletManager.__canBePurged(wallet)).toBeTrue()
     })
 
     it('should not be removed if wallet.secondPublicKey is set', async () => {
@@ -440,7 +440,7 @@ describe('Wallet Manager', () => {
       wallet.secondPublicKey = 'secondPublicKey'
 
       expect(wallet.secondPublicKey).toBe('secondPublicKey')
-      expect(walletManager.__canBePurged(wallet)).toBeFalsy()
+      expect(walletManager.__canBePurged(wallet)).toBeFalse()
     })
 
     it('should not be removed if wallet.multisignature is set', async () => {
@@ -448,7 +448,7 @@ describe('Wallet Manager', () => {
       wallet.multisignature = 'multisignature'
 
       expect(wallet.multisignature).toBe('multisignature')
-      expect(walletManager.__canBePurged(wallet)).toBeFalsy()
+      expect(walletManager.__canBePurged(wallet)).toBeFalse()
     })
 
     it('should not be removed if wallet.username is set', async () => {
@@ -456,7 +456,7 @@ describe('Wallet Manager', () => {
       wallet.username = 'username'
 
       expect(wallet.username).toBe('username')
-      expect(walletManager.__canBePurged(wallet)).toBeFalsy()
+      expect(walletManager.__canBePurged(wallet)).toBeFalse()
     })
   })
 

--- a/packages/core-json-rpc/__tests__/accounts.test.js
+++ b/packages/core-json-rpc/__tests__/accounts.test.js
@@ -111,7 +111,7 @@ describe('Accounts', () => {
       })
 
       await expect(response.data.result.recipientId).toBe('AUDud8tvyVZa67p3QY7XPRUTjRGnWQQ9Xv')
-      await expect(crypto.verify(response.data.result)).toBeTruthy()
+      await expect(crypto.verify(response.data.result)).toBeTrue()
     })
   })
 })

--- a/packages/core-json-rpc/__tests__/transactions.test.js
+++ b/packages/core-json-rpc/__tests__/transactions.test.js
@@ -53,7 +53,7 @@ describe('Transactions', () => {
       })
 
       expect(response.data.result.recipientId).toBe('APnhwwyTbMiykJwYbGhYjNgtHiVJDSEhSn')
-      expect(ark.crypto.verify(response.data.result)).toBeTruthy()
+      expect(ark.crypto.verify(response.data.result)).toBeTrue()
 
       transaction = response.data.result
     })
@@ -65,7 +65,7 @@ describe('Transactions', () => {
         transactions: [transaction]
       })
 
-      expect(ark.crypto.verify(response.data.result[0])).toBeTruthy()
+      expect(ark.crypto.verify(response.data.result[0])).toBeTrue()
     })
 
     it('should broadcast tx on mainnet using the new method', async () => {
@@ -73,7 +73,7 @@ describe('Transactions', () => {
 
       const response = await request('transactions.broadcast', { id: transaction.id })
 
-      expect(ark.crypto.verify(response.data.result)).toBeTruthy()
+      expect(ark.crypto.verify(response.data.result)).toBeTrue()
     })
   })
 })

--- a/packages/core-p2p/__tests__/peer.test.js
+++ b/packages/core-p2p/__tests__/peer.test.js
@@ -68,7 +68,7 @@ describe('Peer', () => {
 
       expect(response).toBeObject()
       expect(response).toHaveProperty('success')
-      expect(response.success).toBeTruthy()
+      expect(response.success).toBeTrue()
     })
   })
 
@@ -82,7 +82,7 @@ describe('Peer', () => {
 
       expect(response).toBeObject()
       expect(response).toHaveProperty('success')
-      expect(response.success).toBeTruthy()
+      expect(response.success).toBeTrue()
     })
   })
 
@@ -125,7 +125,7 @@ describe('Peer', () => {
 
       expect(response).toBeObject()
       expect(response).toHaveProperty('success')
-      expect(response.success).toBeTruthy()
+      expect(response.success).toBeTrue()
     })
 
     it('should not be ok', async () => {

--- a/packages/core-p2p/__tests__/utils/is-myself.test.js
+++ b/packages/core-p2p/__tests__/utils/is-myself.test.js
@@ -9,9 +9,9 @@ describe('isMyself', () => {
   })
 
   it('should be ok for localhost addresses', () => {
-    expect(isMyself('127.0.0.1')).toBeTruthy()
-    // expect(isMyself('::1')).toBeTruthy() // doesn't work on Travis
-    expect(isMyself('192.167.22.1')).toBeFalsy()
+    expect(isMyself('127.0.0.1')).toBeTrue()
+
+    expect(isMyself('192.167.22.1')).toBeFalse()
   })
 
   it('should be ok for LAN addresses', () => {
@@ -24,7 +24,7 @@ describe('isMyself', () => {
     })
 
     addresses.forEach(ipAddress => {
-      expect(isMyself(ipAddress)).toBeTruthy()
+      expect(isMyself(ipAddress)).toBeTrue()
     })
   })
 })

--- a/packages/core-p2p/__tests__/utils/is-whitelist.test.js
+++ b/packages/core-p2p/__tests__/utils/is-whitelist.test.js
@@ -14,18 +14,18 @@ describe('isWhitelist', () => {
   })
 
   it('should be ok for 127.0.0.1', () => {
-    expect(isWhitelist(whitelisted, '127.0.0.1')).toBeTruthy()
+    expect(isWhitelist(whitelisted, '127.0.0.1')).toBeTrue()
   })
 
   it('should be ok for ::ffff:127.0.0.1', () => {
-    expect(isWhitelist(whitelisted, '::ffff:127.0.0.1')).toBeTruthy()
+    expect(isWhitelist(whitelisted, '::ffff:127.0.0.1')).toBeTrue()
   })
 
   it('should be ok for 192.168.0.10', () => {
-    expect(isWhitelist(whitelisted, '192.168.0.10')).toBeTruthy()
+    expect(isWhitelist(whitelisted, '192.168.0.10')).toBeTrue()
   })
 
   it('should not be ok', () => {
-    expect(isWhitelist(whitelisted, 'dummy')).toBeFalsy()
+    expect(isWhitelist(whitelisted, 'dummy')).toBeFalse()
   })
 })

--- a/packages/core-transaction-pool-mem/__tests__/connection.test.js
+++ b/packages/core-transaction-pool-mem/__tests__/connection.test.js
@@ -230,7 +230,7 @@ describe('Connection', () => {
       expect(connection.hasExceededMaxTransactions).toBeFunction()
     })
 
-    it('should be truthy if exceeded', () => {
+    it('should be true if exceeded', () => {
       connection.options.maxTransactionsPerSender = 5
       connection.options.allowedSenders = []
       connection.addTransaction(mockData.dummy3)
@@ -243,7 +243,7 @@ describe('Connection', () => {
 
       expect(connection.getPoolSize()).toBe(7)
       const exceeded = connection.hasExceededMaxTransactions(mockData.dummy3)
-      expect(exceeded).toBeTruthy()
+      expect(exceeded).toBeTrue()
     })
 
     it('should be falsy if not exceeded', () => {
@@ -256,7 +256,7 @@ describe('Connection', () => {
 
       expect(connection.getPoolSize()).toBe(3)
       const exceeded = connection.hasExceededMaxTransactions(mockData.dummy3)
-      expect(exceeded).toBeFalsy()
+      expect(exceeded).toBeFalse()
     })
 
     it('should be allowed to exceed if whitelisted', () => {
@@ -273,7 +273,7 @@ describe('Connection', () => {
 
       expect(connection.getPoolSize()).toBe(7)
       const exceeded = connection.hasExceededMaxTransactions(mockData.dummy3)
-      expect(exceeded).toBeFalsy()
+      expect(exceeded).toBeFalse()
     })
   })
 
@@ -406,7 +406,7 @@ describe('Connection', () => {
     it('should be false for non-existent sender', () => {
       connection.addTransaction(mockData.dummy1)
 
-      expect(connection.checkIfSenderHasVoteTransactions('nonexistent')).toBeFalsy()
+      expect(connection.checkIfSenderHasVoteTransactions('nonexistent')).toBeFalse()
     })
 
     it('should be false for existent sender with no votes', () => {
@@ -414,7 +414,7 @@ describe('Connection', () => {
 
       connection.addTransaction(tx)
 
-      expect(connection.checkIfSenderHasVoteTransactions(tx.senderPublicKey)).toBeFalsy()
+      expect(connection.checkIfSenderHasVoteTransactions(tx.senderPublicKey)).toBeFalse()
     })
 
     it('should be true for existent sender with votes', () => {
@@ -429,7 +429,7 @@ describe('Connection', () => {
 
       connection.addTransaction(mockData.dummy2)
 
-      expect(connection.checkIfSenderHasVoteTransactions(tx.senderPublicKey)).toBeTruthy()
+      expect(connection.checkIfSenderHasVoteTransactions(tx.senderPublicKey)).toBeTrue()
     })
   })
 

--- a/packages/core-transaction-pool/__tests__/dynamic-fee.test.js
+++ b/packages/core-transaction-pool/__tests__/dynamic-fee.test.js
@@ -24,28 +24,28 @@ describe('Dynamic Fee Matcher with dynamic fees disabled', () => {
   })
 
   it('should accept regular transactions', () => {
-    expect(dynamicFeeMatch(mockData.dummy1)).toBeTruthy()
-    expect(dynamicFeeMatch(mockData.dummy2)).toBeTruthy()
+    expect(dynamicFeeMatch(mockData.dummy1)).toBeTrue()
+    expect(dynamicFeeMatch(mockData.dummy2)).toBeTrue()
   })
 
   it('should decline dynamic transaction', () => {
-    expect(dynamicFeeMatch(mockData.dynamicFeeNormalDummy1)).toBeFalsy()
+    expect(dynamicFeeMatch(mockData.dynamicFeeNormalDummy1)).toBeFalse()
   })
 
   it('should decline dynamic transaction fee too low', () => {
-    expect(dynamicFeeMatch(mockData.dynamicFeeLowDummy2)).toBeFalsy()
+    expect(dynamicFeeMatch(mockData.dynamicFeeLowDummy2)).toBeFalse()
   })
 
   it('should decline dynamic transaction with fee too high', () => {
-    expect(dynamicFeeMatch(mockData.dynamicFeeOverTheTop)).toBeFalsy()
+    expect(dynamicFeeMatch(mockData.dynamicFeeOverTheTop)).toBeFalse()
   })
 
   it('should decline dynamic transaction with fee 0', () => {
-    expect(dynamicFeeMatch(mockData.dynamicFeeZero)).toBeFalsy()
+    expect(dynamicFeeMatch(mockData.dynamicFeeZero)).toBeFalse()
   })
 
   it('should decline dynamic transaction with fee <0', () => {
-    expect(dynamicFeeMatch(mockData.dynamicFeeNegative)).toBeFalsy()
+    expect(dynamicFeeMatch(mockData.dynamicFeeNegative)).toBeFalse()
   })
 })
 
@@ -63,15 +63,15 @@ describe('Dynamic Fee Matcher with changed minimum accepted fee', () => {
   })
 
   it('should accept regular transaction with normal fee', () => {
-    expect(dynamicFeeMatch(mockData.dummy1)).toBeTruthy()
+    expect(dynamicFeeMatch(mockData.dummy1)).toBeTrue()
   })
 
   it('should decline dynamic transactions with fee below delegate minimum', () => {
-    expect(dynamicFeeMatch(mockData.dynamicFeeNormalDummy1)).toBeFalsy()
-    expect(dynamicFeeMatch(mockData.dynamicFeeLowDummy2)).toBeFalsy()
-    expect(dynamicFeeMatch(mockData.dynamicFeeOverTheTop)).toBeFalsy()
-    expect(dynamicFeeMatch(mockData.dynamicFeeZero)).toBeFalsy()
-    expect(dynamicFeeMatch(mockData.dynamicFeeNegative)).toBeFalsy()
+    expect(dynamicFeeMatch(mockData.dynamicFeeNormalDummy1)).toBeFalse()
+    expect(dynamicFeeMatch(mockData.dynamicFeeLowDummy2)).toBeFalse()
+    expect(dynamicFeeMatch(mockData.dynamicFeeOverTheTop)).toBeFalse()
+    expect(dynamicFeeMatch(mockData.dynamicFeeZero)).toBeFalse()
+    expect(dynamicFeeMatch(mockData.dynamicFeeNegative)).toBeFalse()
   })
 })
 
@@ -89,27 +89,27 @@ describe('Dynamic Fee Matcher with dynamic fees enabled', () => {
   })
 
   it('should accept regular transactions', () => {
-    expect(dynamicFeeMatch(mockData.dummy1)).toBeTruthy()
-    expect(dynamicFeeMatch(mockData.dummy2)).toBeTruthy()
+    expect(dynamicFeeMatch(mockData.dummy1)).toBeTrue()
+    expect(dynamicFeeMatch(mockData.dummy2)).toBeTrue()
   })
 
   it('should accept dynamic transaction', () => {
-    expect(dynamicFeeMatch(mockData.dynamicFeeNormalDummy1)).toBeTruthy()
+    expect(dynamicFeeMatch(mockData.dynamicFeeNormalDummy1)).toBeTrue()
   })
 
   it('should decline dynamic transaction fee too low', () => {
-    expect(dynamicFeeMatch(mockData.dynamicFeeLowDummy2)).toBeFalsy()
+    expect(dynamicFeeMatch(mockData.dynamicFeeLowDummy2)).toBeFalse()
   })
 
   it('should decline dynamic transaction with fee too high', () => {
-    expect(dynamicFeeMatch(mockData.dynamicFeeOverTheTop)).toBeFalsy()
+    expect(dynamicFeeMatch(mockData.dynamicFeeOverTheTop)).toBeFalse()
   })
 
   it('should decline dynamic transaction with fee 0', () => {
-    expect(dynamicFeeMatch(mockData.dynamicFeeZero)).toBeFalsy()
+    expect(dynamicFeeMatch(mockData.dynamicFeeZero)).toBeFalse()
   })
 
   it('should decline dynamic transaction with fee <0', () => {
-    expect(dynamicFeeMatch(mockData.dynamicFeeNegative)).toBeFalsy()
+    expect(dynamicFeeMatch(mockData.dynamicFeeNegative)).toBeFalse()
   })
 })

--- a/packages/core-transaction-pool/__tests__/guard.test.js
+++ b/packages/core-transaction-pool/__tests__/guard.test.js
@@ -149,13 +149,13 @@ describe('Transaction Guard', () => {
     it('should be ok', () => {
       guard.excess = [{ id: 1 }, { id: 2 }]
 
-      expect(guard.has('excess', 2)).toBeTruthy()
+      expect(guard.has('excess', 2)).toBeTrue()
     })
 
     it('should not be ok', () => {
       guard.excess = [{ id: 1 }, { id: 2 }]
 
-      expect(guard.has('excess', 1)).toBeFalsy()
+      expect(guard.has('excess', 1)).toBeFalse()
     })
   })
 
@@ -167,13 +167,13 @@ describe('Transaction Guard', () => {
     it('should be ok', () => {
       guard.excess = [{ id: 1 }, { id: 2 }]
 
-      expect(guard.hasAtLeast('excess', 2)).toBeTruthy()
+      expect(guard.hasAtLeast('excess', 2)).toBeTrue()
     })
 
     it('should not be ok', () => {
       guard.excess = [{ id: 1 }]
 
-      expect(guard.hasAtLeast('excess', 2)).toBeFalsy()
+      expect(guard.hasAtLeast('excess', 2)).toBeFalse()
     })
   })
 
@@ -185,13 +185,13 @@ describe('Transaction Guard', () => {
     it('should be ok', () => {
       guard.excess = [{ id: 1 }]
 
-      expect(guard.hasAny('excess')).toBeTruthy()
+      expect(guard.hasAny('excess')).toBeTrue()
     })
 
     it('should not be ok', () => {
       guard.excess = []
 
-      expect(guard.hasAny('excess')).toBeFalsy()
+      expect(guard.hasAny('excess')).toBeFalse()
     })
   })
 

--- a/packages/core-transaction-pool/__tests__/interface.test.js
+++ b/packages/core-transaction-pool/__tests__/interface.test.js
@@ -154,11 +154,11 @@ describe('Transaction Pool Interface', () => {
 
     it('should return true', async () => {
       poolInterface.blockSender('keykeykey')
-      expect(poolInterface.isSenderBlocked('keykeykey')).toBeTruthy()
+      expect(poolInterface.isSenderBlocked('keykeykey')).toBeTrue()
     })
 
     it('should return false', async () => {
-      expect(poolInterface.isSenderBlocked('keykeykey2')).toBeFalsy()
+      expect(poolInterface.isSenderBlocked('keykeykey2')).toBeFalse()
     })
   })
 
@@ -172,7 +172,7 @@ describe('Transaction Pool Interface', () => {
       const blockedTime = poolInterface.blockSender('keykeykey')
       const duration = moment.duration(blockedTime.diff(time))
 
-      expect(poolInterface.isSenderBlocked('keykeykey')).toBeTruthy()
+      expect(poolInterface.isSenderBlocked('keykeykey')).toBeTrue()
       expect(parseInt(duration.asHours())).toEqual(1)
     })
   })

--- a/packages/crypto/__tests__/crypto/crypto.test.js
+++ b/packages/crypto/__tests__/crypto/crypto.test.js
@@ -330,13 +330,13 @@ describe('crypto.js', () => {
     it('should validate MAINNET addresses', () => {
       configManager.setConfig(CONFIGURATIONS.ARK.MAINNET)
 
-      expect(crypto.validateAddress('AdVSe37niA3uFUPgCgMUH2tMsHF4LpLoiX')).toBeTruthy()
+      expect(crypto.validateAddress('AdVSe37niA3uFUPgCgMUH2tMsHF4LpLoiX')).toBeTrue()
     })
 
     it('should validate DEVNET addresses', () => {
       configManager.setConfig(CONFIGURATIONS.ARK.DEVNET)
 
-      expect(crypto.validateAddress('DARiJqhogp2Lu6bxufUFQQMuMyZbxjCydN')).toBeTruthy()
+      expect(crypto.validateAddress('DARiJqhogp2Lu6bxufUFQQMuMyZbxjCydN')).toBeTrue()
     })
   })
 })

--- a/packages/crypto/__tests__/handlers/transactions/delegate-registration.test.js
+++ b/packages/crypto/__tests__/handlers/transactions/delegate-registration.test.js
@@ -39,13 +39,13 @@ describe('DelegateRegistrationHandler', () => {
     })
 
     it('should be ok', () => {
-      expect(handler.canApply(wallet, transaction)).toBeTruthy()
+      expect(handler.canApply(wallet, transaction)).toBeTrue()
     })
 
     it('should not be ok', () => {
       wallet.username = 'dummy'
 
-      expect(handler.canApply(wallet, transaction)).toBeFalsy()
+      expect(handler.canApply(wallet, transaction)).toBeFalse()
     })
   })
 

--- a/packages/crypto/__tests__/handlers/transactions/delegate-resignation.test.js
+++ b/packages/crypto/__tests__/handlers/transactions/delegate-resignation.test.js
@@ -21,13 +21,13 @@ describe('DelegateResignationHandler', () => {
     it('should be ok', () => {
       wallet.username = 'dummy'
 
-      expect(handler.canApply(wallet, transaction)).toBeTruthy()
+      expect(handler.canApply(wallet, transaction)).toBeTrue()
     })
 
     it('should not be ok', () => {
       wallet.username = null
 
-      expect(handler.canApply(wallet, transaction)).toBeFalsy()
+      expect(handler.canApply(wallet, transaction)).toBeFalse()
     })
   })
 

--- a/packages/crypto/__tests__/handlers/transactions/handler.test.js
+++ b/packages/crypto/__tests__/handlers/transactions/handler.test.js
@@ -42,13 +42,13 @@ describe('Handler', () => {
     })
 
     it('should be truthy', () => {
-      expect(handler.canApply(wallet, transaction)).toBeTruthy()
+      expect(handler.canApply(wallet, transaction)).toBeTrue()
     })
 
     it('should be falsy', () => {
       transaction.senderPublicKey = 'a'.repeat(66)
 
-      expect(handler.canApply(wallet, transaction)).toBeFalsy()
+      expect(handler.canApply(wallet, transaction)).toBeFalse()
     })
   })
 

--- a/packages/crypto/__tests__/handlers/transactions/ipfs.test.js
+++ b/packages/crypto/__tests__/handlers/transactions/ipfs.test.js
@@ -19,13 +19,13 @@ describe('IpfsHandler', () => {
     })
 
     it('should be ok', () => {
-      expect(handler.canApply(wallet, transaction)).toBeTruthy()
+      expect(handler.canApply(wallet, transaction)).toBeTrue()
     })
 
     it('should not be ok', () => {
       transaction.senderPublicKey = 'a'.repeat(66)
 
-      expect(handler.canApply(wallet, transaction)).toBeFalsy()
+      expect(handler.canApply(wallet, transaction)).toBeFalse()
     })
   })
 

--- a/packages/crypto/__tests__/handlers/transactions/multi-payment.test.js
+++ b/packages/crypto/__tests__/handlers/transactions/multi-payment.test.js
@@ -50,14 +50,14 @@ describe('MultiPaymentHandler', () => {
     it('should be ok', () => {
       const amount = transaction.asset.payments.reduce((a, p) => (a.plus(p.amount)), Bignum.ZERO)
 
-      expect(handler.canApply(wallet, transaction)).toBeTruthy()
+      expect(handler.canApply(wallet, transaction)).toBeTrue()
     })
 
     it('should not be ok', () => {
       const amount = transaction.asset.payments.reduce((a, p) => (a.plus(p.amount)), Bignum.ZERO)
       wallet.balance = Bignum.ZERO
 
-      expect(handler.canApply(wallet, transaction)).toBeFalsy()
+      expect(handler.canApply(wallet, transaction)).toBeFalse()
     })
   })
 

--- a/packages/crypto/__tests__/handlers/transactions/multi-signature.test.js
+++ b/packages/crypto/__tests__/handlers/transactions/multi-signature.test.js
@@ -102,13 +102,13 @@ describe('MultiSignatureHandler', () => {
     it('should be ok', () => {
       delete wallet.multisignature
 
-      expect(handler.canApply(wallet, transaction)).toBeTruthy()
+      expect(handler.canApply(wallet, transaction)).toBeTrue()
     })
 
     it('should not be ok', () => {
       wallet.multisignature = multisignatureTest
 
-      expect(handler.canApply(wallet, transaction)).toBeFalsy()
+      expect(handler.canApply(wallet, transaction)).toBeFalse()
     })
   })
 

--- a/packages/crypto/__tests__/handlers/transactions/second-signature.test.js
+++ b/packages/crypto/__tests__/handlers/transactions/second-signature.test.js
@@ -44,11 +44,11 @@ describe('SecondSignatureHandler', () => {
     it('should be ok', () => {
       wallet.secondPublicKey = null
 
-      expect(handler.canApply(wallet, transaction)).toBeTruthy()
+      expect(handler.canApply(wallet, transaction)).toBeTrue()
     })
 
     it('should not be ok', () => {
-      expect(handler.canApply(wallet, transaction)).toBeFalsy()
+      expect(handler.canApply(wallet, transaction)).toBeFalse()
     })
   })
 

--- a/packages/crypto/__tests__/handlers/transactions/timelock-transfer.test.js
+++ b/packages/crypto/__tests__/handlers/transactions/timelock-transfer.test.js
@@ -19,13 +19,13 @@ describe('TimelockTransferHandler', () => {
     })
 
     it('should be ok', () => {
-      expect(handler.canApply(wallet, transaction)).toBeTruthy()
+      expect(handler.canApply(wallet, transaction)).toBeTrue()
     })
 
     it('should not be ok', () => {
       transaction.senderPublicKey = 'a'.repeat(66)
 
-      expect(handler.canApply(wallet, transaction)).toBeFalsy()
+      expect(handler.canApply(wallet, transaction)).toBeFalse()
     })
   })
 

--- a/packages/crypto/__tests__/handlers/transactions/transfer.test.js
+++ b/packages/crypto/__tests__/handlers/transactions/transfer.test.js
@@ -19,13 +19,13 @@ describe('TransferHandler', () => {
     })
 
     it('should be ok', () => {
-      expect(handler.canApply(wallet, transaction)).toBeTruthy()
+      expect(handler.canApply(wallet, transaction)).toBeTrue()
     })
 
     it('should not be ok', () => {
       transaction.senderPublicKey = 'a'.repeat(66)
 
-      expect(handler.canApply(wallet, transaction)).toBeFalsy()
+      expect(handler.canApply(wallet, transaction)).toBeFalse()
     })
   })
 

--- a/packages/crypto/__tests__/models/transaction.test.js
+++ b/packages/crypto/__tests__/models/transaction.test.js
@@ -80,7 +80,7 @@ describe('Models - Transaction', () => {
         const ser = Transaction.serialize(transaction.data).toString('hex')
         const newTransaction = Transaction.fromBytes(ser)
         expect(newTransaction.data).toEqual(transaction.data)
-        expect(newTransaction.verified).toBeTruthy()
+        expect(newTransaction.verified).toBeTrue()
       })
     })
 
@@ -197,6 +197,6 @@ describe('Models - Transaction', () => {
   it('Signatures are verified', () => {
     [0, 1, 2, 3, 4]
       .map(type => createRandomTx(type))
-      .forEach(transaction => expect(crypto.verify(transaction)).toBeTruthy())
+      .forEach(transaction => expect(crypto.verify(transaction)).toBeTrue())
   })
 })

--- a/packages/crypto/__tests__/models/wallet.test.js
+++ b/packages/crypto/__tests__/models/wallet.test.js
@@ -36,7 +36,7 @@ describe('Models - Wallet', () => {
 
     xit('should be ok for a multi-transaction', () => {
       Object.keys(data).forEach(k => (testWallet[k] = data[k]))
-      expect(testWallet.canApply(multiTx)).toBeTruthy()
+      expect(testWallet.canApply(multiTx)).toBeTrue()
     })
   })
 
@@ -68,7 +68,7 @@ describe('Models - Wallet', () => {
       expect(testWallet.forgedFees).toEqual(block.totalFee)
       expect(testWallet.forgedRewards).toEqual(block.totalFee)
       expect(testWallet.lastBlock).toBeObject(block)
-      expect(testWallet.dirty).toBeTruthy()
+      expect(testWallet.dirty).toBeTrue()
     })
 
     // Doesn't make sense anymore?
@@ -83,7 +83,7 @@ describe('Models - Wallet', () => {
       expect(testWallet.forgedFees).toBe(originalBlock.totalFee)
       expect(testWallet.forgedRewards).toBe(originalBlock.totalFee)
       expect(testWallet.lastBlock).toBeObject(originalBlock)
-      expect(testWallet.dirty).toBeTruthy()
+      expect(testWallet.dirty).toBeTrue()
     })
 
     it('should not apply incorrect block', () => {
@@ -95,7 +95,7 @@ describe('Models - Wallet', () => {
       expect(testWallet.forgedFees).toEqual(originalWallet.forgedFees)
       expect(testWallet.forgedRewards).toEqual(originalWallet.forgedRewards)
       expect(testWallet.lastBlock).toBe(originalWallet.lastBlock)
-      expect(testWallet.dirty).toBeTruthy()
+      expect(testWallet.dirty).toBeTrue()
     })
   })
 })

--- a/packages/crypto/__tests__/validation/rules/address.test.js
+++ b/packages/crypto/__tests__/validation/rules/address.test.js
@@ -7,11 +7,11 @@ describe('Address Rule', () => {
     expect(rule).toBeFunction()
   })
 
-  it('should be truthy', () => {
-    expect(rule('DARiJqhogp2Lu6bxufUFQQMuMyZbxjCydN').passes).toBeTruthy()
+  it('should be true', () => {
+    expect(rule('DARiJqhogp2Lu6bxufUFQQMuMyZbxjCydN').passes).toBeTrue()
   })
 
-  it('should be falsy', () => {
-    expect(rule('_DARiJqhogp2Lu6bxufUFQQMuMyZbxjCydN_').passes).toBeFalsy()
+  it('should be false', () => {
+    expect(rule('_DARiJqhogp2Lu6bxufUFQQMuMyZbxjCydN_').passes).toBeFalse()
   })
 })

--- a/packages/crypto/__tests__/validation/rules/public-key.test.js
+++ b/packages/crypto/__tests__/validation/rules/public-key.test.js
@@ -7,11 +7,11 @@ describe('Public Key Rule', () => {
     expect(rule).toBeFunction()
   })
 
-  it('should be truthy', () => {
-    expect(rule('022cca9529ec97a772156c152a00aad155ee6708243e65c9d211a589cb5d43234d').passes).toBeTruthy()
+  it('should be true', () => {
+    expect(rule('022cca9529ec97a772156c152a00aad155ee6708243e65c9d211a589cb5d43234d').passes).toBeTrue()
   })
 
-  it('should be falsy', () => {
-    expect(rule('_022cca9529ec97a772156c152a00aad155ee6708243e65c9d211a589cb5d43234d_').passes).toBeFalsy()
+  it('should be false', () => {
+    expect(rule('_022cca9529ec97a772156c152a00aad155ee6708243e65c9d211a589cb5d43234d_').passes).toBeFalse()
   })
 })

--- a/packages/crypto/__tests__/validation/rules/username.test.js
+++ b/packages/crypto/__tests__/validation/rules/username.test.js
@@ -7,11 +7,11 @@ describe('Username Rule', () => {
     expect(rule).toBeFunction()
   })
 
-  it('should be truthy', () => {
-    expect(rule('boldninja').passes).toBeTruthy()
+  it('should be true', () => {
+    expect(rule('boldninja').passes).toBeTrue()
   })
 
-  it('should be falsy', () => {
-    expect(rule('bold ninja').passes).toBeFalsy()
+  it('should be false', () => {
+    expect(rule('bold ninja').passes).toBeFalse()
   })
 })

--- a/packages/crypto/__tests__/validation/validator.test.js
+++ b/packages/crypto/__tests__/validation/validator.test.js
@@ -20,20 +20,20 @@ describe('Validator', () => {
       expect(validator.passes).toBeFunction()
     })
 
-    it('should be truthy', () => {
+    it('should be true', () => {
       validator.results = {
         passes: true
       }
 
-      expect(validator.passes()).toBeTruthy()
+      expect(validator.passes()).toBeTrue()
     })
 
-    it('should be falsy', () => {
+    it('should be false', () => {
       validator.results = {
         passes: false
       }
 
-      expect(validator.passes()).toBeFalsy()
+      expect(validator.passes()).toBeFalse()
     })
   })
 
@@ -42,20 +42,20 @@ describe('Validator', () => {
       expect(validator.fails).toBeFunction()
     })
 
-    it('should be truthy', () => {
+    it('should be true', () => {
       validator.results = {
         fails: true
       }
 
-      expect(validator.fails()).toBeTruthy()
+      expect(validator.fails()).toBeTrue()
     })
 
-    it('should be falsy', () => {
+    it('should be false', () => {
       validator.results = {
         fails: false
       }
 
-      expect(validator.fails()).toBeFalsy()
+      expect(validator.fails()).toBeFalse()
     })
   })
 
@@ -64,7 +64,7 @@ describe('Validator', () => {
       expect(validator.validated).toBeFunction()
     })
 
-    it('should be truthy', () => {
+    it('should be true', () => {
       validator.results = {
         data: {
           key: 'value'
@@ -74,7 +74,7 @@ describe('Validator', () => {
       expect(validator.validated()).toHaveProperty('key', 'value')
     })
 
-    it('should be falsy', () => {
+    it('should be false', () => {
       validator.results = {
         data: {
           invalidKey: 'value'
@@ -104,16 +104,16 @@ describe('Validator', () => {
       expect(validator.__validateWithRule).toBeFunction()
     })
 
-    it('should be truthy', () => {
+    it('should be true', () => {
       validator.__validateWithRule('DARiJqhogp2Lu6bxufUFQQMuMyZbxjCydN', 'address')
 
-      expect(validator.passes()).toBeTruthy()
+      expect(validator.passes()).toBeTrue()
     })
 
-    it('should be falsy', () => {
+    it('should be false', () => {
       validator.__validateWithRule('_DARiJqhogp2Lu6bxufUFQQMuMyZbxjCydN_', 'address')
 
-      expect(validator.passes()).toBeFalsy()
+      expect(validator.passes()).toBeFalse()
     })
   })
 
@@ -122,7 +122,7 @@ describe('Validator', () => {
       expect(validator.__validateWithFunction).toBeFunction()
     })
 
-    it('should be truthy', () => {
+    it('should be true', () => {
       validator.__validateWithFunction('DARiJqhogp2Lu6bxufUFQQMuMyZbxjCydN', value => {
         return {
           data: value,
@@ -131,10 +131,10 @@ describe('Validator', () => {
         }
       })
 
-      expect(validator.passes()).toBeTruthy()
+      expect(validator.passes()).toBeTrue()
     })
 
-    it('should be falsy', () => {
+    it('should be false', () => {
       validator.__validateWithFunction('_DARiJqhogp2Lu6bxufUFQQMuMyZbxjCydN_', value => {
         return {
           data: value,
@@ -143,7 +143,7 @@ describe('Validator', () => {
         }
       })
 
-      expect(validator.passes()).toBeFalsy()
+      expect(validator.passes()).toBeFalse()
     })
   })
 
@@ -152,22 +152,22 @@ describe('Validator', () => {
       expect(validator.__validateWithJoi).toBeFunction()
     })
 
-    it('should be truthy', () => {
+    it('should be true', () => {
       validator.__validateWithJoi(
         'DARiJqhogp2Lu6bxufUFQQMuMyZbxjCydN',
         Joi.string().alphanum().length(34).required()
       )
 
-      expect(validator.passes()).toBeTruthy()
+      expect(validator.passes()).toBeTrue()
     })
 
-    it('should be falsy', () => {
+    it('should be false', () => {
       validator.__validateWithJoi(
         '_DARiJqhogp2Lu6bxufUFQQMuMyZbxjCydN_',
         Joi.string().alphanum().length(34).required()
       )
 
-      expect(validator.passes()).toBeFalsy()
+      expect(validator.passes()).toBeFalse()
     })
   })
 


### PR DESCRIPTION
## Proposed changes

Replace toBeTruthy / Falsy by toBeTrue / False to strictly compare boolean values when appropriate. ( === true , === false)

## Types of changes

- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [x] Test (adding missing tests or fixing existing tests)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
