### PR TITLE
refactor(core-forger): prettify loaded delegate logs

### DIFF
--- a/packages/core-forger/lib/index.js
+++ b/packages/core-forger/lib/index.js
@@ -23,7 +23,7 @@ exports.plugin = {
     delete process.env.ARK_FORGER_PASSWORD
     delete options.password
 
-    container.resolvePlugin('logger').info(`ForgerManager started with ${forgers.length} forgers`)
+    container.resolvePlugin('logger').info(`Forger Manager started with ${forgers.length} forgers`)
 
     forgerManager.startForging()
 

--- a/packages/core-forger/lib/manager.js
+++ b/packages/core-forger/lib/manager.js
@@ -51,7 +51,7 @@ module.exports = class ForgerManager {
       return `${this.usernames[delegate.publicKey]} (${delegate.publicKey})`
     })
 
-    logger.debug(`Loaded ${delegates} delegates.`)
+    logger.debug(`Loaded ${delegates.length} delegate${delegates.length ? 's' : ''}: ${delegates.join(', ')}`)
 
     return this.delegates
   }


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

Prettifies the loaded delegates logs output.

#### Before
```
[DEBUG]: Loaded dated_test_del (pubkey),multiforger (pubkey) delegates.
[INFO]:  ForgerManager started with 2 forgers
```

#### After
```
[DEBUG]: Loaded 2 delegates: dated_test_del (pubkey), multiforger (pubkey)
[INFO]:  Forger Manager started with 2 forgers
```

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
