### PR TITLE
refactor(transaction-pool): combine allowedSender log

### DIFF
--- a/packages/core-transaction-pool-mem/lib/connection.js
+++ b/packages/core-transaction-pool-mem/lib/connection.js
@@ -30,8 +30,8 @@ class TransactionPool extends TransactionPoolInterface {
    */
   async make() {
     this.mem = new Mem()
-
     this.storage = new Storage(this.options.storage)
+    this.loggedAllowedSender = []
 
     const all = this.storage.loadAll()
     all.forEach(t => this.mem.add(t, this.options.maxTransactionAge, true))
@@ -197,12 +197,13 @@ class TransactionPool extends TransactionPoolInterface {
   hasExceededMaxTransactions(transaction) {
     this.__purgeExpired()
 
-    if (this.options.allowedSenders.includes(transaction.senderPublicKey)) {
+    if (this.options.allowedSenders.includes(transaction.senderPublicKey) && !this.loggedAllowedSender.includes(transaction.senderPublicKey)) {
       logger.debug(
         `Transaction pool: allowing sender public key: ${
           transaction.senderPublicKey
         } (listed in options.allowedSenders), thus skipping throttling.`,
       )
+      this.loggedAllowedSender.push(transaction.senderPublicKey)
       return false
     }
 

--- a/packages/core-transaction-pool/lib/guard.js
+++ b/packages/core-transaction-pool/lib/guard.js
@@ -44,6 +44,8 @@ module.exports = class TransactionGuard {
    * }
    */
   async validate(transactionsJson) {
+    this.pool.loggedAllowedSenders = []
+
     // Add transaction id to the state storage. Also removes duplicates.
     this.transactions = transactionsJson.filter(tx => {
       if (container.resolve('state').addTransactionId(tx.id)) {


### PR DESCRIPTION
## Proposed changes
When more txs are send from the same sender, the log is filled with same line as the number of txs, like this one:
> Transaction pool: allowing sender public key: 0366da7ed85cc1e73a13fafb8007d2609d92239355847343cc7b12d85a65d25502 (listed in options.allowedSenders), thus skipping throttling.
Transaction pool: allowing sender public key: 0366da7ed85cc1e73a13fafb8007d2609d92239355847343cc7b12d85a65d25502 (listed in options.allowedSenders), thus skipping throttling.
Transaction pool: allowing sender public key: 0366da7ed85cc1e73a13fafb8007d2609d92239355847343cc7b12d85a65d25502 (listed in options.allowedSenders), thus skipping throttling.
...

With this patch, only one `senderPublicKey` per request is logged.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [ ] Docs (documentation only changes)
- [ ] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [ ] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
