### PR TITLE
refactor: remove unused wallet.voted property

### DIFF
--- a/packages/core-database-postgres/lib/spv.js
+++ b/packages/core-database-postgres/lib/spv.js
@@ -179,14 +179,12 @@ module.exports = class SPV {
     for (const transaction of transactions) {
       const wallet = this.walletManager.findByPublicKey(transaction.senderPublicKey)
 
-      if (!wallet.voted) {
+      if (!wallet.vote) {
         const vote = Transaction.deserialize(transaction.serialized.toString('hex')).asset.votes[0]
 
         if (vote.startsWith('+')) {
           wallet.vote = vote.slice(1)
         }
-
-        wallet.voted = true
       }
     }
 

--- a/packages/crypto/lib/models/wallet.js
+++ b/packages/crypto/lib/models/wallet.js
@@ -36,7 +36,6 @@ module.exports = class Wallet {
     this.secondPublicKey = null
     this.balance = Bignum.ZERO
     this.vote = null
-    this.voted = false
     this.username = null
     this.lastBlock = null
     this.voteBalance = Bignum.ZERO


### PR DESCRIPTION
## Proposed changes

Removes the `voted` property on the `Wallet` class as it was used in the same was as `wallet.vote` can be used to check if it has a value and thus indicating the wallet is voting.

*Unless I am missing something this property is redundant.*

## Types of changes

- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes