### PR TITLE
fix(crypto): use the network WIF as default

### DIFF
--- a/packages/crypto/CHANGELOG.md
+++ b/packages/crypto/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Properly verify block payload length
 - Broken verification of faulty type 1 and 4
 - Broken multisignature serialization
+- Use network WIF as default for WIF operations
 
 ## 0.1.1 - 2018-06-14
 

--- a/packages/crypto/lib/builder/transactions/transaction.js
+++ b/packages/crypto/lib/builder/transactions/transaction.js
@@ -132,12 +132,12 @@ module.exports = class TransactionBuilder {
   /**
    * Sign transaction using wif.
    * @param  {String} wif
-   * @param  {String} networkWif - value associated with network (Ark is 170)
+   * @param  {String} networkWif - value associated with network
    * @return {TransactionBuilder}
    */
-  signWithWif (wif, networkWif = 170) {
+  signWithWif (wif, networkWif) {
     const keys = crypto.getKeysFromWIF(wif, {
-      wif: networkWif
+      wif: networkWif || configManager.get('wif')
     })
     this.data.senderPublicKey = keys.publicKey
     this.data.signature = crypto.sign(this.__getSigningObject(), keys)
@@ -163,13 +163,13 @@ module.exports = class TransactionBuilder {
   /**
    * Sign transaction with wif.
    * @param  {String} wif
-   * @param  {String} networkWif - value associated with network (Ark is 170)
+   * @param  {String} networkWif - value associated with network
    * @return {TransactionBuilder}
    */
-  secondSignWithWif (wif, networkWif = 170) {
+  secondSignWithWif (wif, networkWif) {
     if (wif) {
       const keys = crypto.getKeysFromWIF(wif, {
-        wif: networkWif
+        wif: networkWif || configManager.get('wif')
       })
       // TODO sign or second?
       this.data.signSignature = crypto.secondSign(this.__getSigningObject(), keys)


### PR DESCRIPTION
## Proposed changes

The default WIF was always set to 170 instead of using the network WIF.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes