### PR TITLE
fix(core-api): prevent cold wallet response

### DIFF
--- a/packages/core-api/__tests__/v1/handlers/accounts.test.ts
+++ b/packages/core-api/__tests__/v1/handlers/accounts.test.ts
@@ -29,6 +29,20 @@ describe("API 1.0 - Wallets", () => {
 
             utils.expectWallet(response.data.account);
         });
+
+        it("should not return an empty wallet", async () => {
+            // create a cold wallet in memory with the given senderId
+            const createCold = await utils.request("GET", "transactions", {
+                senderId: "AbhUUMJBw1dZJiZMxKBhHsdXMMafcMaPNG",
+            });
+            expect(createCold).toBeSuccessfulResponse();
+            expect(createCold.data.transactions).toBeEmpty();
+
+            // attempt to retrieve the cold wallet
+            const response = await utils.request("GET", "accounts", { address: "AbhUUMJBw1dZJiZMxKBhHsdXMMafcMaPNG" });
+            expect(response).toBeSuccessfulResponse();
+            expect(response.data.error).toBe("Account not found");
+        });
     });
 
     describe("GET api/accounts/getBalance?address", () => {

--- a/packages/core-api/src/repositories/transactions.ts
+++ b/packages/core-api/src/repositories/transactions.ts
@@ -486,7 +486,11 @@ export class TransactionsRepository extends Repository implements IRepository {
      * @return {String}
      */
     public __publicKeyFromAddress(senderId): string {
-        return this.database.walletManager.findByAddress(senderId).publicKey;
+        if (this.database.walletManager.exists(senderId)) {
+            return this.database.walletManager.findByAddress(senderId).publicKey;
+        }
+
+        return null;
     }
 
     public __orderBy(parameters): string[] {

--- a/packages/core-database/src/wallet-manager.ts
+++ b/packages/core-database/src/wallet-manager.ts
@@ -76,6 +76,22 @@ export class WalletManager {
     }
 
     /**
+     * Checks if wallet exits in wallet manager
+     * @param  {String} key can be publicKey or address of wallet
+     * @return {Boolean} true if exists
+     */
+    public exists(key) {
+        if (this.byPublicKey[key]) {
+            return true;
+        }
+
+        if (this.byAddress[key]) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
      * Find a wallet by the given public key.
      * @param  {String} publicKey
      * @return {Wallet}

--- a/packages/core-transaction-pool/src/pool-wallet-manager.ts
+++ b/packages/core-transaction-pool/src/pool-wallet-manager.ts
@@ -36,23 +36,6 @@ export class PoolWalletManager extends WalletManager {
         return this.byAddress[address];
     }
 
-    /**
-     * Checks if wallet exits in pool wallet manager
-     * Method overrides base class method from WalletManager.
-     * @param  {String} key can be publicKey or address of wallet
-     * @return {Boolean} true if exists
-     */
-    public exists(key) {
-        if (this.byPublicKey[key]) {
-            return true;
-        }
-
-        if (this.byAddress[key]) {
-            return true;
-        }
-        return false;
-    }
-
     public deleteWallet(publicKey) {
         this.forgetByPublicKey(publicKey);
         this.forgetByAddress(crypto.getAddress(publicKey, this.networkId));


### PR DESCRIPTION
 - When querying for /accounts?address, return error if account.publicKey === null (cold wallet)
 - Add test to check for bug

Ref: #1949

## Proposed changes
I will test if the bug is also present on v2 today, I would like to get a review on whether this makes sense. All tests were done incrementally, initially the response (without account.publicKey === null) check was that of an empty cold wallet; now it simply returns an error "Account not found" (as wanted).

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [ ] Docs (documentation only changes)
- [x] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
