### PR TITLE
fix(core-database-postgres): set last block of all delegates during SPV

### DIFF
--- a/packages/core-database-postgres/src/queries/spv/last-forged-blocks.sql
+++ b/packages/core-database-postgres/src/queries/spv/last-forged-blocks.sql
@@ -1,5 +1,11 @@
 SELECT id,
+       height,
        generator_public_key,
        TIMESTAMP
 FROM blocks
-ORDER BY TIMESTAMP DESC LIMIT ${limit}
+WHERE height IN (
+  SELECT MAX(height) AS last_block_height
+  FROM blocks
+  GROUP BY generator_public_key
+)
+ORDER BY TIMESTAMP DESC

--- a/packages/core-database-postgres/src/spv.ts
+++ b/packages/core-database-postgres/src/spv.ts
@@ -97,9 +97,7 @@ export class SPV {
      * @return {void}
      */
     public async __buildLastForgedBlocks() {
-        const blocks = await this.query.many(queries.spv.lastForgedBlocks, {
-            limit: this.activeDelegates,
-        });
+        const blocks = await this.query.many(queries.spv.lastForgedBlocks);
 
         for (const block of blocks) {
             const wallet = this.walletManager.findByPublicKey(block.generatorPublicKey);


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

Instead of fetching only the last 51 blocks during the SPV this PR fetches the last block of all delegates, fixing https://github.com/ArkEcosystem/core/issues/1847.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes