### PR TITLE
fix(core-p2p): get difference in milliseconds

### DIFF
--- a/packages/core-p2p/src/court/guard.ts
+++ b/packages/core-p2p/src/court/guard.ts
@@ -131,7 +131,8 @@ class Guard {
             const nextSuspensionReminder = suspendedPeer.nextSuspensionReminder;
 
             if (!nextSuspensionReminder || dayjs().isAfter(nextSuspensionReminder)) {
-                const untilDiff = suspendedPeer.until.diff(dayjs(), "minute");
+                // @ts-ignore
+                const untilDiff = suspendedPeer.until.diff(dayjs());
 
                 logger.debug(
                     `${peer.ip} still suspended for ${prettyMs(untilDiff, {


### PR DESCRIPTION
## Proposed changes

Same issue as further down the file where we logged 5 milliseconds instead of minutes.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes