### PR TITLE
refactor(core-vote-report): only wallets with balance > 0.1

### DIFF
--- a/packages/core-vote-report/lib/handler.js
+++ b/packages/core-vote-report/lib/handler.js
@@ -10,7 +10,7 @@ const database = container.resolvePlugin('database')
 const formatDelegates = delegates => delegates.map(delegate => {
   const voters = database.walletManager
     .allByPublicKey()
-    .filter(wallet => wallet.vote === delegate.publicKey)
+    .filter(wallet => wallet.vote === delegate.publicKey && wallet.balance > 0.1 * Math.pow(10, 8))
 
   const approval = delegateCalculator.calculateApproval(delegate).toString()
   const rank = delegate.rate.toLocaleString(undefined, { minimumIntegerDigits: 2 })
@@ -43,16 +43,17 @@ module.exports = (request, h) => {
 
   const voters = database.walletManager
     .allByPublicKey()
-    .filter(wallet => wallet.vote)
+    .filter(wallet => wallet.vote && wallet.balance > 0.1 * Math.pow(10, 8))
 
   const totalVotes = sumBy(voters, wallet => +wallet.balance.toFixed())
   const percentage = (totalVotes * 100) / supply
 
   return h.view('index', {
+    token: config.get('client').token,
     activeDelegatesCount: constants.activeDelegates,
     activeDelegates: formatDelegates(active),
     standbyDelegates: formatDelegates(standby),
-    voters: voters.length,
+    voters: voters.length.toLocaleString(undefined, { maximumFractionDigits: 0 }),
     supply: (supply / 1e8).toLocaleString(undefined, { maximumFractionDigits: 0 }),
     totalVotes: (totalVotes / 1e8).toLocaleString(undefined, { maximumFractionDigits: 0 }),
     percentage: percentage.toLocaleString(undefined, { maximumFractionDigits: 2 })

--- a/packages/core-vote-report/lib/handler.js
+++ b/packages/core-vote-report/lib/handler.js
@@ -15,13 +15,14 @@ const formatDelegates = delegates => delegates.map(delegate => {
   const approval = delegateCalculator.calculateApproval(delegate).toString()
   const rank = delegate.rate.toLocaleString(undefined, { minimumIntegerDigits: 2 })
   const votes = delegate.voteBalance.div(1e8).toFixed().toLocaleString(undefined, { maximumFractionDigits: 0 })
+  const voterCount = voters.length.toLocaleString(undefined, { maximumFractionDigits: 0 })
 
   return {
     rank,
     username: delegate.username.padEnd(25),
     approval: approval.padEnd(4),
     votes: votes.padEnd(10),
-    voters: voters.length.toString().padEnd(4)
+    voterCount: voterCount.padEnd(5)
   }
 })
 

--- a/packages/core-vote-report/lib/templates/index.html
+++ b/packages/core-vote-report/lib/templates/index.html
@@ -7,12 +7,12 @@ Top {{activeDelegatesCount}} Delegates Stats
 | Rank | Delegate                  | Vote % |  Vote ARK  | Voters |
 ===================================================================
 {{#each activeDelegates}}
-|  {{rank}}  | {{username}} |  {{approval}}  | {{votes}} |  {{voters}} |
+|  {{rank}}  | {{username}} |  {{approval}}  | {{votes}} |  {{voterCount}} |
 {{/each}}
 ===================================================================
 {{#if standbyDelegates}}
 {{#each standbyDelegates}}
-|  {{rank}}  | {{username}} |  {{approval}}  | {{votes}} |  {{voters}} |
+|  {{rank}}  | {{username}} |  {{approval}}  | {{votes}} |  {{voterCount}} |
 {{/each}}
 ===================================================================
 {{/if}}

--- a/packages/core-vote-report/lib/templates/index.html
+++ b/packages/core-vote-report/lib/templates/index.html
@@ -1,18 +1,18 @@
 Top {{activeDelegatesCount}} Delegates Stats
 
 => Total Votes  : {{percentage}}% ({{totalVotes}} / {{supply}})
-=> Total Voters : {{voters}}
+=> Total Voters : {{voters}} (only voters with more than 0.1 {{token}})
 
 ===================================================================
 | Rank | Delegate                  | Vote % |  Vote ARK  | Voters |
 ===================================================================
 {{#each activeDelegates}}
-|  {{rank}}  | {{username}} |  {{approval}}  | {{votes}} |  {{voters}}  |
+|  {{rank}}  | {{username}} |  {{approval}}  | {{votes}} |  {{voters}} |
 {{/each}}
 ===================================================================
 {{#if standbyDelegates}}
 {{#each standbyDelegates}}
-|  {{rank}}  | {{username}} |  {{approval}}  | {{votes}} |  {{voters}}  |
+|  {{rank}}  | {{username}} |  {{approval}}  | {{votes}} |  {{voters}} |
 {{/each}}
 ===================================================================
 {{/if}}


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

To get a better picture about vote distribution, only wallets with a balance over 0.1 should be regarded - as is currently done in the explorer. Take delegate dr10 for instance, for which the vote report shows 1151 voters. Out of these wallets 542 have a balance smaller than 0.1

This PR also adds localized formating of the voters count
## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes