### PR TITLE
fix(core-api): invalid sorting columns crash

### DIFF
--- a/packages/core-api/lib/repositories/repository.js
+++ b/packages/core-api/lib/repositories/repository.js
@@ -58,9 +58,14 @@ module.exports = class Repository {
       .keys(parameters)
       .filter(arg => this.columns.includes(arg))
       .reduce((items, item) => {
-        const columnName = columns.find(column => (column.prop === item)).name
+        const column = columns.find(column => {
+          return column.name === item || column.prop === item
+        })
 
-        items[columnName] = parameters[item]
+        if (column) {
+          delete items[item]
+          items[snakeCase(column.name)] = parameters[item]
+        }
 
         return items
       }, {})

--- a/packages/core-api/lib/repositories/repository.js
+++ b/packages/core-api/lib/repositories/repository.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const snakeCase = require('lodash/snakeCase')
 const container = require('@arkecosystem/core-container')
 const database = container.resolvePlugin('database')
 
@@ -24,7 +25,7 @@ module.exports = class Repository {
     const { count } = await this._find(countQuery)
 
     if (this.columns.includes(orderBy[0])) {
-      selectQuery.order(this.query[orderBy[0]][orderBy[1]])
+      selectQuery.order(this.query[(snakeCase(orderBy[0]))][orderBy[1]])
     }
 
     selectQuery.offset(offset).limit(limit)

--- a/packages/core-api/lib/repositories/repository.js
+++ b/packages/core-api/lib/repositories/repository.js
@@ -63,9 +63,10 @@ module.exports = class Repository {
         })
 
         if (column) {
-          delete items[item]
           items[snakeCase(column.name)] = parameters[item]
         }
+
+        delete items[item]
 
         return items
       }, {})

--- a/packages/core-api/lib/repositories/repository.js
+++ b/packages/core-api/lib/repositories/repository.js
@@ -62,11 +62,9 @@ module.exports = class Repository {
           return column.name === item || column.prop === item
         })
 
-        if (column) {
-          items[snakeCase(column.name)] = parameters[item]
-        }
-
-        delete items[item]
+        column
+          ? items[column.name] = parameters[item]
+          : delete items[item]
 
         return items
       }, {})

--- a/packages/core-api/lib/repositories/repository.js
+++ b/packages/core-api/lib/repositories/repository.js
@@ -54,20 +54,16 @@ module.exports = class Repository {
       prop: column.prop || column.name
     }))
 
-    const columnNames = columns.map(column => column.name)
-    const columnProps = columns.map(column => column.prop)
+    return Object
+      .keys(parameters)
+      .filter(arg => this.columns.includes(arg))
+      .reduce((items, item) => {
+        const columnName = columns.find(column => (column.prop === item)).name
 
-    const filter = args => args.filter(arg => {
-      return columnNames.includes(arg) || columnProps.includes(arg)
-    })
+        items[columnName] = parameters[item]
 
-    return filter(Object.keys(parameters)).reduce((items, item) => {
-      const columnName = columns.find(column => (column.prop === item)).name
-
-      items[columnName] = parameters[item]
-
-      return items
-    }, {})
+        return items
+      }, {})
   }
 
   __mapColumns () {


### PR DESCRIPTION
## Proposed changes

@dated reported that an API endpoint returned code 500 when sorting them. The issue was that a wrong column name wasn't handled so it would just blow up instead of gracefully handling the rest of the request.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes