### PR TITLE
fix: vendor field length validation

### DIFF
--- a/packages/core-api/lib/versions/2/schema/transactions.js
+++ b/packages/core-api/lib/versions/2/schema/transactions.js
@@ -34,7 +34,7 @@ exports.index = {
  */
 exports.store = {
   payload: {
-    transactions: Joi.array().max(container.resolveOptions('transactionPool').maxTransactionsPerRequest).items(Joi.object({ vendorField: Joi.string().max(64, 'utf8') }).options({ allowUnknown: true }))
+    transactions: Joi.array().max(container.resolveOptions('transactionPool').maxTransactionsPerRequest).items(Joi.object({ vendorField: Joi.string().empty('').max(64, 'utf8') }).options({ allowUnknown: true }))
   }
 }
 

--- a/packages/core-api/lib/versions/2/schema/transactions.js
+++ b/packages/core-api/lib/versions/2/schema/transactions.js
@@ -34,7 +34,7 @@ exports.index = {
  */
 exports.store = {
   payload: {
-    transactions: Joi.array().max(container.resolveOptions('transactionPool').maxTransactionsPerRequest).items(Joi.object())
+    transactions: Joi.array().max(container.resolveOptions('transactionPool').maxTransactionsPerRequest).items(Joi.object({ vendorField: Joi.string().max(64, 'utf8') }).options({ allowUnknown: true }))
   }
 }
 

--- a/packages/crypto/__tests__/validation/rules/models/transactions/transfer.test.js
+++ b/packages/crypto/__tests__/validation/rules/models/transactions/transfer.test.js
@@ -32,6 +32,38 @@ describe('Transfer Transaction Rule', () => {
     expect(rule(transaction.getStruct()).errors).toBeNull()
   })
 
+  it('should be valid with up to 64 bytes in vendor field', () => {
+    transaction.recipientId(address)
+      .amount(amount)
+      .fee(fee)
+      .vendorField('a'.repeat(64))
+      .sign('passphrase')
+    expect(rule(transaction.getStruct()).errors).toBeNull()
+
+    transaction.recipientId(address)
+      .amount(amount)
+      .fee(fee)
+      .vendorField('⊁'.repeat(21))
+      .sign('passphrase')
+    expect(rule(transaction.getStruct()).errors).toBeNull()
+  })
+
+  it('should be invalid with more than 64 bytes in vendor field', () => {
+    transaction.recipientId(address)
+      .amount(amount)
+      .fee(fee)
+      .vendorField('a'.repeat(65))
+      .sign('passphrase')
+    expect(rule(transaction.getStruct()).errors).not.toBeNull()
+
+    transaction.recipientId(address)
+      .amount(amount)
+      .fee(fee)
+      .vendorField('⊁'.repeat(22))
+      .sign('passphrase')
+    expect(rule(transaction.getStruct()).errors).not.toBeNull()
+  })
+
   it('should be invalid due to no transaction as object', () => {
     expect(rule('test').errors).not.toBeNull()
   })

--- a/packages/crypto/lib/builder/transactions/transaction.js
+++ b/packages/crypto/lib/builder/transactions/transaction.js
@@ -92,7 +92,7 @@ module.exports = class TransactionBuilder {
    * @return {TransactionBuilder}
    */
   vendorField (vendorField) {
-    if (vendorField && vendorField.length <= 64) {
+    if (vendorField && Buffer.from(vendorField).length <= 64) {
       this.data.vendorField = vendorField
     }
 

--- a/packages/crypto/lib/validation/rules/models/transactions/transfer.js
+++ b/packages/crypto/lib/validation/rules/models/transactions/transfer.js
@@ -15,7 +15,7 @@ module.exports = (transaction) => {
     signature: engine.joi.string().alphanum().required(),
     signatures: engine.joi.array(),
     secondSignature: engine.joi.string().alphanum(),
-    vendorField: engine.joi.string().max(64),
+    vendorField: engine.joi.string().max(64, 'utf8'),
     confirmations: engine.joi.number().integer().min(0)
   }), {
     allowUnknown: true


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Fixes #1318 .
Adds vendor field length validation so that everything longer than 64 bytes is rejected.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [ ] Docs (documentation only changes)
- [ ] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [ ] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [X] Lint and unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
