### PR TITLE
chore: tail test output only on test failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,6 +67,7 @@ jobs:
             ./node_modules/.bin/cross-env ARK_ENV=test ./node_modules/.bin/jest ${TESTFILES} --detectOpenHandles --runInBand --forceExit | tee test_output.txt
       - run:
           name: Last 1000 lines of test output
+          when: on_fail
           command: tail -n 1000 test_output.txt
       - run: # Running lint here but not in test-node10 as lint doesn't need to be done on both
           name: Lint
@@ -139,6 +140,7 @@ jobs:
             ./node_modules/.bin/cross-env ARK_ENV=test ./node_modules/.bin/jest ${TESTFILES} --detectOpenHandles --runInBand --forceExit --ci --coverage | tee test_output.txt
       - run:
           name: Last 1000 lines of test output
+          when: on_fail
           command: tail -n 1000 test_output.txt
       - run: # See above, so codecov only here, not on node 9
           name: Codecov


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

When the test step fails on CircleCI the whole build is stopped, which means that the step that tails the test output is not reached.

For example: https://circleci.com/gh/ArkEcosystem/core/2009

This PR sets the `when` attribute of the tailing steps to `on_fail`, so that it is executed exactly when it's needed.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Build (changes that affect the build system)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes