### PR TITLE
refactor(core-vote-report): configurable row count and formatting

### DIFF
--- a/packages/core-vote-report/lib/defaults.js
+++ b/packages/core-vote-report/lib/defaults.js
@@ -1,4 +1,5 @@
 module.exports = {
   host: process.env.ARK_VOTE_REPORT_HOST || '0.0.0.0',
   port: process.env.ARK_VOTE_REPORT_PORT || 4006,
+  delegateRows: process.env.ARK_VOTE_REPORT_DELEGATE_ROWS || 80,
 }

--- a/packages/core-vote-report/lib/handler.js
+++ b/packages/core-vote-report/lib/handler.js
@@ -16,14 +16,21 @@ const formatDelegates = delegates =>
           wallet.vote === delegate.publicKey && wallet.balance > 0.1 * 1e8,
       )
 
-    const approval = delegateCalculator.calculateApproval(delegate).toString()
+    const approval = Number(
+      delegateCalculator.calculateApproval(delegate),
+    ).toLocaleString(undefined, {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    })
+
     const rank = delegate.rate.toLocaleString(undefined, {
       minimumIntegerDigits: 2,
     })
-    const votes = delegate.voteBalance
-      .div(1e8)
-      .toFixed()
-      .toLocaleString(undefined, { maximumFractionDigits: 0 })
+
+    const votes = Number(delegate.voteBalance.div(1e8)).toLocaleString(
+      undefined,
+      { maximumFractionDigits: 0 },
+    )
     const voterCount = voters.length.toLocaleString(undefined, {
       maximumFractionDigits: 0,
     })
@@ -32,8 +39,8 @@ const formatDelegates = delegates =>
       rank,
       username: delegate.username.padEnd(25),
       approval: approval.padEnd(4),
-      votes: votes.padEnd(10),
-      voterCount: voterCount.padEnd(5),
+      votes: votes.padStart(10),
+      voterCount: voterCount.padStart(5),
     }
   })
 
@@ -72,11 +79,7 @@ module.exports = (request, h) => {
   return h
     .view('index', {
       client,
-      token: client.token.padEnd(
-        client.token.length === 4
-          ? client.token.length + 1
-          : client.token.length * 2 - 1,
-      ),
+      voteHeader: `Vote ${client.token}`.padStart(10),
       activeDelegatesCount: constants.activeDelegates,
       activeDelegates: formatDelegates(active),
       standbyDelegates: formatDelegates(standby),
@@ -90,6 +93,7 @@ module.exports = (request, h) => {
         maximumFractionDigits: 0,
       }),
       percentage: percentage.toLocaleString(undefined, {
+        minimumFractionDigits: 2,
         maximumFractionDigits: 2,
       }),
     })

--- a/packages/core-vote-report/lib/templates/index.html
+++ b/packages/core-vote-report/lib/templates/index.html
@@ -4,7 +4,7 @@ Top {{activeDelegatesCount}} Delegates Stats
 => Total Voters : {{voters}} (only voters with more than 0.1 {{client.symbol}})
 
 ===================================================================
-| Rank | Delegate                  | Vote % | Vote {{token}} | Voters |
+| Rank | Delegate                  | Vote % | {{voteHeader}} | Voters |
 ===================================================================
 {{#each activeDelegates}}
 |  {{rank}}  | {{username}} |  {{approval}}  | {{votes}} |  {{voterCount}} |


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

Adds the option to set the row count of the report as env variable and adds a bit of formatting to the resulting table:

```
===================================================================
| Rank | Delegate                  | Vote % |  Vote DARK | Voters |
===================================================================
|  01  | arkx                      |  0.34  |    436,258 |  5,005 |
|  02  | obiwan                    |  0.06  |     81,289 |      1 |
|  03  | itsanametoo               |  0.06  |     71,576 |      5 |
```

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes