### PR TITLE
refactor(core-api): use delegate rank as it is always available

### DIFF
--- a/packages/core-api/lib/versions/1/transformers/delegate.js
+++ b/packages/core-api/lib/versions/1/transformers/delegate.js
@@ -16,7 +16,7 @@ module.exports = (delegate) => {
     producedblocks: delegate.producedBlocks,
     missedblocks: delegate.missedBlocks,
     forged: delegate.forged,
-    rate: delegate.rate || 0, // forcing to 0 if undefined  as it is not yet reliable
+    rate: delegate.rate,
     approval: delegateCalculator.calculateApproval(delegate),
     productivity: delegateCalculator.calculateProductivity(delegate)
   }

--- a/packages/core-api/lib/versions/2/transformers/delegate.js
+++ b/packages/core-api/lib/versions/2/transformers/delegate.js
@@ -13,7 +13,7 @@ module.exports = delegate => {
     address: delegate.address,
     publicKey: delegate.publicKey,
     votes: +bignumify(delegate.voteBalance).toFixed(),
-    rank: delegate.rate || 0, // forcing to 0 if undefined  as it is not yet reliable
+    rank: delegate.rate,
     blocks: {
       produced: delegate.producedBlocks,
       missed: delegate.missedBlocks


### PR DESCRIPTION
## Proposed changes

The delegate `rate` property now always exists after the latest PRs.

## Types of changes

- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes