### PR TITLE
feat(core-p2p): add hashid peer log for development networks

### DIFF
--- a/packages/core-p2p/lib/monitor.js
+++ b/packages/core-p2p/lib/monitor.js
@@ -65,8 +65,26 @@ class Monitor {
       groupBy(this.peers, 'version'),
     )) {
       logger.info(
-        `Discovered ${peers.length} peers with ${version} as version.`,
+        `Discovered ${pluralize(
+          'peer',
+          peers.length,
+          true,
+        )} with ${version} as version.`,
       )
+    }
+
+    if (config.network.name !== 'mainnet') {
+      for (const [hashid, peers] of Object.entries(
+        groupBy(this.peers, 'hashid'),
+      )) {
+        logger.info(
+          `Discovered ${pluralize(
+            'peer',
+            peers.length,
+            true,
+          )} with ${hashid} as hashid.`,
+        )
+      }
     }
 
     return this


### PR DESCRIPTION
## Proposed changes

Adds a log for the hashid of peers to easily see on start how many nodes run on which commit.

```
[2018-11-29 10:19:51][INFO]    : Discovered 94 peers with 2.0.0 as version.
[2018-11-29 10:19:51][INFO]    : Discovered 1 peer with 2890ec0 as hashid.
[2018-11-29 10:19:51][INFO]    : Discovered 6 peers with d2d2035 as hashid.
[2018-11-29 10:19:51][INFO]    : Discovered 1 peer with 4e8eba4 as hashid.
[2018-11-29 10:19:51][INFO]    : Discovered 1 peer with bc76f10 as hashid.
[2018-11-29 10:19:51][INFO]    : Discovered 1 peer with 83a4701 as hashid.
[2018-11-29 10:19:51][INFO]    : Discovered 1 peer with d675236 as hashid.
[2018-11-29 10:19:51][INFO]    : Discovered 1 peer with e02cf57 as hashid.
[2018-11-29 10:19:51][INFO]    : Discovered 30 peers with undefined as hashid.
[2018-11-29 10:19:51][INFO]    : Discovered 1 peer with c7c1ce7 as hashid.
[2018-11-29 10:19:51][INFO]    : Discovered 1 peer with 7490a6e as hashid.
[2018-11-29 10:19:51][INFO]    : Discovered 1 peer with c983661 as hashid.
[2018-11-29 10:19:51][INFO]    : Discovered 1 peer with 0a8c7e5 as hashid.
[2018-11-29 10:19:51][INFO]    : Discovered 1 peer with c728e65 as hashid.
[2018-11-29 10:19:51][INFO]    : Discovered 1 peer with 5ebaf11 as hashid.
[2018-11-29 10:19:51][INFO]    : Discovered 1 peer with 870ba51 as hashid.
[2018-11-29 10:19:51][INFO]    : Discovered 1 peer with bd74756 as hashid.
[2018-11-29 10:19:51][INFO]    : Discovered 1 peer with 085e085 as hashid.
[2018-11-29 10:19:51][INFO]    : Discovered 1 peer with e230873 as hashid.
[2018-11-29 10:19:51][INFO]    : Discovered 1 peer with 565754e as hashid.
[2018-11-29 10:19:51][INFO]    : Discovered 1 peer with 007a535 as hashid.
[2018-11-29 10:19:51][INFO]    : Discovered 1 peer with c8b5f68 as hashid.
[2018-11-29 10:19:51][INFO]    : Discovered 1 peer with d955375 as hashid.
[2018-11-29 10:19:51][INFO]    : Discovered 1 peer with 61a0683 as hashid.
[2018-11-29 10:19:51][INFO]    : Discovered 1 peer with c4b2b3d as hashid.
[2018-11-29 10:19:51][INFO]    : Discovered 1 peer with 5fce8d4 as hashid.
[2018-11-29 10:19:51][INFO]    : Discovered 1 peer with a121d25 as hashid.
[2018-11-29 10:19:51][INFO]    : Discovered 1 peer with c6828e3 as hashid.
[2018-11-29 10:19:51][INFO]    : Discovered 1 peer with aa61379 as hashid.
[2018-11-29 10:19:51][INFO]    : Discovered 1 peer with 2dc9f96 as hashid.
[2018-11-29 10:19:51][INFO]    : Discovered 1 peer with 1687b26 as hashid.
[2018-11-29 10:19:51][INFO]    : Discovered 1 peer with 5a79058 as hashid.
[2018-11-29 10:19:51][INFO]    : Discovered 1 peer with 2cc8e1e as hashid.
[2018-11-29 10:19:51][INFO]    : Discovered 1 peer with 0b5b1c4 as hashid.
[2018-11-29 10:19:51][INFO]    : Discovered 1 peer with 38a2e3c as hashid.
[2018-11-29 10:19:51][INFO]    : Discovered 1 peer with 4169f7c as hashid.
[2018-11-29 10:19:51][INFO]    : Discovered 1 peer with 8475a5e as hashid.
[2018-11-29 10:19:51][INFO]    : Discovered 1 peer with 8008fe2 as hashid.
[2018-11-29 10:19:51][INFO]    : Discovered 1 peer with fd9a815 as hashid.
[2018-11-29 10:19:51][INFO]    : Discovered 1 peer with 4263ad5 as hashid.
[2018-11-29 10:19:51][INFO]    : Discovered 1 peer with 39a749f as hashid.
[2018-11-29 10:19:51][INFO]    : Discovered 1 peer with c7e68c2 as hashid.
[2018-11-29 10:19:51][INFO]    : Discovered 7 peers with d2d20350 as hashid.
[2018-11-29 10:19:51][INFO]    : Discovered 1 peer with 1a1417c as hashid.
[2018-11-29 10:19:51][INFO]    : Discovered 1 peer with c7cf847 as hashid.
[2018-11-29 10:19:51][INFO]    : Discovered 1 peer with 4abd149 as hashid.
[2018-11-29 10:19:51][INFO]    : Discovered 1 peer with 54e9846 as hashid.
[2018-11-29 10:19:51][INFO]    : Discovered 1 peer with 65e2aa4 as hashid.
[2018-11-29 10:19:51][INFO]    : Discovered 1 peer with d9de5af as hashid.
[2018-11-29 10:19:51][INFO]    : Discovered 1 peer with d716168 as hashid.
[2018-11-29 10:19:51][INFO]    : Discovered 1 peer with 23fa4b8 as hashid.
[2018-11-29 10:19:51][INFO]    : Discovered 1 peer with fe12b3d as hashid.
[2018-11-29 10:19:51][INFO]    : Discovered 1 peer with 99a90fa as hashid.
[2018-11-29 10:19:51][INFO]    : Discovered 1 peer with 4dc6207 as hashid.
[2018-11-29 10:19:51][INFO]    : Discovered 1 peer with fb5032c as hashid.
```

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes