### PR TITLE
chore: simpler CircleCI config generation script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,17 +64,20 @@ jobs:
           name: Create .ark/database directory
           command: mkdir -p $HOME/.ark/database
       - run:
-          name: core-webhooks
-          command: 'cd ~/ark-core/packages/core-webhooks && yarn test:coverage'
+          name: core-vote-report
+          command: 'cd ~/ark-core/packages/core-vote-report && yarn test:coverage'
       - run:
-          name: core-transaction-pool
-          command: 'cd ~/ark-core/packages/core-transaction-pool && yarn test:coverage'
+          name: core-tester-cli
+          command: 'cd ~/ark-core/packages/core-tester-cli && yarn test:coverage'
       - run:
-          name: core-logger-winston
-          command: 'cd ~/ark-core/packages/core-logger-winston && yarn test:coverage'
+          name: core-snapshots
+          command: 'cd ~/ark-core/packages/core-snapshots && yarn test:coverage'
       - run:
-          name: core-api
-          command: 'cd ~/ark-core/packages/core-api && yarn test:coverage'
+          name: core-logger
+          command: 'cd ~/ark-core/packages/core-logger && yarn test:coverage'
+      - run:
+          name: core-graphql
+          command: 'cd ~/ark-core/packages/core-graphql && yarn test:coverage'
       - run:
           name: core-debugger-cli
           command: 'cd ~/ark-core/packages/core-debugger-cli && yarn test:coverage'
@@ -82,8 +85,8 @@ jobs:
           name: core-container
           command: 'cd ~/ark-core/packages/core-container && yarn test:coverage'
       - run:
-          name: core-graphql
-          command: 'cd ~/ark-core/packages/core-graphql && yarn test:coverage'
+          name: core
+          command: 'cd ~/ark-core/packages/core && yarn test:coverage'
       - run:
           name: Last 1000 lines of test output
           when: on_fail
@@ -155,17 +158,20 @@ jobs:
           name: Create .ark/database directory
           command: mkdir -p $HOME/.ark/database
       - run:
-          name: core-webhooks
-          command: 'cd ~/ark-core/packages/core-webhooks && yarn test:coverage'
+          name: core-vote-report
+          command: 'cd ~/ark-core/packages/core-vote-report && yarn test:coverage'
       - run:
-          name: core-transaction-pool
-          command: 'cd ~/ark-core/packages/core-transaction-pool && yarn test:coverage'
+          name: core-tester-cli
+          command: 'cd ~/ark-core/packages/core-tester-cli && yarn test:coverage'
       - run:
-          name: core-logger-winston
-          command: 'cd ~/ark-core/packages/core-logger-winston && yarn test:coverage'
+          name: core-snapshots
+          command: 'cd ~/ark-core/packages/core-snapshots && yarn test:coverage'
       - run:
-          name: core-api
-          command: 'cd ~/ark-core/packages/core-api && yarn test:coverage'
+          name: core-logger
+          command: 'cd ~/ark-core/packages/core-logger && yarn test:coverage'
+      - run:
+          name: core-graphql
+          command: 'cd ~/ark-core/packages/core-graphql && yarn test:coverage'
       - run:
           name: core-debugger-cli
           command: 'cd ~/ark-core/packages/core-debugger-cli && yarn test:coverage'
@@ -173,8 +179,8 @@ jobs:
           name: core-container
           command: 'cd ~/ark-core/packages/core-container && yarn test:coverage'
       - run:
-          name: core-graphql
-          command: 'cd ~/ark-core/packages/core-graphql && yarn test:coverage'
+          name: core
+          command: 'cd ~/ark-core/packages/core && yarn test:coverage'
       - run:
           name: Last 1000 lines of test output
           when: on_fail
@@ -325,14 +331,14 @@ jobs:
           name: Create .ark/database directory
           command: mkdir -p $HOME/.ark/database
       - run:
-          name: core-utils
-          command: 'cd ~/ark-core/packages/core-utils && yarn test:coverage'
+          name: core-webhooks
+          command: 'cd ~/ark-core/packages/core-webhooks && yarn test:coverage'
       - run:
-          name: core-test-utils
-          command: 'cd ~/ark-core/packages/core-test-utils && yarn test:coverage'
+          name: core-transaction-pool
+          command: 'cd ~/ark-core/packages/core-transaction-pool && yarn test:coverage'
       - run:
-          name: core-p2p
-          command: 'cd ~/ark-core/packages/core-p2p && yarn test:coverage'
+          name: core-logger-winston
+          command: 'cd ~/ark-core/packages/core-logger-winston && yarn test:coverage'
       - run:
           name: core-http-utils
           command: 'cd ~/ark-core/packages/core-http-utils && yarn test:coverage'
@@ -343,8 +349,8 @@ jobs:
           name: core-database
           command: 'cd ~/ark-core/packages/core-database && yarn test:coverage'
       - run:
-          name: core
-          command: 'cd ~/ark-core/packages/core && yarn test:coverage'
+          name: core-api
+          command: 'cd ~/ark-core/packages/core-api && yarn test:coverage'
       - run:
           name: Last 1000 lines of test output
           when: on_fail
@@ -416,17 +422,20 @@ jobs:
           name: Create .ark/database directory
           command: mkdir -p $HOME/.ark/database
       - run:
-          name: core-vote-report
-          command: 'cd ~/ark-core/packages/core-vote-report && yarn test:coverage'
+          name: crypto
+          command: 'cd ~/ark-core/packages/crypto && yarn test:coverage'
       - run:
-          name: core-tester-cli
-          command: 'cd ~/ark-core/packages/core-tester-cli && yarn test:coverage'
+          name: core-utils
+          command: 'cd ~/ark-core/packages/core-utils && yarn test:coverage'
       - run:
-          name: core-snapshots
-          command: 'cd ~/ark-core/packages/core-snapshots && yarn test:coverage'
+          name: core-test-utils
+          command: 'cd ~/ark-core/packages/core-test-utils && yarn test:coverage'
       - run:
-          name: core-logger
-          command: 'cd ~/ark-core/packages/core-logger && yarn test:coverage'
+          name: core-p2p
+          command: 'cd ~/ark-core/packages/core-p2p && yarn test:coverage'
+      - run:
+          name: core-json-rpc
+          command: 'cd ~/ark-core/packages/core-json-rpc && yarn test:coverage'
       - run:
           name: core-forger
           command: 'cd ~/ark-core/packages/core-forger && yarn test:coverage'
@@ -583,14 +592,14 @@ jobs:
           name: Create .ark/database directory
           command: mkdir -p $HOME/.ark/database
       - run:
-          name: core-utils
-          command: 'cd ~/ark-core/packages/core-utils && yarn test:coverage'
+          name: core-webhooks
+          command: 'cd ~/ark-core/packages/core-webhooks && yarn test:coverage'
       - run:
-          name: core-test-utils
-          command: 'cd ~/ark-core/packages/core-test-utils && yarn test:coverage'
+          name: core-transaction-pool
+          command: 'cd ~/ark-core/packages/core-transaction-pool && yarn test:coverage'
       - run:
-          name: core-p2p
-          command: 'cd ~/ark-core/packages/core-p2p && yarn test:coverage'
+          name: core-logger-winston
+          command: 'cd ~/ark-core/packages/core-logger-winston && yarn test:coverage'
       - run:
           name: core-http-utils
           command: 'cd ~/ark-core/packages/core-http-utils && yarn test:coverage'
@@ -601,8 +610,8 @@ jobs:
           name: core-database
           command: 'cd ~/ark-core/packages/core-database && yarn test:coverage'
       - run:
-          name: core
-          command: 'cd ~/ark-core/packages/core && yarn test:coverage'
+          name: core-api
+          command: 'cd ~/ark-core/packages/core-api && yarn test:coverage'
       - run:
           name: Last 1000 lines of test output
           when: on_fail
@@ -674,17 +683,20 @@ jobs:
           name: Create .ark/database directory
           command: mkdir -p $HOME/.ark/database
       - run:
-          name: core-vote-report
-          command: 'cd ~/ark-core/packages/core-vote-report && yarn test:coverage'
+          name: crypto
+          command: 'cd ~/ark-core/packages/crypto && yarn test:coverage'
       - run:
-          name: core-tester-cli
-          command: 'cd ~/ark-core/packages/core-tester-cli && yarn test:coverage'
+          name: core-utils
+          command: 'cd ~/ark-core/packages/core-utils && yarn test:coverage'
       - run:
-          name: core-snapshots
-          command: 'cd ~/ark-core/packages/core-snapshots && yarn test:coverage'
+          name: core-test-utils
+          command: 'cd ~/ark-core/packages/core-test-utils && yarn test:coverage'
       - run:
-          name: core-logger
-          command: 'cd ~/ark-core/packages/core-logger && yarn test:coverage'
+          name: core-p2p
+          command: 'cd ~/ark-core/packages/core-p2p && yarn test:coverage'
+      - run:
+          name: core-json-rpc
+          command: 'cd ~/ark-core/packages/core-json-rpc && yarn test:coverage'
       - run:
           name: core-forger
           command: 'cd ~/ark-core/packages/core-forger && yarn test:coverage'

--- a/.circleci/generateConfig.js
+++ b/.circleci/generateConfig.js
@@ -114,40 +114,12 @@ function generateYAML(options) {
 }
 
 function splitPackagesByTestFiles(packages, splitNumber) {
-    /* distribute test packages by test files count : start by most files package,
-     and distribute package by package in each _packagesSplit_ (not the most effective
-     distribution but simple and enough for now) */
-    const packagesWithCount = packages.map(package => ({
-        package,
-        count: countFiles(`packages/${package}/__tests__`, ".test.js"),
-    })).filter(item => {
+    const packagesWithCount = packages.filter(item => {
         return !slowPerformance.includes(item.package)
     })
 
-    const packagesSortedByCount = packagesWithCount.sort((pkgA, pkgB) => pkgA.count > pkgB.count);
-
     const packagesSplit = new Array(splitNumber);
-    packagesSortedByCount.forEach((pkg, index) => (packagesSplit[index % splitNumber] = [pkg.package].concat(packagesSplit[index % splitNumber] || [])));
+    packagesWithCount.forEach((pkg, index) => (packagesSplit[index % splitNumber] = [pkg].concat(packagesSplit[index % splitNumber] || [])));
 
     return packagesSplit;
-}
-
-function countFiles(startPath, filter) {
-    let count = 0;
-    if (!fs.existsSync(startPath)) {
-        return;
-    }
-
-    var files = fs.readdirSync(startPath);
-    for (let i = 0; i < files.length; i++) {
-        const filename = path.join(startPath, files[i]);
-        const stat = fs.lstatSync(filename);
-        if (stat.isDirectory()) {
-            count += countFiles(filename, filter);
-        } else if (filename.indexOf(filter) >= 0) {
-            count++;
-        }
-    }
-
-    return count;
 }


### PR DESCRIPTION
## Proposed changes

Right now the config file is constantly regenerated because the files count changes over time but since we run the slow crypto tests now in a separate job there is no benefit to running tests in order of file count.

## Types of changes

- [x] Other

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes