### PR TITLE
Revert "chore: use static log file path (#1129)"

### DIFF
--- a/packages/core-logger-winston/README.md
+++ b/packages/core-logger-winston/README.md
@@ -27,7 +27,7 @@ module.exports = {
       constructor: 'DailyRotateFile',
       options: {
         level: process.env.ARK_LOG_LEVEL || 'debug',
-        filename: process.env.ARK_LOG_FILE || `${process.env.ARK_PATH_DATA}/logs/core/${process.env.ARK_NETWORK_NAME}/current.log`,
+        filename: process.env.ARK_LOG_FILE || `${process.env.ARK_PATH_DATA}/logs/core/${process.env.ARK_NETWORK_NAME}/%DATE%.log`,
         datePattern: 'YYYY-MM-DD',
         zippedArchive: true,
         maxSize: '100m',

--- a/packages/core-logger-winston/lib/defaults.js
+++ b/packages/core-logger-winston/lib/defaults.js
@@ -15,7 +15,7 @@ module.exports = {
       options: {
         level: process.env.ARK_LOG_LEVEL || 'debug',
         format: require('./formatter')(false),
-        filename: process.env.ARK_LOG_FILE || `${process.env.ARK_PATH_DATA}/logs/core/${process.env.ARK_NETWORK_NAME}/current.log`,
+        filename: process.env.ARK_LOG_FILE || `${process.env.ARK_PATH_DATA}/logs/core/${process.env.ARK_NETWORK_NAME}/%DATE%.log`,
         datePattern: 'YYYY-MM-DD',
         zippedArchive: true,
         maxSize: '100m',

--- a/packages/core-test-utils/config/testnet/plugins.js
+++ b/packages/core-test-utils/config/testnet/plugins.js
@@ -11,7 +11,7 @@ module.exports = {
       dailyRotate: {
         options: {
           level: process.env.ARK_LOG_LEVEL || 'debug',
-          filename: process.env.ARK_LOG_FILE || `${process.env.ARK_PATH_DATA}/logs/core/${process.env.ARK_NETWORK_NAME}/current.log`
+          filename: process.env.ARK_LOG_FILE || `${process.env.ARK_PATH_DATA}/logs/core/${process.env.ARK_NETWORK_NAME}/%DATE%.log`
         }
       }
     }

--- a/packages/core/lib/config/devnet/plugins.js
+++ b/packages/core/lib/config/devnet/plugins.js
@@ -11,7 +11,7 @@ module.exports = {
       dailyRotate: {
         options: {
           level: process.env.ARK_LOG_LEVEL || 'debug',
-          filename: process.env.ARK_LOG_FILE || `${process.env.ARK_PATH_DATA}/logs/core/${process.env.ARK_NETWORK_NAME}/current.log`
+          filename: process.env.ARK_LOG_FILE || `${process.env.ARK_PATH_DATA}/logs/core/${process.env.ARK_NETWORK_NAME}/%DATE%.log`
         }
       }
     }

--- a/packages/core/lib/config/mainnet/plugins.js
+++ b/packages/core/lib/config/mainnet/plugins.js
@@ -11,7 +11,7 @@ module.exports = {
       dailyRotate: {
         options: {
           level: process.env.ARK_LOG_LEVEL || 'debug',
-          filename: process.env.ARK_LOG_FILE || `${process.env.ARK_PATH_DATA}/logs/core/${process.env.ARK_NETWORK_NAME}/current.log`
+          filename: process.env.ARK_LOG_FILE || `${process.env.ARK_PATH_DATA}/logs/core/${process.env.ARK_NETWORK_NAME}/%DATE%.log`
         }
       }
     }

--- a/packages/core/lib/config/testnet.1/plugins.js
+++ b/packages/core/lib/config/testnet.1/plugins.js
@@ -11,7 +11,7 @@ module.exports = {
       dailyRotate: {
         options: {
           level: process.env.ARK_LOG_LEVEL || 'debug',
-          filename: process.env.ARK_LOG_FILE || `${process.env.ARK_PATH_DATA}/logs/core/${process.env.ARK_NETWORK_NAME}.1/current.log`
+          filename: process.env.ARK_LOG_FILE || `${process.env.ARK_PATH_DATA}/logs/core/${process.env.ARK_NETWORK_NAME}.1/%DATE%.log`
         }
       }
     }

--- a/packages/core/lib/config/testnet.2/plugins.js
+++ b/packages/core/lib/config/testnet.2/plugins.js
@@ -11,7 +11,7 @@ module.exports = {
       dailyRotate: {
         options: {
           level: process.env.ARK_LOG_LEVEL || 'debug',
-          filename: process.env.ARK_LOG_FILE || `${process.env.ARK_PATH_DATA}/logs/core/${process.env.ARK_NETWORK_NAME}.2/current.log`
+          filename: process.env.ARK_LOG_FILE || `${process.env.ARK_PATH_DATA}/logs/core/${process.env.ARK_NETWORK_NAME}.2/%DATE%.log`
         }
       }
     }

--- a/packages/core/lib/config/testnet.live/plugins.js
+++ b/packages/core/lib/config/testnet.live/plugins.js
@@ -11,7 +11,7 @@ module.exports = {
       dailyRotate: {
         options: {
           level: process.env.ARK_LOG_LEVEL || 'debug',
-          filename: process.env.ARK_LOG_FILE || `${process.env.ARK_PATH_DATA}/logs/core/${process.env.ARK_NETWORK_NAME}.live/current.log`
+          filename: process.env.ARK_LOG_FILE || `${process.env.ARK_PATH_DATA}/logs/core/${process.env.ARK_NETWORK_NAME}.live/%DATE%.log`
         }
       }
     }

--- a/packages/core/lib/config/testnet/plugins.js
+++ b/packages/core/lib/config/testnet/plugins.js
@@ -11,7 +11,7 @@ module.exports = {
       dailyRotate: {
         options: {
           level: process.env.ARK_LOG_LEVEL || 'debug',
-          filename: process.env.ARK_LOG_FILE || `${process.env.ARK_PATH_DATA}/logs/core/${process.env.ARK_NETWORK_NAME}/current.log`
+          filename: process.env.ARK_LOG_FILE || `${process.env.ARK_PATH_DATA}/logs/core/${process.env.ARK_NETWORK_NAME}/%DATE%.log`
         }
       }
     }


### PR DESCRIPTION
This reverts commit 8f35ab8

Why? It doesn't address the issue, and creates an odd notation where the file extension ".log" is not actually the extension..

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->
- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
