### PR TITLE
fix(crypto): properly verify the payload length of blocks

### DIFF
--- a/packages/crypto/lib/models/block.js
+++ b/packages/crypto/lib/models/block.js
@@ -250,7 +250,7 @@ module.exports = class Block {
       //   }
       // }
 
-      if (block.payloadLength > constants.maxPayload) {
+      if (block.payloadLength > constants.block.maxPayload) {
         result.errors.push('Payload length is too high')
       }
 


### PR DESCRIPTION
## Proposed changes

The payload length was checked against undefined, which would always result in `false` and allow blocks to be send broadcasted that are bigger than the allowed size. You could for example forge blocks that contain more transaction than the allowed maximum.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes