### PR TITLE
feat(core-database): delegate ordering by 'productivity' & 'approval'

### DIFF
--- a/packages/core-api/__tests__/v2/handlers/delegates.test.ts
+++ b/packages/core-api/__tests__/v2/handlers/delegates.test.ts
@@ -43,13 +43,43 @@ describe("API 2.0 - Delegates", () => {
         describe.each([["API-Version", "request"], ["Accept", "requestWithAcceptHeader"]])(
             "using the %s header",
             (header, request) => {
-                it("should GET all the delegates ordered by 'rank:desc'", async () => {
+                it("should GET all the delegates ordered by descending rank", async () => {
                     const response = await utils[request]("GET", "delegates", { orderBy: "rank:desc" });
                     expect(response).toBeSuccessfulResponse();
                     expect(response.data.data).toBeArray();
 
                     response.data.data.forEach(utils.expectDelegate);
                     expect(response.data.data.sort((a, b) => a.rank > b.rank)).toEqual(response.data.data);
+                });
+            },
+        );
+
+        describe.each([["API-Version", "request"], ["Accept", "requestWithAcceptHeader"]])(
+            "using the %s header",
+            (header, request) => {
+                it("should GET all the delegates ordered by descending productivity", async () => {
+                    const response = await utils[request]("GET", "delegates", { orderBy: "productivity:desc" });
+                    expect(response).toBeSuccessfulResponse();
+                    expect(response.data.data).toBeArray();
+
+                    response.data.data.forEach(utils.expectDelegate);
+                    expect(response.data.data.sort((a, b) =>
+                        a.production.productivity > b.production.productivity)).toEqual(response.data.data);
+                });
+            },
+        );
+
+        describe.each([["API-Version", "request"], ["Accept", "requestWithAcceptHeader"]])(
+            "using the %s header",
+            (header, request) => {
+                it("should GET all the delegates ordered by descending approval", async () => {
+                    const response = await utils[request]("GET", "delegates", { orderBy: "approval:desc" });
+                    expect(response).toBeSuccessfulResponse();
+                    expect(response.data.data).toBeArray();
+
+                    response.data.data.forEach(utils.expectDelegate);
+                    expect(response.data.data.sort((a, b) =>
+                        a.production.approval > b.production.approval)).toEqual(response.data.data);
                 });
             },
         );

--- a/packages/core-database/src/repositories/delegates.ts
+++ b/packages/core-database/src/repositories/delegates.ts
@@ -116,6 +116,19 @@ export class DelegatesRepository {
             return ["rate", "asc"];
         }
 
-        return orderBy[0] === "rank" ? ["rate", orderBy[1]] : orderBy;
+        return [this.__manipulateIteratee(orderBy[0]), orderBy[1]];
+    }
+
+    public __manipulateIteratee(iteratee): any {
+        switch (iteratee) {
+            case "rank":
+                return "rate";
+            case "productivity":
+                return delegateCalculator.calculateProductivity;
+            case "approval":
+                return delegateCalculator.calculateApproval;
+            default:
+                return iteratee;
+        }
     }
 }


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

Allows for ordering of the delegates by `approval` and `productivity` which is needed for ArkEcosystem/desktop-wallet#763.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works