### PR TITLE
test(core-container): cleanup after remote loader test

### DIFF
--- a/packages/core-container/__tests__/remote-loader.test.js
+++ b/packages/core-container/__tests__/remote-loader.test.js
@@ -6,12 +6,18 @@ const MockAdapter = require('axios-mock-adapter')
 const RemoteLoader = require('../lib/remote-loader')
 
 const axiosMock = new MockAdapter(axios)
+const configDir = './__test-remote-config__'
 
 let testSubject
+
+afterAll(() => {
+  fs.removeSync(configDir)
+})
+
 beforeEach(() => {
   testSubject = new RemoteLoader({
     remote: '127.0.0.1:4002',
-    config: './config',
+    config: configDir,
     data: './data',
   })
 })
@@ -56,7 +62,7 @@ describe('Remote Loader', () => {
 
       await testSubject.__configureNetwork()
 
-      expect(fs.existsSync('./config/network.json')).toBeTrue()
+      expect(fs.existsSync(`${configDir}/network.json`)).toBeTrue()
     })
   })
 
@@ -85,7 +91,7 @@ describe('Remote Loader', () => {
 
       await testSubject.__configureGenesisBlock()
 
-      expect(fs.existsSync('./config/genesisBlock.json')).toBeTrue()
+      expect(fs.existsSync(`${configDir}/genesisBlock.json`)).toBeTrue()
     })
   })
 
@@ -116,7 +122,7 @@ describe('Remote Loader', () => {
 
       await testSubject.__configurePeers()
 
-      expect(fs.existsSync('./config/peers.json')).toBeTrue()
+      expect(fs.existsSync(`${configDir}/peers.json`)).toBeTrue()
     })
   })
 
@@ -147,7 +153,7 @@ describe('Remote Loader', () => {
 
       await testSubject.__configureDelegates()
 
-      expect(fs.existsSync('./config/delegates.json')).toBeTrue()
+      expect(fs.existsSync(`${configDir}/delegates.json`)).toBeTrue()
     })
   })
 
@@ -159,7 +165,7 @@ describe('Remote Loader', () => {
     it('should be OK', async () => {
       await testSubject.__configurePlugins({ name: 'devnet' })
 
-      expect(fs.existsSync('./config/plugins.js')).toBeTrue()
+      expect(fs.existsSync(`${configDir}/plugins.js`)).toBeTrue()
     })
   })
 })


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
The `RemoteLoader` tests create a `config` directory, but never remove it. Changed the name to something less generic and make sure it is deleted after all tests are done.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [ ] Docs (documentation only changes)
- [ ] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [ ] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [X] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
