### PR TITLE
fix: reply, on node configuration API endpoint, with integer ports

### DIFF
--- a/packages/core-api/__tests__/v2/handlers/node.test.js
+++ b/packages/core-api/__tests__/v2/handlers/node.test.js
@@ -61,6 +61,10 @@ describe('API 2.0 - Loader', () => {
         expect(response.data.data.symbol).toBeString()
         expect(response.data.data.explorer).toBeString()
         expect(response.data.data.version).toBeNumber()
+
+        Object.values(response.data.data.ports).forEach(port => {
+          expect(port).toBeNumber()
+        })
       })
     })
   })

--- a/packages/core-api/lib/versions/2/handlers/node.js
+++ b/packages/core-api/lib/versions/2/handlers/node.js
@@ -63,6 +63,9 @@ exports.configuration = {
    */
   async handler(request, h) {
     const feeStatisticsData = await transactions.getFeeStatistics()
+    const ports = utils
+      .toResource(request, config, 'ports')
+      .map(port => parseInt(port))
 
     return {
       data: {
@@ -71,7 +74,7 @@ exports.configuration = {
         symbol: config.network.client.symbol,
         explorer: config.network.client.explorer,
         version: config.network.pubKeyHash,
-        ports: utils.toResource(request, config, 'ports'),
+        ports,
         constants: config.getConstants(blockchain.getLastBlock().data.height),
         feeStatistics: utils.toCollection(
           request,

--- a/packages/core-api/lib/versions/2/handlers/node.js
+++ b/packages/core-api/lib/versions/2/handlers/node.js
@@ -63,9 +63,6 @@ exports.configuration = {
    */
   async handler(request, h) {
     const feeStatisticsData = await transactions.getFeeStatistics()
-    const ports = utils
-      .toResource(request, config, 'ports')
-      .map(port => parseInt(port))
 
     return {
       data: {
@@ -74,7 +71,7 @@ exports.configuration = {
         symbol: config.network.client.symbol,
         explorer: config.network.client.explorer,
         version: config.network.pubKeyHash,
-        ports,
+        ports: utils.toResource(request, config, 'ports'),
         constants: config.getConstants(blockchain.getLastBlock().data.height),
         feeStatistics: utils.toCollection(
           request,

--- a/packages/core-api/lib/versions/2/transformers/ports.js
+++ b/packages/core-api/lib/versions/2/transformers/ports.js
@@ -13,17 +13,17 @@ module.exports = config => {
     '@arkecosystem/core-webhooks',
   ]
 
-  result[keys[0]] = config.plugins[keys[0]].port
+  result[keys[0]] = parseInt(config.plugins[keys[0]].port)
 
   for (const [name, options] of Object.entries(config.plugins)) {
     if (keys.includes(name) && options.enabled) {
       if (options.server && options.server.enabled) {
-        result[name] = options.server.port
+        result[name] = parseInt(options.server.port)
 
         continue
       }
 
-      result[name] = options.port
+      result[name] = parseInt(options.port)
     }
   }
 


### PR DESCRIPTION
## Proposed changes
Devnet and Mainnet were returning a different type on the node configuration endpoint (http://167.114.29.54:4003/api/v2/node/configuration). It may be caused by loading the ports from the environment, configuration files, or other causes.

This PR enforces that, independently of the cause, the API ports of the response, are always integers.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Test (adding missing tests or fixing existing tests)

## Checklist
- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works