### PR TITLE
perf: make db calls during applyRound non-blocking

### DIFF
--- a/packages/core-database-postgres/lib/connection.js
+++ b/packages/core-database-postgres/lib/connection.js
@@ -279,15 +279,9 @@ module.exports = class PostgresConnection extends ConnectionInterface {
         }
       }
     } else {
-      // NOTE: UPSERT is far from optimal. It can takes several seconds here
-      // if many accounts have to be updated at each round turn
-      //
-      // What can be done is to update accounts at each block in unsync manner
-      // what is really important is that db is sync with wallets in memory
-      // at round turn because votes computation to calculate active delegate list is made against database
-      //
-      // Other solution is to calculate the list of delegates against WalletManager so we can get rid off
-      // calling this function in sync manner i.e. 'await saveWallets()' -> 'saveWallets()'
+      // NOTE: The list of delegates is calculated in-memory against the WalletManager,
+      // so it is safe to perform the costly UPSERT non-blocking during round change only:
+      // 'await saveWallets(false)' -> 'saveWallets(false)'
       try {
         const queries = wallets.map(wallet => this.db.wallets.updateOrCreate(wallet))
 

--- a/packages/core-database/lib/interface.js
+++ b/packages/core-database/lib/interface.js
@@ -280,10 +280,12 @@ module.exports = class ConnectionInterface {
 
         try {
           this.updateDelegateStats(height, this.activeDelegates)
-          await this.saveWallets(false) // save only modified wallets during the last round
+          this.saveWallets(false) // save modified wallets non-blocking
+
           const delegates = this.walletManager.loadActiveDelegateList(maxDelegates, nextHeight) // get active delegate list from in-memory wallet manager
-          await this.saveRound(delegates) // save next round delegate list
-          await this.getActiveDelegates(nextHeight, delegates) // generate the new active delegates list
+          this.saveRound(delegates) // save next round delegate list non-blocking
+          this.getActiveDelegates(nextHeight, delegates) // generate the new active delegates list non-blocking
+
           this.blocksInCurrentRound.length = 0
         } catch (error) {
           // trying to leave database state has it was


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Now that the calculations are performed in-memory,
we can get rid of the remaining blocking db calls in`applyRound`.

I'm specifically talking about
`await this.saveWallets(false)`
`await this.saveRound(delegates)`

which should be save to be called non-blocking now as we don't rely on them anymore.

Nevermind `getActiveDelegates` which doesn't block anymore during `applyRound` since some commits.

--
Here's a comparison between blocking and non-blocking:

Before:
`saveWallets: 250.177m`

After:
`saveWallets: 29.492ms`

Before:
`saveRound: 82.768ms`
After:
`saveRound: 3.854 ms`

Total before:
`applyRound: 271.226ms`

Total after:
`applyRound: 80.579ms`



## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [ ] Docs (documentation only changes)
- [ ] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [ ] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [X] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
