### PR TITLE
fix(core-p2p): do not show discovery logs when discovery is skipped

### DIFF
--- a/packages/core-p2p/lib/monitor.js
+++ b/packages/core-p2p/lib/monitor.js
@@ -55,35 +55,37 @@ class Monitor {
 
     this.__filterPeers()
 
-    this.config.skipDiscovery
-      ? logger.warn(
-          'Skipped peer discovery because the relay is in skip-discovery mode.',
-        )
-      : await this.updateNetworkStatus(options.networkStart)
-
-    for (const [version, peers] of Object.entries(
-      groupBy(this.peers, 'version'),
-    )) {
-      logger.info(
-        `Discovered ${pluralize(
-          'peer',
-          peers.length,
-          true,
-        )} with ${version} as version.`,
+    if (this.config.skipDiscovery) {
+      logger.warn(
+        'Skipped peer discovery because the relay is in skip-discovery mode.',
       )
-    }
+    } else {
+      await this.updateNetworkStatus(options.networkStart)
 
-    if (config.network.name !== 'mainnet') {
-      for (const [hashid, peers] of Object.entries(
-        groupBy(this.peers, 'hashid'),
+      for (const [version, peers] of Object.entries(
+        groupBy(this.peers, 'version'),
       )) {
         logger.info(
           `Discovered ${pluralize(
             'peer',
             peers.length,
             true,
-          )} with ${hashid} as hashid.`,
+          )} with ${version} as version.`,
         )
+      }
+
+      if (config.network.name !== 'mainnet') {
+        for (const [hashid, peers] of Object.entries(
+          groupBy(this.peers, 'hashid'),
+        )) {
+          logger.info(
+            `Discovered ${pluralize(
+              'peer',
+              peers.length,
+              true,
+            )} with ${hashid} as hashid.`,
+          )
+        }
       }
     }
 

--- a/packages/core-p2p/lib/monitor.js
+++ b/packages/core-p2p/lib/monitor.js
@@ -70,7 +70,7 @@ class Monitor {
             'peer',
             peers.length,
             true,
-          )} with ${version} as version.`,
+          )} with v${version}.`,
         )
       }
 
@@ -83,7 +83,7 @@ class Monitor {
               'peer',
               peers.length,
               true,
-            )} with ${hashid} as hashid.`,
+            )} on commit ${hashid}.`,
           )
         }
       }


### PR DESCRIPTION
## Proposed changes

The discovery logs were shown even if the discovery was skipped.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes