### PR TITLE
refactor(core-api): implement server methods

### DIFF
--- a/packages/core-api/lib/utils/generate-cache-key.js
+++ b/packages/core-api/lib/utils/generate-cache-key.js
@@ -1,0 +1,5 @@
+module.exports = value =>
+  require('crypto')
+    .createHash('sha256')
+    .update(JSON.stringify(value))
+    .digest('hex')

--- a/packages/core-api/lib/versions/1/handlers/accounts.js
+++ b/packages/core-api/lib/versions/1/handlers/accounts.js
@@ -17,7 +17,9 @@ exports.index = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    return request.server.methods.v1.accounts.index(request)
+    const data = await request.server.methods.v1.accounts.index(request)
+
+    return utils.respondWithCache(data, h)
   },
 }
 
@@ -31,7 +33,9 @@ exports.show = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    return request.server.methods.v1.accounts.show(request)
+    const data = await request.server.methods.v1.accounts.show(request)
+
+    return utils.respondWithCache(data, h)
   },
   config: {
     plugins: {
@@ -52,7 +56,9 @@ exports.balance = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    return request.server.methods.v1.accounts.balance(request)
+    const data = await request.server.methods.v1.accounts.balance(request)
+
+    return utils.respondWithCache(data, h)
   },
   config: {
     plugins: {
@@ -73,7 +79,9 @@ exports.publicKey = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    return request.server.methods.v1.accounts.publicKey(request)
+    const data = await request.server.methods.v1.accounts.publicKey(request)
+
+    return utils.respondWithCache(data, h)
   },
   config: {
     plugins: {

--- a/packages/core-api/lib/versions/1/handlers/accounts.js
+++ b/packages/core-api/lib/versions/1/handlers/accounts.js
@@ -17,14 +17,7 @@ exports.index = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    const { rows } = await database.wallets.findAll({
-      ...request.query,
-      ...utils.paginate(request),
-    })
-
-    return utils.respondWith({
-      accounts: utils.toCollection(request, rows, 'account'),
-    })
+    return request.server.methods.v1.accounts.index(request)
   },
 }
 
@@ -38,15 +31,7 @@ exports.show = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    const account = await database.wallets.findById(request.query.address)
-
-    if (!account) {
-      return utils.respondWith('Account not found', true)
-    }
-
-    return utils.respondWith({
-      account: utils.toResource(request, account, 'account'),
-    })
+    return request.server.methods.v1.accounts.show(request)
   },
   config: {
     plugins: {
@@ -67,16 +52,7 @@ exports.balance = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    const account = await database.wallets.findById(request.query.address)
-
-    if (!account) {
-      return utils.respondWith({ balance: '0', unconfirmedBalance: '0' })
-    }
-
-    return utils.respondWith({
-      balance: account ? `${account.balance}` : '0',
-      unconfirmedBalance: account ? `${account.balance}` : '0',
-    })
+    return request.server.methods.v1.accounts.balance(request)
   },
   config: {
     plugins: {
@@ -97,13 +73,7 @@ exports.publicKey = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    const account = await database.wallets.findById(request.query.address)
-
-    if (!account) {
-      return utils.respondWith('Account not found', true)
-    }
-
-    return utils.respondWith({ publicKey: account.publicKey })
+    return request.server.methods.v1.accounts.publicKey(request)
   },
   config: {
     plugins: {

--- a/packages/core-api/lib/versions/1/handlers/blocks.js
+++ b/packages/core-api/lib/versions/1/handlers/blocks.js
@@ -6,7 +6,6 @@ const blockchain = container.resolvePlugin('blockchain')
 
 const utils = require('../utils')
 const schema = require('../schemas/blocks')
-const { blocks: repository } = require('../../../repositories')
 
 /**
  * @type {Object}
@@ -18,7 +17,9 @@ exports.index = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    return request.server.methods.v1.blocks.index(request)
+    const data = await request.server.methods.v1.blocks.index(request)
+
+    return utils.respondWithCache(data, h)
   },
   config: {
     plugins: {
@@ -39,7 +40,9 @@ exports.show = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    return request.server.methods.v1.blocks.show(request)
+    const data = await request.server.methods.v1.blocks.show(request)
+
+    return utils.respondWithCache(data, h)
   },
   config: {
     plugins: {

--- a/packages/core-api/lib/versions/1/handlers/blocks.js
+++ b/packages/core-api/lib/versions/1/handlers/blocks.js
@@ -18,19 +18,7 @@ exports.index = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    const { count, rows } = await repository.findAll({
-      ...request.query,
-      ...utils.paginate(request),
-    })
-
-    if (!rows) {
-      return utils.respondWith('No blocks found', true)
-    }
-
-    return utils.respondWith({
-      blocks: utils.toCollection(request, rows, 'block'),
-      count,
-    })
+    return request.server.methods.v1.blocks.index(request)
   },
   config: {
     plugins: {
@@ -51,18 +39,7 @@ exports.show = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    const block = await repository.findById(request.query.id)
-
-    if (!block) {
-      return utils.respondWith(
-        `Block with id ${request.query.id} not found`,
-        true,
-      )
-    }
-
-    return utils.respondWith({
-      block: utils.toResource(request, block, 'block'),
-    })
+    return request.server.methods.v1.blocks.show(request)
   },
   config: {
     plugins: {

--- a/packages/core-api/lib/versions/1/handlers/delegates.js
+++ b/packages/core-api/lib/versions/1/handlers/delegates.js
@@ -18,18 +18,7 @@ exports.index = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    const { count, rows } = await database.delegates.paginate({
-      ...request.query,
-      ...{
-        offset: request.query.offset || 0,
-        limit: request.query.limit || 51,
-      },
-    })
-
-    return utils.respondWith({
-      delegates: utils.toCollection(request, rows, 'delegate'),
-      totalCount: count,
-    })
+    return request.server.methods.v1.delegates.index(request)
   },
   config: {
     plugins: {
@@ -50,21 +39,7 @@ exports.show = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    if (!request.query.publicKey && !request.query.username) {
-      return utils.respondWith('Delegate not found', true)
-    }
-
-    const delegate = await database.delegates.findById(
-      request.query.publicKey || request.query.username,
-    )
-
-    if (!delegate) {
-      return utils.respondWith('Delegate not found', true)
-    }
-
-    return utils.respondWith({
-      delegate: utils.toResource(request, delegate, 'delegate'),
-    })
+    return request.server.methods.v1.delegates.show(request)
   },
   config: {
     plugins: {
@@ -85,9 +60,7 @@ exports.count = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    const { count } = await database.delegates.findAll()
-
-    return utils.respondWith({ count })
+    return request.server.methods.v1.delegates.count(request)
   },
 }
 
@@ -101,17 +74,7 @@ exports.search = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    const query = {
-      username: request.query.q,
-    }
-    const { rows } = await database.delegates.search({
-      ...query,
-      ...utils.paginate(request),
-    })
-
-    return utils.respondWith({
-      delegates: utils.toCollection(request, rows, 'delegate'),
-    })
+    return request.server.methods.v1.delegates.search(request)
   },
   config: {
     plugins: {
@@ -132,19 +95,7 @@ exports.voters = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    const delegate = await database.delegates.findById(request.query.publicKey)
-
-    if (!delegate) {
-      return utils.respondWith({
-        accounts: [],
-      })
-    }
-
-    const accounts = await database.wallets.findAllByVote(delegate.publicKey)
-
-    return utils.respondWith({
-      accounts: utils.toCollection(request, accounts.rows, 'voter'),
-    })
+    return request.server.methods.v1.delegates.voters(request)
   },
   config: {
     plugins: {

--- a/packages/core-api/lib/versions/1/handlers/delegates.js
+++ b/packages/core-api/lib/versions/1/handlers/delegates.js
@@ -18,7 +18,9 @@ exports.index = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    return request.server.methods.v1.delegates.index(request)
+    const data = await request.server.methods.v1.delegates.index(request)
+
+    return utils.respondWithCache(data, h)
   },
   config: {
     plugins: {
@@ -39,7 +41,9 @@ exports.show = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    return request.server.methods.v1.delegates.show(request)
+    const data = await request.server.methods.v1.delegates.show(request)
+
+    return utils.respondWithCache(data, h)
   },
   config: {
     plugins: {
@@ -60,7 +64,9 @@ exports.count = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    return request.server.methods.v1.delegates.count(request)
+    const data = await request.server.methods.v1.delegates.count(request)
+
+    return utils.respondWithCache(data, h)
   },
 }
 
@@ -74,7 +80,9 @@ exports.search = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    return request.server.methods.v1.delegates.search(request)
+    const data = await request.server.methods.v1.delegates.search(request)
+
+    return utils.respondWithCache(data, h)
   },
   config: {
     plugins: {
@@ -95,7 +103,9 @@ exports.voters = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    return request.server.methods.v1.delegates.voters(request)
+    const data = await request.server.methods.v1.delegates.voters(request)
+
+    return utils.respondWithCache(data, h)
   },
   config: {
     plugins: {

--- a/packages/core-api/lib/versions/1/handlers/transactions.js
+++ b/packages/core-api/lib/versions/1/handlers/transactions.js
@@ -16,19 +16,7 @@ exports.index = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    const { count, rows } = await repository.findAllLegacy({
-      ...request.query,
-      ...utils.paginate(request),
-    })
-
-    if (!rows) {
-      return utils.respondWith('No transactions found', true)
-    }
-
-    return utils.respondWith({
-      transactions: utils.toCollection(request, rows, 'transaction'),
-      count,
-    })
+    return request.server.methods.v1.transactions.index(request)
   },
   config: {
     plugins: {
@@ -49,15 +37,7 @@ exports.show = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    const result = await repository.findById(request.query.id)
-
-    if (!result) {
-      return utils.respondWith('No transactions found', true)
-    }
-
-    return utils.respondWith({
-      transaction: utils.toResource(request, result, 'transaction'),
-    })
+    return request.server.methods.v1.transactions.show(request)
   },
   config: {
     plugins: {

--- a/packages/core-api/lib/versions/1/handlers/transactions.js
+++ b/packages/core-api/lib/versions/1/handlers/transactions.js
@@ -4,7 +4,6 @@ const transactionPool = container.resolvePlugin('transactionPool')
 
 const utils = require('../utils')
 const schema = require('../schemas/transactions')
-const { transactions: repository } = require('../../../repositories')
 
 /**
  * @type {Object}
@@ -16,7 +15,9 @@ exports.index = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    return request.server.methods.v1.transactions.index(request)
+    const data = await request.server.methods.v1.transactions.index(request)
+
+    return utils.respondWithCache(data, h)
   },
   config: {
     plugins: {
@@ -37,7 +38,9 @@ exports.show = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    return request.server.methods.v1.transactions.show(request)
+    const data = await request.server.methods.v1.transactions.show(request)
+
+    return utils.respondWithCache(data, h)
   },
   config: {
     plugins: {

--- a/packages/core-api/lib/versions/1/index.js
+++ b/packages/core-api/lib/versions/1/index.js
@@ -6,7 +6,9 @@ const signatures = require('./handlers/signatures')
 const transactions = require('./handlers/transactions')
 const accounts = require('./handlers/accounts')
 
+const registerAccountMethods = require('./methods/accounts')
 const registerBlockMethods = require('./methods/blocks')
+const registerDelegateMethods = require('./methods/delegates')
 const registerTransactionMethods = require('./methods/transactions')
 
 /**
@@ -16,7 +18,9 @@ const registerTransactionMethods = require('./methods/transactions')
  * @return {void}
  */
 const register = async (server, options) => {
+  registerAccountMethods(server)
   registerBlockMethods(server)
+  registerDelegateMethods(server)
   registerTransactionMethods(server)
 
   server.route([

--- a/packages/core-api/lib/versions/1/index.js
+++ b/packages/core-api/lib/versions/1/index.js
@@ -6,6 +6,9 @@ const signatures = require('./handlers/signatures')
 const transactions = require('./handlers/transactions')
 const accounts = require('./handlers/accounts')
 
+const registerBlockMethods = require('./methods/blocks')
+const registerTransactionMethods = require('./methods/transactions')
+
 /**
  * Register the v1 routes.
  * @param  {Hapi.Server} server
@@ -13,6 +16,9 @@ const accounts = require('./handlers/accounts')
  * @return {void}
  */
 const register = async (server, options) => {
+  registerBlockMethods(server)
+  registerTransactionMethods(server)
+
   server.route([
     { method: 'GET', path: '/accounts/getAllAccounts', ...accounts.index },
     { method: 'GET', path: '/accounts', ...accounts.show },

--- a/packages/core-api/lib/versions/1/methods/accounts.js
+++ b/packages/core-api/lib/versions/1/methods/accounts.js
@@ -1,0 +1,92 @@
+const container = require('@arkecosystem/core-container')
+const generateCacheKey = require('../../../utils/generate-cache-key')
+const utils = require('../utils')
+
+const database = container.resolvePlugin('database')
+
+const index = async request => {
+  const { rows } = await database.wallets.findAll({
+    ...request.query,
+    ...utils.paginate(request),
+  })
+
+  return utils.respondWith({
+    accounts: utils.toCollection(request, rows, 'account'),
+  })
+}
+
+const show = async request => {
+  const account = await database.wallets.findById(request.query.address)
+
+  if (!account) {
+    return utils.respondWith('Account not found', true)
+  }
+
+  return utils.respondWith({
+    account: utils.toResource(request, account, 'account'),
+  })
+}
+
+const balance = async request => {
+  const account = await database.wallets.findById(request.query.address)
+
+  if (!account) {
+    return utils.respondWith({ balance: '0', unconfirmedBalance: '0' })
+  }
+
+  return utils.respondWith({
+    balance: account ? `${account.balance}` : '0',
+    unconfirmedBalance: account ? `${account.balance}` : '0',
+  })
+}
+
+const publicKey = async request => {
+  const account = await database.wallets.findById(request.query.address)
+
+  if (!account) {
+    return utils.respondWith('Account not found', true)
+  }
+
+  return utils.respondWith({ publicKey: account.publicKey })
+}
+
+module.exports = server => {
+  server.method('v1.accounts.index', index, {
+    cache: {
+      expiresIn: 8 * 1000,
+      generateTimeout: 3000,
+    },
+    generateKey: request =>
+      generateCacheKey({
+        ...request.query,
+        ...utils.paginate(request),
+      }),
+  })
+
+  server.method('v1.accounts.show', show, {
+    cache: {
+      expiresIn: 8 * 1000,
+      generateTimeout: 3000,
+    },
+    generateKey: request =>
+      generateCacheKey({ address: request.query.address }),
+  })
+
+  server.method('v1.accounts.balance', balance, {
+    cache: {
+      expiresIn: 8 * 1000,
+      generateTimeout: 3000,
+    },
+    generateKey: request =>
+      generateCacheKey({ address: request.query.address }),
+  })
+
+  server.method('v1.accounts.publicKey', publicKey, {
+    cache: {
+      expiresIn: 600 * 1000,
+      generateTimeout: 3000,
+    },
+    generateKey: request =>
+      generateCacheKey({ address: request.query.address }),
+  })
+}

--- a/packages/core-api/lib/versions/1/methods/accounts.js
+++ b/packages/core-api/lib/versions/1/methods/accounts.js
@@ -55,6 +55,7 @@ module.exports = server => {
     cache: {
       expiresIn: 8 * 1000,
       generateTimeout: 3000,
+      getDecoratedValue: true,
     },
     generateKey: request =>
       generateCacheKey({
@@ -67,6 +68,7 @@ module.exports = server => {
     cache: {
       expiresIn: 8 * 1000,
       generateTimeout: 3000,
+      getDecoratedValue: true,
     },
     generateKey: request =>
       generateCacheKey({ address: request.query.address }),
@@ -76,6 +78,7 @@ module.exports = server => {
     cache: {
       expiresIn: 8 * 1000,
       generateTimeout: 3000,
+      getDecoratedValue: true,
     },
     generateKey: request =>
       generateCacheKey({ address: request.query.address }),
@@ -85,6 +88,7 @@ module.exports = server => {
     cache: {
       expiresIn: 600 * 1000,
       generateTimeout: 3000,
+      getDecoratedValue: true,
     },
     generateKey: request =>
       generateCacheKey({ address: request.query.address }),

--- a/packages/core-api/lib/versions/1/methods/blocks.js
+++ b/packages/core-api/lib/versions/1/methods/blocks.js
@@ -38,6 +38,7 @@ module.exports = server => {
     cache: {
       expiresIn: 8 * 1000,
       generateTimeout: 3000,
+      getDecoratedValue: true,
     },
     generateKey: request =>
       generateCacheKey({
@@ -50,6 +51,7 @@ module.exports = server => {
     cache: {
       expiresIn: 600 * 1000,
       generateTimeout: 3000,
+      getDecoratedValue: true,
     },
     generateKey: request => generateCacheKey({ id: request.query.id }),
   })

--- a/packages/core-api/lib/versions/1/methods/blocks.js
+++ b/packages/core-api/lib/versions/1/methods/blocks.js
@@ -1,0 +1,56 @@
+const generateCacheKey = require('../../../utils/generate-cache-key')
+const { blocks: blocksRepository } = require('../../../repositories')
+const utils = require('../utils')
+
+const index = async request => {
+  const { count, rows } = await blocksRepository.findAll({
+    ...request.query,
+    ...utils.paginate(request),
+  })
+
+  if (!rows) {
+    return utils.respondWith('No blocks found', true)
+  }
+
+  return utils.respondWith({
+    blocks: utils.toCollection(request, rows, 'block'),
+    count,
+  })
+}
+
+const show = async request => {
+  const block = await blocksRepository.findById(request.query.id)
+
+  if (!block) {
+    return utils.respondWith(
+      `Block with id ${request.query.id} not found`,
+      true,
+    )
+  }
+
+  return utils.respondWith({
+    block: utils.toResource(request, block, 'block'),
+  })
+}
+
+module.exports = server => {
+  server.method('v1.blocks.index', index, {
+    cache: {
+      expiresIn: 8 * 1000,
+      generateTimeout: 3000,
+    },
+    generateKey: request =>
+      generateCacheKey({
+        ...request.query,
+        ...utils.paginate(request),
+      }),
+  })
+
+  server.method('v1.blocks.show', show, {
+    cache: {
+      expiresIn: 600 * 1000,
+      generateTimeout: 3000,
+    },
+    generateKey: request => generateCacheKey({ id: request.query.id }),
+  })
+}

--- a/packages/core-api/lib/versions/1/methods/delegates.js
+++ b/packages/core-api/lib/versions/1/methods/delegates.js
@@ -75,6 +75,7 @@ module.exports = server => {
     cache: {
       expiresIn: 8 * 1000,
       generateTimeout: 3000,
+      getDecoratedValue: true,
     },
     generateKey: request =>
       generateCacheKey({
@@ -90,6 +91,7 @@ module.exports = server => {
     cache: {
       expiresIn: 8 * 1000,
       generateTimeout: 3000,
+      getDecoratedValue: true,
     },
     generateKey: request =>
       generateCacheKey({
@@ -101,6 +103,7 @@ module.exports = server => {
     cache: {
       expiresIn: 8 * 1000,
       generateTimeout: 3000,
+      getDecoratedValue: true,
     },
     generateKey: request => generateCacheKey({ time: +new Date() }),
   })
@@ -109,6 +112,7 @@ module.exports = server => {
     cache: {
       expiresIn: 8 * 1000,
       generateTimeout: 3000,
+      getDecoratedValue: true,
     },
     generateKey: request =>
       generateCacheKey({
@@ -121,6 +125,7 @@ module.exports = server => {
     cache: {
       expiresIn: 8 * 1000,
       generateTimeout: 3000,
+      getDecoratedValue: true,
     },
     generateKey: request => generateCacheKey({ id: request.query.publicKey }),
   })

--- a/packages/core-api/lib/versions/1/methods/delegates.js
+++ b/packages/core-api/lib/versions/1/methods/delegates.js
@@ -1,0 +1,127 @@
+const container = require('@arkecosystem/core-container')
+const generateCacheKey = require('../../../utils/generate-cache-key')
+const utils = require('../utils')
+
+const database = container.resolvePlugin('database')
+
+const index = async request => {
+  const { count, rows } = await database.delegates.paginate({
+    ...request.query,
+    ...{
+      offset: request.query.offset || 0,
+      limit: request.query.limit || 51,
+    },
+  })
+
+  return utils.respondWith({
+    delegates: utils.toCollection(request, rows, 'delegate'),
+    totalCount: count,
+  })
+}
+
+const show = async request => {
+  if (!request.query.publicKey && !request.query.username) {
+    return utils.respondWith('Delegate not found', true)
+  }
+
+  const delegate = await database.delegates.findById(
+    request.query.publicKey || request.query.username,
+  )
+
+  if (!delegate) {
+    return utils.respondWith('Delegate not found', true)
+  }
+
+  return utils.respondWith({
+    delegate: utils.toResource(request, delegate, 'delegate'),
+  })
+}
+
+const count = async request => {
+  const delegate = await database.delegates.findAll()
+
+  return utils.respondWith({ count: delegate.count })
+}
+
+const search = async request => {
+  const { rows } = await database.delegates.search({
+    ...{ username: request.query.q },
+    ...utils.paginate(request),
+  })
+
+  return utils.respondWith({
+    delegates: utils.toCollection(request, rows, 'delegate'),
+  })
+}
+
+const voters = async request => {
+  const delegate = await database.delegates.findById(request.query.publicKey)
+
+  if (!delegate) {
+    return utils.respondWith({
+      accounts: [],
+    })
+  }
+
+  const accounts = await database.wallets.findAllByVote(delegate.publicKey)
+
+  return utils.respondWith({
+    accounts: utils.toCollection(request, accounts.rows, 'voter'),
+  })
+}
+
+module.exports = server => {
+  server.method('v1.delegates.index', index, {
+    cache: {
+      expiresIn: 8 * 1000,
+      generateTimeout: 3000,
+    },
+    generateKey: request =>
+      generateCacheKey({
+        ...request.query,
+        ...{
+          offset: request.query.offset || 0,
+          limit: request.query.limit || 51,
+        },
+      }),
+  })
+
+  server.method('v1.delegates.show', show, {
+    cache: {
+      expiresIn: 8 * 1000,
+      generateTimeout: 3000,
+    },
+    generateKey: request =>
+      generateCacheKey({
+        id: request.query.publicKey || request.query.username,
+      }),
+  })
+
+  // server.method('v1.delegates.count', count, {
+  //   cache: {
+  //     expiresIn: 8 * 1000,
+  //     generateTimeout: 3000,
+  //   },
+  //   generateKey: request => generateCacheKey(),
+  // })
+
+  server.method('v1.delegates.search', search, {
+    cache: {
+      expiresIn: 8 * 1000,
+      generateTimeout: 3000,
+    },
+    generateKey: request =>
+      generateCacheKey({
+        ...{ username: request.query.q },
+        ...utils.paginate(request),
+      }),
+  })
+
+  server.method('v1.delegates.voters', voters, {
+    cache: {
+      expiresIn: 8 * 1000,
+      generateTimeout: 3000,
+    },
+    generateKey: request => generateCacheKey({ id: request.query.publicKey }),
+  })
+}

--- a/packages/core-api/lib/versions/1/methods/delegates.js
+++ b/packages/core-api/lib/versions/1/methods/delegates.js
@@ -97,13 +97,13 @@ module.exports = server => {
       }),
   })
 
-  // server.method('v1.delegates.count', count, {
-  //   cache: {
-  //     expiresIn: 8 * 1000,
-  //     generateTimeout: 3000,
-  //   },
-  //   generateKey: request => generateCacheKey(),
-  // })
+  server.method('v1.delegates.count', count, {
+    cache: {
+      expiresIn: 8 * 1000,
+      generateTimeout: 3000,
+    },
+    generateKey: request => generateCacheKey({ time: +new Date() }),
+  })
 
   server.method('v1.delegates.search', search, {
     cache: {

--- a/packages/core-api/lib/versions/1/methods/transactions.js
+++ b/packages/core-api/lib/versions/1/methods/transactions.js
@@ -37,6 +37,7 @@ module.exports = server => {
     cache: {
       expiresIn: 8 * 1000,
       generateTimeout: 3000,
+      getDecoratedValue: true,
     },
     generateKey: request =>
       generateCacheKey({
@@ -49,6 +50,7 @@ module.exports = server => {
     cache: {
       expiresIn: 8 * 1000,
       generateTimeout: 3000,
+      getDecoratedValue: true,
     },
     generateKey: request => generateCacheKey({ id: request.query.id }),
   })

--- a/packages/core-api/lib/versions/1/methods/transactions.js
+++ b/packages/core-api/lib/versions/1/methods/transactions.js
@@ -1,0 +1,55 @@
+const generateCacheKey = require('../../../utils/generate-cache-key')
+const {
+  transactions: transactionsRepository,
+} = require('../../../repositories')
+const utils = require('../utils')
+
+const index = async request => {
+  const { count, rows } = await transactionsRepository.findAllLegacy({
+    ...request.query,
+    ...utils.paginate(request),
+  })
+
+  if (!rows) {
+    return utils.respondWith('No transactions found', true)
+  }
+
+  return utils.respondWith({
+    transactions: utils.toCollection(request, rows, 'transaction'),
+    count,
+  })
+}
+
+const show = async request => {
+  const result = await transactionsRepository.findById(request.query.id)
+
+  if (!result) {
+    return utils.respondWith('No transactions found', true)
+  }
+
+  return utils.respondWith({
+    transaction: utils.toResource(request, result, 'transaction'),
+  })
+}
+
+module.exports = server => {
+  server.method('v1.transactions.index', index, {
+    cache: {
+      expiresIn: 8 * 1000,
+      generateTimeout: 3000,
+    },
+    generateKey: request =>
+      generateCacheKey({
+        ...request.query,
+        ...utils.paginate(request),
+      }),
+  })
+
+  server.method('v1.transactions.show', show, {
+    cache: {
+      expiresIn: 8 * 1000,
+      generateTimeout: 3000,
+    },
+    generateKey: request => generateCacheKey({ id: request.query.id }),
+  })
+}

--- a/packages/core-api/lib/versions/1/utils.js
+++ b/packages/core-api/lib/versions/1/utils.js
@@ -25,6 +25,19 @@ const respondWith = (data, error = false) =>
   error ? { error: data, success: false } : { ...data, success: true }
 
 /**
+ * Respond with data from cache.
+ * @param  {Object} data
+ * @param  {Hapi.Toolkit} h
+ * @return {Object}
+ */
+const respondWithCache = (data, h) => {
+  const { value, cached } = data
+  const lastModified = cached ? new Date(cached.stored) : new Date()
+
+  return h.response(value).header('Last-modified', lastModified.toUTCString())
+}
+
+/**
  * Transform the given data into a resource.
  * @param  {Hapi.Request} request
  * @param  {Object} data
@@ -49,6 +62,7 @@ const toCollection = transformCollection
 module.exports = {
   paginate,
   respondWith,
+  respondWithCache,
   toResource,
   toCollection,
 }

--- a/packages/core-api/lib/versions/2/handlers/blocks.js
+++ b/packages/core-api/lib/versions/2/handlers/blocks.js
@@ -1,11 +1,4 @@
-const Boom = require('boom')
-const utils = require('../utils')
 const schema = require('../schema/blocks')
-
-const {
-  blocks: blocksRepository,
-  transactions: transactionsRepository,
-} = require('../../../repositories')
 
 /**
  * @type {Object}

--- a/packages/core-api/lib/versions/2/handlers/blocks.js
+++ b/packages/core-api/lib/versions/2/handlers/blocks.js
@@ -17,12 +17,7 @@ exports.index = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    const blocks = await blocksRepository.findAll({
-      ...request.query,
-      ...utils.paginate(request),
-    })
-
-    return utils.toPagination(request, blocks, 'block')
+    return request.server.methods.v2.blocks.index(request)
   },
   options: {
     validate: schema.index,
@@ -39,13 +34,7 @@ exports.show = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    const block = await blocksRepository.findById(request.params.id)
-
-    if (!block) {
-      return Boom.notFound('Block not found')
-    }
-
-    return utils.respondWithResource(request, block, 'block')
+    return request.server.methods.v2.blocks.show(request)
   },
   options: {
     validate: schema.show,
@@ -62,18 +51,7 @@ exports.transactions = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    const block = await blocksRepository.findById(request.params.id)
-
-    if (!block) {
-      return Boom.notFound('Block not found')
-    }
-
-    const transactions = await transactionsRepository.findAllByBlock(block.id, {
-      ...request.query,
-      ...utils.paginate(request),
-    })
-
-    return utils.toPagination(request, transactions, 'transaction')
+    return request.server.methods.v2.blocks.transactions(request)
   },
   options: {
     validate: schema.transactions,
@@ -90,13 +68,7 @@ exports.search = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    const blocks = await blocksRepository.search({
-      ...request.payload,
-      ...request.query,
-      ...utils.paginate(request),
-    })
-
-    return utils.toPagination(request, blocks, 'block')
+    return request.server.methods.v2.blocks.search(request)
   },
   options: {
     validate: schema.search,

--- a/packages/core-api/lib/versions/2/handlers/blocks.js
+++ b/packages/core-api/lib/versions/2/handlers/blocks.js
@@ -1,3 +1,4 @@
+const { respondWithCache } = require('../utils')
 const schema = require('../schema/blocks')
 
 /**
@@ -10,7 +11,9 @@ exports.index = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    return request.server.methods.v2.blocks.index(request)
+    const data = await request.server.methods.v2.blocks.index(request)
+
+    return respondWithCache(data, h)
   },
   options: {
     validate: schema.index,
@@ -27,7 +30,9 @@ exports.show = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    return request.server.methods.v2.blocks.show(request)
+    const data = await request.server.methods.v2.blocks.show(request)
+
+    return respondWithCache(data, h)
   },
   options: {
     validate: schema.show,
@@ -44,7 +49,9 @@ exports.transactions = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    return request.server.methods.v2.blocks.transactions(request)
+    const data = await request.server.methods.v2.blocks.transactions(request)
+
+    return respondWithCache(data, h)
   },
   options: {
     validate: schema.transactions,
@@ -61,7 +68,9 @@ exports.search = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    return request.server.methods.v2.blocks.search(request)
+    const data = await request.server.methods.v2.blocks.search(request)
+
+    return respondWithCache(data, h)
   },
   options: {
     validate: schema.search,

--- a/packages/core-api/lib/versions/2/handlers/delegates.js
+++ b/packages/core-api/lib/versions/2/handlers/delegates.js
@@ -1,3 +1,4 @@
+const { respondWithCache } = require('../utils')
 const schema = require('../schema/delegates')
 
 /**
@@ -10,7 +11,9 @@ exports.index = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    return request.server.methods.v2.delegates.index(request)
+    const data = await request.server.methods.v2.delegates.index(request)
+
+    return respondWithCache(data, h)
   },
   options: {
     validate: schema.index,
@@ -27,7 +30,9 @@ exports.show = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    return request.server.methods.v2.delegates.show(request)
+    const data = await request.server.methods.v2.delegates.show(request)
+
+    return respondWithCache(data, h)
   },
   options: {
     validate: schema.show,
@@ -44,7 +49,9 @@ exports.search = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    return request.server.methods.v2.delegates.search(request)
+    const data = await request.server.methods.v2.delegates.search(request)
+
+    return respondWithCache(data, h)
   },
   options: {
     validate: schema.search,
@@ -61,7 +68,9 @@ exports.blocks = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    return request.server.methods.v2.delegates.blocks(request)
+    const data = await request.server.methods.v2.delegates.blocks(request)
+
+    return respondWithCache(data, h)
   },
   options: {
     validate: schema.blocks,
@@ -78,7 +87,9 @@ exports.voters = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    return request.server.methods.v2.delegates.voters(request)
+    const data = await request.server.methods.v2.delegates.voters(request)
+
+    return respondWithCache(data, h)
   },
   options: {
     validate: schema.voters,
@@ -95,7 +106,11 @@ exports.voterBalances = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    return request.server.methods.v2.delegates.voterBalances(request)
+    const data = await request.server.methods.v2.delegates.voterBalances(
+      request,
+    )
+
+    return respondWithCache(data, h)
   },
   options: {
     validate: schema.voterBalances,

--- a/packages/core-api/lib/versions/2/handlers/delegates.js
+++ b/packages/core-api/lib/versions/2/handlers/delegates.js
@@ -1,11 +1,4 @@
-const Boom = require('boom')
-const orderBy = require('lodash/orderBy')
-const database = require('@arkecosystem/core-container').resolvePlugin(
-  'database',
-)
-const utils = require('../utils')
 const schema = require('../schema/delegates')
-const { blocks: blocksRepository } = require('../../../repositories')
 
 /**
  * @type {Object}
@@ -17,12 +10,7 @@ exports.index = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    const delegates = await database.delegates.paginate({
-      ...request.query,
-      ...utils.paginate(request),
-    })
-
-    return utils.toPagination(request, delegates, 'delegate')
+    return request.server.methods.v2.delegates.index(request)
   },
   options: {
     validate: schema.index,
@@ -39,13 +27,7 @@ exports.show = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    const delegate = await database.delegates.findById(request.params.id)
-
-    if (!delegate) {
-      return Boom.notFound('Delegate not found')
-    }
-
-    return utils.respondWithResource(request, delegate, 'delegate')
+    return request.server.methods.v2.delegates.show(request)
   },
   options: {
     validate: schema.show,
@@ -62,13 +44,7 @@ exports.search = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    const delegates = await database.delegates.search({
-      ...request.payload,
-      ...request.query,
-      ...utils.paginate(request),
-    })
-
-    return utils.toPagination(request, delegates, 'delegate')
+    return request.server.methods.v2.delegates.search(request)
   },
   options: {
     validate: schema.search,
@@ -85,18 +61,7 @@ exports.blocks = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    const delegate = await database.delegates.findById(request.params.id)
-
-    if (!delegate) {
-      return Boom.notFound('Delegate not found')
-    }
-
-    const blocks = await blocksRepository.findAllByGenerator(
-      delegate.publicKey,
-      utils.paginate(request),
-    )
-
-    return utils.toPagination(request, blocks, 'block')
+    return request.server.methods.v2.delegates.blocks(request)
   },
   options: {
     validate: schema.blocks,
@@ -113,18 +78,7 @@ exports.voters = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    const delegate = await database.delegates.findById(request.params.id)
-
-    if (!delegate) {
-      return Boom.notFound('Delegate not found')
-    }
-
-    const wallets = await database.wallets.findAllByVote(
-      delegate.publicKey,
-      utils.paginate(request),
-    )
-
-    return utils.toPagination(request, wallets, 'wallet')
+    return request.server.methods.v2.delegates.voters(request)
   },
   options: {
     validate: schema.voters,
@@ -141,22 +95,7 @@ exports.voterBalances = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    const delegate = await database.delegates.findById(request.params.id)
-
-    if (!delegate) {
-      return Boom.notFound('Delegate not found')
-    }
-
-    const wallets = await database.wallets
-      .all()
-      .filter(wallet => wallet.vote === delegate.publicKey)
-
-    const voters = {}
-    orderBy(wallets, ['balance'], ['desc']).forEach(wallet => {
-      voters[wallet.address] = +wallet.balance.toFixed()
-    })
-
-    return { data: voters }
+    return request.server.methods.v2.delegates.voterBalances(request)
   },
   options: {
     validate: schema.voterBalances,

--- a/packages/core-api/lib/versions/2/handlers/transactions.js
+++ b/packages/core-api/lib/versions/2/handlers/transactions.js
@@ -22,7 +22,9 @@ exports.index = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    return request.server.methods.v2.transactions.index(request)
+    const data = await request.server.methods.v2.transactions.index(request)
+
+    return utils.respondWithCache(data, h)
   },
   options: {
     validate: schema.index,
@@ -83,7 +85,9 @@ exports.show = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    return request.server.methods.v2.transactions.show(request)
+    const data = await request.server.methods.v2.transactions.show(request)
+
+    return utils.respondWithCache(data, h)
   },
   options: {
     validate: schema.show,
@@ -167,7 +171,9 @@ exports.search = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    return request.server.methods.v2.transactions.search(request)
+    const data = await request.server.methods.v2.transactions.search(request)
+
+    return utils.respondWithCache(data, h)
   },
   options: {
     validate: schema.search,

--- a/packages/core-api/lib/versions/2/handlers/transactions.js
+++ b/packages/core-api/lib/versions/2/handlers/transactions.js
@@ -1,5 +1,4 @@
 const Boom = require('boom')
-const pluralize = require('pluralize')
 
 const { TRANSACTION_TYPES } = require('@arkecosystem/crypto').constants
 const { TransactionGuard } = require('@arkecosystem/core-transaction-pool')

--- a/packages/core-api/lib/versions/2/handlers/transactions.js
+++ b/packages/core-api/lib/versions/2/handlers/transactions.js
@@ -8,12 +8,10 @@ const container = require('@arkecosystem/core-container')
 
 const blockchain = container.resolvePlugin('blockchain')
 const config = container.resolvePlugin('config')
-const logger = container.resolvePlugin('logger')
 const transactionPool = container.resolvePlugin('transactionPool')
 
 const utils = require('../utils')
 const schema = require('../schema/transactions')
-const { transactions: repository } = require('../../../repositories')
 
 /**
  * @type {Object}
@@ -25,12 +23,7 @@ exports.index = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    const transactions = await repository.findAll({
-      ...request.query,
-      ...utils.paginate(request),
-    })
-
-    return utils.toPagination(request, transactions, 'transaction')
+    return request.server.methods.v2.transactions.index(request)
   },
   options: {
     validate: schema.index,
@@ -91,13 +84,7 @@ exports.show = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    const transaction = await repository.findById(request.params.id)
-
-    if (!transaction) {
-      return Boom.notFound('Transaction not found')
-    }
-
-    return utils.respondWithResource(request, transaction, 'transaction')
+    return request.server.methods.v2.transactions.index(request)
   },
   options: {
     validate: schema.show,
@@ -181,13 +168,7 @@ exports.search = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    const transactions = await repository.search({
-      ...request.query,
-      ...request.payload,
-      ...utils.paginate(request),
-    })
-
-    return utils.toPagination(request, transactions, 'transaction')
+    return request.server.methods.v2.transactions.search(request)
   },
   options: {
     validate: schema.search,

--- a/packages/core-api/lib/versions/2/handlers/transactions.js
+++ b/packages/core-api/lib/versions/2/handlers/transactions.js
@@ -83,7 +83,7 @@ exports.show = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    return request.server.methods.v2.transactions.index(request)
+    return request.server.methods.v2.transactions.show(request)
   },
   options: {
     validate: schema.show,

--- a/packages/core-api/lib/versions/2/handlers/votes.js
+++ b/packages/core-api/lib/versions/2/handlers/votes.js
@@ -1,10 +1,4 @@
-const Boom = require('boom')
-const { TRANSACTION_TYPES } = require('@arkecosystem/crypto').constants
-const utils = require('../utils')
 const schema = require('../schema/votes')
-const {
-  transactions: transactionsRepository,
-} = require('../../../repositories')
 
 /**
  * @type {Object}
@@ -16,15 +10,7 @@ exports.index = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    const transactions = await transactionsRepository.findAllByType(
-      TRANSACTION_TYPES.VOTE,
-      {
-        ...request.query,
-        ...utils.paginate(request),
-      },
-    )
-
-    return utils.toPagination(request, transactions, 'transaction')
+    return request.server.methods.v2.votes.index(request)
   },
   options: {
     validate: schema.index,
@@ -41,16 +27,7 @@ exports.show = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    const transaction = await transactionsRepository.findByTypeAndId(
-      TRANSACTION_TYPES.VOTE,
-      request.params.id,
-    )
-
-    if (!transaction) {
-      return Boom.notFound('Vote not found')
-    }
-
-    return utils.respondWithResource(request, transaction, 'transaction')
+    return request.server.methods.v2.votes.show(request)
   },
   options: {
     validate: schema.show,

--- a/packages/core-api/lib/versions/2/handlers/votes.js
+++ b/packages/core-api/lib/versions/2/handlers/votes.js
@@ -1,3 +1,4 @@
+const { respondWithCache } = require('../utils')
 const schema = require('../schema/votes')
 
 /**
@@ -10,7 +11,9 @@ exports.index = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    return request.server.methods.v2.votes.index(request)
+    const data = await request.server.methods.v2.votes.index(request)
+
+    return respondWithCache(data, h)
   },
   options: {
     validate: schema.index,
@@ -27,7 +30,9 @@ exports.show = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    return request.server.methods.v2.votes.show(request)
+    const data = await request.server.methods.v2.votes.show(request)
+
+    return respondWithCache(data, h)
   },
   options: {
     validate: schema.show,

--- a/packages/core-api/lib/versions/2/handlers/wallets.js
+++ b/packages/core-api/lib/versions/2/handlers/wallets.js
@@ -1,3 +1,4 @@
+const { respondWithCache } = require('../utils')
 const schema = require('../schema/wallets')
 
 /**
@@ -10,7 +11,9 @@ exports.index = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    return request.server.methods.v2.wallets.index(request)
+    const data = await request.server.methods.v2.wallets.index(request)
+
+    return respondWithCache(data, h)
   },
   options: {
     validate: schema.index,
@@ -27,7 +30,9 @@ exports.top = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    return request.server.methods.v2.wallets.top(request)
+    const data = await request.server.methods.v2.wallets.top(request)
+
+    return respondWithCache(data, h)
   },
   // TODO: create top schema
 }
@@ -42,7 +47,9 @@ exports.show = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    return request.server.methods.v2.wallets.show(request)
+    const data = await request.server.methods.v2.wallets.show(request)
+
+    return respondWithCache(data, h)
   },
   options: {
     validate: schema.show,
@@ -59,7 +66,9 @@ exports.transactions = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    return request.server.methods.v2.wallets.transactions(request)
+    const data = await request.server.methods.v2.wallets.transactions(request)
+
+    return respondWithCache(data, h)
   },
   options: {
     validate: schema.transactions,
@@ -76,7 +85,11 @@ exports.transactionsSent = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    return request.server.methods.v2.wallets.transactionsSent(request)
+    const data = await request.server.methods.v2.wallets.transactionsSent(
+      request,
+    )
+
+    return respondWithCache(data, h)
   },
   options: {
     validate: schema.transactionsSent,
@@ -93,7 +106,11 @@ exports.transactionsReceived = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    return request.server.methods.v2.wallets.transactionsReceived(request)
+    const data = await request.server.methods.v2.wallets.transactionsReceived(
+      request,
+    )
+
+    return respondWithCache(data, h)
   },
   options: {
     validate: schema.transactionsReceived,
@@ -110,7 +127,9 @@ exports.votes = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    return request.server.methods.v2.wallets.votes(request)
+    const data = await request.server.methods.v2.wallets.votes(request)
+
+    return respondWithCache(data, h)
   },
   options: {
     validate: schema.votes,
@@ -127,7 +146,9 @@ exports.search = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    return request.server.methods.v2.wallets.search(request)
+    const data = await request.server.methods.v2.wallets.search(request)
+
+    return respondWithCache(data, h)
   },
   options: {
     validate: schema.search,

--- a/packages/core-api/lib/versions/2/handlers/wallets.js
+++ b/packages/core-api/lib/versions/2/handlers/wallets.js
@@ -1,12 +1,4 @@
-const Boom = require('boom')
-const database = require('@arkecosystem/core-container').resolvePlugin(
-  'database',
-)
-const utils = require('../utils')
 const schema = require('../schema/wallets')
-const {
-  transactions: transactionsRepository,
-} = require('../../../repositories')
 
 /**
  * @type {Object}
@@ -18,12 +10,7 @@ exports.index = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    const wallets = await database.wallets.findAll({
-      ...request.query,
-      ...utils.paginate(request),
-    })
-
-    return utils.toPagination(request, wallets, 'wallet')
+    return request.server.methods.v2.wallets.index(request)
   },
   options: {
     validate: schema.index,
@@ -40,9 +27,7 @@ exports.top = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    const wallets = await database.wallets.top(utils.paginate(request))
-
-    return utils.toPagination(request, wallets, 'wallet')
+    return request.server.methods.v2.wallets.top(request)
   },
   // TODO: create top schema
 }
@@ -57,13 +42,7 @@ exports.show = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    const wallet = await database.wallets.findById(request.params.id)
-
-    if (!wallet) {
-      return Boom.notFound('Wallet not found')
-    }
-
-    return utils.respondWithResource(request, wallet, 'wallet')
+    return request.server.methods.v2.wallets.show(request)
   },
   options: {
     validate: schema.show,
@@ -80,19 +59,7 @@ exports.transactions = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    const wallet = await database.wallets.findById(request.params.id)
-
-    if (!wallet) {
-      return Boom.notFound('Wallet not found')
-    }
-
-    const transactions = await transactionsRepository.findAllByWallet(wallet, {
-      ...request.query,
-      ...request.params,
-      ...utils.paginate(request),
-    })
-
-    return utils.toPagination(request, transactions, 'transaction')
+    return request.server.methods.v2.wallets.transactions(request)
   },
   options: {
     validate: schema.transactions,
@@ -109,25 +76,7 @@ exports.transactionsSent = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    const wallet = await database.wallets.findById(request.params.id)
-
-    if (!wallet) {
-      return Boom.notFound('Wallet not found')
-    }
-
-    // NOTE: We unset this value because it otherwise will produce a faulty SQL query
-    delete request.params.id
-
-    const transactions = await transactionsRepository.findAllBySender(
-      wallet.publicKey,
-      {
-        ...request.query,
-        ...request.params,
-        ...utils.paginate(request),
-      },
-    )
-
-    return utils.toPagination(request, transactions, 'transaction')
+    return request.server.methods.v2.wallets.transactionsSent(request)
   },
   options: {
     validate: schema.transactionsSent,
@@ -144,25 +93,7 @@ exports.transactionsReceived = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    const wallet = await database.wallets.findById(request.params.id)
-
-    if (!wallet) {
-      return Boom.notFound('Wallet not found')
-    }
-
-    // NOTE: We unset this value because it otherwise will produce a faulty SQL query
-    delete request.params.id
-
-    const transactions = await transactionsRepository.findAllByRecipient(
-      wallet.address,
-      {
-        ...request.query,
-        ...request.params,
-        ...utils.paginate(request),
-      },
-    )
-
-    return utils.toPagination(request, transactions, 'transaction')
+    return request.server.methods.v2.wallets.transactionsReceived(request)
   },
   options: {
     validate: schema.transactionsReceived,
@@ -179,24 +110,7 @@ exports.votes = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    const wallet = await database.wallets.findById(request.params.id)
-
-    if (!wallet) {
-      return Boom.notFound('Wallet not found')
-    }
-
-    // NOTE: We unset this value because it otherwise will produce a faulty SQL query
-    delete request.params.id
-
-    const transactions = await transactionsRepository.allVotesBySender(
-      wallet.publicKey,
-      {
-        ...request.params,
-        ...utils.paginate(request),
-      },
-    )
-
-    return utils.toPagination(request, transactions, 'transaction')
+    return request.server.methods.v2.wallets.votes(request)
   },
   options: {
     validate: schema.votes,
@@ -213,13 +127,7 @@ exports.search = {
    * @return {Hapi.Response}
    */
   async handler(request, h) {
-    const wallets = await database.wallets.search({
-      ...request.payload,
-      ...request.query,
-      ...utils.paginate(request),
-    })
-
-    return utils.toPagination(request, wallets, 'wallet')
+    return request.server.methods.v2.wallets.search(request)
   },
   options: {
     validate: schema.search,

--- a/packages/core-api/lib/versions/2/index.js
+++ b/packages/core-api/lib/versions/2/index.js
@@ -7,6 +7,9 @@ const transactions = require('./handlers/transactions')
 const votes = require('./handlers/votes')
 const wallets = require('./handlers/wallets')
 
+const registerBlockMethods = require('./methods/blocks')
+const registerTransactionMethods = require('./methods/transactions')
+
 /**
  * Register the v2 routes.
  * @param  {Hapi.Server} server
@@ -14,6 +17,9 @@ const wallets = require('./handlers/wallets')
  * @return {void}
  */
 const register = async (server, options) => {
+  registerBlockMethods(server)
+  registerTransactionMethods(server)
+
   server.route([
     { method: 'GET', path: '/blockchain', ...blockchain.index },
 

--- a/packages/core-api/lib/versions/2/index.js
+++ b/packages/core-api/lib/versions/2/index.js
@@ -9,6 +9,8 @@ const wallets = require('./handlers/wallets')
 
 const registerBlockMethods = require('./methods/blocks')
 const registerTransactionMethods = require('./methods/transactions')
+const registerWalletMethods = require('./methods/wallets')
+const registerVoteMethods = require('./methods/votes')
 
 /**
  * Register the v2 routes.
@@ -19,6 +21,8 @@ const registerTransactionMethods = require('./methods/transactions')
 const register = async (server, options) => {
   registerBlockMethods(server)
   registerTransactionMethods(server)
+  registerWalletMethods(server)
+  registerVoteMethods(server)
 
   server.route([
     { method: 'GET', path: '/blockchain', ...blockchain.index },

--- a/packages/core-api/lib/versions/2/index.js
+++ b/packages/core-api/lib/versions/2/index.js
@@ -8,6 +8,7 @@ const votes = require('./handlers/votes')
 const wallets = require('./handlers/wallets')
 
 const registerBlockMethods = require('./methods/blocks')
+const registerDelegateMethods = require('./methods/delegates')
 const registerTransactionMethods = require('./methods/transactions')
 const registerWalletMethods = require('./methods/wallets')
 const registerVoteMethods = require('./methods/votes')
@@ -20,6 +21,7 @@ const registerVoteMethods = require('./methods/votes')
  */
 const register = async (server, options) => {
   registerBlockMethods(server)
+  registerDelegateMethods(server)
   registerTransactionMethods(server)
   registerWalletMethods(server)
   registerVoteMethods(server)

--- a/packages/core-api/lib/versions/2/methods/blocks.js
+++ b/packages/core-api/lib/versions/2/methods/blocks.js
@@ -55,6 +55,7 @@ module.exports = server => {
     cache: {
       expiresIn: 8 * 1000,
       generateTimeout: 3000,
+      getDecoratedValue: true,
     },
     generateKey: request =>
       generateCacheKey({
@@ -67,6 +68,7 @@ module.exports = server => {
     cache: {
       expiresIn: 600 * 1000,
       generateTimeout: 3000,
+      getDecoratedValue: true,
     },
     generateKey: request => generateCacheKey({ id: request.params.id }),
   })
@@ -75,6 +77,7 @@ module.exports = server => {
     cache: {
       expiresIn: 600 * 1000,
       generateTimeout: 3000,
+      getDecoratedValue: true,
     },
     generateKey: request =>
       generateCacheKey({
@@ -87,6 +90,7 @@ module.exports = server => {
     cache: {
       expiresIn: 30 * 1000,
       generateTimeout: 3000,
+      getDecoratedValue: true,
     },
     generateKey: request =>
       generateCacheKey({

--- a/packages/core-api/lib/versions/2/methods/blocks.js
+++ b/packages/core-api/lib/versions/2/methods/blocks.js
@@ -1,0 +1,98 @@
+const Boom = require('boom')
+const generateCacheKey = require('../../../utils/generate-cache-key')
+const {
+  blocks: blocksRepository,
+  transactions: transactionsRepository,
+} = require('../../../repositories')
+const utils = require('../utils')
+
+const index = async request => {
+  const blocks = await blocksRepository.findAll({
+    ...request.query,
+    ...utils.paginate(request),
+  })
+
+  return utils.toPagination(request, blocks, 'block')
+}
+
+const show = async request => {
+  const block = await blocksRepository.findById(request.params.id)
+
+  if (!block) {
+    return Boom.notFound('Block not found')
+  }
+
+  return utils.respondWithResource(request, block, 'block')
+}
+
+const transactions = async request => {
+  const block = await blocksRepository.findById(request.params.id)
+
+  if (!block) {
+    return Boom.notFound('Block not found')
+  }
+
+  const rows = await transactionsRepository.findAllByBlock(block.id, {
+    ...request.query,
+    ...utils.paginate(request),
+  })
+
+  return utils.toPagination(request, rows, 'transaction')
+}
+
+const search = async request => {
+  const blocks = await blocksRepository.search({
+    ...request.payload,
+    ...request.query,
+    ...utils.paginate(request),
+  })
+
+  return utils.toPagination(request, blocks, 'block')
+}
+
+module.exports = server => {
+  server.method('v2.blocks.index', index, {
+    cache: {
+      expiresIn: 8 * 1000,
+      generateTimeout: 3000,
+    },
+    generateKey: request =>
+      generateCacheKey({
+        ...request.query,
+        ...utils.paginate(request),
+      }),
+  })
+
+  server.method('v2.blocks.show', show, {
+    cache: {
+      expiresIn: 600 * 1000,
+      generateTimeout: 3000,
+    },
+    generateKey: request => generateCacheKey({ id: request.params.id }),
+  })
+
+  server.method('v2.blocks.transactions', transactions, {
+    cache: {
+      expiresIn: 600 * 1000,
+      generateTimeout: 3000,
+    },
+    generateKey: request =>
+      generateCacheKey({
+        ...request.query,
+        ...utils.paginate(request),
+      }),
+  })
+
+  server.method('v2.blocks.search', search, {
+    cache: {
+      expiresIn: 30 * 1000,
+      generateTimeout: 3000,
+    },
+    generateKey: request =>
+      generateCacheKey({
+        ...request.payload,
+        ...request.query,
+        ...utils.paginate(request),
+      }),
+  })
+}

--- a/packages/core-api/lib/versions/2/methods/delegates.js
+++ b/packages/core-api/lib/versions/2/methods/delegates.js
@@ -1,0 +1,160 @@
+const Boom = require('boom')
+const orderBy = require('lodash/orderBy')
+const container = require('@arkecosystem/core-container')
+const generateCacheKey = require('../../../utils/generate-cache-key')
+const { blocks: blocksRepository } = require('../../../repositories')
+const utils = require('../utils')
+
+const database = container.resolvePlugin('database')
+
+const index = async request => {
+  const delegates = await database.delegates.paginate({
+    ...request.query,
+    ...utils.paginate(request),
+  })
+
+  return utils.toPagination(request, delegates, 'delegate')
+}
+
+const show = async request => {
+  const delegate = await database.delegates.findById(request.params.id)
+
+  if (!delegate) {
+    return Boom.notFound('Delegate not found')
+  }
+
+  return utils.respondWithResource(request, delegate, 'delegate')
+}
+
+const search = async request => {
+  const delegates = await database.delegates.search({
+    ...request.payload,
+    ...request.query,
+    ...utils.paginate(request),
+  })
+
+  return utils.toPagination(request, delegates, 'delegate')
+}
+
+const blocks = async request => {
+  const delegate = await database.delegates.findById(request.params.id)
+
+  if (!delegate) {
+    return Boom.notFound('Delegate not found')
+  }
+
+  const rows = await blocksRepository.findAllByGenerator(
+    delegate.publicKey,
+    utils.paginate(request),
+  )
+
+  return utils.toPagination(request, rows, 'block')
+}
+
+const voters = async request => {
+  const delegate = await database.delegates.findById(request.params.id)
+
+  if (!delegate) {
+    return Boom.notFound('Delegate not found')
+  }
+
+  const wallets = await database.wallets.findAllByVote(
+    delegate.publicKey,
+    utils.paginate(request),
+  )
+
+  return utils.toPagination(request, wallets, 'wallet')
+}
+
+const voterBalances = async request => {
+  const delegate = await database.delegates.findById(request.params.id)
+
+  if (!delegate) {
+    return Boom.notFound('Delegate not found')
+  }
+
+  const wallets = await database.wallets
+    .all()
+    .filter(wallet => wallet.vote === delegate.publicKey)
+
+  const data = {}
+  orderBy(wallets, ['balance'], ['desc']).forEach(wallet => {
+    data[wallet.address] = +wallet.balance.toFixed()
+  })
+
+  return { data }
+}
+
+module.exports = server => {
+  server.method('v2.delegates.index', index, {
+    cache: {
+      expiresIn: 8 * 1000,
+      generateTimeout: 3000,
+    },
+    generateKey: request =>
+      generateCacheKey({
+        ...request.query,
+        ...utils.paginate(request),
+      }),
+  })
+
+  server.method('v2.delegates.show', show, {
+    cache: {
+      expiresIn: 8 * 1000,
+      generateTimeout: 3000,
+    },
+    generateKey: request =>
+      generateCacheKey({
+        ...request.query,
+        ...utils.paginate(request),
+      }),
+  })
+
+  server.method('v2.delegates.search', search, {
+    cache: {
+      expiresIn: 30 * 1000,
+      generateTimeout: 3000,
+    },
+    generateKey: request =>
+      generateCacheKey({
+        ...request.query,
+        ...utils.paginate(request),
+      }),
+  })
+
+  server.method('v2.delegates.blocks', blocks, {
+    cache: {
+      expiresIn: 8 * 1000,
+      generateTimeout: 3000,
+    },
+    generateKey: request =>
+      generateCacheKey({
+        ...request.query,
+        ...utils.paginate(request),
+      }),
+  })
+
+  server.method('v2.delegates.voters', voters, {
+    cache: {
+      expiresIn: 8 * 1000,
+      generateTimeout: 3000,
+    },
+    generateKey: request =>
+      generateCacheKey({
+        ...request.query,
+        ...utils.paginate(request),
+      }),
+  })
+
+  server.method('v2.delegates.voterBalances', voterBalances, {
+    cache: {
+      expiresIn: 8 * 1000,
+      generateTimeout: 3000,
+    },
+    generateKey: request =>
+      generateCacheKey({
+        ...request.query,
+        ...utils.paginate(request),
+      }),
+  })
+}

--- a/packages/core-api/lib/versions/2/methods/delegates.js
+++ b/packages/core-api/lib/versions/2/methods/delegates.js
@@ -90,6 +90,7 @@ module.exports = server => {
     cache: {
       expiresIn: 8 * 1000,
       generateTimeout: 3000,
+      getDecoratedValue: true,
     },
     generateKey: request =>
       generateCacheKey({
@@ -102,6 +103,7 @@ module.exports = server => {
     cache: {
       expiresIn: 8 * 1000,
       generateTimeout: 3000,
+      getDecoratedValue: true,
     },
     generateKey: request => generateCacheKey({ id: request.params.id }),
   })
@@ -110,6 +112,7 @@ module.exports = server => {
     cache: {
       expiresIn: 30 * 1000,
       generateTimeout: 3000,
+      getDecoratedValue: true,
     },
     generateKey: request =>
       generateCacheKey({
@@ -123,6 +126,7 @@ module.exports = server => {
     cache: {
       expiresIn: 8 * 1000,
       generateTimeout: 3000,
+      getDecoratedValue: true,
     },
     generateKey: request =>
       generateCacheKey({
@@ -135,6 +139,7 @@ module.exports = server => {
     cache: {
       expiresIn: 8 * 1000,
       generateTimeout: 3000,
+      getDecoratedValue: true,
     },
     generateKey: request =>
       generateCacheKey({
@@ -147,6 +152,7 @@ module.exports = server => {
     cache: {
       expiresIn: 8 * 1000,
       generateTimeout: 3000,
+      getDecoratedValue: true,
     },
     generateKey: request => generateCacheKey({ id: request.params.id }),
   })

--- a/packages/core-api/lib/versions/2/methods/delegates.js
+++ b/packages/core-api/lib/versions/2/methods/delegates.js
@@ -103,11 +103,7 @@ module.exports = server => {
       expiresIn: 8 * 1000,
       generateTimeout: 3000,
     },
-    generateKey: request =>
-      generateCacheKey({
-        ...request.query,
-        ...utils.paginate(request),
-      }),
+    generateKey: request => generateCacheKey({ id: request.params.id }),
   })
 
   server.method('v2.delegates.search', search, {
@@ -117,6 +113,7 @@ module.exports = server => {
     },
     generateKey: request =>
       generateCacheKey({
+        ...request.payload,
         ...request.query,
         ...utils.paginate(request),
       }),
@@ -129,7 +126,7 @@ module.exports = server => {
     },
     generateKey: request =>
       generateCacheKey({
-        ...request.query,
+        ...{ id: request.params.id },
         ...utils.paginate(request),
       }),
   })
@@ -141,7 +138,7 @@ module.exports = server => {
     },
     generateKey: request =>
       generateCacheKey({
-        ...request.query,
+        ...{ id: request.params.id },
         ...utils.paginate(request),
       }),
   })
@@ -151,10 +148,6 @@ module.exports = server => {
       expiresIn: 8 * 1000,
       generateTimeout: 3000,
     },
-    generateKey: request =>
-      generateCacheKey({
-        ...request.query,
-        ...utils.paginate(request),
-      }),
+    generateKey: request => generateCacheKey({ id: request.params.id }),
   })
 }

--- a/packages/core-api/lib/versions/2/methods/transactions.js
+++ b/packages/core-api/lib/versions/2/methods/transactions.js
@@ -1,0 +1,70 @@
+const Boom = require('boom')
+const generateCacheKey = require('../../../utils/generate-cache-key')
+const {
+  transactions: transactionsRepository,
+} = require('../../../repositories')
+const utils = require('../utils')
+
+const index = async request => {
+  const transactions = await transactionsRepository.findAll({
+    ...request.query,
+    ...utils.paginate(request),
+  })
+
+  return utils.toPagination(request, transactions, 'transaction')
+}
+
+const show = async request => {
+  const transaction = await transactionsRepository.findById(request.params.id)
+
+  if (!transaction) {
+    return Boom.notFound('Transaction not found')
+  }
+
+  return utils.respondWithResource(request, transaction, 'transaction')
+}
+
+const search = async request => {
+  const transactions = await transactionsRepository.search({
+    ...request.query,
+    ...request.payload,
+    ...utils.paginate(request),
+  })
+
+  return utils.toPagination(request, transactions, 'transaction')
+}
+
+module.exports = server => {
+  server.method('v2.transactions.index', index, {
+    cache: {
+      expiresIn: 8 * 1000,
+      generateTimeout: 3000,
+    },
+    generateKey: request =>
+      generateCacheKey({
+        ...request.query,
+        ...utils.paginate(request),
+      }),
+  })
+
+  server.method('v2.transactions.show', show, {
+    cache: {
+      expiresIn: 8 * 1000,
+      generateTimeout: 3000,
+    },
+    generateKey: request => generateCacheKey({ id: request.params.id }),
+  })
+
+  server.method('v2.transactions.search', search, {
+    cache: {
+      expiresIn: 30 * 1000,
+      generateTimeout: 3000,
+    },
+    generateKey: request =>
+      generateCacheKey({
+        ...request.payload,
+        ...request.query,
+        ...utils.paginate(request),
+      }),
+  })
+}

--- a/packages/core-api/lib/versions/2/methods/transactions.js
+++ b/packages/core-api/lib/versions/2/methods/transactions.js
@@ -39,6 +39,7 @@ module.exports = server => {
     cache: {
       expiresIn: 8 * 1000,
       generateTimeout: 3000,
+      getDecoratedValue: true,
     },
     generateKey: request =>
       generateCacheKey({
@@ -51,6 +52,7 @@ module.exports = server => {
     cache: {
       expiresIn: 8 * 1000,
       generateTimeout: 3000,
+      getDecoratedValue: true,
     },
     generateKey: request => generateCacheKey({ id: request.params.id }),
   })
@@ -59,6 +61,7 @@ module.exports = server => {
     cache: {
       expiresIn: 30 * 1000,
       generateTimeout: 3000,
+      getDecoratedValue: true,
     },
     generateKey: request =>
       generateCacheKey({

--- a/packages/core-api/lib/versions/2/methods/votes.js
+++ b/packages/core-api/lib/versions/2/methods/votes.js
@@ -36,6 +36,7 @@ module.exports = server => {
     cache: {
       expiresIn: 8 * 1000,
       generateTimeout: 3000,
+      getDecoratedValue: true,
     },
     generateKey: request =>
       generateCacheKey({
@@ -48,6 +49,7 @@ module.exports = server => {
     cache: {
       expiresIn: 8 * 1000,
       generateTimeout: 3000,
+      getDecoratedValue: true,
     },
     generateKey: request => generateCacheKey({ id: request.params.id }),
   })

--- a/packages/core-api/lib/versions/2/methods/votes.js
+++ b/packages/core-api/lib/versions/2/methods/votes.js
@@ -1,0 +1,54 @@
+const Boom = require('boom')
+const { TRANSACTION_TYPES } = require('@arkecosystem/crypto').constants
+const generateCacheKey = require('../../../utils/generate-cache-key')
+const {
+  transactions: transactionsRepository,
+} = require('../../../repositories')
+const utils = require('../utils')
+
+const index = async request => {
+  const transactions = await transactionsRepository.findAllByType(
+    TRANSACTION_TYPES.VOTE,
+    {
+      ...request.query,
+      ...utils.paginate(request),
+    },
+  )
+
+  return utils.toPagination(request, transactions, 'transaction')
+}
+
+const show = async request => {
+  const transaction = await transactionsRepository.findByTypeAndId(
+    TRANSACTION_TYPES.VOTE,
+    request.params.id,
+  )
+
+  if (!transaction) {
+    return Boom.notFound('Vote not found')
+  }
+
+  return utils.respondWithResource(request, transaction, 'transaction')
+}
+
+module.exports = server => {
+  server.method('v2.votes.index', index, {
+    cache: {
+      expiresIn: 8 * 1000,
+      generateTimeout: 3000,
+    },
+    generateKey: request =>
+      generateCacheKey({
+        ...request.query,
+        ...utils.paginate(request),
+      }),
+  })
+
+  server.method('v2.votes.show', show, {
+    cache: {
+      expiresIn: 8 * 1000,
+      generateTimeout: 3000,
+    },
+    generateKey: request => generateCacheKey({ id: request.params.id }),
+  })
+}

--- a/packages/core-api/lib/versions/2/methods/wallets.js
+++ b/packages/core-api/lib/versions/2/methods/wallets.js
@@ -120,6 +120,7 @@ module.exports = server => {
     cache: {
       expiresIn: 30 * 1000,
       generateTimeout: 3000,
+      getDecoratedValue: true,
     },
     generateKey: request =>
       generateCacheKey({
@@ -133,6 +134,7 @@ module.exports = server => {
     cache: {
       expiresIn: 30 * 1000,
       generateTimeout: 3000,
+      getDecoratedValue: true,
     },
     generateKey: request => generateCacheKey(utils.paginate(request)),
   })
@@ -141,6 +143,7 @@ module.exports = server => {
     cache: {
       expiresIn: 30 * 1000,
       generateTimeout: 3000,
+      getDecoratedValue: true,
     },
     generateKey: request => generateCacheKey({ id: request.params.id }),
   })
@@ -149,6 +152,7 @@ module.exports = server => {
     cache: {
       expiresIn: 30 * 1000,
       generateTimeout: 3000,
+      getDecoratedValue: true,
     },
     generateKey: request =>
       generateCacheKey({
@@ -162,6 +166,7 @@ module.exports = server => {
     cache: {
       expiresIn: 30 * 1000,
       generateTimeout: 3000,
+      getDecoratedValue: true,
     },
     generateKey: request =>
       generateCacheKey({
@@ -175,6 +180,7 @@ module.exports = server => {
     cache: {
       expiresIn: 30 * 1000,
       generateTimeout: 3000,
+      getDecoratedValue: true,
     },
     generateKey: request =>
       generateCacheKey({
@@ -188,6 +194,7 @@ module.exports = server => {
     cache: {
       expiresIn: 30 * 1000,
       generateTimeout: 3000,
+      getDecoratedValue: true,
     },
     generateKey: request =>
       generateCacheKey({
@@ -200,6 +207,7 @@ module.exports = server => {
     cache: {
       expiresIn: 30 * 1000,
       generateTimeout: 3000,
+      getDecoratedValue: true,
     },
     generateKey: request =>
       generateCacheKey({

--- a/packages/core-api/lib/versions/2/methods/wallets.js
+++ b/packages/core-api/lib/versions/2/methods/wallets.js
@@ -1,0 +1,211 @@
+const Boom = require('boom')
+const container = require('@arkecosystem/core-container')
+const generateCacheKey = require('../../../utils/generate-cache-key')
+const utils = require('../utils')
+const {
+  transactions: transactionsRepository,
+} = require('../../../repositories')
+
+const database = container.resolvePlugin('database')
+
+const index = async request => {
+  const wallets = await database.wallets.findAll({
+    ...request.query,
+    ...utils.paginate(request),
+  })
+
+  return utils.toPagination(request, wallets, 'wallet')
+}
+
+const top = async request => {
+  const wallets = await database.wallets.top(utils.paginate(request))
+
+  return utils.toPagination(request, wallets, 'wallet')
+}
+
+const show = async request => {
+  const wallet = await database.wallets.findById(request.params.id)
+
+  if (!wallet) {
+    return Boom.notFound('Wallet not found')
+  }
+
+  return utils.respondWithResource(request, wallet, 'wallet')
+}
+
+const transactions = async request => {
+  const wallet = await database.wallets.findById(request.params.id)
+
+  if (!wallet) {
+    return Boom.notFound('Wallet not found')
+  }
+
+  const rows = await transactionsRepository.findAllByWallet(wallet, {
+    ...request.query,
+    ...request.params,
+    ...utils.paginate(request),
+  })
+
+  return utils.toPagination(request, rows, 'transaction')
+}
+
+const transactionsSent = async request => {
+  const wallet = await database.wallets.findById(request.params.id)
+
+  if (!wallet) {
+    return Boom.notFound('Wallet not found')
+  }
+
+  // NOTE: We unset this value because it otherwise will produce a faulty SQL query
+  delete request.params.id
+
+  const rows = await transactionsRepository.findAllBySender(wallet.publicKey, {
+    ...request.query,
+    ...request.params,
+    ...utils.paginate(request),
+  })
+
+  return utils.toPagination(request, rows, 'transaction')
+}
+
+const transactionsReceived = async request => {
+  const wallet = await database.wallets.findById(request.params.id)
+
+  if (!wallet) {
+    return Boom.notFound('Wallet not found')
+  }
+
+  // NOTE: We unset this value because it otherwise will produce a faulty SQL query
+  delete request.params.id
+
+  const rows = await transactionsRepository.findAllByRecipient(wallet.address, {
+    ...request.query,
+    ...request.params,
+    ...utils.paginate(request),
+  })
+
+  return utils.toPagination(request, rows, 'transaction')
+}
+
+const votes = async request => {
+  const wallet = await database.wallets.findById(request.params.id)
+
+  if (!wallet) {
+    return Boom.notFound('Wallet not found')
+  }
+
+  // NOTE: We unset this value because it otherwise will produce a faulty SQL query
+  delete request.params.id
+
+  const rows = await transactionsRepository.allVotesBySender(wallet.publicKey, {
+    ...request.params,
+    ...utils.paginate(request),
+  })
+
+  return utils.toPagination(request, rows, 'transaction')
+}
+
+const search = async request => {
+  const wallets = await database.wallets.search({
+    ...request.payload,
+    ...request.query,
+    ...utils.paginate(request),
+  })
+
+  return utils.toPagination(request, wallets, 'wallet')
+}
+
+module.exports = server => {
+  server.method('v2.wallets.index', index, {
+    cache: {
+      expiresIn: 30 * 1000,
+      generateTimeout: 3000,
+    },
+    generateKey: request =>
+      generateCacheKey({
+        ...request.payload,
+        ...request.query,
+        ...utils.paginate(request),
+      }),
+  })
+
+  server.method('v2.wallets.top', top, {
+    cache: {
+      expiresIn: 30 * 1000,
+      generateTimeout: 3000,
+    },
+    generateKey: request => generateCacheKey(utils.paginate(request)),
+  })
+
+  server.method('v2.wallets.show', show, {
+    cache: {
+      expiresIn: 30 * 1000,
+      generateTimeout: 3000,
+    },
+    generateKey: request => generateCacheKey({ id: request.params.id }),
+  })
+
+  server.method('v2.wallets.transactions', transactions, {
+    cache: {
+      expiresIn: 30 * 1000,
+      generateTimeout: 3000,
+    },
+    generateKey: request =>
+      generateCacheKey({
+        ...request.query,
+        ...request.params,
+        ...utils.paginate(request),
+      }),
+  })
+
+  server.method('v2.wallets.transactionsSent', transactionsSent, {
+    cache: {
+      expiresIn: 30 * 1000,
+      generateTimeout: 3000,
+    },
+    generateKey: request =>
+      generateCacheKey({
+        ...request.query,
+        ...request.params,
+        ...utils.paginate(request),
+      }),
+  })
+
+  server.method('v2.wallets.transactionsReceived', transactionsReceived, {
+    cache: {
+      expiresIn: 30 * 1000,
+      generateTimeout: 3000,
+    },
+    generateKey: request =>
+      generateCacheKey({
+        ...request.query,
+        ...request.params,
+        ...utils.paginate(request),
+      }),
+  })
+
+  server.method('v2.wallets.votes', votes, {
+    cache: {
+      expiresIn: 30 * 1000,
+      generateTimeout: 3000,
+    },
+    generateKey: request =>
+      generateCacheKey({
+        ...request.params,
+        ...utils.paginate(request),
+      }),
+  })
+
+  server.method('v2.wallets.search', search, {
+    cache: {
+      expiresIn: 30 * 1000,
+      generateTimeout: 3000,
+    },
+    generateKey: request =>
+      generateCacheKey({
+        ...request.payload,
+        ...request.query,
+        ...utils.paginate(request),
+      }),
+  })
+}

--- a/packages/core-api/lib/versions/2/utils.js
+++ b/packages/core-api/lib/versions/2/utils.js
@@ -29,9 +29,10 @@ const paginate = request => {
  * @param  {String} transformer
  * @return {Object}
  */
-const respondWithResource = (request, data, transformer) => (data
-  ? { data: transformResource(request, data, transformer) }
-  : Boom.notFound())
+const respondWithResource = (request, data, transformer) =>
+  data
+    ? { data: transformResource(request, data, transformer) }
+    : Boom.notFound()
 
 /**
  * Respond with a collection.
@@ -45,13 +46,27 @@ const respondWithCollection = (request, data, transformer) => ({
 })
 
 /**
+ * Respond with data from cache.
+ * @param  {Object} data
+ * @param  {Hapi.Toolkit} h
+ * @return {Object}
+ */
+const respondWithCache = (data, h) => {
+  const { value, cached } = data
+  const lastModified = cached ? new Date(cached.stored) : new Date()
+
+  return h.response(value).header('Last-modified', lastModified.toUTCString())
+}
+
+/**
  * Transform the given data into a resource.
  * @param  {Hapi.Request} request
  * @param  {Object} data
  * @param  {String} transformer
  * @return {Object}
  */
-const toResource = (request, data, transformer) => transformResource(request, data, transformer)
+const toResource = (request, data, transformer) =>
+  transformResource(request, data, transformer)
 
 /**
  * Transform the given data into a collection.
@@ -60,7 +75,8 @@ const toResource = (request, data, transformer) => transformResource(request, da
  * @param  {String} transformer
  * @return {Object}
  */
-const toCollection = (request, data, transformer) => transformCollection(request, data, transformer)
+const toCollection = (request, data, transformer) =>
+  transformCollection(request, data, transformer)
 
 /**
  * Transform the given data into a pagination.
@@ -81,6 +97,7 @@ module.exports = {
   paginate,
   respondWithResource,
   respondWithCollection,
+  respondWithCache,
   toResource,
   toCollection,
   toPagination,

--- a/packages/core-api/package.json
+++ b/packages/core-api/package.json
@@ -34,8 +34,7 @@
     "joi": "^14.1.0",
     "lodash": "^4.17.11",
     "lodash.orderby": "^4.6.0",
-    "lodash.snakecase": "^4.1.1",
-    "pluralize": "^7.0.0"
+    "lodash.snakecase": "^4.1.1"
   },
   "devDependencies": {
     "@arkecosystem/core-test-utils": "^0.1.1",


### PR DESCRIPTION
## Proposed changes

Quickly implemented server methods to provide caching for blocks and transactions. Function wise everything is still the same but methods are now called through server methods and cached rather then directly in the server handler.

## Types of changes

- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes