### PR TITLE
fix(core-database): cast bignumber to string on insert

### DIFF
--- a/packages/core-database-postgres/lib/models/block.js
+++ b/packages/core-database-postgres/lib/models/block.js
@@ -40,16 +40,16 @@ module.exports = class Block extends Model {
       {
         name: 'total_amount',
         prop: 'totalAmount',
-        init: col => +bignumify(col.value).toFixed(),
+        init: col => bignumify(col.value).toFixed(),
       },
       {
         name: 'total_fee',
         prop: 'totalFee',
-        init: col => +bignumify(col.value).toFixed(),
+        init: col => bignumify(col.value).toFixed(),
       },
       {
         name: 'reward',
-        init: col => +bignumify(col.value).toFixed(),
+        init: col => bignumify(col.value).toFixed(),
       },
       {
         name: 'payload_length',

--- a/packages/core-database-postgres/lib/models/round.js
+++ b/packages/core-database-postgres/lib/models/round.js
@@ -23,7 +23,7 @@ module.exports = class Round extends Model {
       {
         name: 'balance',
         prop: 'voteBalance',
-        init: col => +bignumify(col.value).toFixed(),
+        init: col => bignumify(col.value).toFixed(),
       },
       {
         name: 'round',

--- a/packages/core-database-postgres/lib/models/transaction.js
+++ b/packages/core-database-postgres/lib/models/transaction.js
@@ -49,11 +49,11 @@ module.exports = class Transaction extends Model {
       },
       {
         name: 'amount',
-        init: col => +bignumify(col.value).toFixed(),
+        init: col => bignumify(col.value).toFixed(),
       },
       {
         name: 'fee',
-        init: col => +bignumify(col.value).toFixed(),
+        init: col => bignumify(col.value).toFixed(),
       },
       {
         name: 'serialized',

--- a/packages/core-database-postgres/lib/models/wallet.js
+++ b/packages/core-database-postgres/lib/models/wallet.js
@@ -35,12 +35,12 @@ module.exports = class WalletModel extends Model {
       },
       {
         name: 'balance',
-        init: col => +bignumify(col.value).toFixed(),
+        init: col => bignumify(col.value).toFixed(),
       },
       {
         name: 'vote_balance',
         prop: 'voteBalance',
-        init: col => (col.value ? +bignumify(col.value).toFixed() : null),
+        init: col => (col.value ? bignumify(col.value).toFixed() : null),
       },
       {
         name: 'produced_blocks',


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

The wallets rebuild is triggered too often, even though it shouldn't (i.e. clean shutdown). So the reason is that at startup there's a minor difference in balances:
```
dbWallet.balance: "12394029028487604"
inMemoryWallet.balance: "12394029028487605"
```
The issue is we cast the bignumber to a number on insert, which causes an overflow:
```
12394029028487605 > Number.MAX_SAFE_INTEGER
true

Number("12394029028487605")
12394029028487604
```

Fixed by casting to string instead of number. With that change I can't reproduce it anymore.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [ ] Docs (documentation only changes)
- [ ] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [ ] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
