### PR TITLE
fix: cast delegate round to number

### DIFF
--- a/packages/core-database-postgres/lib/connection.js
+++ b/packages/core-database-postgres/lib/connection.js
@@ -164,6 +164,8 @@ module.exports = class PostgresConnection extends ConnectionInterface {
     let currentSeed = crypto.createHash('sha256').update(seedSource, 'utf8').digest()
 
     for (let i = 0, delCount = data.length; i < delCount; i++) {
+      data[i].round = +round
+
       for (let x = 0; x < 4 && i < delCount; i++, x++) {
         const newIndex = currentSeed[x] % delCount
         const b = data[newIndex]


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
This check `this.activeDelegates[0].round === round` always evaluates to false, because `delegate.round` is a string at this point while `round` is a number.

There are two places where we performed this comparison:
https://github.com/ArkEcosystem/core/blob/603030e554bfb208fd8457d0b145f55eac05b87a/packages/core-database/lib/interface.js#L287
https://github.com/ArkEcosystem/core/blob/69e21fb3f7e0d17daa31d71b00ef2ccc440cf940/packages/core-database-postgres/lib/connection.js#L157

Once everything is done in memory this is probably unnecessary.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [X] Bugfix (non-breaking change which fixes an issue)


## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [ ] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [X] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
