### PR TITLE
perf: don't always purge expired txs when checking for existence

### DIFF
--- a/packages/core-transaction-pool-mem/lib/connection.js
+++ b/packages/core-transaction-pool-mem/lib/connection.js
@@ -359,6 +359,12 @@ class TransactionPool extends TransactionPoolInterface {
    * @return {Boolean}
    */
   transactionExists(transactionId) {
+    if (!this.mem.transactionExists(transactionId)) {
+      // If it does not exist then no need to purge expired transactions because
+      // we know it will not exist after purge too.
+      return false
+    }
+
     this.__purgeExpired()
 
     return this.mem.transactionExists(transactionId)

--- a/packages/core-transaction-pool-mem/lib/connection.js
+++ b/packages/core-transaction-pool-mem/lib/connection.js
@@ -367,7 +367,7 @@ class TransactionPool extends TransactionPoolInterface {
 
     this.__purgeExpired()
 
-    return true
+    return this.mem.transactionExists(transactionId)
   }
 
   /**

--- a/packages/core-transaction-pool-mem/lib/connection.js
+++ b/packages/core-transaction-pool-mem/lib/connection.js
@@ -367,7 +367,7 @@ class TransactionPool extends TransactionPoolInterface {
 
     this.__purgeExpired()
 
-    return this.mem.transactionExists(transactionId)
+    return true
   }
 
   /**


### PR DESCRIPTION
Before we check whether a transaction exists in the pool we remove
expired ones to avoid false positive - pretending that an expired
transaction exists in the pool.

However, if a transaction is not in the pool there is no need to purge
in order provide a definite answer.

## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [ ] Docs (documentation only changes)
- [ ] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [ ] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
