### PR TITLE
fix(core-transaction-pool-mem): sort transactions by numerical fee value

### DIFF
--- a/packages/core-transaction-pool-mem/__tests__/connection.test.js
+++ b/packages/core-transaction-pool-mem/__tests__/connection.test.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const app = require('./__support__/setup')
+const { bignumify } = require('@arkecosystem/core-utils')
 const container = require('@arkecosystem/core-container')
 const crypto = require('@arkecosystem/crypto')
 const defaultConfig = require('../lib/defaults')
@@ -365,7 +366,7 @@ describe('Connection', () => {
 
       // This should be dropped due to checkDynamicFeeMatch()
       const lowFeeTransaction = new Transaction(mockData.dummy3)
-      lowFeeTransaction.fee = 1 // 1 ARKTOSHI
+      lowFeeTransaction.fee = bignumify(1) // 1 ARKTOSHI
 
       connection.addTransaction(lowFeeTransaction)
       connection.addTransaction(mockData.dummy4)
@@ -589,7 +590,7 @@ describe('Connection', () => {
       for (let i = 0; i < nAdd; i++) {
         const transaction = new Transaction(mockData.dummy1)
         transaction.id = fakeTransactionId(i)
-        transaction.fee = rand.intBetween(0.002 * ARKTOSHI, 2 * ARKTOSHI)
+        transaction.fee = bignumify(rand.intBetween(0.002 * ARKTOSHI, 2 * ARKTOSHI))
         transaction.serialized = Transaction.serialize(transaction).toString('hex')
         allTransactions.push(transaction)
       }

--- a/packages/core-transaction-pool-mem/lib/mem.js
+++ b/packages/core-transaction-pool-mem/lib/mem.js
@@ -219,10 +219,10 @@ class Mem {
   getTransactionsOrderedByFee () {
     if (!this.allIsSorted) {
       this.all.sort(function (a, b) {
-        if (+bignumify(a.transaction.fee).toFixed() > +bignumify(b.transaction.fee).toFixed()) {
+        if (a.transaction.fee.isGreaterThan(b.transaction.fee)) {
           return -1
         }
-        if (+bignumify(a.transaction.fee).toFixed() < +bignumify(b.transaction.fee).toFixed()) {
+        if (a.transaction.fee.isLessThan(b.transaction.fee)) {
           return 1
         }
         return a.sequence - b.sequence

--- a/packages/core-transaction-pool-mem/lib/mem.js
+++ b/packages/core-transaction-pool-mem/lib/mem.js
@@ -2,6 +2,7 @@
 
 const assert = require('assert')
 const { slots } = require('@arkecosystem/crypto')
+const { bignumify } = require('@arkecosystem/core-utils')
 
 class Mem {
   /**
@@ -218,10 +219,10 @@ class Mem {
   getTransactionsOrderedByFee () {
     if (!this.allIsSorted) {
       this.all.sort(function (a, b) {
-        if (a.transaction.fee > b.transaction.fee) {
+        if (+bignumify(a.transaction.fee).toFixed() > +bignumify(b.transaction.fee).toFixed()) {
           return -1
         }
-        if (a.transaction.fee < b.transaction.fee) {
+        if (+bignumify(a.transaction.fee).toFixed() < +bignumify(b.transaction.fee).toFixed()) {
           return 1
         }
         return a.sequence - b.sequence

--- a/packages/core-transaction-pool-mem/lib/mem.js
+++ b/packages/core-transaction-pool-mem/lib/mem.js
@@ -2,7 +2,6 @@
 
 const assert = require('assert')
 const { slots } = require('@arkecosystem/crypto')
-const { bignumify } = require('@arkecosystem/core-utils')
 
 class Mem {
   /**

--- a/packages/core-transaction-pool-mem/package.json
+++ b/packages/core-transaction-pool-mem/package.json
@@ -30,12 +30,13 @@
   },
   "devDependencies": {
     "@arkecosystem/core-test-utils": "^0.1.1",
+    "@arkecosystem/core-utils": "^0.1.0",
     "random-seed": "^0.3.0"
   },
   "publishConfig": {
     "access": "public"
   },
   "engines": {
-    "node" : ">=10.x"
+    "node": ">=10.x"
   }
 }


### PR DESCRIPTION
In [getTransactionsOrderedByFee()](https://github.com/ArkEcosystem/core/blob/0ab42975b23a479c6168fb5a73ebbbc51932f031/packages/core-transaction-pool-mem/lib/mem.js#L218) `a.transaction.fee` and `b.transaction.fee` are BigNumber objects not numbers and the comparison fails.

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [ ] Docs (documentation only changes)
- [ ] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [ ] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
