### PR TITLE
perf: lazily sort transactions by expiration when adding them

### DIFF
--- a/packages/core-transaction-pool-mem/lib/mem.js
+++ b/packages/core-transaction-pool-mem/lib/mem.js
@@ -56,7 +56,8 @@ class Mem {
      * - find all transactions that have expired (have an expiration date
      *   earlier than a given date) - they are at the beginning of the array.
      */
-    this.sortedByExpiration = []
+    this.byExpiration = []
+    this.byExpirationIsSorted = true
 
     /**
      * List of dirty transactions ids (that are not saved in the on-disk
@@ -109,12 +110,8 @@ class Mem {
     }
 
     if (memPoolTransaction.expireAt(maxTransactionAge) !== null) {
-      this.sortedByExpiration.push(memPoolTransaction)
-
-      // XXX worst case: O(n * log(n))
-      this.sortedByExpiration.sort(
-        (a, b) => a.expireAt(maxTransactionAge) - b.expireAt(maxTransactionAge),
-      )
+      this.byExpiration.push(memPoolTransaction)
+      this.byExpirationIsSorted = false
     }
 
     if (!thisIsDBLoad) {
@@ -147,9 +144,9 @@ class Mem {
     const memPoolTransaction = this.byId[id]
 
     // XXX worst case: O(n)
-    let i = this.sortedByExpiration.findIndex(e => e.transaction.id === id)
+    let i = this.byExpiration.findIndex(e => e.transaction.id === id)
     if (i !== -1) {
-      this.sortedByExpiration.splice(i, 1)
+      this.byExpiration.splice(i, 1)
     }
 
     this.bySender[senderPublicKey].delete(memPoolTransaction)
@@ -245,11 +242,16 @@ class Mem {
    * @return {Array of Transaction} expired transactions
    */
   getExpired(maxTransactionAge) {
+    if (!this.byExpirationIsSorted) {
+      this.byExpiration.sort((a, b) => a.expireAt(maxTransactionAge) - b.expireAt(maxTransactionAge))
+      this.byExpirationIsSorted = true
+    }
+
     const now = slots.getTime()
 
     const transactions = []
 
-    for (const memPoolTransaction of this.sortedByExpiration) {
+    for (const memPoolTransaction of this.byExpiration) {
       if (memPoolTransaction.expireAt(maxTransactionAge) <= now) {
         transactions.push(memPoolTransaction.transaction)
       } else {
@@ -268,7 +270,8 @@ class Mem {
     this.allIsSorted = true
     this.byId = {}
     this.bySender = {}
-    this.sortedByExpiration = []
+    this.byExpiration = []
+    this.byExpirationIsSorted = true
     this.dirty.added.clear()
     this.dirty.removed.clear()
   }


### PR DESCRIPTION
We do not need to keep the list of transactions ordered by expiration
all the time, after every new transaction is added. We only need to
sort it whenever we are about to read that list - when fetching
transactions by expiration.

## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [ ] Docs (documentation only changes)
- [ ] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [ ] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
