### PR TITLE
feat(core-p2p): remote API authentication

### DIFF
--- a/packages/core-p2p/lib/server/index.js
+++ b/packages/core-p2p/lib/server/index.js
@@ -86,12 +86,12 @@ module.exports = async (p2p, config) => {
     routes: { prefix: '/internal' }
   })
 
-  // if (config.remoteInterface) {
-  //   await server.register({
-  //     plugin: require('./versions/remote'),
-  //     routes: { prefix: '/remote' }
-  //   })
-  // }
+  if (config.remoteInterface) {
+    await server.register({
+      plugin: require('./versions/remote'),
+      routes: { prefix: '/remote' }
+    })
+  }
 
   try {
     await server.start()

--- a/packages/core-p2p/lib/server/plugins/accept-request.js
+++ b/packages/core-p2p/lib/server/plugins/accept-request.js
@@ -23,21 +23,12 @@ const register = async (server, options) => {
         return h.continue
       }
 
-      if (request.path.startsWith('/remote')) {
-        return isWhitelist(options.whitelist, remoteAddress)
-          ? h.continue
-          : Boom.unauthorized()
-      }
-
       if (!monitor.guard) {
         return Boom.serverUnavailable('Peer Monitor not ready')
       }
 
       if ((request.path.startsWith('/internal') || request.path.startsWith('/remote')) && !isWhitelist(options.whitelist, remoteAddress)) {
-        return h.response({
-          code: 'ResourceNotFound',
-          message: `${request.path} does not exist`
-        }).code(400).takeover()
+        return Boom.badRequest()
       }
 
       if (request.path.startsWith('/peer')) {

--- a/packages/core-p2p/lib/server/plugins/accept-request.js
+++ b/packages/core-p2p/lib/server/plugins/accept-request.js
@@ -23,6 +23,12 @@ const register = async (server, options) => {
         return h.continue
       }
 
+      if (request.path.startsWith('/remote')) {
+        return isWhitelist(options.whitelist, remoteAddress)
+          ? h.continue
+          : Boom.unauthorized()
+      }
+
       if (!monitor.guard) {
         return Boom.serverUnavailable('Peer Monitor not ready')
       }

--- a/packages/core-p2p/lib/server/plugins/accept-request.js
+++ b/packages/core-p2p/lib/server/plugins/accept-request.js
@@ -2,7 +2,7 @@
 
 const Boom = require('boom')
 const requestIp = require('request-ip')
-const isWhitelist = require('../../utils/is-whitelist')
+const isWhitelisted = require('../../utils/is-whitelist')
 const monitor = require('../../monitor')
 
 /**
@@ -23,12 +23,14 @@ const register = async (server, options) => {
         return h.continue
       }
 
-      if (!monitor.guard) {
-        return Boom.serverUnavailable('Peer Monitor not ready')
+      if (request.path.startsWith('/internal') || request.path.startsWith('/remote')) {
+        return isWhitelisted(options.whitelist, remoteAddress)
+          ? h.continue
+          : Boom.forbidden()
       }
 
-      if ((request.path.startsWith('/internal') || request.path.startsWith('/remote')) && !isWhitelist(options.whitelist, remoteAddress)) {
-        return Boom.badRequest()
+      if (!monitor.guard) {
+        return Boom.serverUnavailable('Peer Monitor not ready')
       }
 
       if (request.path.startsWith('/peer')) {

--- a/packages/core-p2p/lib/server/versions/remote/handlers/blockchain.js
+++ b/packages/core-p2p/lib/server/versions/remote/handlers/blockchain.js
@@ -17,7 +17,7 @@ exports.emitEvent = {
     const event = container.resolvePlugin('blockchain').events[request.params.event]
 
     request.query.param
-      ? event(request.query.paramrequest.params.param)
+      ? event(request.query.params)
       : event()
 
     return h.response(null).code(204)

--- a/packages/core-p2p/lib/server/versions/remote/schemas/blockchain.js
+++ b/packages/core-p2p/lib/server/versions/remote/schemas/blockchain.js
@@ -1,13 +1,12 @@
 'use strict'
 
 const Joi = require('joi')
-const container = require('@arkecosystem/core-container')
 
 /**
  * @type {Object}
  */
 exports.emitEvent = {
   params: {
-    event: Joi.string().valid(container.resolvePlugin('blockchain').events)
+    event: Joi.string()
   }
 }


### PR DESCRIPTION
## Proposed changes

Enables the P2P remote API and fixes the authentication via whitelisting to avoid accepting requests to the internal and remote APIs as a new peer.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes