### PR TITLE
refactor(core-p2p): replace the network update timeout with a period check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,8 +84,8 @@ jobs:
           name: core-config
           command: 'cd ~/ark-core/packages/core-config && yarn test:coverage'
       - run:
-          name: core-forger
-          command: 'cd ~/ark-core/packages/core-forger && yarn test:coverage'
+          name: core
+          command: 'cd ~/ark-core/packages/core && yarn test:coverage'
       - run:
           name: Last 1000 lines of test output
           when: on_fail
@@ -177,8 +177,8 @@ jobs:
           name: core-config
           command: 'cd ~/ark-core/packages/core-config && yarn test:coverage'
       - run:
-          name: core-forger
-          command: 'cd ~/ark-core/packages/core-forger && yarn test:coverage'
+          name: core
+          command: 'cd ~/ark-core/packages/core && yarn test:coverage'
       - run:
           name: Last 1000 lines of test output
           when: on_fail
@@ -345,8 +345,8 @@ jobs:
           name: core-logger
           command: 'cd ~/ark-core/packages/core-logger && yarn test:coverage'
       - run:
-          name: core-api
-          command: 'cd ~/ark-core/packages/core-api && yarn test:coverage'
+          name: core-forger
+          command: 'cd ~/ark-core/packages/core-forger && yarn test:coverage'
       - run:
           name: core-debugger-cli
           command: 'cd ~/ark-core/packages/core-debugger-cli && yarn test:coverage'
@@ -354,8 +354,8 @@ jobs:
           name: core-container
           command: 'cd ~/ark-core/packages/core-container && yarn test:coverage'
       - run:
-          name: core
-          command: 'cd ~/ark-core/packages/core && yarn test:coverage'
+          name: core-api
+          command: 'cd ~/ark-core/packages/core-api && yarn test:coverage'
       - run:
           name: Last 1000 lines of test output
           when: on_fail
@@ -615,8 +615,8 @@ jobs:
           name: core-logger
           command: 'cd ~/ark-core/packages/core-logger && yarn test:coverage'
       - run:
-          name: core-api
-          command: 'cd ~/ark-core/packages/core-api && yarn test:coverage'
+          name: core-forger
+          command: 'cd ~/ark-core/packages/core-forger && yarn test:coverage'
       - run:
           name: core-debugger-cli
           command: 'cd ~/ark-core/packages/core-debugger-cli && yarn test:coverage'
@@ -624,8 +624,8 @@ jobs:
           name: core-container
           command: 'cd ~/ark-core/packages/core-container && yarn test:coverage'
       - run:
-          name: core
-          command: 'cd ~/ark-core/packages/core && yarn test:coverage'
+          name: core-api
+          command: 'cd ~/ark-core/packages/core-api && yarn test:coverage'
       - run:
           name: Last 1000 lines of test output
           when: on_fail

--- a/packages/core-blockchain/src/state-machine.ts
+++ b/packages/core-blockchain/src/state-machine.ts
@@ -57,8 +57,6 @@ blockchainMachine.actionMap = blockchain => ({
             `Queued blocks (rebuild: ${blockchain.rebuildQueue.length()} process: ${blockchain.processQueue.length()})`,
         );
 
-        await blockchain.p2p.updateNetworkStatusIfNotEnoughPeers();
-
         if (blockchain.rebuildQueue.length() > 10000 || blockchain.processQueue.length() > 10000) {
             event = "PAUSED";
         }

--- a/packages/core-p2p/package.json
+++ b/packages/core-p2p/package.json
@@ -66,7 +66,6 @@
         "lodash.sumby": "^4.6.0",
         "lodash.take": "^4.1.1",
         "micromatch": "^3.1.10",
-        "p-timeout": "^2.0.1",
         "pluralize": "^7.0.0",
         "pretty-ms": "^4.0.0",
         "semver": "^5.6.0",

--- a/packages/core-p2p/src/monitor.ts
+++ b/packages/core-p2p/src/monitor.ts
@@ -117,8 +117,8 @@ class Monitor {
             logger.info(`Couldn't find enough peers, trying again in ${nextRunDelaySeconds} seconds`);
         }
 
-        // @ts-ignore
-        if (!this.lastNetworkUpdate && this.lastNetworkUpdate.isBefore(dayjs())) {
+        if (!this.lastNetworkUpdate || this.lastNetworkUpdate.isAfter(dayjs())) {
+            // @ts-ignore
             this.lastNetworkUpdate = dayjs().add(nextRunDelaySeconds, "seconds");
         }
 

--- a/packages/core-p2p/src/monitor.ts
+++ b/packages/core-p2p/src/monitor.ts
@@ -10,7 +10,6 @@ import groupBy from "lodash/groupBy";
 import sample from "lodash/sample";
 import shuffle from "lodash/shuffle";
 import take from "lodash/take";
-import pTimeout from "p-timeout";
 import pluralize from "pluralize";
 import prettyMs from "pretty-ms";
 


### PR DESCRIPTION
## Proposed changes

The whole logic around how the `updateNetworkStatusIfNotEnoughPeers` method is called is rather odd so it is replaced with a period check instead.

## Types of changes

- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes