### PR TITLE
chore: raise minimumVersion to 1.3.3

### DIFF
--- a/packages/core-deployer/bin/deployer
+++ b/packages/core-deployer/bin/deployer
@@ -140,7 +140,7 @@ const requestNodeIp = options.nodeIp === '0.0.0.0' ? '127.0.0.1' : options.nodeI
 
 updateConfig('network.json', networkConfig, options.configPath)
 updateConfig('peers.json', {
-  minimumVersion: '>=1.1.1',
+  minimumVersion: '>=1.3.3',
   minimumNetworkReach: 1,
   list: [{
     ip: requestNodeIp,

--- a/packages/core-test-utils/config/testnet/peers.json
+++ b/packages/core-test-utils/config/testnet/peers.json
@@ -1,5 +1,5 @@
 {
-  "minimumVersion": ">=1.1.1",
+  "minimumVersion": ">=1.3.3",
   "minimumNetworkReach": 5,
   "globalTimeout": 5000,
   "coldStart": 30,

--- a/packages/core/lib/config/devnet/peers.json
+++ b/packages/core/lib/config/devnet/peers.json
@@ -1,5 +1,5 @@
 {
-  "minimumVersion": ">=1.1.1",
+  "minimumVersion": ">=1.3.3",
   "minimumNetworkReach": 5,
   "globalTimeout": 5000,
   "coldStart": 5,

--- a/packages/core/lib/config/mainnet/peers.json
+++ b/packages/core/lib/config/mainnet/peers.json
@@ -1,5 +1,5 @@
 {
-  "minimumVersion": ">=1.1.1",
+  "minimumVersion": ">=1.3.3",
   "minimumNetworkReach": 20,
   "globalTimeout": 5000,
   "coldStart": 30,

--- a/packages/core/lib/config/testnet.1/peers.json
+++ b/packages/core/lib/config/testnet.1/peers.json
@@ -1,5 +1,5 @@
 {
-  "minimumVersion": ">=1.1.1",
+  "minimumVersion": ">=1.3.3",
   "minimumNetworkReach": 20,
   "globalTimeout": 5000,
   "coldStart": 30,

--- a/packages/core/lib/config/testnet.2/peers.json
+++ b/packages/core/lib/config/testnet.2/peers.json
@@ -1,5 +1,5 @@
 {
-  "minimumVersion": ">=1.1.1",
+  "minimumVersion": ">=1.3.3",
   "minimumNetworkReach": 20,
   "globalTimeout": 5000,
   "coldStart": 30,

--- a/packages/core/lib/config/testnet.live/peers.json
+++ b/packages/core/lib/config/testnet.live/peers.json
@@ -1,5 +1,5 @@
 {
-  "minimumVersion": ">=1.1.1",
+  "minimumVersion": ">=1.3.3",
   "minimumNetworkReach": 10,
   "blackList": [],
   "globalTimeout": 3000,

--- a/packages/core/lib/config/testnet/peers.json
+++ b/packages/core/lib/config/testnet/peers.json
@@ -1,5 +1,5 @@
 {
-  "minimumVersion": ">=1.1.1",
+  "minimumVersion": ">=1.3.3",
   "minimumNetworkReach": 5,
   "globalTimeout": 5000,
   "coldStart": 30,


### PR DESCRIPTION
## Proposed changes

ark-node has received some important updates so we only want to peer with the latest version.

## Types of changes

- [x] Other

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes