### PR TITLE
fix: add associated username to wallet api response

### DIFF
--- a/packages/core-api/lib/versions/2/transformers/wallet.js
+++ b/packages/core-api/lib/versions/2/transformers/wallet.js
@@ -11,6 +11,7 @@ module.exports = (model) => {
   return {
     address: model.address,
     publicKey: model.publicKey,
+    username: model.username,
     secondPublicKey: model.secondPublicKey,
     balance: +bignumify(model.balance).toFixed(),
     isDelegate: !!model.username


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

The wallets API response does currently not include the associated username of an address.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes