### PR TITLE
chore(core-api): increase cache generation timeout for block and transaction endpoints

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,10 +72,11 @@ jobs:
             ./node_modules/.bin/cross-env ARK_ENV=test ./node_modules/.bin/jest
             ./packages/core-vote-report/ ./packages/core-transaction-pool/
             ./packages/core-snapshots-cli/ ./packages/core-logger-winston/
-            ./packages/core-http-utils/ ./packages/core-event-emitter/
+            ./packages/core-api/ ./packages/core-event-emitter/
             ./packages/core-elasticsearch/ ./packages/core-database-postgres/
-            ./packages/core-config/ ./packages/core/ --detectOpenHandles
-            --runInBand --forceExit --ci --coverage | tee test_output.txt
+            ./packages/core-config/ ./packages/core-http-utils/
+            --detectOpenHandles --runInBand --forceExit --ci --coverage | tee
+            test_output.txt
       - run:
           name: Last 1000 lines of test output
           when: on_fail
@@ -157,7 +158,7 @@ jobs:
             ./packages/core-test-utils/ ./packages/core-p2p/
             ./packages/core-json-rpc/ ./packages/core-forger/
             ./packages/core-error-tracker-bugsnag/ ./packages/core-debugger-cli/
-            ./packages/core-container/ ./packages/core-api/ --detectOpenHandles
+            ./packages/core-container/ ./packages/core/ --detectOpenHandles
             --runInBand --forceExit --ci --coverage | tee test_output.txt
       - run:
           name: Last 1000 lines of test output

--- a/packages/core-api/CHANGELOG.md
+++ b/packages/core-api/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Changed
+
+- Increase cache generation timeout for block and transaction endpoints
+
 ## 0.2.11 - 2018-12-05
 
 ### Fixed

--- a/packages/core-api/lib/versions/1/methods/blocks.js
+++ b/packages/core-api/lib/versions/1/methods/blocks.js
@@ -37,7 +37,7 @@ module.exports = server => {
   server.method('v1.blocks.index', index, {
     cache: {
       expiresIn: 8 * 1000,
-      generateTimeout: 3000,
+      generateTimeout: 8000,
       getDecoratedValue: true,
     },
     generateKey: request =>
@@ -50,7 +50,7 @@ module.exports = server => {
   server.method('v1.blocks.show', show, {
     cache: {
       expiresIn: 600 * 1000,
-      generateTimeout: 3000,
+      generateTimeout: 8000,
       getDecoratedValue: true,
     },
     generateKey: request => generateCacheKey({ id: request.query.id }),

--- a/packages/core-api/lib/versions/1/methods/transactions.js
+++ b/packages/core-api/lib/versions/1/methods/transactions.js
@@ -36,7 +36,7 @@ module.exports = server => {
   server.method('v1.transactions.index', index, {
     cache: {
       expiresIn: 8 * 1000,
-      generateTimeout: 3000,
+      generateTimeout: 8000,
       getDecoratedValue: true,
     },
     generateKey: request =>
@@ -49,7 +49,7 @@ module.exports = server => {
   server.method('v1.transactions.show', show, {
     cache: {
       expiresIn: 8 * 1000,
-      generateTimeout: 3000,
+      generateTimeout: 8000,
       getDecoratedValue: true,
     },
     generateKey: request => generateCacheKey({ id: request.query.id }),

--- a/packages/core-api/lib/versions/2/methods/blocks.js
+++ b/packages/core-api/lib/versions/2/methods/blocks.js
@@ -54,7 +54,7 @@ module.exports = server => {
   server.method('v2.blocks.index', index, {
     cache: {
       expiresIn: 8 * 1000,
-      generateTimeout: 3000,
+      generateTimeout: 8000,
       getDecoratedValue: true,
     },
     generateKey: request =>
@@ -67,7 +67,7 @@ module.exports = server => {
   server.method('v2.blocks.show', show, {
     cache: {
       expiresIn: 600 * 1000,
-      generateTimeout: 3000,
+      generateTimeout: 8000,
       getDecoratedValue: true,
     },
     generateKey: request => generateCacheKey({ id: request.params.id }),
@@ -76,7 +76,7 @@ module.exports = server => {
   server.method('v2.blocks.transactions', transactions, {
     cache: {
       expiresIn: 600 * 1000,
-      generateTimeout: 3000,
+      generateTimeout: 8000,
       getDecoratedValue: true,
     },
     generateKey: request =>
@@ -89,7 +89,7 @@ module.exports = server => {
   server.method('v2.blocks.search', search, {
     cache: {
       expiresIn: 30 * 1000,
-      generateTimeout: 3000,
+      generateTimeout: 8000,
       getDecoratedValue: true,
     },
     generateKey: request =>

--- a/packages/core-api/lib/versions/2/methods/delegates.js
+++ b/packages/core-api/lib/versions/2/methods/delegates.js
@@ -125,7 +125,7 @@ module.exports = server => {
   server.method('v2.delegates.blocks', blocks, {
     cache: {
       expiresIn: 8 * 1000,
-      generateTimeout: 3000,
+      generateTimeout: 8000,
       getDecoratedValue: true,
     },
     generateKey: request =>

--- a/packages/core-api/lib/versions/2/methods/transactions.js
+++ b/packages/core-api/lib/versions/2/methods/transactions.js
@@ -38,7 +38,7 @@ module.exports = server => {
   server.method('v2.transactions.index', index, {
     cache: {
       expiresIn: 8 * 1000,
-      generateTimeout: 3000,
+      generateTimeout: 8000,
       getDecoratedValue: true,
     },
     generateKey: request =>
@@ -51,7 +51,7 @@ module.exports = server => {
   server.method('v2.transactions.show', show, {
     cache: {
       expiresIn: 8 * 1000,
-      generateTimeout: 3000,
+      generateTimeout: 8000,
       getDecoratedValue: true,
     },
     generateKey: request => generateCacheKey({ id: request.params.id }),
@@ -60,7 +60,7 @@ module.exports = server => {
   server.method('v2.transactions.search', search, {
     cache: {
       expiresIn: 30 * 1000,
-      generateTimeout: 3000,
+      generateTimeout: 8000,
       getDecoratedValue: true,
     },
     generateKey: request =>

--- a/packages/core-api/lib/versions/2/methods/votes.js
+++ b/packages/core-api/lib/versions/2/methods/votes.js
@@ -35,7 +35,7 @@ module.exports = server => {
   server.method('v2.votes.index', index, {
     cache: {
       expiresIn: 8 * 1000,
-      generateTimeout: 3000,
+      generateTimeout: 8000,
       getDecoratedValue: true,
     },
     generateKey: request =>
@@ -48,7 +48,7 @@ module.exports = server => {
   server.method('v2.votes.show', show, {
     cache: {
       expiresIn: 8 * 1000,
-      generateTimeout: 3000,
+      generateTimeout: 8000,
       getDecoratedValue: true,
     },
     generateKey: request => generateCacheKey({ id: request.params.id }),

--- a/packages/core-api/lib/versions/2/methods/wallets.js
+++ b/packages/core-api/lib/versions/2/methods/wallets.js
@@ -151,7 +151,7 @@ module.exports = server => {
   server.method('v2.wallets.transactions', transactions, {
     cache: {
       expiresIn: 30 * 1000,
-      generateTimeout: 3000,
+      generateTimeout: 8000,
       getDecoratedValue: true,
     },
     generateKey: request =>
@@ -165,7 +165,7 @@ module.exports = server => {
   server.method('v2.wallets.transactionsSent', transactionsSent, {
     cache: {
       expiresIn: 30 * 1000,
-      generateTimeout: 3000,
+      generateTimeout: 8000,
       getDecoratedValue: true,
     },
     generateKey: request =>
@@ -179,7 +179,7 @@ module.exports = server => {
   server.method('v2.wallets.transactionsReceived', transactionsReceived, {
     cache: {
       expiresIn: 30 * 1000,
-      generateTimeout: 3000,
+      generateTimeout: 8000,
       getDecoratedValue: true,
     },
     generateKey: request =>
@@ -193,7 +193,7 @@ module.exports = server => {
   server.method('v2.wallets.votes', votes, {
     cache: {
       expiresIn: 30 * 1000,
-      generateTimeout: 3000,
+      generateTimeout: 8000,
       getDecoratedValue: true,
     },
     generateKey: request =>


### PR DESCRIPTION
## Proposed changes

Increasing the timeouts for block and transaction cache generation as it can take a long time on potatos that a lot of people run which results in a 503 status code.

## Types of changes

- [x] Other

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes