### PR TITLE
fix(core-database): wrong log statements

### DIFF
--- a/packages/core-database/lib/wallet-manager.js
+++ b/packages/core-database/lib/wallet-manager.js
@@ -424,8 +424,9 @@ module.exports = class WalletManager {
       this.byUsername[asset.delegate.username.toLowerCase()]
     ) {
       logger.error(
-        `Can't apply transaction ${data.id}: delegate name already taken.`,
-        JSON.stringify(data),
+        `Can't apply transaction ${
+          data.id
+        }: delegate name '${asset.delegate.username.toLowerCase()}' already taken.`,
       )
       throw new Error(
         `Can't apply transaction ${data.id}: delegate name already taken.`,
@@ -438,10 +439,9 @@ module.exports = class WalletManager {
       !this.__isDelegate(asset.votes[0].slice(1))
     ) {
       logger.error(
-        `Can't apply vote transaction: delegate ${
+        `Can't apply vote transaction ${data.id}: delegate ${
           asset.votes[0]
         } does not exist.`,
-        JSON.stringify(data),
       )
       throw new Error(
         `Can't apply transaction ${data.id}: delegate ${
@@ -455,8 +455,9 @@ module.exports = class WalletManager {
     // handle exceptions / verify that we can apply the transaction to the sender
     if (this.__isException(data)) {
       logger.warn(
-        'Transaction forcibly applied because it has been added as an exception:',
-        data,
+        `Transaction ${
+          data.id
+        } forcibly applied because it has been added as an exception.`,
       )
     } else if (!sender.canApply(data, errors)) {
       logger.error(

--- a/packages/core-test-utils/lib/generators/transactions/transaction.js
+++ b/packages/core-test-utils/lib/generators/transactions/transaction.js
@@ -66,6 +66,7 @@ module.exports = (
           .random()
           .toLowerCase()
           .replace(/[^a-z0-9]/g, '_')
+          .substring(0, 20)
         builder = builder.delegateRegistration().usernameAsset(username)
         break
       }


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
This log statement passes `data` as the second argument:
```javascript
logger.warn(
  'Transaction forcibly applied because it has been added as an exception:',
  data,
)
```
Funnily the `data` object in this case has a `timestamp` property which is interpreted by winston and sets the timestamp. 

Resulting in:
`[1970-01-01 14:00:04][WARN] : Transaction forcibly applied because it has been added as an exception:`


Example to reproduce:
```javascript
logger.info(`Bla`, { timestamp: 12000000 })
```
`[1970-01-01 04:20:00][INFO]    : Bla`

Fixed by properly interpolating the log string.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [ ] Docs (documentation only changes)
- [ ] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [ ] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
