### PR TITLE
refactor: close database connection earlier

### DIFF
--- a/packages/core-snapshots/lib/manager.js
+++ b/packages/core-snapshots/lib/manager.js
@@ -43,9 +43,9 @@ module.exports = class SnapshotManager {
       codec: options.codec,
       skipCompression: params.meta.skipCompression,
     }
-
-    utils.writeMetaFile(metaInfo)
+    
     this.database.close()
+    utils.writeMetaFile(metaInfo)
   }
 
   async importData(options) {


### PR DESCRIPTION
## Proposed changes
In theory, as DB is not needed to export the metafile to disk, closing DB connection earlier could free the connection for other processes.

## Types of changes
- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist
- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes

