### PR TITLE
chore: circleci show last 1000 lines of test output + update node 10 test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,10 @@ jobs:
           name: Test
           command: |
             TESTFILES=$(circleci tests glob "packages/**/*.test.js" | circleci tests split --split-by=filesize)
-            ./node_modules/.bin/cross-env ARK_ENV=test ./node_modules/.bin/jest ${TESTFILES} --detectOpenHandles --runInBand --forceExit
+            ./node_modules/.bin/cross-env ARK_ENV=test ./node_modules/.bin/jest ${TESTFILES} --detectOpenHandles --runInBand --forceExit | tee test_output.txt
+      - run:
+          name: Last 1000 lines of test output
+          command: tail -n 1000 test_output.txt
       - run: # Running lint here but not in test-node10 as lint doesn't need to be done on both
           name: Lint
           command: yarn lint
@@ -131,7 +134,12 @@ jobs:
           command: mkdir -p $HOME/.ark/database
       - run: # Running --ci --coverage only here because causes "heap out of memory" error on node 9
           name: Test
-          command: ./node_modules/.bin/cross-env ARK_ENV=test ./node_modules/.bin/jest --detectOpenHandles --runInBand --forceExit --ci --coverage
+          command: |
+            TESTFILES=$(circleci tests glob "packages/**/*.test.js" | circleci tests split --split-by=filesize)
+            ./node_modules/.bin/cross-env ARK_ENV=test ./node_modules/.bin/jest ${TESTFILES} --detectOpenHandles --runInBand --forceExit --ci --coverage | tee test_output.txt
+      - run:
+          name: Last 1000 lines of test output
+          command: tail -n 1000 test_output.txt
       - run: # See above, so codecov only here, not on node 9
           name: Codecov
           command: ./node_modules/.bin/codecov


### PR DESCRIPTION
## Proposed changes

Looks like sometimes, the test output is too big and CircleCI crops it (providing the full log for download).

With this, we can still see the last 1000 lines of test output which generally are useful because containing the possibly failed tests.

Also, I noticed parallelization of tests was not correctly done for CircleCI node 10 job. This fixes it.

## Types of changes

- [x] Build (changes that affect the build system)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
