### PR TITLE
test: reduce nondeterminism in the tx expiration test

### DIFF
--- a/packages/core-transaction-pool-mem/__tests__/connection.test.js
+++ b/packages/core-transaction-pool-mem/__tests__/connection.test.js
@@ -1,13 +1,16 @@
 'use strict'
 
 const app = require('./__support__/setup')
+const crypto = require('@arkecosystem/crypto')
 const defaultConfig = require('../lib/defaults')
 const delay = require('delay')
 const delegatesSecrets = require('@arkecosystem/core-test-utils/fixtures/testnet/passphrases')
 const generateTransfer = require('@arkecosystem/core-test-utils/lib/generators/transactions/transfer')
 const mockData = require('./__fixtures__/transactions')
-const { TRANSACTION_TYPES } = require('@arkecosystem/crypto').constants
-const { Transaction } = require('@arkecosystem/crypto').models
+
+const TRANSACTION_TYPES = crypto.constants.TRANSACTION_TYPES
+const Transaction = crypto.models.Transaction
+const slots = crypto.slots
 
 let connection
 
@@ -114,10 +117,16 @@ describe('Connection', () => {
     it('should add the transactions to the pool and they should expire', async () => {
       expect(connection.getPoolSize()).toBe(0)
 
+      const expireAfterSeconds = 3
+      const expiration = slots.getTime() + expireAfterSeconds
+
+      mockData.dummyExp1.expiration = expiration
+      mockData.dummyExp2.expiration = expiration
+
       connection.addTransactions([mockData.dummyExp1, mockData.dummyExp2])
 
       expect(connection.getPoolSize()).toBe(2)
-      await delay(7000)
+      await delay((expireAfterSeconds + 1) * 1000)
       expect(connection.getPoolSize()).toBe(0)
     })
   })


### PR DESCRIPTION
The fixtures in
packages/core-transaction-pool-mem/__tests__/__fixtures__/ contain
transactions that are set to expire after 5 seconds:
  expiration: slots.getTime() + 5
but this is evaluated as soon as jest starts and it takes some time to
set up the test environment which may be more than 5 seconds. If this
happens then the transactions are already expired by the time the
expiration test starts.

To fix this set the expiration from within the test, just before
executing it.

## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [ ] Docs (documentation only changes)
- [x] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
