### PR TITLE
fix(core-database): ensure that delegate search deals with "undefined" as username

### DIFF
--- a/packages/core-database/__tests__/repositories/delegates.test.ts
+++ b/packages/core-database/__tests__/repositories/delegates.test.ts
@@ -256,22 +256,22 @@ describe("Delegate Repository", () => {
         });
 
         describe("when searching without params", () => {
-            it("should return no results", () => {
+            it("should return all results", () => {
                 const { count, rows } = repository.search({});
 
-                expect(count).toBe(0);
-                expect(rows).toHaveLength(0);
+                expect(count).toBe(52);
+                expect(rows).toHaveLength(52);
             });
 
             describe('when a username is "undefined"', () => {
-                it("should return no results", () => {
+                it("should return all results", () => {
                     // Index a wallet with username "undefined"
                     const address = Object.keys(walletManager.byAddress)[0];
                     walletManager.byAddress[address].username = "undefined";
 
                     const { count, rows } = repository.search({});
-                    expect(count).toBe(0);
-                    expect(rows).toHaveLength(0);
+                    expect(count).toBe(52);
+                    expect(rows).toHaveLength(52);
                 });
             });
         });

--- a/packages/core-database/__tests__/repositories/delegates.test.ts
+++ b/packages/core-database/__tests__/repositories/delegates.test.ts
@@ -168,23 +168,22 @@ describe("Delegate Repository", () => {
     });
 
     describe("search", () => {
+        beforeEach(() => {
+            const wallets = generateWallets();
+            walletManager.index(wallets);
+        });
+
         describe("by `username`", () => {
             it("should search by exact match", () => {
-                const wallets = generateWallets();
-                walletManager.index(wallets);
-
-                const { count, rows } = repository.search({
-                    username: "username-APnhwwyTbMiykJwYbGhYjNgtHiVJDSEhSn",
-                });
+                const username = "username-APnhwwyTbMiykJwYbGhYjNgtHiVJDSEhSn";
+                const { count, rows } = repository.search({ username });
 
                 expect(count).toBe(1);
                 expect(rows).toHaveLength(1);
+                expect(rows[0].username).toEqual(username);
             });
 
             it("should search that username contains the string", () => {
-                const wallets = generateWallets();
-                walletManager.index(wallets);
-
                 const { count, rows } = repository.search({ username: "username" });
 
                 expect(count).toBe(52);
@@ -193,9 +192,6 @@ describe("Delegate Repository", () => {
 
             describe('when a username is "undefined"', () => {
                 it("should return it", () => {
-                    const wallets = generateWallets();
-                    walletManager.index(wallets);
-
                     // Index a wallet with username "undefined"
                     const address = Object.keys(walletManager.byAddress)[0];
                     walletManager.byAddress[address].username = "undefined";
@@ -221,9 +217,6 @@ describe("Delegate Repository", () => {
             });
 
             it("should be ok with params", () => {
-                const wallets = generateWallets();
-                walletManager.index(wallets);
-
                 const { count, rows } = repository.search({
                     username: "username",
                     offset: 10,
@@ -234,9 +227,6 @@ describe("Delegate Repository", () => {
             });
 
             it("should be ok with params (no offset)", () => {
-                const wallets = generateWallets();
-                walletManager.index(wallets);
-
                 const { count, rows } = repository.search({
                     username: "username",
                     limit: 10,
@@ -246,9 +236,6 @@ describe("Delegate Repository", () => {
             });
 
             it("should be ok with params (offset = 0)", () => {
-                const wallets = generateWallets();
-                walletManager.index(wallets);
-
                 const { count, rows } = repository.search({
                     username: "username",
                     offset: 0,
@@ -259,9 +246,6 @@ describe("Delegate Repository", () => {
             });
 
             it("should be ok with params (no limit)", () => {
-                const wallets = generateWallets();
-                walletManager.index(wallets);
-
                 const { count, rows } = repository.search({
                     username: "username",
                     offset: 10,
@@ -273,9 +257,6 @@ describe("Delegate Repository", () => {
 
         describe("when searching without params", () => {
             it("should return no results", () => {
-                const wallets = generateWallets();
-                walletManager.index(wallets);
-
                 const { count, rows } = repository.search({});
 
                 expect(count).toBe(0);
@@ -284,9 +265,6 @@ describe("Delegate Repository", () => {
 
             describe('when a username is "undefined"', () => {
                 it("should return no results", () => {
-                    const wallets = generateWallets();
-                    walletManager.index(wallets);
-
                     // Index a wallet with username "undefined"
                     const address = Object.keys(walletManager.byAddress)[0];
                     walletManager.byAddress[address].username = "undefined";

--- a/packages/core-database/__tests__/repositories/delegates.test.ts
+++ b/packages/core-database/__tests__/repositories/delegates.test.ts
@@ -168,87 +168,134 @@ describe("Delegate Repository", () => {
     });
 
     describe("search", () => {
-        it("should search by exact username match", () => {
-            const wallets = generateWallets();
-            walletManager.index(wallets);
+        describe("by `username`", () => {
+            it("should search by exact match", () => {
+                const wallets = generateWallets();
+                walletManager.index(wallets);
 
-            const { count, rows } = repository.search({
-                username: "username-APnhwwyTbMiykJwYbGhYjNgtHiVJDSEhSn",
+                const { count, rows } = repository.search({
+                    username: "username-APnhwwyTbMiykJwYbGhYjNgtHiVJDSEhSn",
+                });
+
+                expect(count).toBe(1);
+                expect(rows).toHaveLength(1);
             });
 
-            expect(count).toBe(1);
-            expect(rows).toHaveLength(1);
-        });
+            it("should search that username contains the string", () => {
+                const wallets = generateWallets();
+                walletManager.index(wallets);
 
-        it("should search that username contains the string", () => {
-            const wallets = generateWallets();
-            walletManager.index(wallets);
+                const { count, rows } = repository.search({ username: "username" });
 
-            const { count, rows } = repository.search({ username: "username" });
+                expect(count).toBe(52);
+                expect(rows).toHaveLength(52);
+            });
 
-            expect(count).toBe(52);
-            expect(rows).toHaveLength(52);
-        });
+            describe('when a username is "undefined"', () => {
+                it("should return it", () => {
+                    const wallets = generateWallets();
+                    walletManager.index(wallets);
 
-        describe("when no results", () => {
-            it("should be ok", () => {
-                const { count, rows } = repository.search({
-                    username: "unknown-dummy-username",
+                    // Index a wallet with username "undefined"
+                    const address = Object.keys(walletManager.byAddress)[0];
+                    walletManager.byAddress[address].username = "undefined";
+
+                    const username = "undefined";
+                    const { count, rows } = repository.search({ username });
+
+                    expect(count).toBe(1);
+                    expect(rows).toHaveLength(1);
+                    expect(rows[0].username).toEqual(username);
                 });
+            });
+
+            describe("when the username does not exist", () => {
+                it("should return no results", () => {
+                    const { count, rows } = repository.search({
+                        username: "unknown-dummy-username",
+                    });
+
+                    expect(count).toBe(0);
+                    expect(rows).toHaveLength(0);
+                });
+            });
+
+            it("should be ok with params", () => {
+                const wallets = generateWallets();
+                walletManager.index(wallets);
+
+                const { count, rows } = repository.search({
+                    username: "username",
+                    offset: 10,
+                    limit: 10,
+                });
+                expect(count).toBe(52);
+                expect(rows).toHaveLength(10);
+            });
+
+            it("should be ok with params (no offset)", () => {
+                const wallets = generateWallets();
+                walletManager.index(wallets);
+
+                const { count, rows } = repository.search({
+                    username: "username",
+                    limit: 10,
+                });
+                expect(count).toBe(52);
+                expect(rows).toHaveLength(10);
+            });
+
+            it("should be ok with params (offset = 0)", () => {
+                const wallets = generateWallets();
+                walletManager.index(wallets);
+
+                const { count, rows } = repository.search({
+                    username: "username",
+                    offset: 0,
+                    limit: 12,
+                });
+                expect(count).toBe(52);
+                expect(rows).toHaveLength(12);
+            });
+
+            it("should be ok with params (no limit)", () => {
+                const wallets = generateWallets();
+                walletManager.index(wallets);
+
+                const { count, rows } = repository.search({
+                    username: "username",
+                    offset: 10,
+                });
+                expect(count).toBe(52);
+                expect(rows).toHaveLength(42);
+            });
+        });
+
+        describe("when searching without params", () => {
+            it("should return no results", () => {
+                const wallets = generateWallets();
+                walletManager.index(wallets);
+
+                const { count, rows } = repository.search({});
 
                 expect(count).toBe(0);
                 expect(rows).toHaveLength(0);
             });
-        });
 
-        it("should be ok with params", () => {
-            const wallets = generateWallets();
-            walletManager.index(wallets);
+            describe('when a username is "undefined"', () => {
+                it("should return no results", () => {
+                    const wallets = generateWallets();
+                    walletManager.index(wallets);
 
-            const { count, rows } = repository.search({
-                username: "username",
-                offset: 10,
-                limit: 10,
+                    // Index a wallet with username "undefined"
+                    const address = Object.keys(walletManager.byAddress)[0];
+                    walletManager.byAddress[address].username = "undefined";
+
+                    const { count, rows } = repository.search({});
+                    expect(count).toBe(0);
+                    expect(rows).toHaveLength(0);
+                });
             });
-            expect(count).toBe(52);
-            expect(rows).toHaveLength(10);
-        });
-
-        it("should be ok with params (no offset)", () => {
-            const wallets = generateWallets();
-            walletManager.index(wallets);
-
-            const { count, rows } = repository.search({
-                username: "username",
-                limit: 10,
-            });
-            expect(count).toBe(52);
-            expect(rows).toHaveLength(10);
-        });
-
-        it("should be ok with params (offset = 0)", () => {
-            const wallets = generateWallets();
-            walletManager.index(wallets);
-
-            const { count, rows } = repository.search({
-                username: "username",
-                offset: 0,
-                limit: 12,
-            });
-            expect(count).toBe(52);
-            expect(rows).toHaveLength(12);
-        });
-
-        it("should be ok with params (no limit)", () => {
-            const wallets = generateWallets();
-            walletManager.index(wallets);
-
-            const { count, rows } = repository.search({
-                username: "username",
-                offset: 10,
-            });
-            expect(count).toBe(52);
-            expect(rows).toHaveLength(42);
         });
     });
 

--- a/packages/core-database/src/repositories/delegates.ts
+++ b/packages/core-database/src/repositories/delegates.ts
@@ -50,6 +50,11 @@ export class DelegatesRepository {
      * @return {Object}
      */
     public search(params) {
+        const hasSearchParams = ["username"].some(param => params.hasOwnProperty(param));
+        if (!hasSearchParams) {
+            return { rows: [], count: 0 };
+        }
+
         let delegates = this.getLocalDelegates().filter(delegate => delegate.username.indexOf(params.username) > -1);
 
         if (params.orderBy) {

--- a/packages/core-database/src/repositories/delegates.ts
+++ b/packages/core-database/src/repositories/delegates.ts
@@ -50,12 +50,10 @@ export class DelegatesRepository {
      * @return {Object}
      */
     public search(params) {
-        const hasSearchParams = ["username"].some(param => params.hasOwnProperty(param));
-        if (!hasSearchParams) {
-            return { rows: [], count: 0 };
+        let delegates = this.getLocalDelegates();
+        if (params.hasOwnProperty("username")) {
+            delegates = delegates.filter(delegate => delegate.username.indexOf(params.username) > -1);
         }
-
-        let delegates = this.getLocalDelegates().filter(delegate => delegate.username.indexOf(params.username) > -1);
 
         if (params.orderBy) {
             const orderByField = params.orderBy.split(":")[0];


### PR DESCRIPTION
## Proposed changes
Searching delegates without parameters return the delegate with username "undefined" when it should not return anything.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Test (adding missing tests or fixing existing tests)

## Checklist
- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
