### PR TITLE
refactor(core-forger): better logging if unable to get tx from pool

### DIFF
--- a/packages/core-forger/lib/manager.js
+++ b/packages/core-forger/lib/manager.js
@@ -9,6 +9,8 @@ const config = container.resolvePlugin('config')
 const { slots } = require('@arkecosystem/crypto')
 const { Delegate, Transaction } = require('@arkecosystem/crypto').models
 
+const isEmpty = require('lodash/isEmpty')
+
 const Client = require('./client')
 
 module.exports = class ForgerManager {
@@ -184,7 +186,7 @@ module.exports = class ForgerManager {
   }
 
   /**
-   * Gets the unconfirmed transactions from the relay nodes transactio pool
+   * Gets the unconfirmed transactions from the relay nodes transaction pool
    */
   async __getTransactionsForForging () {
     const response = await this.client.getTransactions()
@@ -193,7 +195,11 @@ module.exports = class ForgerManager {
       ? response.transactions.map(serializedTx => Transaction.fromBytes(serializedTx))
       : []
 
-    logger.debug(`Received ${transactions.length} transactions from the pool containing ${response.poolSize} :money_with_wings:`)
+    if (isEmpty(response)) {
+      logger.error('Could not get unconfirmed transactions from transaction pool.')
+    } else {
+      logger.debug(`Received ${transactions.length} transactions from the pool containing ${response.poolSize} :money_with_wings:`)
+    }
 
     return transactions
   }


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

If getting transactions from the pool fails the forger still tries to access a field of the empty response object and logs:

`[DEBUG]: Received 0 transactions from the pool containing undefined 💸`

With this PR a more descriptive message will be logged.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
