### PR TITLE
build: CircleCI improve caching - generate yml config on pre-commit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,8 +3,8 @@ jobs:
   test-node10:
     working_directory: ~/ark-core
     docker:
-      - image: circleci/node:10-browsers
-      - image: postgres:alpine
+      - image: 'circleci/node:10-browsers'
+      - image: 'postgres:alpine'
         environment:
           POSTGRES_PASSWORD: password
           POSTGRES_DB: ark_development
@@ -14,56 +14,73 @@ jobs:
       - checkout
       - run:
           name: Apt update
-          command: sudo sh -c 'echo "deb http://ftp.debian.org/debian stable main contrib non-free" >> /etc/apt/sources.list' && sudo apt-get update
+          command: >-
+            sudo sh -c 'echo "deb http://ftp.debian.org/debian stable main
+            contrib non-free" >> /etc/apt/sources.list' && sudo apt-get update
       - run:
           name: Install xsel
-          command: 'sudo apt-get install -q xsel'
+          command: sudo apt-get install -q xsel
       - run:
           name: Install yarn
-          command: 'curl -o- -L https://yarnpkg.com/install.sh | bash && export PATH="$HOME/.yarn/bin:$PATH" && yarn config set cache-folder $HOME/.cache/yarn'
+          command: >-
+            curl -o- -L https://yarnpkg.com/install.sh | bash && export
+            PATH="$HOME/.yarn/bin:$PATH" && yarn config set cache-folder
+            $HOME/.cache/yarn
       - run:
           name: Generate cache key
-          command: find ./packages/ -name package.json -print0 | sort -z | xargs -r0 echo ./package.json | xargs md5sum | md5sum - > checksum.txt
+          command: >-
+            find ./packages/ -name package.json -print0 | sort -z | xargs -r0
+            echo ./package.json | xargs md5sum | md5sum - > checksum.txt
       - restore_cache:
-          key: core-node10-{{ checksum "checksum.txt" }}-1
+          key: 'core-node10-{{ checksum "checksum.txt" }}-1'
       - run:
           name: Install packages
           command: yarn
       - save_cache:
-          key: core-node10-{{ checksum "checksum.txt" }}-1
+          key: 'core-node10-{{ checksum "checksum.txt" }}-1'
           paths:
-            -  ./node_modules
-            -  ./packages/core-api/node_modules
-            -  ./packages/core-blockchain/node_modules
-            -  ./packages/core-config/node_modules
-            -  ./packages/core-container/node_modules
-            -  ./packages/core-database-postgres/node_modules
-            -  ./packages/core-database/node_modules
-            -  ./packages/core-debugger-cli/node_modules
-            -  ./packages/core-deployer/node_modules
-            -  ./packages/core-event-emitter/node_modules
-            -  ./packages/core-forger/node_modules
-            -  ./packages/core-graphql/node_modules
-            -  ./packages/core-json-rpc/node_modules
-            -  ./packages/core-logger-winston/node_modules
-            -  ./packages/core-logger/node_modules
-            -  ./packages/core-p2p/node_modules
-            -  ./packages/core-test-utils/node_modules
-            -  ./packages/core-tester-cli/node_modules
-            -  ./packages/core-transaction-pool-mem/node_modules
-            -  ./packages/core-transaction-pool/node_modules
-            -  ./packages/core-utils/node_modules
-            -  ./packages/core-webhooks/node_modules
-            -  ./packages/core/node_modules
-            -  ./packages/crypto/node_modules
+            - ./packages/core/node_modules
+            - ./packages/core-api/node_modules
+            - ./packages/core-blockchain/node_modules
+            - ./packages/core-config/node_modules
+            - ./packages/core-container/node_modules
+            - ./packages/core-database/node_modules
+            - ./packages/core-database-postgres/node_modules
+            - ./packages/core-debugger-cli/node_modules
+            - ./packages/core-deployer/node_modules
+            - ./packages/core-elasticsearch/node_modules
+            - ./packages/core-error-tracker-bugsnag/node_modules
+            - ./packages/core-error-tracker-sentry/node_modules
+            - ./packages/core-event-emitter/node_modules
+            - ./packages/core-forger/node_modules
+            - ./packages/core-graphql/node_modules
+            - ./packages/core-http-utils/node_modules
+            - ./packages/core-json-rpc/node_modules
+            - ./packages/core-logger/node_modules
+            - ./packages/core-logger-winston/node_modules
+            - ./packages/core-p2p/node_modules
+            - ./packages/core-snapshots/node_modules
+            - ./packages/core-snapshots-cli/node_modules
+            - ./packages/core-test-utils/node_modules
+            - ./packages/core-tester-cli/node_modules
+            - ./packages/core-transaction-pool/node_modules
+            - ./packages/core-transaction-pool-mem/node_modules
+            - ./packages/core-utils/node_modules
+            - ./packages/core-vote-report/node_modules
+            - ./packages/core-webhooks/node_modules
+            - ./packages/crypto/node_modules
+            - ./node_modules
       - run:
           name: Create .ark/database directory
           command: mkdir -p $HOME/.ark/database
       - run:
           name: Test
-          command: |
+          command: >
             TESTFILES=$(circleci tests glob "packages/**/*.test.js")
-            ./node_modules/.bin/cross-env ARK_ENV=test ./node_modules/.bin/jest ${TESTFILES} --detectOpenHandles --runInBand --forceExit --ci --coverage | tee test_output.txt
+
+            ./node_modules/.bin/cross-env ARK_ENV=test ./node_modules/.bin/jest
+            ${TESTFILES} --detectOpenHandles --runInBand --forceExit --ci
+            --coverage | tee test_output.txt
       - run:
           name: Last 1000 lines of test output
           when: on_fail
@@ -77,78 +94,8 @@ jobs:
       - run:
           name: Depcheck
           command: yarn depcheck
-  test-node11:
-    working_directory: ~/ark-core
-    docker:
-      - image: circleci/node:11-browsers
-      - image: postgres:alpine
-        environment:
-          POSTGRES_PASSWORD: password
-          POSTGRES_DB: ark_development
-          POSTGRES_USER: ark
-    parallelism: 1
-    steps:
-      - checkout
-      - run:
-          name: Apt update
-          command: sudo sh -c 'echo "deb http://ftp.debian.org/debian stable main contrib non-free" >> /etc/apt/sources.list' && sudo apt-get update
-      - run:
-          name: Install xsel
-          command: 'sudo apt-get install -q xsel'
-      - run:
-          name: Install yarn
-          command: 'curl -o- -L https://yarnpkg.com/install.sh | bash && export PATH="$HOME/.yarn/bin:$PATH" && yarn config set cache-folder $HOME/.cache/yarn'
-      - run:
-          name: Generate cache key
-          command: find ./packages/ -name package.json -print0 | sort -z | xargs -r0 echo ./package.json | xargs md5sum | md5sum - > checksum.txt
-      - restore_cache:
-          key: core-node11-{{ checksum "checksum.txt" }}-1
-      - run:
-          name: Install packages
-          command: yarn
-      - save_cache:
-          key: core-node11-{{ checksum "checksum.txt" }}-1
-          paths:
-            -  ./node_modules
-            -  ./packages/core-api/node_modules
-            -  ./packages/core-blockchain/node_modules
-            -  ./packages/core-config/node_modules
-            -  ./packages/core-container/node_modules
-            -  ./packages/core-database-postgres/node_modules
-            -  ./packages/core-database/node_modules
-            -  ./packages/core-debugger-cli/node_modules
-            -  ./packages/core-deployer/node_modules
-            -  ./packages/core-event-emitter/node_modules
-            -  ./packages/core-forger/node_modules
-            -  ./packages/core-graphql/node_modules
-            -  ./packages/core-json-rpc/node_modules
-            -  ./packages/core-logger-winston/node_modules
-            -  ./packages/core-logger/node_modules
-            -  ./packages/core-p2p/node_modules
-            -  ./packages/core-test-utils/node_modules
-            -  ./packages/core-tester-cli/node_modules
-            -  ./packages/core-transaction-pool-mem/node_modules
-            -  ./packages/core-transaction-pool/node_modules
-            -  ./packages/core-utils/node_modules
-            -  ./packages/core-webhooks/node_modules
-            -  ./packages/core/node_modules
-            -  ./packages/crypto/node_modules
-      - run:
-          name: Create .ark/database directory
-          command: mkdir -p $HOME/.ark/database
-      - run:
-          name: Test
-          command: |
-            TESTFILES=$(circleci tests glob "packages/**/*.test.js")
-            ./node_modules/.bin/cross-env ARK_ENV=test ./node_modules/.bin/jest ${TESTFILES} --detectOpenHandles --runInBand --forceExit --ci --coverage | tee test_output.txt
-      - run:
-          name: Last 1000 lines of test output
-          when: on_fail
-          command: tail -n 1000 test_output.txt
-
 workflows:
   version: 2
   test_depcheck_lint:
     jobs:
       - test-node10
-      # - test-node11

--- a/.circleci/configTemplate.json
+++ b/.circleci/configTemplate.json
@@ -1,0 +1,111 @@
+{
+	"version": 2,
+	"jobs": {
+		"test-node10": {
+			"working_directory": "~/ark-core",
+			"docker": [
+				{
+					"image": "circleci/node:10-browsers"
+				},
+				{
+					"image": "postgres:alpine",
+					"environment": {
+						"POSTGRES_PASSWORD": "password",
+						"POSTGRES_DB": "ark_development",
+						"POSTGRES_USER": "ark"
+					}
+				}
+			],
+			"parallelism": 1,
+			"steps": [
+				"checkout",
+				{
+					"run": {
+						"name": "Apt update",
+						"command": "sudo sh -c 'echo \"deb http://ftp.debian.org/debian stable main contrib non-free\" >> /etc/apt/sources.list' && sudo apt-get update"
+					}
+				},
+				{
+					"run": {
+						"name": "Install xsel",
+						"command": "sudo apt-get install -q xsel"
+					}
+				},
+				{
+					"run": {
+						"name": "Install yarn",
+						"command": "curl -o- -L https://yarnpkg.com/install.sh | bash && export PATH=\"$HOME/.yarn/bin:$PATH\" && yarn config set cache-folder $HOME/.cache/yarn"
+					}
+				},
+				{
+					"run": {
+						"name": "Generate cache key",
+						"command": "find ./packages/ -name package.json -print0 | sort -z | xargs -r0 echo ./package.json | xargs md5sum | md5sum - > checksum.txt"
+					}
+				},
+				{
+					"restore_cache": {
+						"key": "core-node10-{{ checksum \"checksum.txt\" }}-1"
+					}
+				},
+				{
+					"run": {
+						"name": "Install packages",
+						"command": "yarn"
+					}
+				},
+				{
+					"save_cache": {
+						"key": "core-node10-{{ checksum \"checksum.txt\" }}-1",
+						"paths": []
+					}
+				},
+				{
+					"run": {
+						"name": "Create .ark/database directory",
+						"command": "mkdir -p $HOME/.ark/database"
+					}
+				},
+				{
+					"run": {
+						"name": "Test",
+						"command": "TESTFILES=$(circleci tests glob \"packages/**/*.test.js\")\n./node_modules/.bin/cross-env ARK_ENV=test ./node_modules/.bin/jest ${TESTFILES} --detectOpenHandles --runInBand --forceExit --ci --coverage | tee test_output.txt\n"
+					}
+				},
+				{
+					"run": {
+						"name": "Last 1000 lines of test output",
+						"when": "on_fail",
+						"command": "tail -n 1000 test_output.txt"
+					}
+				},
+				{
+					"run": {
+						"name": "Codecov",
+						"command": "./node_modules/.bin/codecov"
+					}
+				},
+				{
+					"run": {
+						"name": "Lint",
+						"command": "yarn lint"
+					}
+				},
+				{
+					"run": {
+						"name": "Depcheck",
+						"command": "yarn depcheck"
+					}
+				}
+			]
+		}
+	},
+  "workflows": {
+		"version": 2,
+		"test_depcheck_lint": {
+			"jobs": [
+				"test-node10"
+			]
+		}
+	}
+}

--- a/.circleci/generateConfig.js
+++ b/.circleci/generateConfig.js
@@ -1,0 +1,19 @@
+const yaml = require('js-yaml')
+const fs   = require('fs')
+
+const config = require('./configTemplate.json')
+
+generateConfig()
+
+function generateConfig() {
+  fs.readdir('./packages', (err, packages) => genYaml({ packages }))
+}
+
+function genYaml(options) {
+  const saveCacheStep = config.jobs['test-node10'].steps.find(step => typeof step === 'object' && step.save_cache)
+  saveCacheStep.save_cache.paths = options.packages.map(package => `./packages/${package}/node_modules`).concat('./node_modules')
+      
+  fs.writeFile('.circleci/config.yml', yaml.safeDump(config), 'utf8', err => {
+    if (err) console.log(err)
+  })
+}

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   ],
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged && node .circleci/generateConfig.js && git add .circleci/config.yml"
+      "pre-commit": "lint-staged && ./pre-commit.sh"
     }
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "husky": "^1.0.0-rc.2",
     "jest": "^23.3.0",
     "jest-extended": "^0.11.0",
+    "js-yaml": "^3.12.0",
     "lerna": "^3.4.3",
     "lint-staged": "^7.1.2",
     "regenerator-runtime": "^0.12.1",
@@ -49,7 +50,7 @@
   ],
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged"
+      "pre-commit": "lint-staged && node .circleci/generateConfig.js && git add .circleci/config.yml"
     }
   },
   "lint-staged": {

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -1,2 +1,5 @@
 echo "Running pre-commit script..."
+
 node .circleci/generateConfig.js && git add .circleci/config.yml
+
+echo "pre-commit script was run succesfully"

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -1,0 +1,2 @@
+echo "Running pre-commit script..."
+node .circleci/generateConfig.js && git add .circleci/config.yml


### PR DESCRIPTION
## Proposed changes

For CircleCI to cache correctly the node_modules folders, we have to explicitly list every node_modules folder we have.
So when we add / remove a package (to our packages folder), we have to update the CircleCI config, which is not cool.

This PR adds a pre-commit script that will generate the CircleCI config so that we don't have to worry about updating manually config.yml.
So now config.yml is generated on pre-commit, based on configTemplate.json and with the generateConfig.js script.

## Types of changes

- [x] Build (changes that affect the build system)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes