### PR TITLE
feat: add core-error-tracker-bugsnag package

### DIFF
--- a/packages/core-error-tracker-bugsnag/.gitattributes
+++ b/packages/core-error-tracker-bugsnag/.gitattributes
@@ -1,0 +1,11 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+/.editorconfig    export-ignore
+/.gitattributes   export-ignore
+/.gitignore       export-ignore
+/.travis.yml      export-ignore
+/__tests__        export-ignore
+/docs             export-ignore
+/README.md        export-ignore

--- a/packages/core-error-tracker-bugsnag/CHANGELOG.md
+++ b/packages/core-error-tracker-bugsnag/CHANGELOG.md
@@ -6,16 +6,3 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
-### Changed
-- Instantly execute webhook jobs instead of queueing a job
-- Dropped node.js 9 as minimum requirement in favour of node.js 10
-
-### Fixed
-- Properly listen for all events
-- Properly check for enabled webhooks
-
-## 0.1.1 - 2018-06-14
-
-### Added
-- initial release

--- a/packages/core-error-tracker-bugsnag/CHANGELOG.md
+++ b/packages/core-error-tracker-bugsnag/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Changed
+- Instantly execute webhook jobs instead of queueing a job
+- Dropped node.js 9 as minimum requirement in favour of node.js 10
+
+### Fixed
+- Properly listen for all events
+- Properly check for enabled webhooks
+
+## 0.1.1 - 2018-06-14
+
+### Added
+- initial release

--- a/packages/core-error-tracker-bugsnag/LICENSE
+++ b/packages/core-error-tracker-bugsnag/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) Ark Ecosystem <info@ark.io>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/core-error-tracker-bugsnag/README.md
+++ b/packages/core-error-tracker-bugsnag/README.md
@@ -16,7 +16,7 @@ yarn add @arkecosystem/core-error-tracker-bugsnag
 
 ```js
 module.exports = {
-  apiKey: null,
+  apiKey: process.env.ARK_ERROR_TRACKER_BUGSNAG_API_KEY,
   configuration: {
     metaData: {
       network: process.env.ARK_NETWORK_NAME

--- a/packages/core-error-tracker-bugsnag/README.md
+++ b/packages/core-error-tracker-bugsnag/README.md
@@ -1,0 +1,39 @@
+# Ark Core - Error Tracker - Bugsnag
+
+<p align="center">
+    <img src="../../banner.png?sanitize=true" />
+</p>
+
+## Installation
+
+```bash
+yarn add @arkecosystem/core-error-tracker-bugsnag
+```
+
+## Configuration
+
+> Check https://docs.bugsnag.com/platforms/nodejs/other/configuration-options/ for more options and details.
+
+```js
+module.exports = {
+  apiKey: null,
+  configuration: {
+    metaData: {
+      network: process.env.ARK_NETWORK_NAME
+    }
+  }
+}
+```
+
+## Security
+
+If you discover a security vulnerability within this package, please send an e-mail to security@ark.io. All security vulnerabilities will be promptly addressed.
+
+## Credits
+
+- [Brian Faust](https://github.com/faustbrian)
+- [All Contributors](../../../../contributors)
+
+## License
+
+[MIT](LICENSE) © [ArkEcosystem](https://ark.io)

--- a/packages/core-error-tracker-bugsnag/jest.config.js
+++ b/packages/core-error-tracker-bugsnag/jest.config.js
@@ -1,0 +1,21 @@
+'use strict'
+module.exports = {
+  testEnvironment: 'node',
+  bail: false,
+  verbose: true,
+  testMatch: [
+    '**/__tests__/**/*.test.js'
+  ],
+  moduleFileExtensions: [
+    'js',
+    'json'
+  ],
+  collectCoverage: false,
+  coverageDirectory: '<rootDir>/.coverage',
+  collectCoverageFrom: [
+    'lib/**/*.js',
+    '!**/node_modules/**'
+  ],
+  watchman: false,
+  setupTestFrameworkScriptFile: 'jest-extended'
+}

--- a/packages/core-error-tracker-bugsnag/jsdoc.json
+++ b/packages/core-error-tracker-bugsnag/jsdoc.json
@@ -1,0 +1,24 @@
+{
+  "tags": {
+    "allowUnknownTags": false
+  },
+  "source": {
+    "include": "./lib",
+    "includePattern": ".js$",
+    "excludePattern": "(node_modules/|docs)"
+  },
+  "plugins": [
+    "plugins/markdown"
+  ],
+  "opts": {
+    "template": "../../node_modules/docdash",
+    "encoding": "utf8",
+    "destination": "docs/",
+    "recurse": true,
+    "verbose": true
+  },
+  "templates": {
+    "cleverLinks": false,
+    "monospaceLinks": false
+  }
+}

--- a/packages/core-error-tracker-bugsnag/lib/defaults.js
+++ b/packages/core-error-tracker-bugsnag/lib/defaults.js
@@ -1,7 +1,7 @@
 'use strict'
 
 module.exports = {
-  apiKey: null,
+  apiKey: process.env.ARK_ERROR_TRACKER_BUGSNAG_API_KEY,
   configuration: {
     metaData: {
       network: process.env.ARK_NETWORK_NAME

--- a/packages/core-error-tracker-bugsnag/lib/defaults.js
+++ b/packages/core-error-tracker-bugsnag/lib/defaults.js
@@ -1,0 +1,10 @@
+'use strict'
+
+module.exports = {
+  apiKey: null,
+  configuration: {
+    metaData: {
+      network: process.env.ARK_NETWORK_NAME
+    }
+  }
+}

--- a/packages/core-error-tracker-bugsnag/lib/index.js
+++ b/packages/core-error-tracker-bugsnag/lib/index.js
@@ -1,0 +1,18 @@
+'use strict'
+
+const bugsnag = require('bugsnag')
+
+/**
+ * The struct used by the plugin container.
+ * @type {Object}
+ */
+exports.plugin = {
+    pkg: require('../package.json'),
+    defaults: require('./defaults'),
+    alias: 'error-tracker',
+    async register (container, options) {
+        bugsnag.register(options.apiKey, options.configuration)
+
+        return bugsnag
+    }
+}

--- a/packages/core-error-tracker-bugsnag/lib/index.js
+++ b/packages/core-error-tracker-bugsnag/lib/index.js
@@ -7,12 +7,12 @@ const bugsnag = require('bugsnag')
  * @type {Object}
  */
 exports.plugin = {
-    pkg: require('../package.json'),
-    defaults: require('./defaults'),
-    alias: 'error-tracker',
-    async register (container, options) {
-        bugsnag.register(options.apiKey, options.configuration)
+  pkg: require('../package.json'),
+  defaults: require('./defaults'),
+  alias: 'error-tracker',
+  async register (container, options) {
+    bugsnag.register(options.apiKey, options.configuration)
 
-        return bugsnag
-    }
+    return bugsnag
+  }
 }

--- a/packages/core-error-tracker-bugsnag/package.json
+++ b/packages/core-error-tracker-bugsnag/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@arkecosystem/core-error-tracker-bugsnag",
+  "description": "Bugsnag error tracker integration for Ark Core.",
+  "version": "0.1.0",
+  "contributors": [
+    "Brian Faust <brian@ark.io>"
+  ],
+  "license": "MIT",
+  "main": "lib/index.js",
+  "scripts": {
+    "build:docs": "../../node_modules/.bin/jsdoc -c jsdoc.json",
+    "test": "cross-env ARK_ENV=test jest --runInBand --detectOpenHandles",
+    "test:coverage": "cross-env ARK_ENV=test jest --coverage --coveragePathIgnorePatterns='/(defaults.js|index.js)$' --runInBand --detectOpenHandles",
+    "test:debug": "cross-env ARK_ENV=test node --inspect-brk ../../node_modules/.bin/jest --runInBand",
+    "test:watch": "cross-env ARK_ENV=test jest --runInBand --watch",
+    "test:watch:all": "cross-env ARK_ENV=test jest --runInBand --watchAll",
+    "lint": "eslint ./ --fix",
+    "depcheck": "depcheck ./"
+  },
+  "dependencies": {
+    "bugsnag": "^2.4.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "engines": {
+    "node": ">=10.x"
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1886,7 +1886,7 @@ arrify@^1.0.0, arrify@^1.0.1:
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
   integrity sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=
 
-asap@^2.0.0:
+asap@^2.0.0, asap@~2.0.3:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
   integrity sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=
@@ -2182,6 +2182,11 @@ backo2@^1.0.2:
   resolved "https://registry.yarnpkg.com/backo2/-/backo2-1.0.2.tgz#31ab1ac8b129363463e35b3ebb69f4dfcfba7947"
   integrity sha1-MasayLEpNjRj41s+u2n038+6eUc=
 
+backo@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/backo/-/backo-1.1.0.tgz#a36c4468923f2d265c9e8a709ea56ecdaff807e6"
+  integrity sha1-o2xEaJI/LSZcnopwnqVuza/4B+Y=
+
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
@@ -2409,6 +2414,11 @@ brorand@^1.0.1:
   resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
   integrity sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=
 
+browser-fingerprint@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/browser-fingerprint/-/browser-fingerprint-0.0.1.tgz#8df3cdca25bf7d5b3542d61545d730053fce604a"
+  integrity sha1-jfPNyiW/fVs1QtYVRdcwBT/OYEo=
+
 browser-process-hrtime@^0.1.2:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz#616f00faef1df7ec1b5bf9cfe2bdc3170f26c7b4"
@@ -2535,6 +2545,18 @@ buffer@^4.3.0:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
     isarray "^1.0.0"
+
+bugsnag@^2.4.3:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/bugsnag/-/bugsnag-2.4.3.tgz#c63129d6a95b9719774ac941537412300fc79044"
+  integrity sha512-7gjpRE+J0BBbwYvmZeYo2ZyX3nCDX+ITqHd5wNb+t6KBXwhvuEbyJrmsDE/U32ndsV441jwaGtJ1o2ppLoQXTg==
+  dependencies:
+    backo "^1.1.0"
+    cuid "^1.3.8"
+    json-stringify-safe "~5.0.1"
+    promise "7.x"
+    request "^2.81.0"
+    stack-trace "~0.0.9"
 
 builtin-modules@^1.0.0, builtin-modules@^1.1.1:
   version "1.1.1"
@@ -3274,6 +3296,11 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
+core-js@^1.1.1:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
+  integrity sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=
+
 core-js@^2.4.0, core-js@^2.5.0, core-js@^2.5.7:
   version "2.5.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"
@@ -3387,6 +3414,15 @@ cssstyle@^1.0.0:
   integrity sha512-364AI1l/M5TYcFH83JnOH/pSqgaNnKmYgKrm0didZMGKWjQB60dymwWy1rKUgL3J1ffdq9xVi2yGLHdSjjSNog==
   dependencies:
     cssom "0.3.x"
+
+cuid@^1.3.8:
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/cuid/-/cuid-1.3.8.tgz#4b875e0969bad764f7ec0706cf44f5fb0831f6b7"
+  integrity sha1-S4deCWm612T37AcGz0T1+wgx9rc=
+  dependencies:
+    browser-fingerprint "0.0.1"
+    core-js "^1.1.1"
+    node-fingerprint "0.0.2"
 
 currently-unhandled@^0.4.1:
   version "0.4.1"
@@ -7664,6 +7700,11 @@ node-fetch@^2.1.2:
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.2.0.tgz#4ee79bde909262f9775f731e3656d0db55ced5b5"
   integrity sha512-OayFWziIxiHY8bCUyLX6sTpDH8Jsbp4FfYd1j1f7vZyfgkcOnAyM4oQR16f8a0s7Gl/viMGRey8eScYk4V4EZA==
 
+node-fingerprint@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/node-fingerprint/-/node-fingerprint-0.0.2.tgz#31cbabeb71a67ae7dd5a7dc042e51c3c75868501"
+  integrity sha1-Mcur63GmeufdWn3AQuUcPHWGhQE=
+
 node-forge@^0.7.6:
   version "0.7.6"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.7.6.tgz#fdf3b418aee1f94f0ef642cd63486c77ca9724ac"
@@ -8672,6 +8713,13 @@ promise-retry@^1.1.1:
     err-code "^1.0.0"
     retry "^0.10.0"
 
+promise@7.x:
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
+  integrity sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==
+  dependencies:
+    asap "~2.0.3"
+
 prompts@^0.1.9:
   version "0.1.14"
   resolved "https://registry.yarnpkg.com/prompts/-/prompts-0.1.14.tgz#a8e15c612c5c9ec8f8111847df3337c9cbd443b2"
@@ -9236,7 +9284,7 @@ request-promise@^4.2.2:
     stealthy-require "^1.1.0"
     tough-cookie ">=2.3.3"
 
-request@^2.87.0:
+request@^2.81.0, request@^2.87.0:
   version "2.88.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
   integrity sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==
@@ -9965,7 +10013,7 @@ ssri@^6.0.0:
   dependencies:
     figgy-pudding "^3.5.1"
 
-stack-trace@0.0.x:
+stack-trace@0.0.x, stack-trace@~0.0.9:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
   integrity sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=


### PR DESCRIPTION
## Proposed changes

Adds support for error tracking and monitoring via https://docs.bugsnag.com/platforms/nodejs/other/configuration-options/ so node maintainers can provide better feedback if they decide to use a proper monitoring service for their node.

Other integrations will follow in the next days to provide a variety of services.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes