### PR TITLE
chore: remove async from __determineValidTransactions()

### DIFF
--- a/packages/core-transaction-pool/lib/guard.js
+++ b/packages/core-transaction-pool/lib/guard.js
@@ -28,7 +28,7 @@ module.exports = class TransactionGuard {
 
     await this.__removeForgedTransactions()
 
-    await this.__determineValidTransactions()
+    this.__determineValidTransactions()
 
     this.__determineExcessTransactions()
   }
@@ -161,7 +161,7 @@ module.exports = class TransactionGuard {
    * - if sender has more than one vote/unvote transaction in pool
    * Transaction that can be broadcasted are confirmed here
    */
-  async __determineValidTransactions () {
+  __determineValidTransactions () {
     this.transactions.forEach(transaction => {
       if (transaction.type === TRANSACTION_TYPES.TRANSFER) {
         if (!isRecipientOnActiveNetwork(transaction)) {


### PR DESCRIPTION
After recent changes __determineValidTransactions() is not async
anymore.

## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [ ] Docs (documentation only changes)
- [ ] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [ ] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
