### PR TITLE
feat(core-p2p): add ability to skip initial peer discovery

### DIFF
--- a/packages/core-p2p/lib/monitor.js
+++ b/packages/core-p2p/lib/monitor.js
@@ -44,7 +44,7 @@ class Monitor {
 
     this.__filterPeers()
 
-    await this.updateNetworkStatus(config.networkStart)
+    await this.updateNetworkStatus(config.networkStart, true)
 
     return this
   }
@@ -52,9 +52,10 @@ class Monitor {
   /**
    * Update network status (currently only peers are updated).
    * @param  {Boolean} networkStart
+   * @param  {Boolean} firstCall
    * @return {Promise}
    */
-  async updateNetworkStatus (networkStart) {
+  async updateNetworkStatus (networkStart, firstCall) {
     if (networkStart) {
       logger.warn('Skipped peer discovery because the relay is in genesis start mode.')
       return
@@ -67,8 +68,9 @@ class Monitor {
 
     try {
       const realEnvironment = process.env.ARK_ENV !== 'test'
+      const skipDiscovery = firstCall && this.config.skipDiscovery
 
-      if (realEnvironment) {
+      if (realEnvironment && !skipDiscovery) {
         await this.discoverPeers()
         await this.cleanPeers()
       }

--- a/packages/core-p2p/lib/monitor.js
+++ b/packages/core-p2p/lib/monitor.js
@@ -57,7 +57,7 @@ class Monitor {
    */
   async updateNetworkStatus (networkStart, firstCall) {
     if (networkStart) {
-      logger.warn('Skipped peer discovery because the relay is in genesis start mode.')
+      logger.warn('Skipped peer discovery because the relay is in genesis-start mode.')
       return
     }
 
@@ -66,11 +66,15 @@ class Monitor {
       return
     }
 
+    if (firstCall && this.config.skipDiscovery) {
+      logger.warn('Skipped peer discovery because the relay is in skip-discovery mode.')
+      return
+    }
+
     try {
       const realEnvironment = process.env.ARK_ENV !== 'test'
-      const skipDiscovery = firstCall && this.config.skipDiscovery
 
-      if (realEnvironment && !skipDiscovery) {
+      if (realEnvironment) {
         await this.discoverPeers()
         await this.cleanPeers()
       }

--- a/packages/core-p2p/lib/monitor.js
+++ b/packages/core-p2p/lib/monitor.js
@@ -44,7 +44,9 @@ class Monitor {
 
     this.__filterPeers()
 
-    await this.updateNetworkStatus(config.networkStart, true)
+    this.config.skipDiscovery
+      ? logger.warn('Skipped peer discovery because the relay is in skip-discovery mode.')
+      : await this.updateNetworkStatus(config.networkStart)
 
     return this
   }
@@ -52,10 +54,9 @@ class Monitor {
   /**
    * Update network status (currently only peers are updated).
    * @param  {Boolean} networkStart
-   * @param  {Boolean} firstCall
    * @return {Promise}
    */
-  async updateNetworkStatus (networkStart, firstCall) {
+  async updateNetworkStatus (networkStart) {
     if (networkStart) {
       logger.warn('Skipped peer discovery because the relay is in genesis-start mode.')
       return
@@ -63,11 +64,6 @@ class Monitor {
 
     if (this.config.disableDiscovery) {
       logger.warn('Skipped peer discovery because the relay is in non-discovery mode.')
-      return
-    }
-
-    if (firstCall && this.config.skipDiscovery) {
-      logger.warn('Skipped peer discovery because the relay is in skip-discovery mode.')
       return
     }
 

--- a/packages/core/bin/ark
+++ b/packages/core/bin/ark
@@ -18,6 +18,7 @@ app
   .option('-p, --password <password>', 'forger password')
   .option('--network-start', 'force genesis network start', false)
   .option('--disable-discovery', 'disable any peer discovery')
+  .option('--skip-discovery', 'skip the initial peer discovery')
   .action(async (options) => require('../lib/start-relay-and-forger')(options))
 
 app
@@ -30,6 +31,7 @@ app
   .option('-r, --remote <remote>', 'remote peer for config')
   .option('--network-start', 'force genesis network start', false)
   .option('--disable-discovery', 'disable any peer discovery')
+  .option('--skip-discovery', 'skip the initial peer discovery')
   .action(async (options) => require('../lib/start-relay')(options))
 
 app

--- a/packages/core/lib/start-relay-and-forger.js
+++ b/packages/core/lib/start-relay-and-forger.js
@@ -12,7 +12,8 @@ module.exports = async options => {
     options: {
       '@arkecosystem/core-p2p': {
         networkStart: options.networkStart,
-        disableDiscovery: options.disableDiscovery
+        disableDiscovery: options.disableDiscovery,
+        skipDiscovery: options.skipDiscovery
       },
       '@arkecosystem/core-blockchain': {
         networkStart: options.networkStart

--- a/packages/core/lib/start-relay.js
+++ b/packages/core/lib/start-relay.js
@@ -13,7 +13,8 @@ module.exports = async options => {
     options: {
       '@arkecosystem/core-p2p': {
         networkStart: options.networkStart,
-        disableDiscovery: options.disableDiscovery
+        disableDiscovery: options.disableDiscovery,
+        skipDiscovery: options.skipDiscovery
       },
       '@arkecosystem/core-blockchain': {
         networkStart: options.networkStart


### PR DESCRIPTION
## Proposed changes

Starting nodes with `--network-start` will already skip the peer discovery but it will also skip a bunch of other things in regards to the state-machine. The `--skip-discovery` flag will allow a node to be started in normal mode and skip the initial peer discovery like `--network-start` does without any of the side effects.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes