### PR TITLE
chore: remove yarn install step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,12 +21,6 @@ jobs:
           name: Install xsel
           command: sudo apt-get install -q xsel
       - run:
-          name: Install yarn
-          command: >-
-            curl -o- -L https://yarnpkg.com/install.sh | bash && export
-            PATH="$HOME/.yarn/bin:$PATH" && yarn config set cache-folder
-            $HOME/.cache/yarn
-      - run:
           name: Generate cache key
           command: >-
             find ./packages/ -name package.json -print0 | sort -z | xargs -r0

--- a/.circleci/configTemplate.json
+++ b/.circleci/configTemplate.json
@@ -1,111 +1,103 @@
 {
-	"version": 2,
-	"jobs": {
-		"test-node10": {
-			"working_directory": "~/ark-core",
-			"docker": [
-				{
-					"image": "circleci/node:10-browsers"
-				},
-				{
-					"image": "postgres:alpine",
-					"environment": {
-						"POSTGRES_PASSWORD": "password",
-						"POSTGRES_DB": "ark_development",
-						"POSTGRES_USER": "ark"
-					}
-				}
-			],
-			"parallelism": 1,
-			"steps": [
-				"checkout",
-				{
-					"run": {
-						"name": "Apt update",
-						"command": "sudo sh -c 'echo \"deb http://ftp.debian.org/debian stable main contrib non-free\" >> /etc/apt/sources.list' && sudo apt-get update"
-					}
-				},
-				{
-					"run": {
-						"name": "Install xsel",
-						"command": "sudo apt-get install -q xsel"
-					}
-				},
-				{
-					"run": {
-						"name": "Install yarn",
-						"command": "curl -o- -L https://yarnpkg.com/install.sh | bash && export PATH=\"$HOME/.yarn/bin:$PATH\" && yarn config set cache-folder $HOME/.cache/yarn"
-					}
-				},
-				{
-					"run": {
-						"name": "Generate cache key",
-						"command": "find ./packages/ -name package.json -print0 | sort -z | xargs -r0 echo ./package.json | xargs md5sum | md5sum - > checksum.txt"
-					}
-				},
-				{
-					"restore_cache": {
-						"key": "core-node10-{{ checksum \"checksum.txt\" }}-1"
-					}
-				},
-				{
-					"run": {
-						"name": "Install packages",
-						"command": "yarn"
-					}
-				},
-				{
-					"save_cache": {
-						"key": "core-node10-{{ checksum \"checksum.txt\" }}-1",
-						"paths": []
-					}
-				},
-				{
-					"run": {
-						"name": "Create .ark/database directory",
-						"command": "mkdir -p $HOME/.ark/database"
-					}
-				},
-				{
-					"run": {
-						"name": "Test",
-						"command": "TESTFILES=$(circleci tests glob \"packages/**/*.test.js\")\n./node_modules/.bin/cross-env ARK_ENV=test ./node_modules/.bin/jest ${TESTFILES} --detectOpenHandles --runInBand --forceExit --ci --coverage | tee test_output.txt\n"
-					}
-				},
-				{
-					"run": {
-						"name": "Last 1000 lines of test output",
-						"when": "on_fail",
-						"command": "tail -n 1000 test_output.txt"
-					}
-				},
-				{
-					"run": {
-						"name": "Codecov",
-						"command": "./node_modules/.bin/codecov"
-					}
-				},
-				{
-					"run": {
-						"name": "Lint",
-						"command": "yarn lint"
-					}
-				},
-				{
-					"run": {
-						"name": "Depcheck",
-						"command": "yarn depcheck"
-					}
-				}
-			]
-		}
-	},
+  "version": 2,
+  "jobs": {
+    "test-node10": {
+      "working_directory": "~/ark-core",
+      "docker": [
+        {
+          "image": "circleci/node:10-browsers"
+        },
+        {
+          "image": "postgres:alpine",
+          "environment": {
+            "POSTGRES_PASSWORD": "password",
+            "POSTGRES_DB": "ark_development",
+            "POSTGRES_USER": "ark"
+          }
+        }
+      ],
+      "parallelism": 1,
+      "steps": [
+        "checkout",
+        {
+          "run": {
+            "name": "Apt update",
+            "command": "sudo sh -c 'echo \"deb http://ftp.debian.org/debian stable main contrib non-free\" >> /etc/apt/sources.list' && sudo apt-get update"
+          }
+        },
+        {
+          "run": {
+            "name": "Install xsel",
+            "command": "sudo apt-get install -q xsel"
+          }
+        },
+        {
+          "run": {
+            "name": "Generate cache key",
+            "command": "find ./packages/ -name package.json -print0 | sort -z | xargs -r0 echo ./package.json | xargs md5sum | md5sum - > checksum.txt"
+          }
+        },
+        {
+          "restore_cache": {
+            "key": "core-node10-{{ checksum \"checksum.txt\" }}-1"
+          }
+        },
+        {
+          "run": {
+            "name": "Install packages",
+            "command": "yarn"
+          }
+        },
+        {
+          "save_cache": {
+            "key": "core-node10-{{ checksum \"checksum.txt\" }}-1",
+            "paths": []
+          }
+        },
+        {
+          "run": {
+            "name": "Create .ark/database directory",
+            "command": "mkdir -p $HOME/.ark/database"
+          }
+        },
+        {
+          "run": {
+            "name": "Test",
+            "command": "TESTFILES=$(circleci tests glob \"packages/**/*.test.js\")\n./node_modules/.bin/cross-env ARK_ENV=test ./node_modules/.bin/jest ${TESTFILES} --detectOpenHandles --runInBand --forceExit --ci --coverage | tee test_output.txt\n"
+          }
+        },
+        {
+          "run": {
+            "name": "Last 1000 lines of test output",
+            "when": "on_fail",
+            "command": "tail -n 1000 test_output.txt"
+          }
+        },
+        {
+          "run": {
+            "name": "Codecov",
+            "command": "./node_modules/.bin/codecov"
+          }
+        },
+        {
+          "run": {
+            "name": "Lint",
+            "command": "yarn lint"
+          }
+        },
+        {
+          "run": {
+            "name": "Depcheck",
+            "command": "yarn depcheck"
+          }
+        }
+      ]
+    }
+  },
   "workflows": {
-		"version": 2,
-		"test_depcheck_lint": {
-			"jobs": [
-				"test-node10"
-			]
-		}
-	}
+    "version": 2,
+    "test_depcheck_lint": {
+      "jobs": ["test-node10"]
+    }
+  }
 }


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

The `*-browsers` docker images come with `yarn` preinstalled already, and the way CircleCI is configured it does not use the yarn version installed in the `Install yarn` step.

![image](https://user-images.githubusercontent.com/6547002/48934595-fa1e5680-ef04-11e8-8250-28f7e409cdb6.png)

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Build (changes that affect the build system)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes