### PR TITLE
fix(core-api): remove reverse mapping from /transactions/types

### DIFF
--- a/packages/core-api/__tests__/v2/handlers/transactions.test.ts
+++ b/packages/core-api/__tests__/v2/handlers/transactions.test.ts
@@ -1,4 +1,5 @@
 import "@arkecosystem/core-test-utils";
+import { constants } from "@arkecosystem/crypto";
 import { setUp, tearDown } from "../../__support__/setup";
 import { utils } from "../utils";
 
@@ -117,6 +118,30 @@ describe("API 2.0 - Transactions", () => {
                     expect(response).toBeSuccessfulResponse();
                     expect(response.data.data).toBeObject();
                     expect(response.data.data).toHaveProperty("id", transaction.id);
+                });
+            },
+        );
+    });
+
+    describe("GET /transactions/types", () => {
+        describe.each([["API-Version", "request"], ["Accept", "requestWithAcceptHeader"]])(
+            "using the %s header",
+            (header, request) => {
+                it("should GET transaction types", async () => {
+                    const response = await utils[request]("GET", "transactions/types");
+                    expect(response).toBeSuccessfulResponse();
+                    expect(response.data.data).toBeObject();
+                    expect(response.data.data).toEqual({
+                        Transfer: 0,
+                        SecondSignature: 1,
+                        DelegateRegistration: 2,
+                        Vote: 3,
+                        MultiSignature: 4,
+                        Ipfs: 5,
+                        TimelockTransfer: 6,
+                        MultiPayment: 7,
+                        DelegateResignation: 8,
+                    });
                 });
             },
         );

--- a/packages/core-api/src/versions/2/transactions/controller.ts
+++ b/packages/core-api/src/versions/2/transactions/controller.ts
@@ -129,9 +129,15 @@ export class TransactionsController extends Controller {
 
     public async types(request: Hapi.Request, h: Hapi.ResponseToolkit) {
         try {
-            return {
-                data: constants.TransactionTypes,
-            };
+            // Remove reverse mapping from TransactionTypes enum.
+            const { TransactionTypes } = constants;
+            const data = Object.assign({}, TransactionTypes);
+            Object.values(TransactionTypes)
+                .filter(value => typeof value === "string")
+                .map((type: string) => data[type])
+                .forEach((key: string) => delete data[key]);
+
+            return { data };
         } catch (error) {
             return Boom.badImplementation(error);
         }


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
TypeScript adds a reverse mapping to enums by default. This should not appear in the output and is now properly removed.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [ ] Docs (documentation only changes)
- [ ] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [ ] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
