### PR TITLE
chore: format arktoshi

### DIFF
--- a/packages/core-tester-cli/__tests__/commands/command.test.ts
+++ b/packages/core-tester-cli/__tests__/commands/command.test.ts
@@ -309,10 +309,10 @@ describe("Command Base", () => {
 
     describe("static __arktoshiToArk", () => {
         it("should give ark", () => {
-            expect(Command.__arktoshiToArk(1)).toBe("0.00000001 DѦ");
-            expect(Command.__arktoshiToArk(10000000)).toBe("0.1 DѦ");
-            expect(Command.__arktoshiToArk(100000000)).toBe("1 DѦ");
-            expect(Command.__arktoshiToArk(1000000000)).toBe("10 DѦ");
+          expect(Command.__arktoshiToArk(1)).toBe("DѦ0.00000001");
+          expect(Command.__arktoshiToArk(10000000)).toBe("DѦ0.10000000");
+          expect(Command.__arktoshiToArk(100000000)).toBe("DѦ1");
+          expect(Command.__arktoshiToArk(1000000000)).toBe("DѦ10");
         });
     });
 

--- a/packages/crypto/__tests__/models/delegate.test.ts
+++ b/packages/crypto/__tests__/models/delegate.test.ts
@@ -154,7 +154,7 @@ describe("Models - Delegate", () => {
                 const wallet = new Wallet(address);
                 wallet.balance = new Bignum(ARKTOSHI);
 
-                expect(wallet.toString()).toBe(`${address} (1 ${configManager.config.client.symbol})`);
+              expect(wallet.toString()).toBe(`${address} (${configManager.config.client.symbol}1)`);
             });
         });
     });

--- a/packages/crypto/__tests__/models/wallet.test.ts
+++ b/packages/crypto/__tests__/models/wallet.test.ts
@@ -18,7 +18,7 @@ describe("Models - Wallet", () => {
             const wallet = new Wallet(address);
             const balance = +(Math.random() * 1000).toFixed(8);
             wallet.balance = new Bignum(balance * ARKTOSHI);
-            expect(wallet.toString()).toBe(`${address} (${balance} ${configManager.config.client.symbol})`);
+          expect(wallet.toString()).toBe(`${address} (${configManager.config.client.symbol}${balance})`);
         });
     });
 

--- a/packages/crypto/__tests__/utils/format-arktoshi.test.ts
+++ b/packages/crypto/__tests__/utils/format-arktoshi.test.ts
@@ -5,7 +5,7 @@ import { Bignum, formatArktoshi } from "../../src/utils";
 
 describe("Format Arktoshi", () => {
     it("should format arktoshis", () => {
-      expect(formatArktoshi(ARKTOSHI)).toBe("DѦ0.00000001");
+      expect(formatArktoshi(1)).toBe("DѦ0.00000001");
       expect(formatArktoshi(0.1 * ARKTOSHI)).toBe("DѦ0.10000000");
       expect(formatArktoshi((0.1 * ARKTOSHI).toString())).toBe("DѦ0.10000000");
       expect(formatArktoshi(new Bignum(10))).toBe("DѦ0.00000010");

--- a/packages/crypto/__tests__/utils/format-arktoshi.test.ts
+++ b/packages/crypto/__tests__/utils/format-arktoshi.test.ts
@@ -5,10 +5,10 @@ import { Bignum, formatArktoshi } from "../../src/utils";
 
 describe("Format Arktoshi", () => {
     it("should format arktoshis", () => {
-        expect(formatArktoshi(ARKTOSHI)).toBe("1 DѦ");
-        expect(formatArktoshi(0.1 * ARKTOSHI)).toBe("0.1 DѦ");
-        expect(formatArktoshi((0.1 * ARKTOSHI).toString())).toBe("0.1 DѦ");
-        expect(formatArktoshi(new Bignum(10))).toBe("0.0000001 DѦ");
-        expect(formatArktoshi(new Bignum(ARKTOSHI + 10012))).toBe("1.00010012 DѦ");
+      expect(formatArktoshi(ARKTOSHI)).toBe("DѦ0.00000001");
+      expect(formatArktoshi(0.1 * ARKTOSHI)).toBe("DѦ0.10000000");
+      expect(formatArktoshi((0.1 * ARKTOSHI).toString())).toBe("DѦ0.10000000");
+      expect(formatArktoshi(new Bignum(10))).toBe("DѦ0.00000010");
+      expect(formatArktoshi(new Bignum(ARKTOSHI + 10012))).toBe("DѦ1.00010012");
     });
 });

--- a/packages/crypto/src/utils/format-arktoshi.ts
+++ b/packages/crypto/src/utils/format-arktoshi.ts
@@ -8,9 +8,9 @@ import { configManager } from "../managers/config";
  */
 export const formatArktoshi = amount => {
     const localeString = (+amount / ARKTOSHI).toLocaleString("en", {
-        minimumFractionDigits: 0,
+        minimumFractionDigits: 8,
         maximumFractionDigits: 8,
     });
 
-    return `${localeString} ${configManager.config.client.symbol}`;
+  return `${configManager.config.client.symbol}${localeString}`;
 };

--- a/packages/crypto/src/utils/format-arktoshi.ts
+++ b/packages/crypto/src/utils/format-arktoshi.ts
@@ -7,10 +7,11 @@ import { configManager } from "../managers/config";
  * @return {String}
  */
 export const formatArktoshi = amount => {
-    const localeString = (+amount / ARKTOSHI).toLocaleString("en", {
-      minimumFractionDigits: (amount < ARKTOSHI ? 8 : 0),
-        maximumFractionDigits: 8,
-    });
+  const decimalPlaces = ARKTOSHI.toString().length - 1
+  const localeString = (+amount / ARKTOSHI).toLocaleString("en", {
+    minimumFractionDigits: decimalPlaces,
+    maximumFractionDigits: decimalPlaces,
+  });
 
   return `${configManager.config.client.symbol}${localeString}`;
 };

--- a/packages/crypto/src/utils/format-arktoshi.ts
+++ b/packages/crypto/src/utils/format-arktoshi.ts
@@ -8,7 +8,7 @@ import { configManager } from "../managers/config";
  */
 export const formatArktoshi = amount => {
     const localeString = (+amount / ARKTOSHI).toLocaleString("en", {
-      minimumFractionDigits: (amount < 1 * ARKTOSHI ? 8 : 0),
+      minimumFractionDigits: (amount < ARKTOSHI ? 8 : 0),
         maximumFractionDigits: 8,
     });
 

--- a/packages/crypto/src/utils/format-arktoshi.ts
+++ b/packages/crypto/src/utils/format-arktoshi.ts
@@ -8,7 +8,7 @@ import { configManager } from "../managers/config";
  */
 export const formatArktoshi = amount => {
     const localeString = (+amount / ARKTOSHI).toLocaleString("en", {
-        minimumFractionDigits: 8,
+      minimumFractionDigits: (amount < 1 * ARKTOSHI ? 8 : 0),
         maximumFractionDigits: 8,
     });
 

--- a/packages/crypto/src/utils/format-arktoshi.ts
+++ b/packages/crypto/src/utils/format-arktoshi.ts
@@ -8,10 +8,14 @@ import { configManager } from "../managers/config";
  */
 export const formatArktoshi = amount => {
   const decimalPlaces = ARKTOSHI.toString().length - 1
-  const localeString = (+amount / ARKTOSHI).toLocaleString("en", {
+  let localeString = (+amount / ARKTOSHI).toLocaleString("en", {
     minimumFractionDigits: decimalPlaces,
     maximumFractionDigits: decimalPlaces,
   });
+
+  if (localeString.substr(-decimalPlaces) === "0".repeat(decimalPlaces)) {
+    localeString = localeString.substr(0, localeString.length - decimalPlaces - 1)
+  }
 
   return `${configManager.config.client.symbol}${localeString}`;
 };


### PR DESCRIPTION
## Proposed changes
Very often I have hard time reading the amount/fee in the logs, for example:
`0.00765 Ѧ`
I'm not sure is this `765,000` arktoshi or is it `76,500`?! Also to figure this out, you must know the network's decimal places.

IMO it should be printed like this:
`Ѧ0.00765000`

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [ ] Docs (documentation only changes)
- [ ] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [ ] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
