### PR TITLE
refactor(core-api): use totalAmount of block if available

### DIFF
--- a/packages/core-api/lib/versions/2/transformers/block.js
+++ b/packages/core-api/lib/versions/2/transformers/block.js
@@ -14,10 +14,6 @@ module.exports = model => {
   model.reward = bignumify(model.reward)
   model.totalFee = bignumify(model.totalFee)
 
-  const totalAmount = model.totalAmount
-    ? +bignumify(model.totalAmount).toFixed()
-    : +model.reward.plus(model.totalFee).toFixed()
-
   return {
     id: model.id,
     version: +model.version,
@@ -26,7 +22,7 @@ module.exports = model => {
     forged: {
       reward: +model.reward.toFixed(),
       fee: +model.totalFee.toFixed(),
-      total: totalAmount
+      total: +bignumify(model.totalAmount).toFixed()
     },
     payload: {
       hash: model.payloadHash,

--- a/packages/core-api/lib/versions/2/transformers/block.js
+++ b/packages/core-api/lib/versions/2/transformers/block.js
@@ -14,6 +14,10 @@ module.exports = model => {
   model.reward = bignumify(model.reward)
   model.totalFee = bignumify(model.totalFee)
 
+  const totalAmount = model.totalAmount
+    ? +bignumify(model.totalAmount).toFixed()
+    : +model.reward.plus(model.totalFee).toFixed()
+
   return {
     id: model.id,
     version: +model.version,
@@ -22,7 +26,7 @@ module.exports = model => {
     forged: {
       reward: +model.reward.toFixed(),
       fee: +model.totalFee.toFixed(),
-      total: +model.reward.plus(model.totalFee).toFixed()
+      total: totalAmount
     },
     payload: {
       hash: model.payloadHash,


### PR DESCRIPTION
## Proposed changes

If the `totalAmount` is available we can use that prop instead of calculating it.

## Types of changes

- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes