### PR TITLE
refactor(core-transaction-pool): transaction fee logs

### DIFF
--- a/packages/core-tester-cli/__tests__/commands/command.test.js
+++ b/packages/core-tester-cli/__tests__/commands/command.test.js
@@ -389,6 +389,7 @@ describe('Command Base', () => {
       expect(Command.__arkToArktoshi).toBeFunction()
     })
     it('should give arktoshi', () => {
+      expect(Command.__arkToArktoshi(0.00000001).toString()).toBe('1')
       expect(Command.__arkToArktoshi(0.1).toString()).toBe('10000000')
       expect(Command.__arkToArktoshi(1).toString()).toBe('100000000')
       expect(Command.__arkToArktoshi(10).toString()).toBe('1000000000')
@@ -400,6 +401,7 @@ describe('Command Base', () => {
       expect(Command.__arktoshiToArk).toBeFunction()
     })
     it('should give ark', () => {
+      expect(Command.__arktoshiToArk(1)).toBe('0.00000001 DѦ')
       expect(Command.__arktoshiToArk(10000000)).toBe('0.1 DѦ')
       expect(Command.__arktoshiToArk(100000000)).toBe('1 DѦ')
       expect(Command.__arktoshiToArk(1000000000)).toBe('10 DѦ')

--- a/packages/core-transaction-pool/lib/utils/dynamicfee-matcher.js
+++ b/packages/core-transaction-pool/lib/utils/dynamicfee-matcher.js
@@ -1,5 +1,9 @@
 const container = require('@arkecosystem/core-container')
-const { feeManager, dynamicFeeManager } = require('@arkecosystem/crypto')
+const {
+  feeManager,
+  dynamicFeeManager,
+  formatArktoshi,
+} = require('@arkecosystem/crypto')
 
 /**
  * Determine if a transaction's fee meets the minimum requirements for broadcasting
@@ -28,12 +32,18 @@ module.exports = transaction => {
     if (fee >= minFeeBroadcast) {
       broadcast = true
       logger.debug(
-        `Transaction ${id} eligible for broadcast (fee=${fee} >= min=${minFeeBroadcast})`,
+        `Transaction ${id} eligible for broadcast - fee of ${formatArktoshi(
+          fee,
+        )} is ${
+          fee === minFeeBroadcast ? 'equal too' : 'greater than'
+        } minimum fee (${formatArktoshi(minFeeBroadcast)})`,
       )
     } else {
       broadcast = false
       logger.debug(
-        `Transaction ${id} not eligible for broadcast (fee=${fee} < min=${minFeeBroadcast})`,
+        `Transaction ${id} not eligible for broadcast - fee of ${formatArktoshi(
+          fee,
+        )} is smaller than minimum fee (${formatArktoshi(minFeeBroadcast)})`,
       )
     }
 
@@ -44,12 +54,18 @@ module.exports = transaction => {
     if (fee >= minFeePool) {
       enterPool = true
       logger.debug(
-        `Transaction ${id} eligible to enter pool (fee=${fee} >= min=${minFeePool})`,
+        `Transaction ${id} eligible to enter pool - fee of ${formatArktoshi(
+          fee,
+        )} ${
+          fee === minFeePool ? 'equal too' : 'greater than'
+        } minimum fee (${formatArktoshi(minFeePool)})`,
       )
     } else {
       enterPool = false
       logger.debug(
-        `Transaction ${id} not eligible to enter pool (fee=${fee} < min=${minFeePool})`,
+        `Transaction ${id} not eligible to enter pool - fee of ${formatArktoshi(
+          fee,
+        )} is smaller than minimum fee (${formatArktoshi(minFeePool)})`,
       )
     }
   } else {
@@ -60,13 +76,17 @@ module.exports = transaction => {
       broadcast = true
       enterPool = true
       logger.debug(
-        `Transaction ${id} eligible for broadcast and to enter pool (fee=${fee} = static=${staticFee})`,
+        `Transaction ${id} eligible for broadcast and to enter pool - fee of ${formatArktoshi(
+          fee,
+        )} is equal to static fee (${formatArktoshi(staticFee)})`,
       )
     } else {
       broadcast = false
       enterPool = false
       logger.debug(
-        `Transaction ${id} not eligible for broadcast and not eligible to enter pool (fee=${fee} != static=${staticFee})`,
+        `Transaction ${id} not eligible for broadcast and not eligible to enter pool - fee of ${formatArktoshi(
+          fee,
+        )} does not match static fee (${formatArktoshi(staticFee)})`,
       )
     }
   }

--- a/packages/crypto/lib/utils/format-arktoshi.js
+++ b/packages/crypto/lib/utils/format-arktoshi.js
@@ -7,19 +7,10 @@ const configManager = require('../managers/config')
  * @return {String}
  */
 module.exports = amount => {
-  let localeString = (+amount / ARKTOSHI).toLocaleString('en', {
-    minimumFractionDigits: 8,
+  const localeString = (+amount / ARKTOSHI).toLocaleString('en', {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 8,
   })
-
-  if (localeString.includes('.')) {
-    while (localeString.slice(-1) === '0') {
-      localeString = localeString.slice(0, -1)
-    }
-
-    if (localeString.slice(-1) === '.') {
-      localeString = localeString.slice(0, -1)
-    }
-  }
 
   return `${localeString} ${configManager.config.client.symbol}`
 }


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

The original change was proposed in #1427, which stood in conflict with some pending changes at the time. This PR makes the transaction logs a bit more verbose and adds formatting of the arktoshi values.

e.g.

```
Transaction TXID eligible to enter pool (fee=10000000 >= min=280)
```

becomes

```
Transaction TXID eligible to enter pool - fee of 0.1 Ѧ is greater than minimum fee (0.0000028 Ѧ)
```

It also removes the loop from the `arktoshiToArk` function.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
