### PR TITLE
fix: allow p2p config without headers

### DIFF
--- a/packages/core-p2p/lib/server/plugins/validate-headers.js
+++ b/packages/core-p2p/lib/server/plugins/validate-headers.js
@@ -22,6 +22,10 @@ const register = async (server, options) => {
   server.ext({
     type: 'onRequest',
     async method (request, h) {
+      if (request.path.startsWith('/config')) {
+        return h.continue
+      }
+
       if (request.headers.port) {
         request.headers.port = +request.headers.port
       }


### PR DESCRIPTION
## Proposed changes
This is to allow the p2p `/config` endpoint without the need for the `port`, `nethash` or `version` endpoint. @faustbrian could you confirm if you intentionally wanted the headers for this endpoint, as it's not really used for p2p functionality 🤔 thanks!

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
