### PR TITLE
refactor(core-p2p): enable validate-headers plugin

### DIFF
--- a/packages/core-blockchain/lib/state-machine.js
+++ b/packages/core-blockchain/lib/state-machine.js
@@ -237,7 +237,7 @@ blockchainMachine.actionMap = blockchain => {
          ********************************/
         // SPV rebuild
         const verifiedWalletsIntegrity = await blockchain.database.buildWallets(block.data.height)
-        if (!verifiedWalletsIntegrity) {
+        if (!verifiedWalletsIntegrity && block.data.height > 1) {
           logger.warn('Rebuilding wallets table because of some inconsistencies. Most likely due to an unfortunate shutdown. :hammer:')
           await blockchain.database.saveWallets(true)
         }

--- a/packages/core-database-postgres/lib/spv.js
+++ b/packages/core-database-postgres/lib/spv.js
@@ -222,7 +222,7 @@ module.exports = class SPV {
    * @returns {Boolean}
    */
   async __verifyWalletsConsistency () {
-    const dbWallets = await this.query.many(queries.wallets.all)
+    const dbWallets = await this.query.manyOrNone(queries.wallets.all)
     const inMemoryWallets = this.walletManager.allByPublicKey()
 
     let detectedInconsistency = false

--- a/packages/core-p2p/lib/server/index.js
+++ b/packages/core-p2p/lib/server/index.js
@@ -13,9 +13,9 @@ module.exports = async (p2p, config) => {
     port: config.port
   })
 
-  // await server.register({
-  //  plugin: require('./plugins/validate-headers')
-  // })
+  await server.register({
+   plugin: require('./plugins/validate-headers')
+  })
 
   await server.register({
     plugin: require('./plugins/accept-request'),

--- a/packages/core-p2p/lib/server/plugins/validate-headers.js
+++ b/packages/core-p2p/lib/server/plugins/validate-headers.js
@@ -22,6 +22,10 @@ const register = async (server, options) => {
   server.ext({
     type: 'onRequest',
     async method (request, h) {
+      if (request.headers.port) {
+        request.headers.port = +request.headers.port
+      }
+
       const errors = ajv.validate({
         type: 'object',
         properties: {

--- a/packages/core-p2p/lib/server/plugins/validate-headers.js
+++ b/packages/core-p2p/lib/server/plugins/validate-headers.js
@@ -22,10 +22,6 @@ const register = async (server, options) => {
   server.ext({
     type: 'onRequest',
     async method (request, h) {
-      if (!request.path.startsWith('/peer')) {
-        return h.continue
-      }
-
       const errors = ajv.validate({
         type: 'object',
         properties: {


### PR DESCRIPTION
## Proposed changes

Enables the plugin that validates the P2P headers like on v1. Currently you can just hit the P2P API without providing any of those headers.

@supaiku0 when you test it make sure your node can sync from 0 and accept new peers.

## Types of changes

- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes