### PR TITLE
fix: call updateNetworkStatus with possible networkStart option

### DIFF
--- a/packages/core-p2p/lib/monitor.js
+++ b/packages/core-p2p/lib/monitor.js
@@ -152,7 +152,7 @@ class Monitor {
    */
   async updateNetworkStatusIfNotEnoughPeers() {
     if (!this.hasMinimumPeers() && process.env.ARK_ENV !== 'test') {
-      await this.updateNetworkStatus()
+      await this.updateNetworkStatus(this.config.networkStart)
     }
   }
 


### PR DESCRIPTION
## Proposed changes

When a node is launched with network start option, it should not discover peers.

Fix updateNetworkStatusIfNotEnoughPeers which was calling updateNetworkStatus without possible networkStart option, therefore making a node with network start option try to discover peers anyway.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes