### PR TITLE
fix(json-rpc): mark block IDs as unsafe integers

### DIFF
--- a/packages/core-json-rpc/lib/server/methods/blocks/info.js
+++ b/packages/core-json-rpc/lib/server/methods/blocks/info.js
@@ -9,6 +9,6 @@ module.exports = {
     return response ? response.data : {}
   },
   schema: {
-    id: Joi.number().required()
+    id: Joi.number().unsafe().required()
   }
 }

--- a/packages/core-json-rpc/lib/server/methods/blocks/transactions.js
+++ b/packages/core-json-rpc/lib/server/methods/blocks/transactions.js
@@ -15,7 +15,7 @@ module.exports = {
     } : {}
   },
   schema: {
-    id: Joi.number().required(),
+    id: Joi.number().unsafe().required(),
     offset: Joi.number().default(0)
   }
 }


### PR DESCRIPTION
## Proposed changes

The latest version of `Joi` has better handling for unsafe integers in javascript but this also means that block IDs got rejected as invalid because of their size.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
