### PR TITLE
feat(core-api): allow block display via height in v2 API

### DIFF
--- a/packages/core-api/CHANGELOG.md
+++ b/packages/core-api/CHANGELOG.md
@@ -7,7 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Added
+
+- Allow block display via height in v2 API
+
 ### Fixed
+
 - Return the correct total count for `/api/v2/peers`
 
 ## 0.2.0 - 2018-12-03

--- a/packages/core-api/lib/repositories/blocks.js
+++ b/packages/core-api/lib/repositories/blocks.js
@@ -52,15 +52,18 @@ class BlocksRepository extends Repository {
 
   /**
    * Get a block.
-   * @param  {Number} id
+   * @param  {Number} value
    * @return {Object}
    */
-  async findById(id) {
+  async findById(value) {
     const query = this.query
       .select()
       .from(this.query)
-      .where(this.query.id.equals(id))
-      .or(this.query.height.equals(id))
+      .where(this.query.id.equals(value))
+
+    if (Number.isSafeInteger(value)) {
+      query.or(this.query.height.equals(value))
+    }
 
     return this._find(query)
   }

--- a/packages/core-api/lib/repositories/blocks.js
+++ b/packages/core-api/lib/repositories/blocks.js
@@ -60,6 +60,7 @@ class BlocksRepository extends Repository {
       .select()
       .from(this.query)
       .where(this.query.id.equals(id))
+      .or(this.query.height.equals(id))
 
     return this._find(query)
   }


### PR DESCRIPTION
## Proposed changes

Allows to display blocks via `http://localhost:4003/api/v2/blocks/14367` based on a height to remove the need to know the block ID.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes