### PR TITLE
refactor(crypto): export type definitions

### DIFF
--- a/packages/core-blockchain/src/blockchain.ts
+++ b/packages/core-blockchain/src/blockchain.ts
@@ -1,8 +1,8 @@
 /* tslint:disable:max-line-length */
 import { app } from "@arkecosystem/core-container";
 import { PostgresConnection } from "@arkecosystem/core-database-postgres";
-import { TransactionPool } from "@arkecosystem/core-transaction-pool";
 import { AbstractLogger } from "@arkecosystem/core-logger";
+import { TransactionPool } from "@arkecosystem/core-transaction-pool";
 import { models, slots } from "@arkecosystem/crypto";
 
 import delay from "delay";

--- a/packages/core-p2p/src/server/versions/1/handlers.ts
+++ b/packages/core-p2p/src/server/versions/1/handlers.ts
@@ -1,7 +1,7 @@
 import { app } from "@arkecosystem/core-container";
 import { PostgresConnection } from "@arkecosystem/core-database-postgres";
-import { TransactionPool }  from "@arkecosystem/core-transaction-pool";
 import { AbstractLogger } from "@arkecosystem/core-logger";
+import { TransactionPool }  from "@arkecosystem/core-transaction-pool";
 import { TransactionGuard } from "@arkecosystem/core-transaction-pool";
 import { crypto, Joi, models, slots } from "@arkecosystem/crypto";
 

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -11,7 +11,8 @@
         "Joshua Noack <joshua@ark.io>"
     ],
     "license": "MIT",
-    "main": "dist/index.js",
+    "main": "dist/index",
+    "types": "dist/index",
     "browser": "dist/index.umd.js",
     "module": "dist/index.cjs.js",
     "files": [

--- a/packages/crypto/src/builder/index.ts
+++ b/packages/crypto/src/builder/index.ts
@@ -83,4 +83,15 @@ export class TransactionBuilderDirector {
 }
 
 const transactionBuilder = new TransactionBuilderDirector();
-export { transactionBuilder };
+export {
+    transactionBuilder,
+    DelegateRegistrationBuilder,
+    DelegateResignationBuilder,
+    IPFSBuilder,
+    MultiPaymentBuilder,
+    MultiSignatureBuilder,
+    SecondSignatureBuilder,
+    TimelockTransferBuilder,
+    TransferBuilder,
+    VoteBuilder,
+};

--- a/packages/crypto/src/builder/transactions/delegate-registration.ts
+++ b/packages/crypto/src/builder/transactions/delegate-registration.ts
@@ -1,6 +1,6 @@
 import { TransactionTypes } from "../../constants";
 import { crypto } from "../../crypto";
-import { feeManager } from "../../managers/fee";
+import { feeManager } from "../../managers";
 import { TransactionBuilder } from "./transaction";
 
 export class DelegateRegistrationBuilder extends TransactionBuilder {

--- a/packages/crypto/src/builder/transactions/delegate-resignation.ts
+++ b/packages/crypto/src/builder/transactions/delegate-resignation.ts
@@ -1,5 +1,5 @@
 import { TransactionTypes } from "../../constants";
-import { feeManager } from "../../managers/fee";
+import { feeManager } from "../../managers";
 import { TransactionBuilder } from "./transaction";
 
 export class DelegateResignationBuilder extends TransactionBuilder {

--- a/packages/crypto/src/builder/transactions/ipfs.ts
+++ b/packages/crypto/src/builder/transactions/ipfs.ts
@@ -1,5 +1,5 @@
 import { TransactionTypes } from "../../constants";
-import { feeManager } from "../../managers/fee";
+import { feeManager } from "../../managers";
 import { TransactionBuilder } from "./transaction";
 
 export class IPFSBuilder extends TransactionBuilder {

--- a/packages/crypto/src/builder/transactions/multi-payment.ts
+++ b/packages/crypto/src/builder/transactions/multi-payment.ts
@@ -1,5 +1,5 @@
 import { TransactionTypes } from "../../constants";
-import { feeManager } from "../../managers/fee";
+import { feeManager } from "../../managers";
 import { TransactionBuilder } from "./transaction";
 
 export class MultiPaymentBuilder extends TransactionBuilder {

--- a/packages/crypto/src/builder/transactions/multi-signature.ts
+++ b/packages/crypto/src/builder/transactions/multi-signature.ts
@@ -1,5 +1,5 @@
 import { TransactionTypes } from "../../constants";
-import { feeManager } from "../../managers/fee";
+import { feeManager } from "../../managers";
 import { TransactionBuilder } from "./transaction";
 
 export class MultiSignatureBuilder extends TransactionBuilder {

--- a/packages/crypto/src/builder/transactions/second-signature.ts
+++ b/packages/crypto/src/builder/transactions/second-signature.ts
@@ -1,6 +1,6 @@
 import { TransactionTypes } from "../../constants";
 import { crypto } from "../../crypto";
-import { feeManager } from "../../managers/fee";
+import { feeManager } from "../../managers";
 import { TransactionBuilder } from "./transaction";
 
 export class SecondSignatureBuilder extends TransactionBuilder {

--- a/packages/crypto/src/builder/transactions/timelock-transfer.ts
+++ b/packages/crypto/src/builder/transactions/timelock-transfer.ts
@@ -1,5 +1,5 @@
 import { TransactionTypes } from "../../constants";
-import { feeManager } from "../../managers/fee";
+import { feeManager } from "../../managers";
 import { TransactionBuilder } from "./transaction";
 
 export class TimelockTransferBuilder extends TransactionBuilder {

--- a/packages/crypto/src/builder/transactions/transaction.ts
+++ b/packages/crypto/src/builder/transactions/transaction.ts
@@ -1,6 +1,6 @@
 import { crypto, slots } from "../../crypto";
-import { configManager } from "../../managers/config";
-import { Transaction } from "../../models/transaction";
+import { configManager } from "../../managers";
+import { Transaction } from "../../models";
 
 export abstract class TransactionBuilder {
     public data: any;

--- a/packages/crypto/src/builder/transactions/transfer.ts
+++ b/packages/crypto/src/builder/transactions/transfer.ts
@@ -1,5 +1,5 @@
 import { TransactionTypes } from "../../constants";
-import { feeManager } from "../../managers/fee";
+import { feeManager } from "../../managers";
 import { TransactionBuilder } from "./transaction";
 
 export class TransferBuilder extends TransactionBuilder {

--- a/packages/crypto/src/builder/transactions/vote.ts
+++ b/packages/crypto/src/builder/transactions/vote.ts
@@ -1,5 +1,5 @@
 import { TransactionTypes } from "../../constants";
-import { feeManager } from "../../managers/fee";
+import { feeManager } from "../../managers";
 import { TransactionBuilder } from "./transaction";
 
 export class VoteBuilder extends TransactionBuilder {

--- a/packages/crypto/src/client.ts
+++ b/packages/crypto/src/client.ts
@@ -1,7 +1,7 @@
 import { transactionBuilder } from "./builder";
-import { configManager } from "./managers/config";
-import { feeManager } from "./managers/fee";
-import { NetworkManager } from "./managers/network";
+import { configManager } from "./managers";
+import { feeManager } from "./managers";
+import { NetworkManager } from "./managers";
 
 export class Client {
     /**
@@ -45,5 +45,4 @@ export class Client {
     }
 }
 
-const client = new Client();
-export { client };
+export const client = new Client();

--- a/packages/crypto/src/crypto/crypto.ts
+++ b/packages/crypto/src/crypto/crypto.ts
@@ -6,8 +6,8 @@ import crypto from "crypto";
 import secp256k1 from "secp256k1";
 import wif from "wif";
 
-import { configManager } from "../managers/config";
-import { feeManager } from "../managers/fee";
+import { configManager } from "../managers";
+import { feeManager } from "../managers";
 import { Bignum } from "../utils";
 import { HashAlgorithms } from "./hash-algorithms";
 

--- a/packages/crypto/src/crypto/hdwallet.ts
+++ b/packages/crypto/src/crypto/hdwallet.ts
@@ -1,13 +1,9 @@
 import bip32 from "bip32";
 import bip39 from "bip39";
-import { configManager } from "../managers/config";
+import { configManager } from "../managers";
 
 class HDWallet {
-    public readonly slip44: number;
-
-    constructor() {
-        this.slip44 = 111;
-    }
+    public readonly slip44 = 111;
 
     /**
      * Get root node from the given mnemonic with an optional passphrase.

--- a/packages/crypto/src/crypto/message.ts
+++ b/packages/crypto/src/crypto/message.ts
@@ -1,5 +1,5 @@
 import crypto from "crypto";
-import { configManager } from "../managers/config";
+import { configManager } from "../managers";
 import { crypto as arkCrypto } from "./crypto";
 
 const createHash = message =>

--- a/packages/crypto/src/crypto/slots.ts
+++ b/packages/crypto/src/crypto/slots.ts
@@ -1,5 +1,5 @@
 import dayjs from "dayjs-ext";
-import { configManager } from "../managers/config";
+import { configManager } from "../managers";
 
 class Slots {
     public height: number;

--- a/packages/crypto/src/handlers/transactions/multi-payment.ts
+++ b/packages/crypto/src/handlers/transactions/multi-payment.ts
@@ -1,5 +1,4 @@
 import sumBy from "lodash/sumBy";
-import { Bignum } from "../../utils/bignum";
 import { Handler } from "./handler";
 
 export class MultiPaymentHandler extends Handler {

--- a/packages/crypto/src/identities/address.ts
+++ b/packages/crypto/src/identities/address.ts
@@ -1,6 +1,6 @@
 import bs58check from "bs58check";
-import { HashAlgorithms } from "../crypto/hash-algorithms";
-import { configManager } from "../managers/config";
+import { HashAlgorithms } from "../crypto";
+import { configManager } from "../managers";
 import { PublicKey } from "./public-key";
 
 export class Address {

--- a/packages/crypto/src/identities/keys.ts
+++ b/packages/crypto/src/identities/keys.ts
@@ -1,8 +1,8 @@
 import secp256k1 from "secp256k1";
 import wif from "wif";
 
-import { HashAlgorithms } from "../crypto/hash-algorithms";
-import { configManager } from "../managers/config";
+import { HashAlgorithms } from "../crypto";
+import { configManager } from "../managers";
 
 export class Keys {
     public static fromPassphrase(passphrase, compressed = true) {

--- a/packages/crypto/src/identities/public-key.ts
+++ b/packages/crypto/src/identities/public-key.ts
@@ -1,4 +1,4 @@
-import { configManager } from "../managers/config";
+import { configManager } from "../managers";
 import { Address } from "./address";
 import { Keys } from "./keys";
 

--- a/packages/crypto/src/identities/wif.ts
+++ b/packages/crypto/src/identities/wif.ts
@@ -1,5 +1,5 @@
 import wif from "wif";
-import { configManager } from "../managers/config";
+import { configManager } from "../managers";
 import { Keys } from "./keys";
 
 export class WIF {

--- a/packages/crypto/src/index.ts
+++ b/packages/crypto/src/index.ts
@@ -1,5 +1,4 @@
-import { transactionBuilder } from "./builder";
-import { client } from "./client";
+export * from "./builder";
 
 import * as constants from "./constants";
 import * as models from "./models";
@@ -11,4 +10,4 @@ export * from "./validation";
 export * from "./crypto";
 export * from "./client";
 
-export { client, models, transactionBuilder, constants };
+export { models, constants };

--- a/packages/crypto/src/managers/config.ts
+++ b/packages/crypto/src/managers/config.ts
@@ -2,10 +2,8 @@ import deepmerge from "deepmerge";
 import camelCase from "lodash/camelCase";
 import get from "lodash/get";
 import set from "lodash/set";
-import { Engine } from "../validation/engine";
 import { feeManager } from "./fee";
 
-import { EventEmitter } from "events";
 import { TransactionTypes } from "../constants";
 import * as networks from "../networks";
 

--- a/packages/crypto/src/models/delegate.ts
+++ b/packages/crypto/src/models/delegate.ts
@@ -3,10 +3,10 @@ import { createHash } from "crypto";
 import forge from "node-forge";
 import { authenticator } from "otplib";
 import wif from "wif";
-import { Bignum } from "../utils/bignum";
+import { Bignum } from "../utils";
 
 import { crypto } from "../crypto/crypto";
-import { sortTransactions } from "../utils/sort-transactions";
+import { sortTransactions } from "../utils";
 import { Block } from "./block";
 
 /**

--- a/packages/crypto/src/models/transaction.ts
+++ b/packages/crypto/src/models/transaction.ts
@@ -5,7 +5,7 @@ import ByteBuffer from "bytebuffer";
 import { createHash } from "crypto";
 import { TransactionTypes } from "../constants";
 import { crypto } from "../crypto/crypto";
-import { configManager } from "../managers/config";
+import { configManager } from "../managers";
 import { Bignum } from "../utils";
 
 const { transactionIdFixTable } = configManager.getPreset("mainnet").exceptions;

--- a/packages/crypto/src/models/wallet.ts
+++ b/packages/crypto/src/models/wallet.ts
@@ -1,7 +1,6 @@
 import { TransactionTypes } from "../constants";
 import { crypto } from "../crypto/crypto";
 import { transactionHandler } from "../handlers/transactions";
-import { configManager } from "../managers/config";
 import { Bignum, formatArktoshi } from "../utils";
 
 /**

--- a/packages/crypto/src/utils/format-arktoshi.ts
+++ b/packages/crypto/src/utils/format-arktoshi.ts
@@ -1,5 +1,5 @@
 import { ARKTOSHI } from "../constants";
-import { configManager } from "../managers/config";
+import { configManager } from "../managers";
 
 /**
  * Get human readable string from arktoshis

--- a/packages/crypto/src/validation/engine.ts
+++ b/packages/crypto/src/validation/engine.ts
@@ -1,5 +1,4 @@
 import Joi from "joi";
-import { configManager } from "../managers";
 import { extensions } from "./extensions";
 
 export class Engine {


### PR DESCRIPTION
## Proposed changes
Resolves #1792

This PR simply exposes the types in crypto, but it doesn't propagate those types around their dependencies. The code-base is already using these types already. 
The next step would be to improve type-safety, replacing a lot of 'any' with their actual expected types. This will require a lot more effort  because it'll start introducing compile errors all over :)

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [ ] Docs (documentation only changes)
- [ ] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:
<!--

-->
- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!--
