### PR TITLE
fix(core-api): add missing orderBy parameter to block transactions

### DIFF
--- a/packages/core-api/lib/versions/2/handlers/blocks.js
+++ b/packages/core-api/lib/versions/2/handlers/blocks.js
@@ -67,7 +67,9 @@ exports.transactions = {
       return Boom.notFound('Block not found')
     }
 
-    const transactions = await transactionsRepository.findAllByBlock(block.id, utils.paginate(request))
+    const transactions = await transactionsRepository.findAllByBlock(block.id, {
+      ...request.query, ...utils.paginate(request)
+    })
 
     return utils.toPagination(request, transactions, 'transaction')
   },

--- a/packages/core-api/lib/versions/2/schema/blocks.js
+++ b/packages/core-api/lib/versions/2/schema/blocks.js
@@ -24,7 +24,8 @@ exports.show = {
  */
 exports.transactions = {
   params: {
-    id: Joi.string()
+    id: Joi.string(),
+    orderBy: Joi.string()
   },
   query: pagination
 }


### PR DESCRIPTION
## Proposed changes

The `orderBy` parameter was missing from the blocks endpoint that returns transactions.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes