### PR TITLE
refactor(core-api): allow registration of additional plugins

### DIFF
--- a/packages/core-api/CHANGELOG.md
+++ b/packages/core-api/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Limit the number of transactions per request if posting
 - `ownerId` property for transaction searches
 - Blockchains endpoint to provide information like supply
+- Allow registration of additional plugins
 
 ### Changed
 - Use the IANA format for the API vendor in the `Accept` header

--- a/packages/core-api/lib/defaults.js
+++ b/packages/core-api/lib/defaults.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const path = require('path')
+
 module.exports = {
   enabled: false,
   host: process.env.ARK_API_HOST || '0.0.0.0',
@@ -44,5 +46,12 @@ module.exports = {
   whitelist: [
     '127.0.0.1',
     '::ffff:127.0.0.1'
-  ]
+  ],
+  plugins: [{
+    plugin: path.resolve(__dirname, './versions/1'),
+    routes: { prefix: '/api/v1' }
+  }, {
+    plugin: path.resolve(__dirname, './versions/2'),
+    routes: { prefix: '/api/v2' }
+  }]
 }

--- a/packages/core-api/lib/server.js
+++ b/packages/core-api/lib/server.js
@@ -89,16 +89,13 @@ module.exports = async (config) => {
     }
   })
 
-  await server.register({
-    plugin: require('./versions/1'),
-    routes: { prefix: '/api/v1' }
-  })
+  for (const plugin of config.plugins) {
+    if (typeof plugin.plugin === 'string') {
+      plugin.plugin = require(plugin.plugin)
+    }
 
-  await server.register({
-    plugin: require('./versions/2'),
-    routes: { prefix: '/api/v2' },
-    options: config
-  })
+    await server.register(plugin)
+  }
 
   return mountServer('Public API', server)
 }


### PR DESCRIPTION
## Proposed changes

Makes it possible to register additional plugins and moves the API versions to additional plugins so they can receive configuration for things like route prefixes.

## Types of changes

- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes