### PR TITLE
fix(core-api): properly return boom errors if cached

### DIFF
--- a/packages/core-api/lib/versions/1/utils.js
+++ b/packages/core-api/lib/versions/1/utils.js
@@ -34,7 +34,9 @@ const respondWithCache = (data, h) => {
   const { value, cached } = data
   const lastModified = cached ? new Date(cached.stored) : new Date()
 
-  return h.response(value).header('Last-modified', lastModified.toUTCString())
+  return value.isBoom
+    ? value
+    : h.response(value).header('Last-modified', lastModified.toUTCString())
 }
 
 /**

--- a/packages/core-api/lib/versions/2/utils.js
+++ b/packages/core-api/lib/versions/2/utils.js
@@ -55,7 +55,9 @@ const respondWithCache = (data, h) => {
   const { value, cached } = data
   const lastModified = cached ? new Date(cached.stored) : new Date()
 
-  return h.response(value).header('Last-modified', lastModified.toUTCString())
+  return value.isBoom
+    ? value
+    : h.response(value).header('Last-modified', lastModified.toUTCString())
 }
 
 /**


### PR DESCRIPTION
## Proposed changes

Cached `Boom` errors were not properly returned which resulted in a 500 because errors can't be wrapped again.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes