### PR TITLE
fix(core-transaction-pool): keep tx broadcast when pool is full

### DIFF
--- a/packages/core-transaction-pool/lib/guard.js
+++ b/packages/core-transaction-pool/lib/guard.js
@@ -284,9 +284,8 @@ module.exports = class TransactionGuard {
     notAdded.forEach(item => {
       this.accept.delete(item.transaction.id)
 
-      // The transaction should still be broadcasted, if it has been
-      // rejected for any other reason.
-      if (item.type === 'ERR_ALREADY_IN_POOL') {
+      // The transaction should still be broadcasted if the pool is full
+      if (item.type !== 'ERR_POOL_FULL') {
         this.broadcast.delete(item.transaction.id)
       }
 

--- a/packages/core-transaction-pool/lib/guard.js
+++ b/packages/core-transaction-pool/lib/guard.js
@@ -256,9 +256,9 @@ module.exports = class TransactionGuard {
   async __removeForgedTransactions() {
     const database = container.resolvePlugin('database')
 
-    const forgedIdsSet = await database.getForgedTransactionsIds(
-      new Set([...this.accept.keys(), ...this.broadcast.keys()]),
-    )
+    const forgedIdsSet = await database.getForgedTransactionsIds([
+      ...new Set([...this.accept.keys(), ...this.broadcast.keys()]),
+    ])
 
     container.resolve('state').removeCachedTransactionIds(forgedIdsSet)
 

--- a/packages/core-transaction-pool/lib/guard.js
+++ b/packages/core-transaction-pool/lib/guard.js
@@ -283,7 +283,12 @@ module.exports = class TransactionGuard {
     // Exclude transactions which were refused from the pool
     notAdded.forEach(item => {
       this.accept.delete(item.transaction.id)
-      this.broadcast.delete(item.transaction.id)
+
+      // The transaction should still be broadcasted, if it has been
+      // rejected for any other reason.
+      if (item.type === 'ERR_ALREADY_IN_POOL') {
+        this.broadcast.delete(item.transaction.id)
+      }
 
       this.__pushError(item.transaction, item.type, item.message)
     })

--- a/packages/core-transaction-pool/lib/guard.js
+++ b/packages/core-transaction-pool/lib/guard.js
@@ -256,8 +256,8 @@ module.exports = class TransactionGuard {
   async __removeForgedTransactions() {
     const database = container.resolvePlugin('database')
 
-    const forgedIdsSet = new Set(
-      await database.getForgedTransactionsIds(Array.from(this.accept.keys())),
+    const forgedIdsSet = await database.getForgedTransactionsIds(
+      new Set([...this.accept.keys(), ...this.broadcast.keys()]),
     )
 
     container.resolve('state').removeCachedTransactionIds(forgedIdsSet)


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Don't remove a transaction from broadcast when it was rejected due to `ERR_POOL_FULL` and include the broadcast ids when looking up forged transactions.

Also added some missing tests.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [ ] Docs (documentation only changes)
- [X] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [ ] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [X] Lint and unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
