### PR TITLE
fix: calculate correct logger padding

### DIFF
--- a/packages/core-logger-winston/lib/driver.js
+++ b/packages/core-logger-winston/lib/driver.js
@@ -38,8 +38,8 @@ module.exports = class Logger extends LoggerInterface {
     let line = '\u{1b}[0G  '
     line += title.blue
     line += ' ['
-    line += ('='.repeat(progress / 2)).green
-    line += ' '.repeat(50 - progress / 2) + '] '
+    line += ('='.repeat(Math.floor(progress / 2))).green
+    line += ' '.repeat(Math.ceil(50 - progress / 2)) + '] '
     line += progress.toFixed(figures) + '% '
 
     if (postTitle) {


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

The padding is currently not being calculated correctly in the `printTracker` function:

![image](https://user-images.githubusercontent.com/6547002/47249364-e9188c00-d412-11e8-9f74-a450e9183f87.png)

Fixed:

![image](https://user-images.githubusercontent.com/6547002/47249333-98089800-d412-11e8-9943-6482a3e3ccd9.png)

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
