### PR TITLE
fix(core-container): cast env options to number

### DIFF
--- a/packages/core-container/__tests__/registrars/plugin.test.js
+++ b/packages/core-container/__tests__/registrars/plugin.test.js
@@ -105,4 +105,17 @@ describe('Plugin Registrar', () => {
       expect(spy).toHaveBeenNthCalledWith(2, 'a')
     })
   })
+
+  describe('__castOptions', () => {
+    it('should cast options', async () => {
+      const options = {
+        number: '1',
+        notANumber: '0.0.0.0',
+      }
+
+      instance.__castOptions(options)
+      expect(options.number).toEqual(1)
+      expect(options.notANumber).toEqual('0.0.0.0')
+    })
+  })
 })

--- a/packages/core-container/lib/registrars/plugin.js
+++ b/packages/core-container/lib/registrars/plugin.js
@@ -18,7 +18,7 @@ module.exports = class PluginRegistrars {
     this.container = container
     this.plugins = this.__loadPlugins()
     this.resolvedPlugins = []
-    this.options = options
+    this.options = this.__castOptions(options)
     this.deregister = []
   }
 
@@ -153,6 +153,27 @@ module.exports = class PluginRegistrars {
     if (this.options.options && this.options.options[name]) {
       options = Hoek.applyToDefaults(options, this.options.options[name])
     }
+
+    return this.__castOptions(options)
+  }
+
+  /**
+   * When the env is used to overwrite options, we get strings even if we
+   * expect a number. This is in most cases not desired and leads to side-
+   * effects. Here is assumed all numeric strings except blacklisted ones
+   * should be treated as numbers.
+   * @param {Object} options
+   * @return {Object} options
+   */
+  __castOptions(options) {
+    const blacklist = []
+    const regex = new RegExp(/^\d+$/)
+    Object.keys(options).forEach(key => {
+      const value = options[key]
+      if (isString(value) && !blacklist.includes(key) && regex.test(value)) {
+        options[key] = +value
+      }
+    })
 
     return options
   }


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
If we set defaults via env (i.e `ARK_TRANSACTION_POOL_MAX_PER_REQUEST`) it gets interpreted as a string.

So this is not a number anymore:
```javascript
  maxTransactionsPerRequest:
    process.env.ARK_TRANSACTION_POOL_MAX_PER_REQUEST || 40,
```

This has a lot of potential side effects, the precursor being Joi blowing up:
```javascript
exports.store = {
  payload: {
    transactions: Joi.arkTransactions()
      .min(1)
      .max(
        container.resolveOptions('transactionPool').maxTransactionsPerRequest,
      )
      .options({ stripUnknown: true }),
  },
}

AssertionError [ERR_ASSERTION]: limit must be a positive integer or reference
```

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [ ] Docs (documentation only changes)
- [ ] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [ ] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
