### PR TITLE
fix(core-database-postgres): add missing block_id index to transactions table

### DIFF
--- a/packages/core-api/__tests__/v2/handlers/transactions.test.js
+++ b/packages/core-api/__tests__/v2/handlers/transactions.test.js
@@ -169,10 +169,10 @@ describe('API 2.0 - Transactions', () => {
         expect(response.data.data).toHaveLength(100)
         expect(response.data.meta.totalCount).toBe(153)
 
-        const transaction = response.data.data[0]
-        utils.expectTransaction(transaction)
-        expect(transaction.id).toBe(transactionId)
-        expect(transaction.blockId).toBe(blockId)
+        for (const transaction of response.data.data) {
+          utils.expectTransaction(transaction)
+          expect(transaction.blockId).toBe(blockId)
+        }
       })
     })
 

--- a/packages/core-database-postgres/lib/migrations/20181129400000-add-block_id-index-to-transactions-table.sql
+++ b/packages/core-database-postgres/lib/migrations/20181129400000-add-block_id-index-to-transactions-table.sql
@@ -1,0 +1,2 @@
+-- Constraints
+CREATE INDEX IF NOT EXISTS "transactions_block_id" ON transactions ("block_id");

--- a/packages/core-database-postgres/lib/migrations/index.js
+++ b/packages/core-database-postgres/lib/migrations/index.js
@@ -5,4 +5,5 @@ module.exports = [
   loadQueryFile(__dirname, './20180305200000-create-rounds-table.sql'),
   loadQueryFile(__dirname, './20180305300000-create-blocks-table.sql'),
   loadQueryFile(__dirname, './20180305400000-create-transactions-table.sql'),
+  loadQueryFile(__dirname, './20181129400000-add-block_id-index-to-transactions-table.sql'),
 ]


### PR DESCRIPTION
## Proposed changes

Adds a missing index on the block_id column to the transactions table.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes