### PR TITLE
refactor(core-blockchain): median block height and action logs

### DIFF
--- a/packages/core-blockchain/lib/blockchain.js
+++ b/packages/core-blockchain/lib/blockchain.js
@@ -47,9 +47,9 @@ module.exports = class Blockchain {
       logger.debug(
         `event '${event}': ${JSON.stringify(
           this.state.blockchain.value,
-        )} -> ${JSON.stringify(nextState.value)} -> actions: ${JSON.stringify(
-          nextState.actions,
-        )}`,
+        )} -> ${JSON.stringify(
+          nextState.value,
+        )} -> actions: [${nextState.actions.map(a => a.type).join(', ')}]`,
       )
     }
 

--- a/packages/core-p2p/lib/monitor.js
+++ b/packages/core-p2p/lib/monitor.js
@@ -258,7 +258,9 @@ class Monitor {
         `${max -
           unresponsivePeers} of ${max} peers on the network are responsive`,
       )
-      logger.info(`Median Network Height: ${this.getNetworkHeight()}`)
+      logger.info(
+        `Median Network Height: ${this.getNetworkHeight().toLocaleString()}`,
+      )
       logger.info(`Network PBFT status: ${this.getPBFTForgingStatus()}`)
     }
   }
@@ -412,7 +414,7 @@ class Monitor {
       .map(peer => peer.state.height)
       .sort()
 
-    return medians[Math.floor(medians.length / 2)]
+    return medians[Math.floor(medians.length / 2)] || 0
   }
 
   /**


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

Outputs the median block height in localized form and shortens the `nextState.actions` portion of the state machine logs.

e.g.

```
event 'PROCESSFINISHED': "newBlock" -> "idle" -> actions: [{"type":"checkLater"},{"type":"blockchainReady"}]
```

becomes

```
event 'PROCESSFINISHED': "newBlock" -> "idle" -> actions: [checkLater, blockchainReady]
```
## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes