### PR TITLE
chore(mempool): use an assert with more verbose output

### DIFF
--- a/packages/core-transaction-pool-mem/lib/connection.js
+++ b/packages/core-transaction-pool-mem/lib/connection.js
@@ -199,7 +199,7 @@ class TransactionPool extends TransactionPoolInterface {
     const ids = this.getTransactionsData(start, size, 'id')
 
     /* There should be no forged transactions in the mem pool. */
-    assert.strictEqual((await database.getForgedTransactionsIds(ids)).length, 0)
+    assert.deepStrictEqual((await database.getForgedTransactionsIds(ids)), [])
 
     return ids
 


### PR DESCRIPTION
If we assert that arr.length == 0, and if that fails, then we would only
see e.g. 5 != 0 in the output. Instead, assert that arr == [], so that
if the array contains some elements we will see those elements in the
assertion failure message.

## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [ ] Docs (documentation only changes)
- [ ] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [ ] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
