### PR TITLE
fix(core-api): ensure booleans for the cache timeout are handled

### DIFF
--- a/packages/core-api/CHANGELOG.md
+++ b/packages/core-api/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## 0.2.12 - 2018-12-05
+
 ### Changed
 
 - Increase cache generation timeout and make it configurable

--- a/packages/core-api/lib/versions/1/methods/accounts.js
+++ b/packages/core-api/lib/versions/1/methods/accounts.js
@@ -51,9 +51,7 @@ const publicKey = async request => {
 }
 
 module.exports = server => {
-  const {
-    generateTimeout,
-  } = require('@arkecosystem/core-container').resolveOptions('api').cache
+  const generateTimeout = require('../../utils').getCacheTimeout()
 
   server.method('v1.accounts.index', index, {
     cache: {

--- a/packages/core-api/lib/versions/1/methods/blocks.js
+++ b/packages/core-api/lib/versions/1/methods/blocks.js
@@ -34,9 +34,7 @@ const show = async request => {
 }
 
 module.exports = server => {
-  const {
-    generateTimeout,
-  } = require('@arkecosystem/core-container').resolveOptions('api').cache
+  const generateTimeout = require('../../utils').getCacheTimeout()
 
   server.method('v1.blocks.index', index, {
     cache: {

--- a/packages/core-api/lib/versions/1/methods/delegates.js
+++ b/packages/core-api/lib/versions/1/methods/delegates.js
@@ -71,9 +71,7 @@ const voters = async request => {
 }
 
 module.exports = server => {
-  const {
-    generateTimeout,
-  } = require('@arkecosystem/core-container').resolveOptions('api').cache
+  const generateTimeout = require('../../utils').getCacheTimeout()
 
   server.method('v1.delegates.index', index, {
     cache: {

--- a/packages/core-api/lib/versions/1/methods/transactions.js
+++ b/packages/core-api/lib/versions/1/methods/transactions.js
@@ -33,9 +33,7 @@ const show = async request => {
 }
 
 module.exports = server => {
-  const {
-    generateTimeout,
-  } = require('@arkecosystem/core-container').resolveOptions('api').cache
+  const generateTimeout = require('../../utils').getCacheTimeout()
 
   server.method('v1.transactions.index', index, {
     cache: {

--- a/packages/core-api/lib/versions/2/methods/blocks.js
+++ b/packages/core-api/lib/versions/2/methods/blocks.js
@@ -51,9 +51,7 @@ const search = async request => {
 }
 
 module.exports = server => {
-  const {
-    generateTimeout,
-  } = require('@arkecosystem/core-container').resolveOptions('api').cache
+  const generateTimeout = require('../../utils').getCacheTimeout()
 
   server.method('v2.blocks.index', index, {
     cache: {

--- a/packages/core-api/lib/versions/2/methods/delegates.js
+++ b/packages/core-api/lib/versions/2/methods/delegates.js
@@ -86,9 +86,7 @@ const voterBalances = async request => {
 }
 
 module.exports = server => {
-  const {
-    generateTimeout,
-  } = require('@arkecosystem/core-container').resolveOptions('api').cache
+  const generateTimeout = require('../../utils').getCacheTimeout()
 
   server.method('v2.delegates.index', index, {
     cache: {

--- a/packages/core-api/lib/versions/2/methods/transactions.js
+++ b/packages/core-api/lib/versions/2/methods/transactions.js
@@ -35,9 +35,7 @@ const search = async request => {
 }
 
 module.exports = server => {
-  const {
-    generateTimeout,
-  } = require('@arkecosystem/core-container').resolveOptions('api').cache
+  const generateTimeout = require('../../utils').getCacheTimeout()
 
   server.method('v2.transactions.index', index, {
     cache: {

--- a/packages/core-api/lib/versions/2/methods/votes.js
+++ b/packages/core-api/lib/versions/2/methods/votes.js
@@ -32,9 +32,7 @@ const show = async request => {
 }
 
 module.exports = server => {
-  const {
-    generateTimeout,
-  } = require('@arkecosystem/core-container').resolveOptions('api').cache
+  const generateTimeout = require('../../utils').getCacheTimeout()
 
   server.method('v2.votes.index', index, {
     cache: {

--- a/packages/core-api/lib/versions/2/methods/wallets.js
+++ b/packages/core-api/lib/versions/2/methods/wallets.js
@@ -116,9 +116,7 @@ const search = async request => {
 }
 
 module.exports = server => {
-  const {
-    generateTimeout,
-  } = require('@arkecosystem/core-container').resolveOptions('api').cache
+  const generateTimeout = require('../../utils').getCacheTimeout()
 
   server.method('v2.wallets.index', index, {
     cache: {

--- a/packages/core-api/lib/versions/utils.js
+++ b/packages/core-api/lib/versions/utils.js
@@ -1,0 +1,7 @@
+exports.getCacheTimeout = () => {
+  const {
+    generateTimeout,
+  } = require('@arkecosystem/core-container').resolveOptions('api').cache
+
+  return JSON.parse(generateTimeout)
+}

--- a/packages/core-api/package.json
+++ b/packages/core-api/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@arkecosystem/core-api",
   "description": "Public API for Ark Core",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "contributors": [
     "Kristjan Košič <kristjan@ark.io>",
     "Brian Faust <brian@ark.io>"


### PR DESCRIPTION
## Proposed changes

Ensures that booleans and numbers are properly handled for the `generateTimeout` config.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes