### PR TITLE
fix: revert not matching dynamic fee state

### DIFF
--- a/packages/core-tester-cli/lib/commands/transfer.js
+++ b/packages/core-tester-cli/lib/commands/transfer.js
@@ -24,9 +24,13 @@ module.exports = class TransferCommand extends Command {
       wallets = this.generateWallets()
     }
 
-    logger.info(`Sending ${wallets.length} transfer ${
-      pluralize('transaction', wallets.length, true)
-    }`)
+    logger.info(
+      `Sending ${wallets.length} transfer ${pluralize(
+        'transaction',
+        wallets.length,
+        true,
+      )}`,
+    )
 
     const walletBalance = await this.getWalletBalance(primaryAddress)
 
@@ -80,10 +84,10 @@ module.exports = class TransferCommand extends Command {
       if (!this.options.floodAttempts) {
         const successfulTest = await this.__performRun(runOptions, 1)
         if (
-          successfulTest
-          && !this.options.skipSecondRun
-          && !this.options.skipValidation
-          && !this.options.skipTesting
+          successfulTest &&
+          !this.options.skipSecondRun &&
+          !this.options.skipValidation &&
+          !this.options.skipTesting
         ) {
           await this.__performRun(runOptions, 2, false, true)
         }
@@ -103,7 +107,7 @@ module.exports = class TransferCommand extends Command {
       logger.error(`There was a problem sending transactions: ${message}`)
     }
 
-    if (this.options.skipTesting) {
+    if (this.options.skipValidation) {
       return
     }
 
@@ -259,8 +263,8 @@ module.exports = class TransferCommand extends Command {
       const uniqueLength = unique(postResponse[key]).length
       if (dataLength !== uniqueLength) {
         logger.error(
-          `Response data for '${key}' has ${dataLength
-            - uniqueLength} duplicate transaction ids`,
+          `Response data for '${key}' has ${dataLength -
+            uniqueLength} duplicate transaction ids`,
         )
         successfulTest = false
       }

--- a/packages/core-transaction-pool/lib/guard.js
+++ b/packages/core-transaction-pool/lib/guard.js
@@ -139,13 +139,15 @@ module.exports = class TransactionGuard {
         this.__pushError(
           transaction,
           'ERR_DUPLICATE',
-          `Duplicate transaction ${transaction.id}`
+          `Duplicate transaction ${transaction.id}`,
         )
       } else if (this.pool.isSenderBlocked(transaction.senderPublicKey)) {
         this.__pushError(
           transaction,
           'ERR_SENDER_BLOCKED',
-          `Transaction ${transaction.id} rejected. Sender ${transaction.senderPublicKey} is blocked.`
+          `Transaction ${transaction.id} rejected. Sender ${
+            transaction.senderPublicKey
+          } is blocked.`,
         )
       } else {
         try {
@@ -292,6 +294,7 @@ module.exports = class TransactionGuard {
           'ERR_LOW_FEE',
           'Peer rejected the transaction because of not meeting the minimum accepted fee. It is still broadcasted to other peers.',
         )
+        this.pool.walletManager.revertTransaction(transaction)
         return false
       }
       return true


### PR DESCRIPTION
## Proposed changes
Currently - even if transaction was not accepted in the pool, the sender state was applied  - which in turn resulted in wrong state of the sender and denying of later transaction.

## Types of changes
A fix is to revert the not matching dynamic-fee transactions. A bigger refactor of this is following in a separate PR, this is to make the state operational again.

- [ ] Bugfix (non-breaking change which fixes an issue)


## Checklist


- [ ] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
