### PR TITLE
test: pool wallet "chained transfers" tests

### DIFF
--- a/packages/core-test-utils/fixtures/testnet/delegates.js
+++ b/packages/core-test-utils/fixtures/testnet/delegates.js
@@ -20,6 +20,7 @@ module.exports = delegatesConfig.secrets.map(secret => {
   ).amount
   return {
     secret,
+    passphrase: secret, // just an alias for delegate secret
     publicKey,
     address,
     balance,

--- a/packages/core-transaction-pool/__tests__/pool-wallet-manager.test.js
+++ b/packages/core-transaction-pool/__tests__/pool-wallet-manager.test.js
@@ -2,8 +2,10 @@ const { crypto } = require('@arkecosystem/crypto')
 const bip39 = require('bip39')
 const delegates = require('@arkecosystem/core-test-utils/fixtures/testnet/delegates')
 const generateTransfer = require('@arkecosystem/core-test-utils/lib/generators/transactions/transfer')
+const generateWallets = require('@arkecosystem/core-test-utils/lib/generators/wallets')
 const app = require('./__support__/setup')
 
+const arktoshi = 10 ** 8
 let container
 let poolWalletManager
 
@@ -77,6 +79,93 @@ describe('applyPoolTransaction', () => {
 
       expect(+delegateWallet.balance).toBe(+delegate0.balance - amount1 - fee)
       expect(+newWallet.balance).toBe(amount1)
+    })
+
+    it('should apply chained transfers involving cold wallets - and update balances', async () => {
+      const delegate = delegates[7]
+      const delegateWallet = poolWalletManager.findByPublicKey(
+        delegate.publicKey,
+      )
+
+      const wallets = generateWallets('testnet', 4)
+      const poolWallets = wallets.map(w =>
+        poolWalletManager.findByAddress(w.address),
+      )
+
+      expect(+delegateWallet.balance).toBe(+delegate.balance)
+      poolWallets.forEach(w => {
+        expect(+w.balance).toBe(0)
+      })
+
+      const transfers = [
+        {
+          // transfer from delegate to wallet 0
+          from: delegate,
+          to: wallets[0],
+          amount: 100 * arktoshi,
+        },
+        {
+          // transfer from wallet 0 to wallet 1
+          from: wallets[0],
+          to: wallets[1],
+          amount: 55 * arktoshi,
+        },
+        {
+          // transfer from wallet 1 to wallet 2
+          from: wallets[1],
+          to: wallets[2],
+          amount: 40 * arktoshi,
+        },
+        {
+          // transfer from wallet 2 to delegate
+          from: wallets[2],
+          to: delegate,
+          amount: 15 * arktoshi,
+        },
+        {
+          // transfer from delegate to wallet 1
+          from: delegate,
+          to: wallets[1],
+          amount: 33 * arktoshi,
+        },
+        {
+          // transfer from delegate to wallet 3
+          from: delegate,
+          to: wallets[3],
+          amount: 17 * arktoshi,
+        },
+      ]
+
+      transfers.forEach(t => {
+        const transfer = generateTransfer(
+          'testnet',
+          t.from.passphrase,
+          t.to.address,
+          t.amount,
+          1,
+        )[0]
+
+        const fromWallet = poolWalletManager.findByAddress(t.from.address)
+        const fromBalanceBefore = +fromWallet.balance
+        const toWallet = poolWalletManager.findByAddress(t.to.address)
+        const toBalanceBefore = +toWallet.balance
+
+        poolWalletManager.applyPoolTransaction(transfer)
+
+        expect(+fromWallet.balance).toBe(
+          fromBalanceBefore - t.amount - 0.1 * arktoshi,
+        )
+        expect(+toWallet.balance).toBe(toBalanceBefore + t.amount)
+      })
+
+      // check final balances
+      expect(+delegateWallet.balance).toBe(
+        delegate.balance + (-100 + 15 - 33 - 17 - 3 * 0.1) * arktoshi,
+      )
+      expect(+poolWallets[0].balance).toBe((100 - 55 - 0.1) * arktoshi)
+      expect(+poolWallets[1].balance).toBe((55 - 40 - 0.1 + 33) * arktoshi)
+      expect(+poolWallets[2].balance).toBe((40 - 15 - 0.1) * arktoshi)
+      expect(+poolWallets[3].balance).toBe(17 * arktoshi)
     })
   })
 })


### PR DESCRIPTION
## Proposed changes

Tests for "chained transfers" : for example A => B => C with B and C being cold wallets.

Default behavior now is B => C cannot happen if B didn't received first a transaction, forged in a block (so can't do A => B => C within the same block).

## Types of changes

- [x] Test (adding missing tests or fixing existing tests)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
