### PR TITLE
refactor(mempool): simplify transaction expiration

### DIFF
--- a/packages/core-transaction-pool-mem/lib/connection.js
+++ b/packages/core-transaction-pool-mem/lib/connection.js
@@ -301,7 +301,7 @@ class TransactionPool extends TransactionPoolInterface {
    * @return {void}
    */
   __purgeExpired () {
-    for (const transaction of this.mem.getExpired()) {
+    for (const transaction of this.mem.getExpired(this.options.maxTransactionAge)) {
       emitter.emit('transaction.expired', transaction.data)
 
       this.walletManager.revertTransaction(transaction)

--- a/packages/core-transaction-pool-mem/lib/storage.js
+++ b/packages/core-transaction-pool-mem/lib/storage.js
@@ -91,7 +91,7 @@ class Storage {
     const rows = this.db.prepare(
       `SELECT sequence, HEX(serialized) AS serialized FROM ${this.table};`).all()
     return rows.map(r =>
-      new MemPoolTransaction(new Transaction(r.serialized), { sequence: r.sequence }))
+      new MemPoolTransaction(new Transaction(r.serialized), r.sequence))
   }
 
   /**

--- a/packages/core-transaction-pool-mem/package.json
+++ b/packages/core-transaction-pool-mem/package.json
@@ -23,7 +23,6 @@
   "dependencies": {
     "@arkecosystem/core-container": "^0.1.1",
     "@arkecosystem/core-transaction-pool": "^0.1.1",
-    "@arkecosystem/core-utils": "^0.1.0",
     "@arkecosystem/crypto": "^0.2.0",
     "better-sqlite3": "^5.0.1",
     "delay": "^4.1.0",


### PR DESCRIPTION
Do not convert transaction.expiration to "number of seconds since 1970",
but instead compare the provided number with slots.getTime() as the unit
for both is "number of seconds since genesis block".

As a side effect we do not need the MemPoolTransaction.expireAt member
anymore which used to store the expiration in "number of seconds since
1970".

## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [ ] Docs (documentation only changes)
- [ ] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
