### PR TITLE
refactor(core-p2p): peer blocks request handling

### DIFF
--- a/packages/core-p2p/lib/server/versions/1/handlers.js
+++ b/packages/core-p2p/lib/server/versions/1/handlers.js
@@ -372,12 +372,14 @@ exports.getBlocks = {
     try {
       const database = container.resolvePlugin('database')
       const blockchain = container.resolvePlugin('blockchain')
-      const reqBlockHeight = parseInt(request.query.lastBlockHeight)
+
+      const reqBlockHeight = parseInt(request.query.lastBlockHeight) + 1
       let blocks = []
+
       if (!request.query.lastBlockHeight || isNaN(reqBlockHeight)) {
         blocks.push(blockchain.getLastBlock())
       } else {
-        blocks = await database.getBlocks(parseInt(reqBlockHeight) + 1, 400)
+        blocks = await database.getBlocks(reqBlockHeight, 400)
       }
 
       logger.info(
@@ -385,7 +387,9 @@ exports.getBlocks = {
           'block',
           blocks.length,
           true,
-        )} from height ${request.query.lastBlockHeight.toLocaleString()}`,
+        )} from height ${(
+          !isNaN(reqBlockHeight) ? reqBlockHeight : blocks[0].data.height
+        ).toLocaleString()}`,
       )
 
       return { success: true, blocks: blocks || [] }

--- a/packages/core-p2p/lib/server/versions/peer/handlers/blocks.js
+++ b/packages/core-p2p/lib/server/versions/peer/handlers/blocks.js
@@ -26,19 +26,21 @@ exports.index = {
     const database = container.resolvePlugin('database')
     const blockchain = container.resolvePlugin('blockchain')
 
-    const height = parseInt(request.query.height)
+    const height = parseInt(request.query.height) + 1
     let data = []
 
     if (isNaN(height)) {
       data.push(blockchain.getLastBlock())
     } else {
-      data = await database.getBlocks(parseInt(height) + 1, 400)
+      data = await database.getBlocks(height, 400)
     }
 
     logger.info(
       `${requestIp.getClientIp(request)} has downloaded ${
         pluralize('block', data.length, true)
-      } from height ${request.query.height}`,
+      } from height ${(
+        !isNaN(height) ? height : data[0].data.height
+      ).toLocaleString()}`,
     )
 
     return { data }


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

One occurrence was missed in #1397, which required a bit of adjustment.

The tests for the block handler would output:

```
# packages/core-p2p/__tests__/server/peer.test.js

# ✓ should be ok
127.0.0.1 has downloaded 1 block from height 0

# ✓ should retrieve lastBlock if no "lastBlockHeight" specified
127.0.0.1 has downloaded 1 block from height undefined
```

After:

```
# packages/core-p2p/__tests__/server/peer.test.js

# ✓ should be ok
127.0.0.1 has downloaded 1 block from height 1

# ✓ should retrieve lastBlock if no "lastBlockHeight" specified
127.0.0.1 has downloaded 1 block from height 1

```

Also, shouldn't the following two `if`s be the same? They behave differently when passed height 0.

https://github.com/ArkEcosystem/core/blob/develop/packages/core-p2p/lib/server/versions/1/handlers.js#L377

https://github.com/ArkEcosystem/core/blob/develop/packages/core-p2p/lib/server/versions/peer/handlers/blocks.js#L32

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes