### PR TITLE
docs: fix wrong database docs and add SPV info

### DIFF
--- a/packages/core-database-postgres/lib/spv.js
+++ b/packages/core-database-postgres/lib/spv.js
@@ -186,6 +186,9 @@ module.exports = class SPV {
           wallet.vote = vote.slice(1)
         }
 
+        // NOTE: The "voted" property is only used within this loop to avoid an issue
+        // that results in not properly applying "unvote" transactions as the "vote" property
+        // would be empty in that case and return a false result.
         wallet.voted = true
       }
     }

--- a/packages/core-database/lib/interface.js
+++ b/packages/core-database/lib/interface.js
@@ -105,7 +105,7 @@ module.exports = class ConnectionInterface {
   }
 
   /**
-   * Save the given number of block in the memory.
+   * Queue a query to save the given block.
    * NOTE: Must call commitQueuedQueries() to save to database.
    * NOTE: to use when rebuilding to decrease the number of database transactions, and commit blocks (save only every 1000s for instance) by calling commit
    * @param  {Block} block
@@ -117,7 +117,7 @@ module.exports = class ConnectionInterface {
   }
 
   /**
-   * Delete the given block.
+   * Queue a query to delete the given block.
    * See also enqueueSaveBlock
    * @param  {Block} block
    * @return {void}
@@ -128,7 +128,7 @@ module.exports = class ConnectionInterface {
   }
 
   /**
-   * Delete the round at given height.
+   * Queue a query to delete the round at given height.
    * See also enqueueSaveBlock and enqueueDeleteBlock
    * @param  {Number} height
    * @return {void}
@@ -140,7 +140,7 @@ module.exports = class ConnectionInterface {
 
   /**
    * Commit all queued queries to the database.
-   * NOTE: to be used in combination with other enqueue-functions
+   * NOTE: to be used in combination with other enqueue-functions.
    * @return {void}
    * @throws Error
    */


### PR DESCRIPTION
## Proposed changes

Fixes some invalid docs for the `enqueue` methods and explains the `voted` property during SPV.

## Types of changes

- [x] Docs (documentation only changes)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works