### PR TITLE
fix(core-transaction-pool): pass correct transaction data

### DIFF
--- a/packages/core-transaction-pool/lib/interface.js
+++ b/packages/core-transaction-pool/lib/interface.js
@@ -198,35 +198,35 @@ module.exports = class TransactionPoolInterface {
    * @return {void}
    */
   acceptChainedBlock(block) {
-    for (const transaction of block.transactions) {
-      const exists = this.transactionExists(transaction.id)
-      const senderPublicKey = transaction.senderPublicKey
+    for (const { data } of block.transactions) {
+      const exists = this.transactionExists(data.id)
+      const senderPublicKey = data.senderPublicKey
 
       const senderWallet = this.walletManager.exists(senderPublicKey)
         ? this.walletManager.findByPublicKey(senderPublicKey)
         : false
 
-      const recipientWallet = this.walletManager.exists(transaction.recipientId)
-        ? this.walletManager.findByAddress(transaction.recipientId)
+      const recipientWallet = this.walletManager.exists(data.recipientId)
+        ? this.walletManager.findByAddress(data.recipientId)
         : false
 
       if (recipientWallet) {
-        recipientWallet.applyTransactionToRecipient(transaction)
+        recipientWallet.applyTransactionToRecipient(data)
       }
 
       if (exists) {
-        this.removeTransaction(transaction)
+        this.removeTransaction(data)
       } else if (senderWallet) {
         const errors = []
-        if (senderWallet.canApply(transaction, errors)) {
-          senderWallet.applyTransactionToSender(transaction)
+        if (senderWallet.canApply(data, errors)) {
+          senderWallet.applyTransactionToSender(data)
         } else {
-          this.purgeByPublicKey(transaction.senderPublicKey)
-          this.blockSender(transaction.senderPublicKey)
+          this.purgeByPublicKey(data.senderPublicKey)
+          this.blockSender(data.senderPublicKey)
 
           logger.error(
             `CanApply transaction test failed on acceptChainedBlock() in transaction pool for transaction id:${
-              transaction.id
+              data.id
             } due to ${JSON.stringify(
               errors,
             )}. Possible double spending attack :bomb:`,


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Passing `transaction` to `wallet.canApply` is wrong, as the timestamp is modified by the Block constructor to match its own timestamp.  We need to pass `transaction.data` as we only have here the unmodified timestamp  which was used to calculate the signature(s).

Second signature transactions no longer cause a double spend error.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->


- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [ ] Docs (documentation only changes)
- [ ] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [ ] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [X] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
