### PR TITLE
fix(core-json-rpc): return the encoded WIF for BIP38 wallets instead of the encrypted WIF

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,11 +72,10 @@ jobs:
             ./node_modules/.bin/cross-env ARK_ENV=test ./node_modules/.bin/jest
             ./packages/core-vote-report/ ./packages/core-transaction-pool/
             ./packages/core-snapshots-cli/ ./packages/core-logger-winston/
-            ./packages/core-api/ ./packages/core-event-emitter/
+            ./packages/core-http-utils/ ./packages/core-event-emitter/
             ./packages/core-elasticsearch/ ./packages/core-database-postgres/
-            ./packages/core-config/ ./packages/core-http-utils/
-            --detectOpenHandles --runInBand --forceExit --ci --coverage | tee
-            test_output.txt
+            ./packages/core-config/ ./packages/core/ --detectOpenHandles
+            --runInBand --forceExit --ci --coverage | tee test_output.txt
       - run:
           name: Last 1000 lines of test output
           when: on_fail
@@ -158,7 +157,7 @@ jobs:
             ./packages/core-test-utils/ ./packages/core-p2p/
             ./packages/core-json-rpc/ ./packages/core-forger/
             ./packages/core-error-tracker-bugsnag/ ./packages/core-debugger-cli/
-            ./packages/core-container/ ./packages/core/ --detectOpenHandles
+            ./packages/core-container/ ./packages/core-api/ --detectOpenHandles
             --runInBand --forceExit --ci --coverage | tee test_output.txt
       - run:
           name: Last 1000 lines of test output

--- a/packages/core-json-rpc/CHANGELOG.md
+++ b/packages/core-json-rpc/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Properly handle bip38 creation and reading for wallets
+- Return the encoded WIF for BIP38 wallets instead of the encrypted WIF
 
 ## 0.2.0 - 2018-12-03
 

--- a/packages/core-json-rpc/CHANGELOG.md
+++ b/packages/core-json-rpc/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Fixed
+
+- Properly handle bip38 creation and reading for wallets
+
 ## 0.2.0 - 2018-12-03
 
 ### Changed

--- a/packages/core-json-rpc/__tests__/wallets.test.js
+++ b/packages/core-json-rpc/__tests__/wallets.test.js
@@ -169,14 +169,20 @@ describe('Wallets', () => {
 
     describe('info', () => {
       it('should find the wallet for the given userId', async () => {
-        const response = await request('wallets.bip38.info', { userId })
+        const response = await request('wallets.bip38.info', {
+          bip38: 'this is a top secret passphrase',
+          userId,
+        })
 
+        expect(response.data.result).toHaveProperty('address')
+        expect(response.data.result).toHaveProperty('publicKey')
         expect(response.data.result).toHaveProperty('wif')
         expect(response.data.result.wif).toBe(bip38wif)
       })
 
       it('should fail to find the wallet for the given userId', async () => {
         const response = await request('wallets.bip38.info', {
+          bip38: 'invalid',
           userId: '123456789',
         })
 

--- a/packages/core-json-rpc/lib/server/methods/blocks/latest.js
+++ b/packages/core-json-rpc/lib/server/methods/blocks/latest.js
@@ -1,3 +1,4 @@
+const Boom = require('boom')
 const network = require('../../services/network')
 
 module.exports = {
@@ -7,6 +8,8 @@ module.exports = {
       'blocks?orderBy=height:desc&limit=1',
     )
 
-    return response.data[0]
+    return response
+      ? response.data[0]
+      : Boom.notFound(`Latest block could not be found.`)
   },
 }

--- a/packages/core-json-rpc/lib/server/methods/wallets/bip38/create.js
+++ b/packages/core-json-rpc/lib/server/methods/wallets/bip38/create.js
@@ -4,6 +4,7 @@ const bip39 = require('bip39')
 const bip38 = require('bip38')
 const database = require('../../../services/database')
 const getBIP38Wallet = require('../../../utils/bip38-keys')
+const decryptWIF = require('../../../utils/decrypt-wif')
 
 module.exports = {
   name: 'wallets.bip38.create',
@@ -19,20 +20,22 @@ module.exports = {
     } catch (error) {
       const { publicKey, privateKey } = crypto.getKeys(bip39.generateMnemonic())
 
-      const encryptedWif = bip38.encrypt(
+      const encryptedWIF = bip38.encrypt(
         Buffer.from(privateKey, 'hex'),
         true,
         params.bip38 + params.userId,
       )
       await database.set(
         utils.sha256(Buffer.from(params.userId)).toString('hex'),
-        encryptedWif,
+        encryptedWIF,
       )
+
+      const { wif } = decryptWIF(encryptedWIF, params.userId, params.bip38)
 
       return {
         publicKey,
         address: crypto.getAddress(publicKey),
-        wif: encryptedWif,
+        wif,
       }
     }
   },

--- a/packages/core-json-rpc/lib/server/methods/wallets/bip38/show.js
+++ b/packages/core-json-rpc/lib/server/methods/wallets/bip38/show.js
@@ -1,20 +1,31 @@
 const Boom = require('boom')
 const Joi = require('joi')
-const { utils } = require('@arkecosystem/crypto')
+const bip38 = require('bip38')
+const { crypto, utils } = require('@arkecosystem/crypto')
 const database = require('../../../services/database')
+const decryptWIF = require('../../../utils/decrypt-wif')
 
 module.exports = {
   name: 'wallets.bip38.info',
   async method(params) {
-    const wif = await database.get(
+    const encryptedWIF = await database.get(
       utils.sha256(Buffer.from(params.userId)).toString('hex'),
     )
 
-    return wif
-      ? { wif }
-      : Boom.notFound(`User ${params.userId} could not be found.`)
+    if (!encryptedWIF) {
+      return Boom.notFound(`User ${params.userId} could not be found.`)
+    }
+
+    const { keys, wif } = decryptWIF(encryptedWIF, params.userId, params.bip38)
+
+    return {
+      publicKey: keys.publicKey,
+      address: crypto.getAddress(keys.publicKey),
+      wif,
+    }
   },
   schema: {
+    bip38: Joi.string().required(),
     userId: Joi.string()
       .hex()
       .required(),

--- a/packages/core-json-rpc/lib/server/utils/bip38-keys.js
+++ b/packages/core-json-rpc/lib/server/utils/bip38-keys.js
@@ -2,6 +2,7 @@ const { configManager, crypto, utils } = require('@arkecosystem/crypto')
 const bip38 = require('bip38')
 const wif = require('wif')
 const database = require('../services/database')
+const decryptWIF = require('./decrypt-wif')
 
 module.exports = async (userId, bip38password) => {
   try {
@@ -10,18 +11,7 @@ module.exports = async (userId, bip38password) => {
     )
 
     if (encryptedWif) {
-      const decrypted = bip38.decrypt(
-        encryptedWif.toString('hex'),
-        bip38password + userId,
-      )
-      const wifKey = wif.encode(
-        configManager.get('wif'),
-        decrypted.privateKey,
-        decrypted.compressed,
-      )
-      const keys = crypto.getKeysFromWIF(wifKey)
-
-      return { keys, wif: wifKey }
+      return decryptWIF(encryptedWif, userId, bip38password)
     }
   } catch (error) {
     throw Error('Could not find a matching WIF')

--- a/packages/core-json-rpc/lib/server/utils/decrypt-wif.js
+++ b/packages/core-json-rpc/lib/server/utils/decrypt-wif.js
@@ -1,0 +1,18 @@
+const { configManager, crypto } = require('@arkecosystem/crypto')
+const bip38 = require('bip38')
+const wif = require('wif')
+
+module.exports = (encryptedWif, userId, bip38password) => {
+  const decrypted = bip38.decrypt(
+    encryptedWif.toString('hex'),
+    bip38password + userId,
+  )
+
+  const encodedWIF = wif.encode(
+    configManager.get('wif'),
+    decrypted.privateKey,
+    decrypted.compressed,
+  )
+
+  return { keys: crypto.getKeysFromWIF(encodedWIF), wif: encodedWIF }
+}


### PR DESCRIPTION
## Proposed changes

Resolves https://github.com/ArkEcosystem/core/issues/1644 and also changes how BIP38 wallets are accessed.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x Lint and unit tests pass locally with my changes