### PR TITLE
fix: broken peer tests in core-p2p

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ packages/**/dist/
 
 # Random
 peers_backup.json
+
+# Intellij/Webstorm settings
+.idea

--- a/packages/core-p2p/__tests__/court/guard.test.js
+++ b/packages/core-p2p/__tests__/court/guard.test.js
@@ -22,6 +22,7 @@ beforeAll(async () => {
 })
 
 afterAll(async () => {
+  jest.restoreAllMocks()
   await app.tearDown()
 })
 
@@ -46,6 +47,7 @@ describe('Guard', () => {
 
     it('should return true', async () => {
       process.env.ARK_ENV = false
+      jest.spyOn(guard, 'isMyself').mockReturnValue(false)
       await guard.monitor.acceptNewPeer(peerMock)
       process.env.ARK_ENV = ARK_ENV
 

--- a/packages/core-p2p/__tests__/monitor.test.js
+++ b/packages/core-p2p/__tests__/monitor.test.js
@@ -7,11 +7,19 @@ const app = require('./__support__/setup')
 
 const defaults = require('../lib/defaults')
 
+const { guard } = require('../lib/court')
+
 let monitor
 let Peer
 let peerMock
 
 beforeAll(async () => {
+  jest.spyOn(guard, 'isMyself').mockReturnValue(false)
+  jest.spyOn(guard, 'isSuspended').mockReturnValue(false)
+  jest.spyOn(guard, 'isBlacklisted').mockReturnValue(false)
+  jest.spyOn(guard, 'isValidVersion').mockReturnValue(true)
+  jest.spyOn(guard, 'isValidNetwork').mockReturnValue(true)
+
   await app.setUp()
 
   monitor = require('../lib/monitor')
@@ -19,6 +27,7 @@ beforeAll(async () => {
 })
 
 afterAll(async () => {
+  jest.restoreAllMocks()
   await app.tearDown()
 })
 


### PR DESCRIPTION
## Proposed changes
Fixes some peer oriented tests that were recently broken by changing how 'Guard.isMyself' works

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Test (adding missing tests or fixing existing tests)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
