### PR TITLE
refactor(core-p2p): adjust some ban durations

### DIFF
--- a/packages/core-p2p/__tests__/court/guard.test.ts
+++ b/packages/core-p2p/__tests__/court/guard.test.ts
@@ -89,7 +89,7 @@ describe("Guard", () => {
             state: {},
         };
 
-        it('should return a 1 day suspension for "Blacklisted"', () => {
+        it('should return a 1 year suspension for "Blacklisted"', () => {
             guard.config.set("blacklist", ["dummy-ip-addr"]);
 
             const { until, reason } = guard.__determineOffence({
@@ -97,7 +97,7 @@ describe("Guard", () => {
                 ip: "dummy-ip-addr",
             });
 
-            expect(convertToMinutes(until)).toBe(720);
+            expect(convertToMinutes(until)).toBe(525600);
             expect(reason).toBe("Blacklisted");
 
             guard.config.set("blacklist", []);
@@ -115,7 +115,7 @@ describe("Guard", () => {
             expect(reason).toBe("No Common Blocks");
         });
 
-        it('should return a 6 hours suspension for "Invalid Version"', () => {
+        it('should return a 5 minute suspension for "Invalid Version"', () => {
             const { until, reason } = guard.__determineOffence({
                 nethash: "d9acd04bde4234a81addb8482333b4ac906bed7be5a9970ce8ada428bd083192",
                 version: "1.0.0",
@@ -123,7 +123,7 @@ describe("Guard", () => {
                 delay: 1000,
             });
 
-            expect(convertToMinutes(until)).toBe(360);
+            expect(convertToMinutes(until)).toBe(5);
             expect(reason).toBe("Invalid Version");
         });
 
@@ -191,10 +191,10 @@ describe("Guard", () => {
             expect(reason).toBe("Rate limit exceeded");
         });
 
-        it('should return a 30 minutes suspension for "Unknown"', () => {
+        it('should return a 10 minutes suspension for "Unknown"', () => {
             const { until, reason } = guard.__determineOffence(dummy);
 
-            expect(convertToMinutes(until)).toBe(30);
+            expect(convertToMinutes(until)).toBe(10);
             expect(reason).toBe("Unknown");
         });
     });

--- a/packages/core-p2p/src/court/offences.ts
+++ b/packages/core-p2p/src/court/offences.ts
@@ -1,9 +1,10 @@
 export const offences = {
     BLACKLISTED: {
-        number: 12,
-        period: "hour",
+        number: 1,
+        period: "year",
         reason: "Blacklisted",
         weight: 10,
+        critical: true,
     },
     NO_COMMON_BLOCKS: {
         number: 5,
@@ -20,22 +21,23 @@ export const offences = {
         critical: true,
     },
     INVALID_VERSION: {
-        number: 6,
-        period: "hour",
+        number: 5,
+        period: "minute",
         reason: "Invalid Version",
-        weight: 7,
+        weight: 2,
     },
     INVALID_HEIGHT: {
         number: 10,
         period: "minute",
         reason: "Node is not at height",
-        weight: 5,
+        weight: 3,
     },
     INVALID_NETWORK: {
         number: 5,
         period: "minute",
         reason: "Invalid Network",
         weight: 5,
+        critical: true,
     },
     INVALID_STATUS: {
         number: 5,
@@ -67,8 +69,14 @@ export const offences = {
         reason: "Rate limit exceeded",
         weight: 0,
     },
+    FORK: {
+        number: 15,
+        period: "minute",
+        reason: "Fork",
+        weight: 10,
+    },
     UNKNOWN: {
-        number: 30,
+        number: 10,
         period: "minute",
         reason: "Unknown",
         weight: 5,
@@ -78,12 +86,5 @@ export const offences = {
         period: "day",
         reason: "Repeat Offender",
         weight: 100,
-    },
-    FORK: {
-        number: 1,
-        period: "day",
-        reason: "Fork",
-        weight: 150,
-        critical: true,
     },
 };


### PR DESCRIPTION
## Proposed changes

Adjusts some ban durations to make network recovery more stable and take proper advantage of the repeat offender ban.

## Types of changes

- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes