### PR TITLE
refactor(core-transaction-pool): transaction fee logs

### DIFF
--- a/packages/core-transaction-pool/lib/utils/dynamicfee-matcher.js
+++ b/packages/core-transaction-pool/lib/utils/dynamicfee-matcher.js
@@ -1,5 +1,5 @@
 const container = require('@arkecosystem/core-container')
-const { feeManager, dynamicFeeManager } = require('@arkecosystem/crypto')
+const { feeManager, dynamicFeeManager, formatArktoshi } = require('@arkecosystem/crypto')
 
 const config = container.resolvePlugin('config')
 const logger = container.resolvePlugin('logger')
@@ -19,9 +19,13 @@ module.exports = transaction => {
 
   if (!feeConstants.dynamic && transactionFee !== staticFee) {
     logger.debug(
-      `Received transaction fee '${transactionFee}' for '${
+      `Fee declined - Received transaction (${
         transaction.id
-      }' does not match static fee of '${staticFee}'`,
+      }) with a fee of ${
+        formatArktoshi(transactionFee)
+      } does not match static fee of ${
+        formatArktoshi(staticFee)
+      }`,
     )
     return false
   }
@@ -30,10 +34,13 @@ module.exports = transaction => {
     const minFeeFixed = config.delegates.dynamicFees.minAcceptableFee
     if (transactionFee < minFeeFixed) {
       logger.debug(
-        `Fee declined - Received transaction "${
+        `Fee declined - Received transaction (${
           transaction.id
-        }" with a fee of `
-          + `"${transactionFee}" which is below the minimum accepted fixed fee of "${minFeeFixed}".`,
+        }) with a fee of ${
+          formatArktoshi(transactionFee)
+        } which is below the minimum accepted fixed fee of ${
+          formatArktoshi(minFeeFixed)
+        }`,
       )
       return false
     }
@@ -42,21 +49,30 @@ module.exports = transaction => {
       config.delegates.dynamicFees.feeMultiplier,
       transaction,
     )
+
     if (transactionFee < minFeeCalculated) {
       logger.debug(
-        `Fee declined - Received transaction "${
+        `Fee declined - Received transaction (${
           transaction.id
-        }" with a fee of `
-          + `"${transactionFee}" which is below the calculated minimum fee of "${minFeeCalculated}".`,
+        }) with a fee of ${
+          formatArktoshi(transactionFee)
+        } which is below the calculated minimum fee of ${
+          formatArktoshi(minFeeCalculated)
+        }`,
       )
       return false
     }
 
     logger.debug(
-      `Transaction "${
+      `Fee accepted - Received transaction (${
         transaction.id
-      }" accepted with fee of "${transactionFee}". `
-        + `The calculated minimum fee is "${minFeeCalculated}".`,
+      }) with a fee of ${
+        formatArktoshi(transactionFee)
+      } which is ${
+        transactionFee > minFeeCalculated ? 'higher than' : 'equal to'
+      } the calculated minimum fee of ${
+        formatArktoshi(minFeeCalculated)
+      }`,
     )
   }
   return true


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

The logging of declined transactions is kinda inconsistent at the moment, e.g.

```
Received transaction fee '1' for 'txid' does not match static fee of '10000000'

Fee declined - Received transaction "txid" with a fee of "1" which is below the minimum accepted fixed fee of "30000".
```

With this PR above logs would look like:

```
Fee declined - Received transaction (txid) with a fee of 0.00000001 DѦ does not match static fee of 0.1 DѦ

Fee declined - Received transaction (txid) with a fee of 0.00000001 DѦ which is below the minimum accepted fixed fee of 0.0003 DѦ
```

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
