### PR TITLE
fix(core-tester-cli): fee parsing & display output in ark

### DIFF
--- a/packages/core-tester-cli/lib/commands/command.js
+++ b/packages/core-tester-cli/lib/commands/command.js
@@ -293,7 +293,7 @@ module.exports = class Command {
    * @return {String}
    */
   static __arktoshiToArk (arktoshi) {
-    return (arktoshi.toNumber() / Math.pow(10, 8)).toFixed()
+    return arktoshi.div(1e8).toFixed()
   }
 
   /**

--- a/packages/core-tester-cli/lib/commands/command.js
+++ b/packages/core-tester-cli/lib/commands/command.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Bignum, crypto } = require('@arkecosystem/crypto')
+const { Bignum, crypto, formatArktoshi } = require('@arkecosystem/crypto')
 const { bignumify } = require('@arkecosystem/core-utils')
 const bip39 = require('bip39')
 const clipboardy = require('clipboardy')
@@ -179,7 +179,7 @@ module.exports = class Command {
    */
   static parseFee (fee) {
     if (typeof fee === 'string' && fee.indexOf('-') !== -1) {
-      const feeRange = fee.split('-').map(f => +bignumify(Number(f) * Math.pow(10, 8)).toFixed())
+      const feeRange = fee.split('-').map(f => +bignumify(f).times(1e8).toFixed())
       if (feeRange[1] < feeRange[0]) {
         return feeRange[0]
       }
@@ -187,7 +187,7 @@ module.exports = class Command {
       return bignumify(Math.floor((Math.random() * (feeRange[1] - feeRange[0] + 1)) + feeRange[0]))
     }
 
-    return bignumify(fee * Math.pow(10, 8))
+    return bignumify(fee).times(1e8)
   }
 
   /**
@@ -293,7 +293,7 @@ module.exports = class Command {
    * @return {String}
    */
   static __arktoshiToArk (arktoshi) {
-    return arktoshi.div(1e8).toFixed()
+    return formatArktoshi(arktoshi)
   }
 
   /**

--- a/packages/core-tester-cli/lib/commands/command.js
+++ b/packages/core-tester-cli/lib/commands/command.js
@@ -179,7 +179,7 @@ module.exports = class Command {
    */
   static parseFee (fee) {
     if (typeof fee === 'string' && fee.indexOf('-') !== -1) {
-      const feeRange = fee.split('-').map(f => +bignumify(f * Math.pow(10, 8)).toFixed())
+      const feeRange = fee.split('-').map(f => +bignumify(Number(f) * Math.pow(10, 8)).toFixed())
       if (feeRange[1] < feeRange[0]) {
         return feeRange[0]
       }
@@ -187,7 +187,7 @@ module.exports = class Command {
       return bignumify(Math.floor((Math.random() * (feeRange[1] - feeRange[0] + 1)) + feeRange[0]))
     }
 
-    return bignumify(fee)
+    return bignumify(fee * Math.pow(10, 8))
   }
 
   /**

--- a/packages/core-tester-cli/lib/commands/command.js
+++ b/packages/core-tester-cli/lib/commands/command.js
@@ -288,6 +288,15 @@ module.exports = class Command {
   }
 
   /**
+   * Convert Arktoshi to ARK.
+   * @param  {Bignum} arktoshi
+   * @return {String}
+   */
+  static __arktoshiToArk (arktoshi) {
+    return (arktoshi.toNumber() / Math.pow(10, 8)).toFixed()
+  }
+
+  /**
    * Quit command and output error when problem sending transactions.
    * @param  {Error} error
    * @return {void}

--- a/packages/core-tester-cli/lib/commands/command.js
+++ b/packages/core-tester-cli/lib/commands/command.js
@@ -179,7 +179,7 @@ module.exports = class Command {
    */
   static parseFee (fee) {
     if (typeof fee === 'string' && fee.indexOf('-') !== -1) {
-      const feeRange = fee.split('-').map(f => +bignumify(f).toFixed())
+      const feeRange = fee.split('-').map(f => +bignumify(f * Math.pow(10, 8)).toFixed())
       if (feeRange[1] < feeRange[0]) {
         return feeRange[0]
       }

--- a/packages/core-tester-cli/lib/commands/delegate-registration.js
+++ b/packages/core-tester-cli/lib/commands/delegate-registration.js
@@ -40,7 +40,7 @@ module.exports = class DelegateRegistrationCommand extends Command {
       usedDelegateNames.push(wallet.username)
 
       const transaction = client.getBuilder().delegateRegistration()
-        .fee(Command.__arkToArktoshi(Command.parseFee(this.options.delegateFee)))
+        .fee(Command.parseFee(this.options.delegateFee))
         .usernameAsset(wallet.username)
         .network(this.config.network.version)
         .sign(wallet.passphrase)

--- a/packages/core-tester-cli/lib/commands/delegate-registration.js
+++ b/packages/core-tester-cli/lib/commands/delegate-registration.js
@@ -49,7 +49,7 @@ module.exports = class DelegateRegistrationCommand extends Command {
 
       transactions.push(transaction)
 
-      logger.info(`${i} ==> ${transaction.id}, ${wallet.address} (fee: ${transaction.fee}, username: ${wallet.username})`)
+      logger.info(`${i} ==> ${transaction.id}, ${wallet.address} (fee: ${Command.__arktoshiToArk(transaction.fee)}, username: ${wallet.username})`)
     })
 
     if (this.options.copy) {

--- a/packages/core-tester-cli/lib/commands/multi-signature.js
+++ b/packages/core-tester-cli/lib/commands/multi-signature.js
@@ -112,7 +112,7 @@ module.exports = class MultiSignatureCommand extends Command {
       transactions.push(transaction)
 
       if (log) {
-        logger.info(`${i} ==> ${transaction.id}, ${wallet.address} (fee: ${transaction.fee})`)
+        logger.info(`${i} ==> ${transaction.id}, ${wallet.address} (fee: ${Command.__arktoshiToArk(transaction.fee)})`)
       }
     })
 

--- a/packages/core-tester-cli/lib/commands/multi-signature.js
+++ b/packages/core-tester-cli/lib/commands/multi-signature.js
@@ -89,7 +89,7 @@ module.exports = class MultiSignatureCommand extends Command {
       const builder = client.getBuilder().multiSignature()
 
       builder
-        .fee(Command.__arkToArktoshi(Command.parseFee(this.options.multisigFee)))
+        .fee(Command.parseFee(this.options.multisigFee))
         .multiSignatureAsset({
           lifetime: this.options.lifetime,
           keysgroup: publicKeys,

--- a/packages/core-tester-cli/lib/commands/second-signature.js
+++ b/packages/core-tester-cli/lib/commands/second-signature.js
@@ -36,7 +36,7 @@ module.exports = class DelegateRegistrationCommand extends Command {
       wallet.secondPublicKey = transaction.asset.signature.publicKey
       transactions.push(transaction)
 
-      logger.info(`${i} ==> ${transaction.id}, ${wallet.address} (fee: ${transaction.fee})`)
+      logger.info(`${i} ==> ${transaction.id}, ${wallet.address} (fee: ${Command.__arktoshiToArk(transaction.fee)})`)
     })
 
     if (this.options.copy) {

--- a/packages/core-tester-cli/lib/commands/second-signature.js
+++ b/packages/core-tester-cli/lib/commands/second-signature.js
@@ -26,7 +26,7 @@ module.exports = class DelegateRegistrationCommand extends Command {
     wallets.forEach((wallet, i) => {
       wallet.secondPassphrase = this.config.secondPassphrase || wallet.passphrase
       const transaction = client.getBuilder().secondSignature()
-        .fee(Command.__arkToArktoshi(Command.parseFee(this.options.signatureFee)))
+        .fee(Command.parseFee(this.options.signatureFee))
         .signatureAsset(wallet.secondPassphrase)
         .network(this.config.network.version)
         .sign(wallet.passphrase)

--- a/packages/core-tester-cli/lib/commands/transfer.js
+++ b/packages/core-tester-cli/lib/commands/transfer.js
@@ -105,7 +105,7 @@ module.exports = class TransferCommand extends Command {
       const builder = client.getBuilder().transfer()
       // noinspection JSCheckFunctionSignatures
       builder
-        .fee(Command.__arkToArktoshi(Command.parseFee(this.options.transferFee)))
+        .fee(Command.parseFee(this.options.transferFee))
         .recipientId(this.options.recipient || wallet.address)
         .network(this.config.network.version)
         .amount(transactionAmount)

--- a/packages/core-tester-cli/lib/commands/transfer.js
+++ b/packages/core-tester-cli/lib/commands/transfer.js
@@ -27,7 +27,7 @@ module.exports = class TransferCommand extends Command {
     const walletBalance = await this.getWalletBalance(primaryAddress)
 
     if (!this.options.skipValidation) {
-      logger.info(`Sender starting balance: ${walletBalance}`)
+      logger.info(`Sender starting balance: ${Command.__arktoshiToArk(walletBalance)}`)
     }
 
     let totalDeductions = Bignum.ZERO
@@ -45,7 +45,7 @@ module.exports = class TransferCommand extends Command {
 
     const expectedSenderBalance = (new Bignum(walletBalance)).minus(totalDeductions)
     if (!this.options.skipValidation) {
-      logger.info(`Sender expected ending balance: ${expectedSenderBalance}`)
+      logger.info(`Sender expected ending balance: ${Command.__arktoshiToArk(expectedSenderBalance)}`)
     }
 
     const runOptions = {
@@ -126,7 +126,7 @@ module.exports = class TransferCommand extends Command {
       transactions.push(transaction)
 
       if (log) {
-        logger.info(`${i} ==> ${transaction.id}, ${transaction.recipientId} (fee: ${transaction.fee})`)
+        logger.info(`${i} ==> ${transaction.id}, ${transaction.recipientId} (fee: ${Command.__arktoshiToArk(transaction.fee)})`)
       }
     })
 
@@ -231,7 +231,7 @@ module.exports = class TransferCommand extends Command {
       const walletBalance = await this.getWalletBalance(runOptions.primaryAddress)
       if (!walletBalance.isEqualTo(runOptions.expectedSenderBalance)) {
         successfulTest = false
-        logger.error(`Sender balance incorrect: '${walletBalance}' but should be '${runOptions.expectedSenderBalance}'`)
+        logger.error(`Sender balance incorrect: '${Command.__arktoshiToArk(walletBalance)}' but should be '${Command.__arktoshiToArk(runOptions.expectedSenderBalance)}'`)
       }
     }
 
@@ -239,7 +239,7 @@ module.exports = class TransferCommand extends Command {
       const balance = await this.getWalletBalance(wallet.address)
       if (!balance.isEqualTo(runOptions.transactionAmount)) {
         successfulTest = false
-        logger.error(`Incorrect destination balance for ${wallet.address}. Should be '${runOptions.transactionAmount}' but is '${balance}'`)
+        logger.error(`Incorrect destination balance for ${Command.__arktoshiToArk(wallet.address)}. Should be '${runOptions.transactionAmount}' but is '${Command.__arktoshiToArk(balance)}'`)
       }
     }
 

--- a/packages/core-tester-cli/lib/commands/vote.js
+++ b/packages/core-tester-cli/lib/commands/vote.js
@@ -37,7 +37,7 @@ module.exports = class VoteCommand extends Command {
     const transactions = []
     wallets.forEach((wallet, i) => {
       const transaction = client.getBuilder().vote()
-        .fee(Command.__arkToArktoshi(Command.parseFee(this.options.voteFee)))
+        .fee(Command.parseFee(this.options.voteFee))
         .votesAsset([`+${delegate}`])
         .network(this.config.network.version)
         .sign(wallet.passphrase)

--- a/packages/core-tester-cli/lib/commands/vote.js
+++ b/packages/core-tester-cli/lib/commands/vote.js
@@ -46,7 +46,7 @@ module.exports = class VoteCommand extends Command {
 
       transactions.push(transaction)
 
-      logger.info(`${i} ==> ${transaction.id}, ${wallet.address} (fee: ${transaction.fee})`)
+      logger.info(`${i} ==> ${transaction.id}, ${wallet.address} (fee: ${Command.__arktoshiToArk(transaction.fee)})`)
     })
 
     if (this.options.copy) {


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

The recent changes to `core-tester-cli` caused the random fee calculation to not work as expected when a fee-range was provided, always returning `0` or `1`. This also changes the log outputs to display the numeric values in ARK instead of ARKtoshis.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes