### PR TITLE
chore(core-p2p): adjust rate limit values

### DIFF
--- a/packages/core-api/lib/defaults.js
+++ b/packages/core-api/lib/defaults.js
@@ -27,6 +27,7 @@ module.exports = {
     userCache: {
       expiresIn: 60000,
     },
+    ipWhitelist: ['127.0.0.1', '::ffff:127.0.0.1'],
   },
   // @see https://github.com/fknop/hapi-pagination
   pagination: {

--- a/packages/core-p2p/lib/defaults.js
+++ b/packages/core-p2p/lib/defaults.js
@@ -19,9 +19,9 @@ module.exports = {
   rateLimit: {
     enabled: true,
     pathLimit: false,
-    userLimit: 1000,
+    userLimit: 20,
     userCache: {
-      expiresIn: 60000,
+      expiresIn: 1000,
     },
     ipWhitelist: ['127.0.0.1', '::ffff:127.0.0.1'],
   },


### PR DESCRIPTION
## Proposed changes

Changes the p2p rate limiting to allow 20 requests per second. Will have to see if that results in more stable rate limiting rather then using a minute based approach.

## Types of changes

- [x] Other

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes