### PR TITLE
refactor: add additional checks for transactions types

### DIFF
--- a/packages/core-transaction-pool-mem/lib/connection.js
+++ b/packages/core-transaction-pool-mem/lib/connection.js
@@ -303,16 +303,16 @@ class TransactionPool extends TransactionPoolInterface {
     return this.__checkIfSenderHasUnconfirmedTransactionsOfType(senderPublicKey, TRANSACTION_TYPES.DELEGATE_REGISTRATION)
   }
   /**
-   * Check whether there are unconfirmed transactions of a
-   * given type (transaction.type == txtype) in the pool
+   * Check whether there are unconfirmed transactions of a given
+   * transaction type (transaction.type == transactionType) in the pool
    * from a given sender.
    * @return {Boolean} true if exist
    */
-  __checkIfSenderHasUnconfirmedTransactionsOfType (senderPublicKey, txtype) {
+  __checkIfSenderHasUnconfirmedTransactionsOfType (senderPublicKey, transactionType) {
     this.__purgeExpired()
 
     for (const memPoolTransaction of this.mem.getBySender(senderPublicKey)) {
-      if (memPoolTransaction.transaction.type === txtype) {
+      if (memPoolTransaction.transaction.type === transactionType) {
         return true
       }
     }

--- a/packages/core-transaction-pool-mem/lib/connection.js
+++ b/packages/core-transaction-pool-mem/lib/connection.js
@@ -280,10 +280,39 @@ class TransactionPool extends TransactionPoolInterface {
    * @return {Boolean} true if exist
    */
   checkIfSenderHasVoteTransactions (senderPublicKey) {
+    return this.__checkIfSenderHasUnconfirmedTransactionsOfType(senderPublicKey, TRANSACTION_TYPES.VOTE)
+  }
+
+  /**
+   * Check whether there are any second signature
+   * transactions (transaction.type == TRANSACTION_TYPES.SECOND_SIGNATURE) in the pool
+   * from a given sender.
+   * @return {Boolean} true if exist
+   */
+  checkIfSenderHasSecondSignatureTransactions (senderPublicKey) {
+    return this.__checkIfSenderHasUnconfirmedTransactionsOfType(senderPublicKey, TRANSACTION_TYPES.SECOND_SIGNATURE)
+  }
+
+  /**
+   * Check whether there are any vote or unvote
+   * transactions (transaction.type == TRANSACTION_TYPES.DELEGATE_REGISTRATION) in the pool
+   * from a given sender.
+   * @return {Boolean} true if exist
+   */
+  checkIfSenderHasDelegateRegistrationTransactions (senderPublicKey) {
+    return this.__checkIfSenderHasUnconfirmedTransactionsOfType(senderPublicKey, TRANSACTION_TYPES.DELEGATE_REGISTRATION)
+  }
+  /**
+   * Check whether there are unconfirmed transactions of a
+   * given type (transaction.type == txtype) in the pool
+   * from a given sender.
+   * @return {Boolean} true if exist
+   */
+  __checkIfSenderHasUnconfirmedTransactionsOfType (senderPublicKey, txtype) {
     this.__purgeExpired()
 
     for (const memPoolTransaction of this.mem.getBySender(senderPublicKey)) {
-      if (memPoolTransaction.transaction.type === TRANSACTION_TYPES.VOTE) {
+      if (memPoolTransaction.transaction.type === txtype) {
         return true
       }
     }

--- a/packages/core-transaction-pool/__tests__/interface.test.js
+++ b/packages/core-transaction-pool/__tests__/interface.test.js
@@ -127,6 +127,26 @@ describe('Transaction Pool Interface', () => {
     })
   })
 
+  describe('checkIfSenderHasSecondSignatureTransactions', () => {
+    it('should be a function', () => {
+      expect(poolInterface.checkIfSenderHasSecondSignatureTransactions).toBeFunction()
+    })
+
+    it('should throw an exception', async () => {
+      expect(poolInterface.checkIfSenderHasSecondSignatureTransactions).toThrowError('Method [checkIfSenderHasSecondSignatureTransactions] not implemented!')
+    })
+  })
+
+  describe('checkIfSenderHasDelegateRegistrationTransactions', () => {
+    it('should be a function', () => {
+      expect(poolInterface.checkIfSenderHasDelegateRegistrationTransactions).toBeFunction()
+    })
+
+    it('should throw an exception', async () => {
+      expect(poolInterface.checkIfSenderHasDelegateRegistrationTransactions).toThrowError('Method [checkIfSenderHasDelegateRegistrationTransactions] not implemented!')
+    })
+  })
+
   describe('transactionExists', () => {
     it('should be a function', () => {
       expect(poolInterface.transactionExists).toBeFunction()

--- a/packages/core-transaction-pool/lib/interface.js
+++ b/packages/core-transaction-pool/lib/interface.js
@@ -281,4 +281,24 @@ module.exports = class TransactionPoolInterface {
   checkIfSenderHasVoteTransactions (senderPublicKey) {
     throw new Error('Method [checkIfSenderHasVoteTransactions] not implemented!')
   }
+
+  /**
+   * Check whether there are any second signature
+   * transactions (transaction.type == TRANSACTION_TYPES.SECOND_SIGNATURE) in the pool
+   * from a given sender.
+   * @return {Boolean} true if exist
+   */
+  checkIfSenderHasSecondSignatureTransactions (senderPublicKey) {
+    throw new Error('Method [checkIfSenderHasSecondSignatureTransactions] not implemented!')
+  }
+
+  /**
+   * Check whether there are any vote or unvote
+   * transactions (transaction.type == TRANSACTION_TYPES.DELEGATE_REGISTRATION) in the pool
+   * from a given sender.
+   * @return {Boolean} true if exist
+   */
+  checkIfSenderHasDelegateRegistrationTransactions (senderPublicKey) {
+    throw new Error('Method [checkIfSenderHasDelegateRegistrationTransactions] not implemented!')
+  }
 }


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

#1301 introduces validity checks for transactions in the transaction pool, which currently invalidate second signature and delegate registration transactions. This PR adds methods to check if there are pending transactions of the afore mentioned types already, which can be used in the `switch/case` statement used in #1301.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
