### PR TITLE
fix: pagination allow 0 offset

### DIFF
--- a/packages/core-api/lib/versions/2/schema/pagination.js
+++ b/packages/core-api/lib/versions/2/schema/pagination.js
@@ -6,7 +6,7 @@ module.exports = {
     .positive(),
   offset: Joi.number()
     .integer()
-    .positive(),
+    .min(0),
   limit: Joi.number()
     .integer()
     .min(1)


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

The `Joi.positive()` does not allow zero, which means the most recent value can't be fetched if offset is used.

Resolves #1375 

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
