### PR TITLE
chore: require node 10 as minimum engine

### DIFF
--- a/packages/core-api/package.json
+++ b/packages/core-api/package.json
@@ -35,11 +35,14 @@
     "lodash": "^4.17.11",
     "moment": "^2.22.2"
   },
-  "publishConfig": {
-    "access": "public"
-  },
   "devDependencies": {
     "@arkecosystem/core-test-utils": "^0.1.1",
     "axios": "^0.18.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "engines": {
+    "node" : ">=10.x"
   }
 }

--- a/packages/core-blockchain/package.json
+++ b/packages/core-blockchain/package.json
@@ -30,13 +30,16 @@
     "xstate": "^3.3.3",
     "immutable": "^3.8.2"
   },
-  "publishConfig": {
-    "access": "public"
-  },
   "devDependencies": {
     "@arkecosystem/core-test-utils": "^0.1.1",
     "@arkecosystem/core-p2p": "^0.1.1",
     "axios": "^0.18.0",
     "axios-mock-adapter": "^1.15.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "engines": {
+    "node" : ">=10.x"
   }
 }

--- a/packages/core-config/package.json
+++ b/packages/core-config/package.json
@@ -27,5 +27,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "engines": {
+    "node" : ">=10.x"
   }
 }

--- a/packages/core-container/package.json
+++ b/packages/core-container/package.json
@@ -30,5 +30,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "engines": {
+    "node" : ">=10.x"
   }
 }

--- a/packages/core-database-postgres/package.json
+++ b/packages/core-database-postgres/package.json
@@ -29,5 +29,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "engines": {
+    "node" : ">=10.x"
   }
 }

--- a/packages/core-database/package.json
+++ b/packages/core-database/package.json
@@ -30,5 +30,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "engines": {
+    "node" : ">=10.x"
   }
 }

--- a/packages/core-debugger-cli/package.json
+++ b/packages/core-debugger-cli/package.json
@@ -27,5 +27,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "engines": {
+    "node" : ">=10.x"
   }
 }

--- a/packages/core-deployer/package.json
+++ b/packages/core-deployer/package.json
@@ -36,5 +36,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "engines": {
+    "node" : ">=10.x"
   }
 }

--- a/packages/core-event-emitter/package.json
+++ b/packages/core-event-emitter/package.json
@@ -22,5 +22,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "engines": {
+    "node" : ">=10.x"
   }
 }

--- a/packages/core-forger/package.json
+++ b/packages/core-forger/package.json
@@ -32,5 +32,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "engines": {
+    "node" : ">=10.x"
   }
 }

--- a/packages/core-graphql/package.json
+++ b/packages/core-graphql/package.json
@@ -30,5 +30,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "engines": {
+    "node" : ">=10.x"
   }
 }

--- a/packages/core-http-utils/package.json
+++ b/packages/core-http-utils/package.json
@@ -31,5 +31,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "engines": {
+    "node" : ">=10.x"
   }
 }

--- a/packages/core-json-rpc/package.json
+++ b/packages/core-json-rpc/package.json
@@ -41,5 +41,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "engines": {
+    "node" : ">=10.x"
   }
 }

--- a/packages/core-logger-winston/package.json
+++ b/packages/core-logger-winston/package.json
@@ -32,5 +32,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "engines": {
+    "node" : ">=10.x"
   }
 }

--- a/packages/core-logger/package.json
+++ b/packages/core-logger/package.json
@@ -19,5 +19,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "engines": {
+    "node" : ">=10.x"
   }
 }

--- a/packages/core-p2p/package.json
+++ b/packages/core-p2p/package.json
@@ -40,11 +40,14 @@
     "semver": "^5.6.0",
     "sntp": "^3.0.1"
   },
-  "publishConfig": {
-    "access": "public"
-  },
   "devDependencies": {
     "@arkecosystem/core-test-utils": "^0.1.1",
     "axios-mock-adapter": "^1.15.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "engines": {
+    "node" : ">=10.x"
   }
 }

--- a/packages/core-test-utils/package.json
+++ b/packages/core-test-utils/package.json
@@ -26,5 +26,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "engines": {
+    "node" : ">=10.x"
   }
 }

--- a/packages/core-tester-cli/package.json
+++ b/packages/core-tester-cli/package.json
@@ -39,5 +39,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "engines": {
+    "node" : ">=10.x"
   }
 }

--- a/packages/core-transaction-pool-mem/package.json
+++ b/packages/core-transaction-pool-mem/package.json
@@ -34,5 +34,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "engines": {
+    "node" : ">=10.x"
   }
 }

--- a/packages/core-transaction-pool/package.json
+++ b/packages/core-transaction-pool/package.json
@@ -32,5 +32,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "engines": {
+    "node" : ">=10.x"
   }
 }

--- a/packages/core-utils/package.json
+++ b/packages/core-utils/package.json
@@ -25,5 +25,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "engines": {
+    "node" : ">=10.x"
   }
 }

--- a/packages/core-webhooks/package.json
+++ b/packages/core-webhooks/package.json
@@ -34,5 +34,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "engines": {
+    "node" : ">=10.x"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -69,5 +69,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "engines": {
+    "node" : ">=10.x"
   }
 }


### PR DESCRIPTION
## Proposed changes

Follow up to https://github.com/ArkEcosystem/core/pull/1245 as we use some features for snapshots that are only available from node 10 and afterwards.

## Types of changes

- [x] Build (changes that affect the build system)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes