### PR TITLE
refactor(core-api): allow better config of hapi-rate-limit

### DIFF
--- a/packages/core-api/lib/defaults.js
+++ b/packages/core-api/lib/defaults.js
@@ -16,8 +16,11 @@ module.exports = {
   },
   rateLimit: {
     enabled: false,
-    limit: 300,
-    expires: 60000
+    pathLimit: false,
+    userLimit: 300,
+    userCache: {
+      expiresIn: 60000
+    }
   },
   pagination: {
     limit: 100,

--- a/packages/core-api/lib/server.js
+++ b/packages/core-api/lib/server.js
@@ -60,14 +60,7 @@ module.exports = async (config) => {
 
   await server.register({
     plugin: require('hapi-rate-limit'),
-    options: {
-      enabled: config.rateLimit.enabled,
-      pathLimit: false,
-      userLimit: config.rateLimit.limit,
-      userCache: {
-        expiresIn: config.rateLimit.expires
-      }
-    }
+    options: config.rateLimit.enabled
   })
 
   await server.register({

--- a/packages/core-api/lib/server.js
+++ b/packages/core-api/lib/server.js
@@ -60,7 +60,7 @@ module.exports = async (config) => {
 
   await server.register({
     plugin: require('hapi-rate-limit'),
-    options: config.rateLimit.enabled
+    options: config.rateLimit
   })
 
   await server.register({


### PR DESCRIPTION
## Proposed changes

Allows to pass in a full config object to the `hapi-rate-limit` plugin.

## Types of changes

- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes