### PR TITLE
chore(core-p2p): add secDecimalDigits option to prettyms call

### DIFF
--- a/packages/core-p2p/lib/court/guard.js
+++ b/packages/core-p2p/lib/court/guard.js
@@ -126,6 +126,7 @@ class Guard {
         logger.debug(
           `${peer.ip} still suspended for ${prettyMs(untilDiff, {
             verbose: true,
+            secDecimalDigits: 0,
           })} because of "${suspendedPeer.reason}".`,
         )
 
@@ -301,6 +302,7 @@ class Guard {
     logger.debug(
       `Suspended ${peer.ip} for ${prettyMs(untilDiff, {
         verbose: true,
+        secDecimalDigits: 0,
       })} because of "${offence.reason}"`,
     )
 


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

Adds the `secDecimalDigits` to certain `prettyms` calls where the precision is unnecessary, for instance:

```
x.x.x.x still suspended for 1 minute 59.3 seconds because of "Timeout".
```

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes