### PR TITLE
refactor(core-api): add number validation to schemata

### DIFF
--- a/packages/core-api/lib/versions/2/schema/blocks.js
+++ b/packages/core-api/lib/versions/2/schema/blocks.js
@@ -11,10 +11,10 @@ exports.index = {
     ...pagination,
     ...{
       orderBy: Joi.string(),
-      id: Joi.string(),
+      id: Joi.string().regex(/^[0-9]+$/, 'numbers'),
       version: Joi.number().integer().min(0),
       timestamp: Joi.number().integer().min(0),
-      previousBlock: Joi.string(),
+      previousBlock: Joi.string().regex(/^[0-9]+$/, 'numbers'),
       height: Joi.number().integer().positive(),
       numberOfTransactions: Joi.number().integer().min(0),
       totalAmount: Joi.number().integer().min(0),
@@ -33,7 +33,7 @@ exports.index = {
  */
 exports.show = {
   params: {
-    id: Joi.string()
+    id: Joi.string().regex(/^[0-9]+$/, 'numbers')
   }
 }
 
@@ -49,7 +49,7 @@ exports.transactions = {
     ...{
       orderBy: Joi.string(),
       id: Joi.string().hex().length(66),
-      blockId: Joi.string(),
+      blockId: Joi.string().regex(/^[0-9]+$/, 'numbers'),
       type: Joi.number().integer().min(0),
       version: Joi.number().integer().min(0),
       senderPublicKey: Joi.string().hex().length(66),
@@ -69,9 +69,9 @@ exports.transactions = {
 exports.search = {
   query: pagination,
   payload: {
-    id: Joi.string(),
+    id: Joi.string().regex(/^[0-9]+$/, 'numbers'),
     version: Joi.number().integer().min(0),
-    previousBlock: Joi.string(),
+    previousBlock: Joi.string().regex(/^[0-9]+$/, 'numbers'),
     payloadHash: Joi.string().hex(),
     generatorPublicKey: Joi.string().hex().length(66),
     blockSignature: Joi.string().hex(),

--- a/packages/core-api/lib/versions/2/schema/blocks.js
+++ b/packages/core-api/lib/versions/2/schema/blocks.js
@@ -11,10 +11,10 @@ exports.index = {
     ...pagination,
     ...{
       orderBy: Joi.string(),
-      id: Joi.string().regex(/^[0-9]+$/, 'numbers'),
+      id: Joi.number().unsafe(),
       version: Joi.number().integer().min(0),
       timestamp: Joi.number().integer().min(0),
-      previousBlock: Joi.string().regex(/^[0-9]+$/, 'numbers'),
+      previousBlock: Joi.number().unsafe(),
       height: Joi.number().integer().positive(),
       numberOfTransactions: Joi.number().integer().min(0),
       totalAmount: Joi.number().integer().min(0),
@@ -33,7 +33,7 @@ exports.index = {
  */
 exports.show = {
   params: {
-    id: Joi.string().regex(/^[0-9]+$/, 'numbers')
+    id: Joi.number().unsafe()
   }
 }
 
@@ -49,7 +49,7 @@ exports.transactions = {
     ...{
       orderBy: Joi.string(),
       id: Joi.string().hex().length(66),
-      blockId: Joi.string().regex(/^[0-9]+$/, 'numbers'),
+      blockId: Joi.number().unsafe(),
       type: Joi.number().integer().min(0),
       version: Joi.number().integer().min(0),
       senderPublicKey: Joi.string().hex().length(66),
@@ -69,9 +69,9 @@ exports.transactions = {
 exports.search = {
   query: pagination,
   payload: {
-    id: Joi.string().regex(/^[0-9]+$/, 'numbers'),
+    id: Joi.number().unsafe(),
     version: Joi.number().integer().min(0),
-    previousBlock: Joi.string().regex(/^[0-9]+$/, 'numbers'),
+    previousBlock: Joi.number().unsafe(),
     payloadHash: Joi.string().hex(),
     generatorPublicKey: Joi.string().hex().length(66),
     blockSignature: Joi.string().hex(),

--- a/packages/core-api/lib/versions/2/schema/blocks.js
+++ b/packages/core-api/lib/versions/2/schema/blocks.js
@@ -11,10 +11,10 @@ exports.index = {
     ...pagination,
     ...{
       orderBy: Joi.string(),
-      id: Joi.number().unsafe(),
+      id: Joi.string().regex(/^[0-9]+$/, 'numbers'),
       version: Joi.number().integer().min(0),
       timestamp: Joi.number().integer().min(0),
-      previousBlock: Joi.number().unsafe(),
+      previousBlock: Joi.string().regex(/^[0-9]+$/, 'numbers'),
       height: Joi.number().integer().positive(),
       numberOfTransactions: Joi.number().integer().min(0),
       totalAmount: Joi.number().integer().min(0),
@@ -33,7 +33,7 @@ exports.index = {
  */
 exports.show = {
   params: {
-    id: Joi.number().unsafe()
+    id: Joi.string().regex(/^[0-9]+$/, 'numbers')
   }
 }
 
@@ -49,7 +49,7 @@ exports.transactions = {
     ...{
       orderBy: Joi.string(),
       id: Joi.string().hex().length(66),
-      blockId: Joi.number().unsafe(),
+      blockId: Joi.string().regex(/^[0-9]+$/, 'numbers'),
       type: Joi.number().integer().min(0),
       version: Joi.number().integer().min(0),
       senderPublicKey: Joi.string().hex().length(66),
@@ -69,9 +69,9 @@ exports.transactions = {
 exports.search = {
   query: pagination,
   payload: {
-    id: Joi.number().unsafe(),
+    id: Joi.string().regex(/^[0-9]+$/, 'numbers'),
     version: Joi.number().integer().min(0),
-    previousBlock: Joi.number().unsafe(),
+    previousBlock: Joi.string().regex(/^[0-9]+$/, 'numbers'),
     payloadHash: Joi.string().hex(),
     generatorPublicKey: Joi.string().hex().length(66),
     blockSignature: Joi.string().hex(),

--- a/packages/core-api/lib/versions/2/schema/delegates.js
+++ b/packages/core-api/lib/versions/2/schema/delegates.js
@@ -54,10 +54,10 @@ exports.blocks = {
     ...pagination,
     ...{
       orderBy: Joi.string(),
-      id: Joi.string(),
+      id: Joi.string().regex(/^[0-9]+$/, 'numbers'),
       version: Joi.number().integer().min(0),
       timestamp: Joi.number().integer().min(0),
-      previousBlock: Joi.string(),
+      previousBlock: Joi.string().regex(/^[0-9]+$/, 'numbers'),
       height: Joi.number().integer().positive(),
       numberOfTransactions: Joi.number().integer().min(0),
       totalAmount: Joi.number().integer().min(0),

--- a/packages/core-api/lib/versions/2/schema/delegates.js
+++ b/packages/core-api/lib/versions/2/schema/delegates.js
@@ -54,10 +54,10 @@ exports.blocks = {
     ...pagination,
     ...{
       orderBy: Joi.string(),
-      id: Joi.string().regex(/^[0-9]+$/, 'numbers'),
+      id: Joi.number().unsafe(),
       version: Joi.number().integer().min(0),
       timestamp: Joi.number().integer().min(0),
-      previousBlock: Joi.string().regex(/^[0-9]+$/, 'numbers'),
+      previousBlock: Joi.number().unsafe(),
       height: Joi.number().integer().positive(),
       numberOfTransactions: Joi.number().integer().min(0),
       totalAmount: Joi.number().integer().min(0),

--- a/packages/core-api/lib/versions/2/schema/delegates.js
+++ b/packages/core-api/lib/versions/2/schema/delegates.js
@@ -54,10 +54,10 @@ exports.blocks = {
     ...pagination,
     ...{
       orderBy: Joi.string(),
-      id: Joi.number().unsafe(),
+      id: Joi.string().regex(/^[0-9]+$/, 'numbers'),
       version: Joi.number().integer().min(0),
       timestamp: Joi.number().integer().min(0),
-      previousBlock: Joi.number().unsafe(),
+      previousBlock: Joi.string().regex(/^[0-9]+$/, 'numbers'),
       height: Joi.number().integer().positive(),
       numberOfTransactions: Joi.number().integer().min(0),
       totalAmount: Joi.number().integer().min(0),

--- a/packages/core-api/lib/versions/2/schema/transactions.js
+++ b/packages/core-api/lib/versions/2/schema/transactions.js
@@ -43,7 +43,7 @@ exports.store = {
  */
 exports.show = {
   params: {
-    id: Joi.string()
+    id: Joi.string().hex().length(64)
   }
 }
 
@@ -59,7 +59,7 @@ exports.unconfirmed = {
  */
 exports.showUnconfirmed = {
   params: {
-    id: Joi.string()
+    id: Joi.string().hex().length(64)
   }
 }
 

--- a/packages/core-api/lib/versions/2/schema/transactions.js
+++ b/packages/core-api/lib/versions/2/schema/transactions.js
@@ -14,7 +14,7 @@ exports.index = {
     ...{
       orderBy: Joi.string(),
       id: Joi.string().hex().length(64),
-      blockId: Joi.string(),
+      blockId: Joi.string().regex(/^[0-9]+$/, 'numbers'),
       type: Joi.number().integer().min(0),
       version: Joi.number().integer().positive(),
       senderPublicKey: Joi.string().hex().length(66),
@@ -71,7 +71,7 @@ exports.search = {
   payload: {
     orderBy: Joi.string(),
     id: Joi.string().hex().length(64),
-    blockId: Joi.string(),
+    blockId: Joi.string().regex(/^[0-9]+$/, 'numbers'),
     type: Joi.number().integer().min(0),
     version: Joi.number().integer().positive(),
     senderPublicKey: Joi.string().hex().length(66),

--- a/packages/core-api/lib/versions/2/schema/transactions.js
+++ b/packages/core-api/lib/versions/2/schema/transactions.js
@@ -14,7 +14,7 @@ exports.index = {
     ...{
       orderBy: Joi.string(),
       id: Joi.string().hex().length(64),
-      blockId: Joi.string().regex(/^[0-9]+$/, 'numbers'),
+      blockId: Joi.number().unsafe(),
       type: Joi.number().integer().min(0),
       version: Joi.number().integer().positive(),
       senderPublicKey: Joi.string().hex().length(66),
@@ -71,7 +71,7 @@ exports.search = {
   payload: {
     orderBy: Joi.string(),
     id: Joi.string().hex().length(64),
-    blockId: Joi.string().regex(/^[0-9]+$/, 'numbers'),
+    blockId: Joi.number().unsafe(),
     type: Joi.number().integer().min(0),
     version: Joi.number().integer().positive(),
     senderPublicKey: Joi.string().hex().length(66),

--- a/packages/core-api/lib/versions/2/schema/transactions.js
+++ b/packages/core-api/lib/versions/2/schema/transactions.js
@@ -14,7 +14,7 @@ exports.index = {
     ...{
       orderBy: Joi.string(),
       id: Joi.string().hex().length(64),
-      blockId: Joi.number().unsafe(),
+      blockId: Joi.string().regex(/^[0-9]+$/, 'numbers'),
       type: Joi.number().integer().min(0),
       version: Joi.number().integer().positive(),
       senderPublicKey: Joi.string().hex().length(66),
@@ -71,7 +71,7 @@ exports.search = {
   payload: {
     orderBy: Joi.string(),
     id: Joi.string().hex().length(64),
-    blockId: Joi.number().unsafe(),
+    blockId: Joi.string().regex(/^[0-9]+$/, 'numbers'),
     type: Joi.number().integer().min(0),
     version: Joi.number().integer().positive(),
     senderPublicKey: Joi.string().hex().length(66),

--- a/packages/core-api/lib/versions/2/schema/votes.js
+++ b/packages/core-api/lib/versions/2/schema/votes.js
@@ -30,6 +30,6 @@ exports.index = {
  */
 exports.show = {
   params: {
-    id: Joi.string()
+    id: Joi.string().hex().length(64)
   }
 }

--- a/packages/core-api/lib/versions/2/schema/votes.js
+++ b/packages/core-api/lib/versions/2/schema/votes.js
@@ -12,7 +12,7 @@ exports.index = {
     ...{
       orderBy: Joi.string(),
       id: Joi.string().hex().length(64),
-      blockId: Joi.string(),
+      blockId: Joi.string().regex(/^[0-9]+$/, 'numbers'),
       version: Joi.number().integer().positive(),
       senderPublicKey: Joi.string().hex().length(66),
       senderId: Joi.string().alphanum().length(34),

--- a/packages/core-api/lib/versions/2/schema/votes.js
+++ b/packages/core-api/lib/versions/2/schema/votes.js
@@ -12,7 +12,7 @@ exports.index = {
     ...{
       orderBy: Joi.string(),
       id: Joi.string().hex().length(64),
-      blockId: Joi.number().unsafe(),
+      blockId: Joi.string().regex(/^[0-9]+$/, 'numbers'),
       version: Joi.number().integer().positive(),
       senderPublicKey: Joi.string().hex().length(66),
       senderId: Joi.string().alphanum().length(34),

--- a/packages/core-api/lib/versions/2/schema/votes.js
+++ b/packages/core-api/lib/versions/2/schema/votes.js
@@ -12,7 +12,7 @@ exports.index = {
     ...{
       orderBy: Joi.string(),
       id: Joi.string().hex().length(64),
-      blockId: Joi.string().regex(/^[0-9]+$/, 'numbers'),
+      blockId: Joi.number().unsafe(),
       version: Joi.number().integer().positive(),
       senderPublicKey: Joi.string().hex().length(66),
       senderId: Joi.string().alphanum().length(34),


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

Some API endpoints were missing proper validation of the input values in their schemata, such as block and transaction ids, allowing for requests such as the following to be valid:

https://dexplorer.ark.io:8443/api/v2/blocks/xxx
https://dexplorer.ark.io:8443/api/v2/transactions/aaa
https://dexplorer.ark.io:8443/api/v2/votes/bbb

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
