### PR TITLE
fix(core-snapshots-cli) fix app being declared twice

### DIFF
--- a/packages/core-snapshots-cli/bin/snapshot
+++ b/packages/core-snapshots-cli/bin/snapshot
@@ -1,12 +1,13 @@
 #!/usr/bin/env node
 
+const cli = require('commander')
 const util = require('../lib/utils')
 const app = require('@arkecosystem/core-container')
 
-app.version(require('../package.json').version)
+cli.version(require('../package.json').version)
 
 const registerCommand = (name, description) => {
-  return app
+  return cli
     .command(name)
     .description(description)
     .option('-d, --data <data>', 'data directory', '~/.ark')
@@ -60,12 +61,12 @@ registerCommand('truncate', 'truncate blockchain database')
     require('../lib/commands/truncate')(options)
   })
 
-app
+cli
   .command('*')
   .action(env => {
-    app.help()
+    cli.help()
     process.exit(0)
   })
 
 app.silentShutdown = true
-app.parse(process.argv)
+cli.parse(process.argv)

--- a/packages/core-snapshots-cli/bin/snapshot
+++ b/packages/core-snapshots-cli/bin/snapshot
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-const app = require('commander')
 const util = require('../lib/utils')
 const app = require('@arkecosystem/core-container')
 


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

`const app` was being declared twice, preventing the snapshot script to run. This fixed the issue and I was able to create, rollback and restore snapshots again.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [ ] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation (link is not working btw)
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
