### PR TITLE
fix(core-api): ensure safe integer range for block height lookups

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,92 @@ jobs:
       - save_cache:
           key: 'core-node10-{{ checksum "checksum.txt" }}-1'
           paths:
+            - ./packages/.DS_Store/node_modules
+            - ./packages/core/node_modules
+            - ./packages/core-api/node_modules
+            - ./packages/core-blockchain/node_modules
+            - ./packages/core-config/node_modules
+            - ./packages/core-container/node_modules
+            - ./packages/core-database/node_modules
+            - ./packages/core-database-postgres/node_modules
+            - ./packages/core-debugger-cli/node_modules
+            - ./packages/core-deployer/node_modules
+            - ./packages/core-elasticsearch/node_modules
+            - ./packages/core-error-tracker-bugsnag/node_modules
+            - ./packages/core-error-tracker-sentry/node_modules
+            - ./packages/core-event-emitter/node_modules
+            - ./packages/core-forger/node_modules
+            - ./packages/core-graphql/node_modules
+            - ./packages/core-http-utils/node_modules
+            - ./packages/core-json-rpc/node_modules
+            - ./packages/core-logger/node_modules
+            - ./packages/core-logger-winston/node_modules
+            - ./packages/core-p2p/node_modules
+            - ./packages/core-snapshots/node_modules
+            - ./packages/core-snapshots-cli/node_modules
+            - ./packages/core-test-utils/node_modules
+            - ./packages/core-tester-cli/node_modules
+            - ./packages/core-transaction-pool/node_modules
+            - ./packages/core-transaction-pool-mem/node_modules
+            - ./packages/core-utils/node_modules
+            - ./packages/core-vote-report/node_modules
+            - ./packages/core-webhooks/node_modules
+            - ./packages/crypto/node_modules
+            - ./node_modules
+      - run:
+          name: Create .ark/database directory
+          command: mkdir -p $HOME/.ark/database
+      - run:
+          name: Test
+          command: >
+            ./node_modules/.bin/cross-env ARK_ENV=test ./node_modules/.bin/jest
+            ./packages/crypto/ ./packages/core-utils/
+            ./packages/core-tester-cli/ ./packages/core-snapshots/
+            ./packages/core-logger/ ./packages/core/
+            ./packages/core-error-tracker-sentry/ ./packages/core-deployer/
+            ./packages/core-database/ ./packages/core-blockchain/
+            ./packages/core-graphql/ --detectOpenHandles --runInBand --forceExit
+            --ci --coverage | tee test_output.txt
+      - run:
+          name: Last 1000 lines of test output
+          when: on_fail
+          command: tail -n 1000 test_output.txt
+      - run:
+          name: Codecov
+          command: ./node_modules/.bin/codecov
+  test-node10-1:
+    working_directory: ~/ark-core
+    docker:
+      - image: 'circleci/node:10-browsers'
+      - image: 'postgres:alpine'
+        environment:
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: ark_development
+          POSTGRES_USER: ark
+    steps:
+      - checkout
+      - run:
+          name: Apt update
+          command: >-
+            sudo sh -c 'echo "deb http://ftp.debian.org/debian stable main
+            contrib non-free" >> /etc/apt/sources.list' && sudo apt-get update
+      - run:
+          name: Install xsel
+          command: sudo apt-get install -q xsel
+      - run:
+          name: Generate cache key
+          command: >-
+            find ./packages/ -name package.json -print0 | sort -z | xargs -r0
+            echo ./package.json | xargs md5sum | md5sum - > checksum.txt
+      - restore_cache:
+          key: 'core-node10-{{ checksum "checksum.txt" }}-1'
+      - run:
+          name: Install packages
+          command: yarn
+      - save_cache:
+          key: 'core-node10-{{ checksum "checksum.txt" }}-1'
+          paths:
+            - ./packages/.DS_Store/node_modules
             - ./packages/core/node_modules
             - ./packages/core-api/node_modules
             - ./packages/core-blockchain/node_modules
@@ -74,7 +160,7 @@ jobs:
             ./packages/core-snapshots-cli/ ./packages/core-logger-winston/
             ./packages/core-http-utils/ ./packages/core-event-emitter/
             ./packages/core-elasticsearch/ ./packages/core-database-postgres/
-            ./packages/core-config/ ./packages/core/ --detectOpenHandles
+            ./packages/core-config/ ./packages/.DS_Store/ --detectOpenHandles
             --runInBand --forceExit --ci --coverage | tee test_output.txt
       - run:
           name: Last 1000 lines of test output
@@ -83,7 +169,7 @@ jobs:
       - run:
           name: Codecov
           command: ./node_modules/.bin/codecov
-  test-node10-1:
+  test-node10-2:
     working_directory: ~/ark-core
     docker:
       - image: 'circleci/node:10-browsers'
@@ -115,6 +201,7 @@ jobs:
       - save_cache:
           key: 'core-node10-{{ checksum "checksum.txt" }}-1'
           paths:
+            - ./packages/.DS_Store/node_modules
             - ./packages/core/node_modules
             - ./packages/core-api/node_modules
             - ./packages/core-blockchain/node_modules
@@ -159,90 +246,6 @@ jobs:
             ./packages/core-error-tracker-bugsnag/ ./packages/core-debugger-cli/
             ./packages/core-container/ ./packages/core-api/ --detectOpenHandles
             --runInBand --forceExit --ci --coverage | tee test_output.txt
-      - run:
-          name: Last 1000 lines of test output
-          when: on_fail
-          command: tail -n 1000 test_output.txt
-      - run:
-          name: Codecov
-          command: ./node_modules/.bin/codecov
-  test-node10-2:
-    working_directory: ~/ark-core
-    docker:
-      - image: 'circleci/node:10-browsers'
-      - image: 'postgres:alpine'
-        environment:
-          POSTGRES_PASSWORD: password
-          POSTGRES_DB: ark_development
-          POSTGRES_USER: ark
-    steps:
-      - checkout
-      - run:
-          name: Apt update
-          command: >-
-            sudo sh -c 'echo "deb http://ftp.debian.org/debian stable main
-            contrib non-free" >> /etc/apt/sources.list' && sudo apt-get update
-      - run:
-          name: Install xsel
-          command: sudo apt-get install -q xsel
-      - run:
-          name: Generate cache key
-          command: >-
-            find ./packages/ -name package.json -print0 | sort -z | xargs -r0
-            echo ./package.json | xargs md5sum | md5sum - > checksum.txt
-      - restore_cache:
-          key: 'core-node10-{{ checksum "checksum.txt" }}-1'
-      - run:
-          name: Install packages
-          command: yarn
-      - save_cache:
-          key: 'core-node10-{{ checksum "checksum.txt" }}-1'
-          paths:
-            - ./packages/core/node_modules
-            - ./packages/core-api/node_modules
-            - ./packages/core-blockchain/node_modules
-            - ./packages/core-config/node_modules
-            - ./packages/core-container/node_modules
-            - ./packages/core-database/node_modules
-            - ./packages/core-database-postgres/node_modules
-            - ./packages/core-debugger-cli/node_modules
-            - ./packages/core-deployer/node_modules
-            - ./packages/core-elasticsearch/node_modules
-            - ./packages/core-error-tracker-bugsnag/node_modules
-            - ./packages/core-error-tracker-sentry/node_modules
-            - ./packages/core-event-emitter/node_modules
-            - ./packages/core-forger/node_modules
-            - ./packages/core-graphql/node_modules
-            - ./packages/core-http-utils/node_modules
-            - ./packages/core-json-rpc/node_modules
-            - ./packages/core-logger/node_modules
-            - ./packages/core-logger-winston/node_modules
-            - ./packages/core-p2p/node_modules
-            - ./packages/core-snapshots/node_modules
-            - ./packages/core-snapshots-cli/node_modules
-            - ./packages/core-test-utils/node_modules
-            - ./packages/core-tester-cli/node_modules
-            - ./packages/core-transaction-pool/node_modules
-            - ./packages/core-transaction-pool-mem/node_modules
-            - ./packages/core-utils/node_modules
-            - ./packages/core-vote-report/node_modules
-            - ./packages/core-webhooks/node_modules
-            - ./packages/crypto/node_modules
-            - ./node_modules
-      - run:
-          name: Create .ark/database directory
-          command: mkdir -p $HOME/.ark/database
-      - run:
-          name: Test
-          command: >
-            ./node_modules/.bin/cross-env ARK_ENV=test ./node_modules/.bin/jest
-            ./packages/crypto/ ./packages/core-utils/
-            ./packages/core-tester-cli/ ./packages/core-snapshots/
-            ./packages/core-logger/ ./packages/core-graphql/
-            ./packages/core-error-tracker-sentry/ ./packages/core-deployer/
-            ./packages/core-database/ ./packages/core-blockchain/
-            --detectOpenHandles --runInBand --forceExit --ci --coverage | tee
-            test_output.txt
       - run:
           name: Last 1000 lines of test output
           when: on_fail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,92 +32,6 @@ jobs:
       - save_cache:
           key: 'core-node10-{{ checksum "checksum.txt" }}-1'
           paths:
-            - ./packages/.DS_Store/node_modules
-            - ./packages/core/node_modules
-            - ./packages/core-api/node_modules
-            - ./packages/core-blockchain/node_modules
-            - ./packages/core-config/node_modules
-            - ./packages/core-container/node_modules
-            - ./packages/core-database/node_modules
-            - ./packages/core-database-postgres/node_modules
-            - ./packages/core-debugger-cli/node_modules
-            - ./packages/core-deployer/node_modules
-            - ./packages/core-elasticsearch/node_modules
-            - ./packages/core-error-tracker-bugsnag/node_modules
-            - ./packages/core-error-tracker-sentry/node_modules
-            - ./packages/core-event-emitter/node_modules
-            - ./packages/core-forger/node_modules
-            - ./packages/core-graphql/node_modules
-            - ./packages/core-http-utils/node_modules
-            - ./packages/core-json-rpc/node_modules
-            - ./packages/core-logger/node_modules
-            - ./packages/core-logger-winston/node_modules
-            - ./packages/core-p2p/node_modules
-            - ./packages/core-snapshots/node_modules
-            - ./packages/core-snapshots-cli/node_modules
-            - ./packages/core-test-utils/node_modules
-            - ./packages/core-tester-cli/node_modules
-            - ./packages/core-transaction-pool/node_modules
-            - ./packages/core-transaction-pool-mem/node_modules
-            - ./packages/core-utils/node_modules
-            - ./packages/core-vote-report/node_modules
-            - ./packages/core-webhooks/node_modules
-            - ./packages/crypto/node_modules
-            - ./node_modules
-      - run:
-          name: Create .ark/database directory
-          command: mkdir -p $HOME/.ark/database
-      - run:
-          name: Test
-          command: >
-            ./node_modules/.bin/cross-env ARK_ENV=test ./node_modules/.bin/jest
-            ./packages/crypto/ ./packages/core-utils/
-            ./packages/core-tester-cli/ ./packages/core-snapshots/
-            ./packages/core-logger/ ./packages/core/
-            ./packages/core-error-tracker-sentry/ ./packages/core-deployer/
-            ./packages/core-database/ ./packages/core-blockchain/
-            ./packages/core-graphql/ --detectOpenHandles --runInBand --forceExit
-            --ci --coverage | tee test_output.txt
-      - run:
-          name: Last 1000 lines of test output
-          when: on_fail
-          command: tail -n 1000 test_output.txt
-      - run:
-          name: Codecov
-          command: ./node_modules/.bin/codecov
-  test-node10-1:
-    working_directory: ~/ark-core
-    docker:
-      - image: 'circleci/node:10-browsers'
-      - image: 'postgres:alpine'
-        environment:
-          POSTGRES_PASSWORD: password
-          POSTGRES_DB: ark_development
-          POSTGRES_USER: ark
-    steps:
-      - checkout
-      - run:
-          name: Apt update
-          command: >-
-            sudo sh -c 'echo "deb http://ftp.debian.org/debian stable main
-            contrib non-free" >> /etc/apt/sources.list' && sudo apt-get update
-      - run:
-          name: Install xsel
-          command: sudo apt-get install -q xsel
-      - run:
-          name: Generate cache key
-          command: >-
-            find ./packages/ -name package.json -print0 | sort -z | xargs -r0
-            echo ./package.json | xargs md5sum | md5sum - > checksum.txt
-      - restore_cache:
-          key: 'core-node10-{{ checksum "checksum.txt" }}-1'
-      - run:
-          name: Install packages
-          command: yarn
-      - save_cache:
-          key: 'core-node10-{{ checksum "checksum.txt" }}-1'
-          paths:
-            - ./packages/.DS_Store/node_modules
             - ./packages/core/node_modules
             - ./packages/core-api/node_modules
             - ./packages/core-blockchain/node_modules
@@ -158,10 +72,11 @@ jobs:
             ./node_modules/.bin/cross-env ARK_ENV=test ./node_modules/.bin/jest
             ./packages/core-vote-report/ ./packages/core-transaction-pool/
             ./packages/core-snapshots-cli/ ./packages/core-logger-winston/
-            ./packages/core-http-utils/ ./packages/core-event-emitter/
+            ./packages/core-api/ ./packages/core-event-emitter/
             ./packages/core-elasticsearch/ ./packages/core-database-postgres/
-            ./packages/core-config/ ./packages/.DS_Store/ --detectOpenHandles
-            --runInBand --forceExit --ci --coverage | tee test_output.txt
+            ./packages/core-config/ ./packages/core-http-utils/
+            --detectOpenHandles --runInBand --forceExit --ci --coverage | tee
+            test_output.txt
       - run:
           name: Last 1000 lines of test output
           when: on_fail
@@ -169,7 +84,7 @@ jobs:
       - run:
           name: Codecov
           command: ./node_modules/.bin/codecov
-  test-node10-2:
+  test-node10-1:
     working_directory: ~/ark-core
     docker:
       - image: 'circleci/node:10-browsers'
@@ -201,7 +116,6 @@ jobs:
       - save_cache:
           key: 'core-node10-{{ checksum "checksum.txt" }}-1'
           paths:
-            - ./packages/.DS_Store/node_modules
             - ./packages/core/node_modules
             - ./packages/core-api/node_modules
             - ./packages/core-blockchain/node_modules
@@ -244,8 +158,92 @@ jobs:
             ./packages/core-test-utils/ ./packages/core-p2p/
             ./packages/core-json-rpc/ ./packages/core-forger/
             ./packages/core-error-tracker-bugsnag/ ./packages/core-debugger-cli/
-            ./packages/core-container/ ./packages/core-api/ --detectOpenHandles
+            ./packages/core-container/ ./packages/core/ --detectOpenHandles
             --runInBand --forceExit --ci --coverage | tee test_output.txt
+      - run:
+          name: Last 1000 lines of test output
+          when: on_fail
+          command: tail -n 1000 test_output.txt
+      - run:
+          name: Codecov
+          command: ./node_modules/.bin/codecov
+  test-node10-2:
+    working_directory: ~/ark-core
+    docker:
+      - image: 'circleci/node:10-browsers'
+      - image: 'postgres:alpine'
+        environment:
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: ark_development
+          POSTGRES_USER: ark
+    steps:
+      - checkout
+      - run:
+          name: Apt update
+          command: >-
+            sudo sh -c 'echo "deb http://ftp.debian.org/debian stable main
+            contrib non-free" >> /etc/apt/sources.list' && sudo apt-get update
+      - run:
+          name: Install xsel
+          command: sudo apt-get install -q xsel
+      - run:
+          name: Generate cache key
+          command: >-
+            find ./packages/ -name package.json -print0 | sort -z | xargs -r0
+            echo ./package.json | xargs md5sum | md5sum - > checksum.txt
+      - restore_cache:
+          key: 'core-node10-{{ checksum "checksum.txt" }}-1'
+      - run:
+          name: Install packages
+          command: yarn
+      - save_cache:
+          key: 'core-node10-{{ checksum "checksum.txt" }}-1'
+          paths:
+            - ./packages/core/node_modules
+            - ./packages/core-api/node_modules
+            - ./packages/core-blockchain/node_modules
+            - ./packages/core-config/node_modules
+            - ./packages/core-container/node_modules
+            - ./packages/core-database/node_modules
+            - ./packages/core-database-postgres/node_modules
+            - ./packages/core-debugger-cli/node_modules
+            - ./packages/core-deployer/node_modules
+            - ./packages/core-elasticsearch/node_modules
+            - ./packages/core-error-tracker-bugsnag/node_modules
+            - ./packages/core-error-tracker-sentry/node_modules
+            - ./packages/core-event-emitter/node_modules
+            - ./packages/core-forger/node_modules
+            - ./packages/core-graphql/node_modules
+            - ./packages/core-http-utils/node_modules
+            - ./packages/core-json-rpc/node_modules
+            - ./packages/core-logger/node_modules
+            - ./packages/core-logger-winston/node_modules
+            - ./packages/core-p2p/node_modules
+            - ./packages/core-snapshots/node_modules
+            - ./packages/core-snapshots-cli/node_modules
+            - ./packages/core-test-utils/node_modules
+            - ./packages/core-tester-cli/node_modules
+            - ./packages/core-transaction-pool/node_modules
+            - ./packages/core-transaction-pool-mem/node_modules
+            - ./packages/core-utils/node_modules
+            - ./packages/core-vote-report/node_modules
+            - ./packages/core-webhooks/node_modules
+            - ./packages/crypto/node_modules
+            - ./node_modules
+      - run:
+          name: Create .ark/database directory
+          command: mkdir -p $HOME/.ark/database
+      - run:
+          name: Test
+          command: >
+            ./node_modules/.bin/cross-env ARK_ENV=test ./node_modules/.bin/jest
+            ./packages/crypto/ ./packages/core-utils/
+            ./packages/core-tester-cli/ ./packages/core-snapshots/
+            ./packages/core-logger/ ./packages/core-graphql/
+            ./packages/core-error-tracker-sentry/ ./packages/core-deployer/
+            ./packages/core-database/ ./packages/core-blockchain/
+            --detectOpenHandles --runInBand --forceExit --ci --coverage | tee
+            test_output.txt
       - run:
           name: Last 1000 lines of test output
           when: on_fail

--- a/packages/core-api/CHANGELOG.md
+++ b/packages/core-api/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## 0.2.14 - 2018-12-07
+
+### Fixed
+
+- Ensure safe integer range for block height lookups
+
 ## 0.2.13 - 2018-12-06
 
 ### Fixed

--- a/packages/core-api/lib/repositories/blocks.js
+++ b/packages/core-api/lib/repositories/blocks.js
@@ -60,11 +60,10 @@ class BlocksRepository extends Repository {
       .select()
       .from(this.query)
       .where(this.query.id.equals(value))
-    
-    // heights are stored as INTEGER of which the maximum safe value is 2147483647.
-    // this means we need to check for both the javascript and psql safe integer
+
+    // ensure that the value is not greater than 2147483647 (psql max int size)
     const height = +value
-    if (Number.isSafeInteger(height) && height <= 2147483647) {
+    if (height <= 2147483647) {
       query.or(this.query.height.equals(height))
     }
 

--- a/packages/core-api/lib/repositories/blocks.js
+++ b/packages/core-api/lib/repositories/blocks.js
@@ -60,9 +60,12 @@ class BlocksRepository extends Repository {
       .select()
       .from(this.query)
       .where(this.query.id.equals(value))
-
-    if (Number.isSafeInteger(+value)) {
-      query.or(this.query.height.equals(value))
+    
+    // heights are stored as INTEGER of which the maximum safe value is 2147483647.
+    // this means we need to check for both the javascript and psql safe integer
+    const height = +value
+    if (Number.isSafeInteger(height) && height <= 2147483647) {
+      query.or(this.query.height.equals(height))
     }
 
     return this._find(query)

--- a/packages/core-api/package.json
+++ b/packages/core-api/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@arkecosystem/core-api",
   "description": "Public API for Ark Core",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "contributors": [
     "Kristjan Košič <kristjan@ark.io>",
     "Brian Faust <brian@ark.io>"

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Ensure safe integer range for block height lookups via API
+
+### Fixed
+
 - Perform second-signature checks in the `canApply` logic of multi-signatures
 
 ## 2.0.11 - 2018-12-05

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@arkecosystem/core",
   "description": "Core of the Ark Blockchain",
-  "version": "2.0.12",
+  "version": "2.0.13",
   "contributors": [
     "François-Xavier Thoorens <fx@ark.io>",
     "Kristjan Košič <kristjan@ark.io>",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11062,19 +11062,19 @@ snyk-config@2.2.0:
     lodash "^4.17.5"
     nconf "^0.10.0"
 
-snyk-docker-plugin@1.12.3:
-  version "1.12.3"
-  resolved "https://registry.yarnpkg.com/snyk-docker-plugin/-/snyk-docker-plugin-1.12.3.tgz#a4a7c81a8e4e3c6a6cc303d4bc9aa98645274bca"
-  integrity sha512-ZbvaFCPCd0wxhqxjzU/iyf39tKlq2nvI9nPW32uZV3RGdHrkQH55BzCtBCF9d0dapxX+PKgae/4u2BKNw8hd9Q==
+snyk-docker-plugin@1.13.1:
+  version "1.13.1"
+  resolved "https://registry.yarnpkg.com/snyk-docker-plugin/-/snyk-docker-plugin-1.13.1.tgz#4d5ad62fe76b03e36b2c414b9576e67daef21f73"
+  integrity sha512-rhVPwMryfGanLXeDoDzjQabGq8VlEPSkvDvraiOhm/F9o5E4zam6vDlVQXsYVRb4ydVKPLgux2ejWyFiG6shFA==
   dependencies:
     debug "^3"
     dockerfile-ast "0.0.12"
     tslib "^1"
 
-snyk-go-plugin@1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/snyk-go-plugin/-/snyk-go-plugin-1.6.0.tgz#4b312db52fdde6d9b2ac75fe1f9712b88563737d"
-  integrity sha512-E6aYw7XAXSs2wJR3fU+vGQ1lVyjAw8PHIQYQwBwMkTHByhJIWPcu6Hy/jT5LcjJHlhYXlpOuk53HeLVK+kcXrQ==
+snyk-go-plugin@1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/snyk-go-plugin/-/snyk-go-plugin-1.6.1.tgz#fad24de943a587d676af9408e5b3976d6b20267d"
+  integrity sha512-hFOMyznfcMzF1HaZP18VmjQSqK/jBOowh0lpJY4UqmaQSZyJury3Ax+44O9oVUJi8lb8A4g7RVbxhlWl6bIqlA==
   dependencies:
     graphlib "^2.1.1"
     tmp "0.0.33"
@@ -11100,10 +11100,10 @@ snyk-mvn-plugin@2.0.0:
   resolved "https://registry.yarnpkg.com/snyk-mvn-plugin/-/snyk-mvn-plugin-2.0.0.tgz#875dcfe0d77b50396321552f2469ee69ca8d1416"
   integrity sha512-9jAhZhv+7YcqtoQYCYlgMoxK+dWBKlk+wkX27Ebg3vNddNop9q5jZitRXTjsXwfSUZHRt+Ptw1f8vei9kjzZVg==
 
-snyk-nodejs-lockfile-parser@1.7.1:
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.7.1.tgz#499fd29db9a9185e3cb90a314b204fa1244fffb6"
-  integrity sha512-0gHELqMhzUxb/t3Tg6d6G9LTDioOXCrEMt9aetOeV8wD/ZRL5VFNjwcdrm8qILLqzDFaFjFIyMc66c0OL4zFAQ==
+snyk-nodejs-lockfile-parser@1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.9.0.tgz#66e7295774e3854a4cc1a61200f01833adb60d25"
+  integrity sha512-GRn70VDe+JISkRbnxc9vxCBV+Ekkdr79krVXbYNDJgQyIjH+FXh6PXVvpregVsvCcNqP1ctbBw/u1w6e9xX1QA==
   dependencies:
     "@yarnpkg/lockfile" "^1.0.2"
     graphlib "^2.1.5"
@@ -11204,10 +11204,10 @@ snyk-try-require@1.3.1, snyk-try-require@^1.1.1, snyk-try-require@^1.3.1:
     lru-cache "^4.0.0"
     then-fs "^2.0.0"
 
-snyk@^1.111.1:
-  version "1.111.1"
-  resolved "https://registry.yarnpkg.com/snyk/-/snyk-1.111.1.tgz#ad259d062bf260b942dcacd77380167991ecd4aa"
-  integrity sha512-u65bSQnIfsrbFSWVb+otdG+9iIxGf4xlRd7P4SS2/ndeWMxgQflaDvz+77LYHRFuWYLydxqAE3gEeVQvkWoe3A==
+snyk@^1.116.0:
+  version "1.116.2"
+  resolved "https://registry.yarnpkg.com/snyk/-/snyk-1.116.2.tgz#d82fa2090bc25f892708a3623fc0e1c2383f53cc"
+  integrity sha512-zkW+IjSEDJ5f4leXck7a7aF36pJcIKRk3o2or78cnabq1mxQzgY8+ooECPDBnwvqySIwUKA8jOjnGRujaNCMpg==
   dependencies:
     "@snyk/dep-graph" "1.1.2"
     "@snyk/gemfile" "1.1.0"
@@ -11227,12 +11227,12 @@ snyk@^1.111.1:
     recursive-readdir "^2.2.2"
     semver "^5.5.0"
     snyk-config "2.2.0"
-    snyk-docker-plugin "1.12.3"
-    snyk-go-plugin "1.6.0"
+    snyk-docker-plugin "1.13.1"
+    snyk-go-plugin "1.6.1"
     snyk-gradle-plugin "2.1.1"
     snyk-module "1.9.1"
     snyk-mvn-plugin "2.0.0"
-    snyk-nodejs-lockfile-parser "1.7.1"
+    snyk-nodejs-lockfile-parser "1.9.0"
     snyk-nuget-plugin "1.6.5"
     snyk-php-plugin "1.5.1"
     snyk-policy "1.13.1"
@@ -11246,6 +11246,7 @@ snyk@^1.111.1:
     tempfile "^2.0.0"
     then-fs "^2.0.0"
     undefsafe "^2.0.0"
+    update-notifier "^2.5.0"
     uuid "^3.2.1"
 
 socks-proxy-agent@^3.0.0:
@@ -12259,7 +12260,7 @@ upath@^1.0.5:
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.1.0.tgz#35256597e46a581db4793d0ce47fa9aebfc9fabd"
   integrity sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw==
 
-update-notifier@^2.2.0:
+update-notifier@^2.2.0, update-notifier@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/update-notifier/-/update-notifier-2.5.0.tgz#d0744593e13f161e406acb1d9408b72cad08aff6"
   integrity sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==
@@ -12837,10 +12838,10 @@ xregexp@2.0.0:
   resolved "https://registry.yarnpkg.com/xregexp/-/xregexp-2.0.0.tgz#52a63e56ca0b84a7f3a5f3d61872f126ad7a5943"
   integrity sha1-UqY+VsoLhKfzpfPWGHLxJq16WUM=
 
-xstate@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/xstate/-/xstate-4.1.2.tgz#588bd4efee695ff15ac96e9074848d9566e2aceb"
-  integrity sha512-YjCpT+si6QfKTX5o7evf1/FvBUeSfvUxz7Eay/SlGFBtPm1ZSeCH4MGuTSgTtRaw63m40MbMj6jc+OF8JuQorg==
+xstate@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/xstate/-/xstate-4.2.1.tgz#d3a8aa304a22117a741b94401b8632cd75ec902f"
+  integrity sha512-dQEHU/78tUWQd43EMm+17xdM9xVqivSYvNh2++5CY0yST8FcBSl0cyfwrL6tF2MZBqpbuuNLWYc+Ib1bG/jlxQ==
 
 xtend@^4.0.0, xtend@~4.0.1:
   version "4.0.1"


### PR DESCRIPTION
## Proposed changes

We store heights as integers in postgresql which can cause issues when block IDs are tried as heights as the max allowed size is 2147483647.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes