### PR TITLE
refactor: use 1e8 instead of math.pow

### DIFF
--- a/packages/core-api/__tests__/v1/utils.js
+++ b/packages/core-api/__tests__/v1/utils.js
@@ -74,7 +74,7 @@ class Helpers {
 
     let transaction = transactionBuilder
       .transfer()
-      .amount(1 * Math.pow(10, 8))
+      .amount(1 * 1e8)
       .recipientId('AZFEPTWnn2Sn8wDZgCRF8ohwKkrmk2AZi1')
       .vendorField('test')
       .sign('prison tobacco acquire stone dignity palace note decade they current lesson robot')

--- a/packages/core-api/__tests__/v2/utils.js
+++ b/packages/core-api/__tests__/v2/utils.js
@@ -140,7 +140,7 @@ class Helpers {
 
     let transaction = transactionBuilder
       .transfer()
-      .amount(1 * Math.pow(10, 8))
+      .amount(1 * 1e8)
       .recipientId('AZFEPTWnn2Sn8wDZgCRF8ohwKkrmk2AZi1')
       .vendorField('test')
       .sign('prison tobacco acquire stone dignity palace note decade they current lesson robot')

--- a/packages/core-tester-cli/lib/commands/command.js
+++ b/packages/core-tester-cli/lib/commands/command.js
@@ -284,7 +284,7 @@ module.exports = class Command {
    * @return {Bignum}
    */
   static __arkToArktoshi (ark) {
-    return bignumify(ark * Math.pow(10, 8))
+    return bignumify(ark * 1e8)
   }
 
   /**

--- a/packages/core-utils/__tests__/delegate-calculator.test.js
+++ b/packages/core-utils/__tests__/delegate-calculator.test.js
@@ -22,7 +22,7 @@ describe('Delegate Calculator', () => {
     })
 
     it('should calculate correctly', () => {
-      delegate.voteBalance = new Bignum(10000 * Math.pow(10, 8))
+      delegate.voteBalance = new Bignum(10000 * 1e8)
 
       container.resolvePlugin = jest.fn(plugin => {
         if (plugin === 'config') {
@@ -30,11 +30,11 @@ describe('Delegate Calculator', () => {
             getConstants: () => {
               return {
                 height: 1,
-                reward: 2 * Math.pow(10, 8)
+                reward: 2 * 1e8
               }
             },
             genesisBlock: {
-              totalAmount: 1000000 * Math.pow(10, 8)
+              totalAmount: 1000000 * 1e8
             }
           }
         }
@@ -44,7 +44,7 @@ describe('Delegate Calculator', () => {
     })
 
     it('should calculate correctly with 2 decimals', () => {
-      delegate.voteBalance = new Bignum(16500 * Math.pow(10, 8))
+      delegate.voteBalance = new Bignum(16500 * 1e8)
 
       container.resolvePlugin = jest.fn(plugin => {
         if (plugin === 'config') {
@@ -52,11 +52,11 @@ describe('Delegate Calculator', () => {
             getConstants: () => {
               return {
                 height: 1,
-                reward: 2 * Math.pow(10, 8)
+                reward: 2 * 1e8
               }
             },
             genesisBlock: {
-              totalAmount: 1000000 * Math.pow(10, 8)
+              totalAmount: 1000000 * 1e8
             }
           }
         }

--- a/packages/core-vote-report/lib/handler.js
+++ b/packages/core-vote-report/lib/handler.js
@@ -11,7 +11,7 @@ const database = container.resolvePlugin('database')
 const formatDelegates = delegates => delegates.map(delegate => {
   const voters = database.walletManager
     .allByPublicKey()
-    .filter(wallet => wallet.vote === delegate.publicKey && wallet.balance > 0.1 * Math.pow(10, 8))
+    .filter(wallet => wallet.vote === delegate.publicKey && wallet.balance > 0.1 * 1e8)
 
   const approval = delegateCalculator.calculateApproval(delegate).toString()
   const rank = delegate.rate.toLocaleString(undefined, { minimumIntegerDigits: 2 })
@@ -45,7 +45,7 @@ module.exports = (request, h) => {
 
   const voters = database.walletManager
     .allByPublicKey()
-    .filter(wallet => wallet.vote && wallet.balance > 0.1 * Math.pow(10, 8))
+    .filter(wallet => wallet.vote && wallet.balance > 0.1 * 1e8)
 
   const totalVotes = sumBy(voters, wallet => +wallet.balance.toFixed())
   const percentage = (totalVotes * 100) / supply

--- a/packages/crypto/lib/constants.js
+++ b/packages/crypto/lib/constants.js
@@ -6,7 +6,7 @@ const configTestnet = require('./networks/ark/testnet.json')
  * The Arktoshi base.
  * @type {Number}
  */
-exports.ARKTOSHI = Math.pow(10, 8)
+exports.ARKTOSHI = 1e8
 
 /**
  * Available transaction types.


### PR DESCRIPTION
## Proposed changes

Replaces `Math.pow(10, 8)` with `1e8` as it is quicker to type and yields the same result, just a syntax nitpick.

## Types of changes

- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes