### PR TITLE
feat: cache last transaction ids

### DIFF
--- a/packages/core-blockchain/__tests__/state-storage.test.js
+++ b/packages/core-blockchain/__tests__/state-storage.test.js
@@ -204,6 +204,42 @@ describe('State Storage', () => {
     })
   })
 
+  describe('addTransactionId', () => {
+    it('should be a function', () => {
+      expect(state.addTransactionId).toBeFunction()
+    })
+
+    it('should add transaction id', () => {
+      expect(state.addTransactionId('1')).toBeTrue()
+      expect(state.getCachedTransactionIds()).toHaveLength(1)
+    })
+
+    it('should not add duplicate transaction ids', () => {
+      expect(state.addTransactionId('1')).toBeTrue()
+      expect(state.addTransactionId('1')).toBeFalse()
+      expect(state.getCachedTransactionIds()).toHaveLength(1)
+    })
+
+    it('should not add more than 1000 unique transaction ids', () => {
+      for (let i = 0; i < 1000; i++) {
+        expect(state.addTransactionId(i.toString())).toBeTrue()
+      }
+
+      expect(state.getCachedTransactionIds()).toHaveLength(1000)
+      expect(state.getCachedTransactionIds()[0]).toEqual('0')
+
+      expect(state.addTransactionId('1000')).toBeTrue()
+      expect(state.getCachedTransactionIds()).toHaveLength(1000)
+      expect(state.getCachedTransactionIds()[0]).toEqual('1')
+    })
+  })
+
+  describe('getCachedTransactionIds', () => {
+    it('should be a function', () => {
+      expect(state.getCachedTransactionIds).toBeFunction()
+    })
+  })
+
   describe('pingBlock', () => {
     it('should be a function', () => {
       expect(state.pingBlock).toBeFunction()

--- a/packages/core-blockchain/lib/defaults.js
+++ b/packages/core-blockchain/lib/defaults.js
@@ -7,5 +7,6 @@ module.exports = {
   },
   state: {
     maxLastBlocks: 100,
+    maxLastTransactionIds: 1000,
   },
 }


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Cache the last `1000` received transaction ids in the state storage. The guard will now drop transactions immediately that are already cached.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [ ] Docs (documentation only changes)
- [ ] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [ ] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [X] Lint and unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
