### PR TITLE
refactor(core-api): redirect requests with trailing slash

### DIFF
--- a/packages/core-api/lib/server.js
+++ b/packages/core-api/lib/server.js
@@ -35,7 +35,9 @@ module.exports = async config => {
   }
 
   for (const [type, server] of Object.entries(servers)) {
-    await server.register({ plugin: plugins.corsHeaders })
+    await server.register({
+      plugin: plugins.corsHeaders
+    })
 
     await server.register({
       plugin: plugins.whitelist,
@@ -55,13 +57,22 @@ module.exports = async config => {
     })
 
     await server.register({
+      plugin: require('hapi-trailing-slash'),
+      options: { method: 'remove' },
+    })
+
+    await server.register({
       plugin: require('./plugins/endpoint-version'),
       options: { validVersions: config.versions.validVersions },
     })
 
-    await server.register({ plugin: require('./plugins/caster') })
+    await server.register({
+      plugin: require('./plugins/caster')
+    })
 
-    await server.register({ plugin: require('./plugins/validation') })
+    await server.register({
+      plugin: require('./plugins/validation')
+    })
 
     await server.register({
       plugin: require('hapi-rate-limit'),

--- a/packages/core-api/lib/versions/1/index.js
+++ b/packages/core-api/lib/versions/1/index.js
@@ -16,12 +16,10 @@ const register = async (server, options) => {
   server.route([
     { method: 'GET', path: '/accounts/getAllAccounts', ...accounts.index },
     { method: 'GET', path: '/accounts', ...accounts.show },
-    { method: 'GET', path: '/accounts/', ...accounts.show }, // v1 inconsistency
     { method: 'GET', path: '/accounts/getBalance', ...accounts.balance },
     { method: 'GET', path: '/accounts/getPublicKey', ...accounts.publicKey },
     { method: 'GET', path: '/accounts/delegates/fee', ...accounts.fee },
     { method: 'GET', path: '/accounts/delegates', ...accounts.delegates },
-    { method: 'GET', path: '/accounts/delegates/', ...accounts.delegates }, // v1 inconsistency
     { method: 'GET', path: '/accounts/top', ...accounts.top },
     { method: 'GET', path: '/accounts/count', ...accounts.count },
 
@@ -41,7 +39,6 @@ const register = async (server, options) => {
 
     { method: 'GET', path: '/delegates', ...delegates.index },
     { method: 'GET', path: '/delegates/get', ...delegates.show },
-    { method: 'GET', path: '/delegates/get/', ...delegates.show }, // v1 inconsistency
     { method: 'GET', path: '/delegates/count', ...delegates.count },
     { method: 'GET', path: '/delegates/search', ...delegates.search },
     { method: 'GET', path: '/delegates/voters', ...delegates.voters },
@@ -63,14 +60,12 @@ const register = async (server, options) => {
 
     { method: 'GET', path: '/peers', ...peers.index },
     { method: 'GET', path: '/peers/get', ...peers.show },
-    { method: 'GET', path: '/peers/get/', ...peers.show }, // v1 inconsistency
     { method: 'GET', path: '/peers/version', ...peers.version },
 
     { method: 'GET', path: '/signatures/fee', ...signatures.fee },
 
     { method: 'GET', path: '/transactions', ...transactions.index },
     { method: 'GET', path: '/transactions/get', ...transactions.show },
-    { method: 'GET', path: '/transactions/get/', ...transactions.show }, // v1 inconsistency
     {
       method: 'GET',
       path: '/transactions/unconfirmed',

--- a/packages/core-api/lib/versions/2/schema/peers.js
+++ b/packages/core-api/lib/versions/2/schema/peers.js
@@ -8,6 +8,7 @@ exports.index = {
   query: {
     ...pagination,
     ...{
+      ip: Joi.string().ip(),
       os: Joi.string(),
       status: Joi.string(),
       port: Joi.number().port(),

--- a/packages/core-api/package.json
+++ b/packages/core-api/package.json
@@ -32,6 +32,7 @@
     "hapi-api-version": "^2.1.0",
     "hapi-pagination": "https://github.com/faustbrian/hapi-pagination",
     "hapi-rate-limit": "^2.1.3",
+    "hapi-trailing-slash": "^3.0.1",
     "ip": "^1.1.5",
     "joi": "^14.0.6",
     "lodash": "^4.17.11",


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

Adds the `hapi-trailing-slash` package, so that incoming requests with a trailing slash are redirected to the correct url. This should also eliminate the need for the `v1 inconsistency` routes.

It also adds the `ip` parameter to the peers API endpoint.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes