### PR TITLE
feat(crypto): implement identities

### DIFF
--- a/packages/crypto/__tests__/identities/address.test.js
+++ b/packages/crypto/__tests__/identities/address.test.js
@@ -1,0 +1,45 @@
+const testSubject = require('../../lib/identities/address')
+const Keys = require('../../lib/identities/keys')
+const { data, passphrase } = require('./fixture')
+
+describe('Identities - Address', () => {
+  describe('fromPassphrase', () => {
+    it('should be a function', () => {
+      expect(testSubject.fromPassphrase).toBeFunction()
+    })
+
+    it('should be OK', () => {
+      expect(testSubject.fromPassphrase(passphrase)).toBe(data.address)
+    })
+  })
+
+  describe('fromPublicKey', () => {
+    it('should be a function', () => {
+      expect(testSubject.fromPublicKey).toBeFunction()
+    })
+
+    it('should be OK', () => {
+      expect(testSubject.fromPublicKey(data.publicKey)).toBe(data.address)
+    })
+  })
+
+  describe('fromPrivateKey', () => {
+    it('should be a function', () => {
+      expect(testSubject.fromPrivateKey).toBeFunction()
+    })
+
+    it('should be OK', () => {
+      expect(testSubject.fromPrivateKey(Keys.fromPassphrase(passphrase))).toBe(data.address)
+    })
+  })
+
+  describe('validate', () => {
+    it('should be a function', () => {
+      expect(testSubject.validate).toBeFunction()
+    })
+
+    it('should be OK', () => {
+      expect(testSubject.validate(data.address)).toBeTrue()
+    })
+  })
+})

--- a/packages/crypto/__tests__/identities/fixture.json
+++ b/packages/crypto/__tests__/identities/fixture.json
@@ -1,0 +1,9 @@
+{
+    "data": {
+        "privateKey": "d8839c2432bfd0a67ef10a804ba991eabba19f154a3d707917681d45822a5712",
+        "publicKey": "034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed192",
+        "address": "D61mfSggzbvQgTUe6JhYKH2doHaqJ3Dyib",
+        "wif": "SGq4xLgZKCGxs7bjmwnBrWcT4C1ADFEermj846KC97FSv1WFD1dA"
+    },
+    "passphrase": "this is a top secret passphrase"
+}

--- a/packages/crypto/__tests__/identities/private-key.test.js
+++ b/packages/crypto/__tests__/identities/private-key.test.js
@@ -1,0 +1,24 @@
+const testSubject = require('../../lib/identities/private-key')
+const { data, passphrase } = require('./fixture')
+
+describe('Identities - Private Key', () => {
+  describe('fromPassphrase', () => {
+    it('should be a function', () => {
+      expect(testSubject.fromPassphrase).toBeFunction()
+    })
+
+    it('should be OK', () => {
+      expect(testSubject.fromPassphrase(passphrase)).toBe(data.privateKey)
+    })
+  })
+
+  describe('fromWIF', () => {
+    it('should be a function', () => {
+      expect(testSubject.fromWIF).toBeFunction()
+    })
+
+    it('should be OK', () => {
+      expect(testSubject.fromWIF(data.wif)).toBe(data.privateKey)
+    })
+  })
+})

--- a/packages/crypto/__tests__/identities/public-key.test.js
+++ b/packages/crypto/__tests__/identities/public-key.test.js
@@ -1,0 +1,34 @@
+const testSubject = require('../../lib/identities/public-key')
+const { data, passphrase } = require('./fixture')
+
+describe('Identities - Public Key', () => {
+  describe('fromPassphrase', () => {
+    it('should be a function', () => {
+      expect(testSubject.fromPassphrase).toBeFunction()
+    })
+
+    it('should be OK', () => {
+      expect(testSubject.fromPassphrase(passphrase)).toBe(data.publicKey)
+    })
+  })
+
+  describe('fromWIF', () => {
+    it('should be a function', () => {
+      expect(testSubject.fromWIF).toBeFunction()
+    })
+
+    it('should be OK', () => {
+      expect(testSubject.fromWIF(data.wif)).toBe(data.publicKey)
+    })
+  })
+
+  describe('validate', () => {
+    it('should be a function', () => {
+      expect(testSubject.validate).toBeFunction()
+    })
+
+    it('should be OK', () => {
+      expect(testSubject.validate(data.publicKey)).toBeTrue()
+    })
+  })
+})

--- a/packages/crypto/__tests__/identities/wif.test.js
+++ b/packages/crypto/__tests__/identities/wif.test.js
@@ -1,0 +1,14 @@
+const testSubject = require('../../lib/identities/wif')
+const { data, passphrase } = require('./fixture')
+
+describe('Identities - WIF', () => {
+  describe('fromPassphrase', () => {
+    it('should be a function', () => {
+      expect(testSubject.fromPassphrase).toBeFunction()
+    })
+
+    it('should be OK', () => {
+      expect(testSubject.fromPassphrase(passphrase)).toBe(data.wif)
+    })
+  })
+})

--- a/packages/crypto/lib/identities/address.js
+++ b/packages/crypto/lib/identities/address.js
@@ -1,0 +1,46 @@
+const bs58check = require('bs58check')
+const configManager = require('../managers/config')
+const utils = require('../crypto/utils')
+const PublicKey = require('./public-key')
+
+module.exports = class Address {
+  static fromPassphrase (passphrase, networkVersion) {
+    return Address.fromPublicKey(PublicKey.fromPassphrase(passphrase), networkVersion)
+  }
+
+  static fromPublicKey (publicKey, networkVersion) {
+    const pubKeyRegex = /^[0-9A-Fa-f]{66}$/;
+    if (!pubKeyRegex.test(publicKey)) {
+      throw new Error(`publicKey '${publicKey}' is invalid`)
+    }
+
+    if (!networkVersion) {
+      networkVersion = configManager.get('pubKeyHash')
+    }
+
+    const buffer = utils.ripemd160(Buffer.from(publicKey, 'hex'))
+    const payload = Buffer.alloc(21)
+
+    payload.writeUInt8(networkVersion, 0)
+    buffer.copy(payload, 1)
+
+    return bs58check.encode(payload)
+  }
+
+  static fromPrivateKey (privateKey, networkVersion) {
+    return Address.fromPublicKey(privateKey.publicKey, networkVersion)
+  }
+
+  static validate (address, networkVersion) {
+    if (!networkVersion) {
+      networkVersion = configManager.get('pubKeyHash')
+    }
+
+    try {
+      const decode = bs58check.decode(address)
+      return decode[0] === networkVersion
+    } catch (e) {
+      return false
+    }
+  }
+}

--- a/packages/crypto/lib/identities/keys.js
+++ b/packages/crypto/lib/identities/keys.js
@@ -1,0 +1,49 @@
+const secp256k1 = require('secp256k1')
+const wif = require('wif')
+
+const configManager = require('../managers/config')
+const utils = require('../crypto/utils')
+
+module.exports = class Keys {
+  static fromPassphrase (passphrase, compressed = true) {
+    const privateKey = utils.sha256(Buffer.from(passphrase, 'utf8'))
+    return Keys.fromPrivateKey(privateKey, compressed)
+  }
+
+  static fromPrivateKey (privateKey, compressed = true) {
+    privateKey = privateKey instanceof Buffer ? privateKey : Buffer.from(privateKey, 'hex')
+
+    const publicKey = secp256k1.publicKeyCreate(privateKey, compressed)
+    const keyPair = {
+      publicKey: publicKey.toString('hex'),
+      privateKey: privateKey.toString('hex'),
+      compressed
+    }
+
+    return keyPair
+  }
+
+  static fromWIF (wifKey, network) {
+    const decoded = wif.decode(wifKey)
+    const version = decoded.version
+
+    if (!network) {
+      network = configManager.all()
+    }
+
+    if (version !== network.wif) {
+      throw new Error('Invalid network version')
+    }
+
+    const privateKey = decoded.privateKey
+    const publicKey = secp256k1.publicKeyCreate(privateKey, decoded.compressed)
+
+    const keyPair = {
+      publicKey: publicKey.toString('hex'),
+      privateKey: privateKey.toString('hex'),
+      compressed: decoded.compressed
+    }
+
+    return keyPair
+  }
+}

--- a/packages/crypto/lib/identities/private-key.js
+++ b/packages/crypto/lib/identities/private-key.js
@@ -1,0 +1,13 @@
+const Keys = require('./keys')
+
+module.exports = class PrivateKey {
+  static fromPassphrase (passphrase) {
+    return Keys.fromPassphrase(passphrase).privateKey
+  }
+
+  // static fromHex (privateKey) {}
+
+  static fromWIF (wif, network) {
+    return Keys.fromWIF(wif, network).privateKey
+  }
+}

--- a/packages/crypto/lib/identities/public-key.js
+++ b/packages/crypto/lib/identities/public-key.js
@@ -1,0 +1,27 @@
+const configManager = require('../managers/config')
+const Address = require('./address')
+const Keys = require('./keys')
+
+module.exports = class PublicKey {
+  static fromPassphrase (passphrase) {
+    return Keys.fromPassphrase(passphrase).publicKey
+  }
+
+  // static fromHex (publicKey) {}
+
+  static fromWIF (wif, network) {
+    return Keys.fromWIF(wif, network).publicKey
+  }
+
+  static validate (publicKey, networkVersion) {
+    if (!networkVersion) {
+      networkVersion = configManager.get('pubKeyHash')
+    }
+
+    try {
+      return Address.fromPublicKey(publicKey, networkVersion).length === 34
+    } catch (e) {
+      return false
+    }
+  }
+}

--- a/packages/crypto/lib/identities/wif.js
+++ b/packages/crypto/lib/identities/wif.js
@@ -1,0 +1,15 @@
+const wif = require('wif')
+const configManager = require('../managers/config')
+const Keys = require('./keys')
+
+module.exports = class WIF {
+  static fromPassphrase (passphrase, network) {
+    const keys = Keys.fromPassphrase(passphrase)
+
+    if (!network) {
+      network = configManager.all()
+    }
+
+    return wif.encode(network.wif, Buffer.from(keys.privateKey, 'hex'), keys.compressed)
+  }
+}

--- a/packages/crypto/lib/index.js
+++ b/packages/crypto/lib/index.js
@@ -10,6 +10,15 @@ module.exports = {
     Wallet: require('./models/wallet')
   },
 
+  // Identities...
+  identities: {
+    address: require('./identities/address'),
+    keys: require('./identities/keys'),
+    privateKey: require('./identities/private-key'),
+    publicKey: require('./identities/public-key'),
+    wif: require('./identities/wif')
+  },
+
   // Builder...
   transactionBuilder: require('./builder'),
 


### PR DESCRIPTION
## Proposed changes

This adds the crypto identities like all other SDKs have. Right now those identities are supplementary as I haven't replaced the method calls to the `crypto` class which has methods like `getKeys`, which could be replaced by `Keys.fromPassphrase`.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works