### PR TITLE
feat(core-p2p): dump the peer list on shutdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ packages/**/dist/
 # Flow
 flow-typed
 flow-coverage
+
+# Random
+peers_backup.json

--- a/packages/core-p2p/lib/index.js
+++ b/packages/core-p2p/lib/index.js
@@ -21,6 +21,9 @@ exports.plugin = {
   async deregister(container, options) {
     container.resolvePlugin('logger').info('Stopping P2P Interface')
 
-    return container.resolvePlugin('p2p').server.stop()
+    const p2p = container.resolvePlugin('p2p')
+    p2p.dumpPeers()
+
+    return p2p.server.stop()
   },
 }

--- a/packages/core-p2p/lib/monitor.js
+++ b/packages/core-p2p/lib/monitor.js
@@ -719,14 +719,14 @@ class Monitor {
    * @return {void}
    */
   __filterPeers() {
-    if (!config.peers.list && !config.peers.backup) {
+    if (!config.peers.list) {
       container.forceExit('No seed peers defined in peers.json :interrobang:')
     }
 
-    let peers = config.peers.list
+    const peers = config.peers.list
 
-    if (config.peers.backup) {
-      peers = { ...peers, ...config.peers.backup }
+    if (config.peers_backup) {
+      peers.list = { ...peers.list, ...config.peers_backup }
     }
 
     const filteredPeers = Object.values(peers).filter(
@@ -792,16 +792,19 @@ class Monitor {
    * @return {void}
    */
   dumpPeers() {
-    const peers = config.peers
-    peers.backup = Object.values(this.peers).map(peer => ({
+    const peers = Object.values(this.peers).map(peer => ({
       ip: peer.ip,
       port: peer.port,
     }))
 
-    fs.writeFileSync(
-      `${process.env.ARK_PATH_CONFIG}/peers.json`,
-      JSON.stringify(peers, null, 2),
-    )
+    try {
+      fs.writeFileSync(
+        `${process.env.ARK_PATH_CONFIG}/peers_backup.json`,
+        JSON.stringify(peers, null, 2),
+      )
+    } catch (err) {
+      logger.error(`Failed to dump the peer list because of "${err.message}"`)
+    }
   }
 }
 

--- a/packages/core-p2p/lib/monitor.js
+++ b/packages/core-p2p/lib/monitor.js
@@ -723,10 +723,10 @@ class Monitor {
       container.forceExit('No seed peers defined in peers.json :interrobang:')
     }
 
-    const peers = config.peers.list
+    let peers = config.peers.list
 
     if (config.peers_backup) {
-      peers.list = { ...peers.list, ...config.peers_backup }
+      peers = { ...peers, ...config.peers_backup }
     }
 
     const filteredPeers = Object.values(peers).filter(


### PR DESCRIPTION
## Proposed changes

Dumps the list of registered peers into the peers.json file on shutdown so we don't have to 100% rely on seeds when a node starts up the next time.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes