### PR TITLE
fix(core-api): cast core-p2p port to number

### DIFF
--- a/packages/core-api/src/versions/1/shared/transformers/ports.ts
+++ b/packages/core-api/src/versions/1/shared/transformers/ports.ts
@@ -10,7 +10,7 @@ export function transformPortsLegacy(config: any) {
 
     const plugins = config.get("plugins");
 
-    result[keys[0]] = plugins[keys[0]].port;
+    result[keys[0]] = +plugins[keys[0]].port;
 
     for (const [name, options] of Object.entries(plugins)) {
         // @ts-ignore

--- a/packages/core-api/src/versions/2/shared/transformers/ports.ts
+++ b/packages/core-api/src/versions/2/shared/transformers/ports.ts
@@ -10,7 +10,7 @@ export function transformPorts(config: any) {
 
     const plugins = config.get("plugins");
 
-    result[keys[0]] = plugins[keys[0]].port;
+    result[keys[0]] = +plugins[keys[0]].port;
 
     for (const [name, options] of Object.entries(plugins)) {
         // @ts-ignore


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
https://dexplorer.ark.io:8443/api/v2/node/configuration

The p2p port isn't casted to a numerical type.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes