### PR TITLE
refactor: avoid the non-deterministic setTimeout

### DIFF
--- a/packages/core-container/lib/container.js
+++ b/packages/core-container/lib/container.js
@@ -138,9 +138,7 @@ module.exports = class Container {
       logger.error(error.stack)
     }
 
-    setTimeout(() => {
-      process.exit(exitCode)
-    }, 10)
+    process.exit(exitCode)
   }
 
   /**

--- a/packages/core-logger-winston/lib/defaults.js
+++ b/packages/core-logger-winston/lib/defaults.js
@@ -6,7 +6,8 @@ module.exports = {
       constructor: 'Console',
       options: {
         level: process.env.ARK_LOG_LEVEL || 'debug',
-        format: require('./formatter')(true)
+        format: require('./formatter')(true),
+        stderrLevels: [ 'error', 'warn' ]
       }
     },
     dailyRotate: {


### PR DESCRIPTION
Using setTimeout() to "wait" for the log to be flushed is
non-deterministic it may happen that process.exit() is called before the
log is flushed. Also it has another problem that other error messages
are printed because the process continues execution.

Instead log errors and warnings to stderr instead of stdout. For some
reason stderr is properly flushed before the process is terminated by
process.exit() (whereas stdout is not). Also, error messages belong to
stderr anyway.

## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [ ] Docs (documentation only changes)
- [ ] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [ ] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
