### PR TITLE
test: transaction replay tests for blockchain and tx-pool

### DIFF
--- a/packages/core-blockchain/__tests__/__support__/setup.ts
+++ b/packages/core-blockchain/__tests__/__support__/setup.ts
@@ -3,14 +3,16 @@ import { setUpContainer } from "@arkecosystem/core-test-utils/src/helpers/contai
 
 jest.setTimeout(60000);
 
-export const setUp = async () => {
-    await setUpContainer({
+export const setUpFull = async () =>
+    setUpContainer({
+        exit: "@arkecosystem/core-blockchain",
+    });
+
+export const setUp = async () =>
+    setUpContainer({
         exit: "@arkecosystem/core-p2p",
         exclude: ["@arkecosystem/core-blockchain"],
     });
-
-    return app;
-};
 
 export const tearDown = async () => {
     await app.tearDown();

--- a/packages/core-blockchain/__tests__/processor/block-processor.test.ts
+++ b/packages/core-blockchain/__tests__/processor/block-processor.test.ts
@@ -1,0 +1,120 @@
+import "@arkecosystem/core-test-utils";
+import { fixtures, generators } from "@arkecosystem/core-test-utils";
+import genesisBlockTestnet from "@arkecosystem/core-test-utils/src/config/testnet/genesisBlock.json";
+import { models } from "@arkecosystem/crypto";
+import { Blockchain } from "../../src/blockchain";
+import { setUpFull, tearDown } from "../__support__/setup";
+
+const { Block } = models;
+const { delegates } = fixtures;
+const { generateTransfers } = generators;
+
+let app;
+let blockchain: Blockchain;
+let blockProcessor;
+
+beforeAll(async () => {
+    app = await setUpFull();
+    blockchain = app.resolvePlugin("blockchain");
+
+    // using require here because if we import before app is set up, it ends up with some undefined references
+    const { BlockProcessor } = require("../../src/processor");
+
+    blockProcessor = new BlockProcessor(blockchain);
+
+    await blockchain.removeBlocks(blockchain.getLastHeight() - 1);
+});
+
+afterAll(async () => {
+    await tearDown();
+});
+
+describe("Block processor", () => {
+    describe("process", () => {
+        describe("should not accept replay transactions", () => {
+            afterEach(async () => blockchain.removeBlocks(blockchain.getLastHeight() - 1)); // reset to block height 1
+
+            const addBlock = async transactions => {
+                const block = {
+                    id: "17882607875259085966",
+                    version: 0,
+                    timestamp: 46583330,
+                    height: 2,
+                    reward: 0,
+                    previousBlock: genesisBlockTestnet.id,
+                    numberOfTransactions: 1,
+                    transactions,
+                    totalAmount: transactions.reduce((acc, curr) => acc + curr.amount),
+                    totalFee: transactions.reduce((acc, curr) => acc + curr.fee),
+                    payloadLength: 0,
+                    payloadHash: genesisBlockTestnet.payloadHash,
+                    generatorPublicKey: delegates[0].publicKey,
+                    blockSignature:
+                        "3045022100e7385c6ea42bd950f7f6ab8c8619cf2f66a41d8f8f185b0bc99af032cb25f30d02200b6210176a6cedfdcbe483167fd91c21d740e0e4011d24d679c601fdd46b0de9",
+                    createdAt: "2019-07-11T16:48:50.550Z",
+                };
+                const blockVerified = new Block(block);
+                blockVerified.verification.verified = true;
+
+                await blockchain.processBlock(blockVerified, () => null);
+
+                return Object.assign(block, { id: blockVerified.data.id });
+            };
+
+            it("should not validate an already forged transaction", async () => {
+                const { AlreadyForgedHandler } = require("../../src/processor/handlers/already-forged-handler");
+                const { BlockProcessorResult } = require("../../src/processor");
+                const transfers = generateTransfers(
+                    "unitnet",
+                    delegates[0].passphrase,
+                    delegates[1].address,
+                    11,
+                    1,
+                    true,
+                );
+                const block = await addBlock(transfers);
+                block.height = 3;
+                block.previousBlock = block.id;
+                block.id = "17882607875259085967";
+                block.timestamp += 1000;
+
+                const blockVerified = new Block(block);
+                blockVerified.verification.verified = true;
+
+                const handler = await blockProcessor.getHandler(blockVerified);
+                expect(handler instanceof AlreadyForgedHandler).toBeTrue();
+
+                const result = await blockProcessor.process(blockVerified);
+                expect(result).toBe(BlockProcessorResult.DiscardedButCanBeBroadcasted);
+            });
+
+            it("should not validate an already forged transaction - trying to tweak the tx id", async () => {
+                const { AlreadyForgedHandler } = require("../../src/processor/handlers/already-forged-handler");
+                const { BlockProcessorResult } = require("../../src/processor");
+                const transfers = generateTransfers(
+                    "unitnet",
+                    delegates[0].passphrase,
+                    delegates[1].address,
+                    11,
+                    1,
+                    true,
+                );
+                const block = await addBlock(transfers);
+                block.height = 3;
+                block.previousBlock = block.id;
+                block.id = "17882607875259085967";
+                block.timestamp += 1000;
+                block.transactions[0].id = "123456"; // change the tx id to try to make it accept as a new transaction
+
+                const blockVerified = new Block(block);
+                blockVerified.verification.verified = true;
+
+                const handler = await blockProcessor.getHandler(blockVerified);
+                expect(handler instanceof AlreadyForgedHandler).toBeTrue();
+
+                const result = await blockProcessor.process(blockVerified);
+                expect(result).toBe(BlockProcessorResult.DiscardedButCanBeBroadcasted);
+            });
+        });
+    });
+});

--- a/packages/core-transaction-pool/__tests__/guard.test.ts
+++ b/packages/core-transaction-pool/__tests__/guard.test.ts
@@ -655,7 +655,7 @@ describe("Transaction Guard", () => {
 
                 const result = await guard.validate(transfers);
 
-                expect(result.errors).toEqual(__forgedErrorMessage(transfers[0].id));
+                expect(result.errors).toEqual(forgedErrorMessage(transfers[0].id));
             });
 
             it("should not validate an already forged transaction - trying to tweak tx id", async () => {
@@ -667,7 +667,7 @@ describe("Transaction Guard", () => {
 
                 const result = await guard.validate(transfers);
 
-                expect(result.errors).toEqual(__forgedErrorMessage(realTransferId));
+                expect(result.errors).toEqual(forgedErrorMessage(realTransferId));
             });
         });
     });

--- a/packages/core-transaction-pool/__tests__/guard.test.ts
+++ b/packages/core-transaction-pool/__tests__/guard.test.ts
@@ -1,8 +1,8 @@
 import { PostgresConnection } from "@arkecosystem/core-database-postgres";
 import { Container } from "@arkecosystem/core-interfaces";
 import { generators } from "@arkecosystem/core-test-utils";
-import { delegates, wallets, wallets2ndSig } from "@arkecosystem/core-test-utils/src/fixtures/unitnet";
-import { configManager, crypto, slots } from "@arkecosystem/crypto";
+import { delegates, genesisBlock, wallets, wallets2ndSig } from "@arkecosystem/core-test-utils/src/fixtures/unitnet";
+import { configManager, crypto, models, slots } from "@arkecosystem/crypto";
 import bip39 from "bip39";
 import "jest-extended";
 import { TransactionPool } from "../src";
@@ -10,6 +10,7 @@ import { TransactionGuard } from "../src";
 import { config as localConfig } from "../src/config";
 import { setUpFull, tearDown } from "./__support__/setup";
 
+const { Block } = models;
 const {
     generateDelegateRegistration,
     generateSecondSignature,
@@ -21,10 +22,12 @@ const {
 let container: Container.IContainer;
 let guard;
 let transactionPool: TransactionPool;
+let blockchain;
 
 beforeAll(async () => {
     container = await setUpFull();
     transactionPool = container.resolvePlugin<TransactionPool>("transactionPool");
+    blockchain = container.resolvePlugin("blockchain");
     localConfig.init(transactionPool.options);
 });
 
@@ -606,6 +609,65 @@ describe("Transaction Guard", () => {
                 expect(result.invalid).toEqual(modifiedTransactions.map(transaction => transaction.id));
                 expect(result.accept).toEqual([]);
                 expect(result.broadcast).toEqual([]);
+            });
+        });
+
+        describe("Transaction replay shouldn't pass validation", () => {
+            afterEach(async () => blockchain.removeBlocks(blockchain.getLastHeight() - 1)); // resets to height 1
+
+            const addBlock = async transactions => {
+                // makes blockchain accept a new block with the transactions specified
+                const block = {
+                    id: "17882607875259085966",
+                    version: 0,
+                    timestamp: 46583330,
+                    height: 2,
+                    reward: 0,
+                    previousBlock: genesisBlock.id,
+                    numberOfTransactions: 1,
+                    transactions,
+                    totalAmount: transactions.reduce((acc, curr) => acc + curr.amount),
+                    totalFee: transactions.reduce((acc, curr) => acc + curr.fee),
+                    payloadLength: 0,
+                    payloadHash: genesisBlock.payloadHash,
+                    generatorPublicKey: delegates[0].publicKey,
+                    blockSignature:
+                        "3045022100e7385c6ea42bd950f7f6ab8c8619cf2f66a41d8f8f185b0bc99af032cb25f30d02200b6210176a6cedfdcbe483167fd91c21d740e0e4011d24d679c601fdd46b0de9",
+                    createdAt: "2019-07-11T16:48:50.550Z",
+                };
+                const blockVerified = new Block(block);
+                blockVerified.verification.verified = true;
+
+                await blockchain.processBlock(blockVerified, () => null);
+            };
+            const forgedErrorMessage = id => ({
+                [id]: [
+                    {
+                        message: "Already forged.",
+                        type: "ERR_FORGED",
+                    },
+                ],
+            });
+
+            it("should not validate an already forged transaction", async () => {
+                const transfers = generateTransfers("unitnet", wallets[0].passphrase, wallets[1].address, 11, 1, true);
+                await addBlock(transfers);
+
+                const result = await guard.validate(transfers);
+
+                expect(result.errors).toEqual(__forgedErrorMessage(transfers[0].id));
+            });
+
+            it("should not validate an already forged transaction - trying to tweak tx id", async () => {
+                const transfers = generateTransfers("unitnet", wallets[0].passphrase, wallets[1].address, 11, 1, true);
+                await addBlock(transfers);
+
+                const realTransferId = transfers[0].id;
+                transfers[0].id = "123456";
+
+                const result = await guard.validate(transfers);
+
+                expect(result.errors).toEqual(__forgedErrorMessage(realTransferId));
             });
         });
     });


### PR DESCRIPTION
## Proposed changes

Added transaction replay tests in core-blockchain and core-transaction-pool, to make sure we won't accept the same transaction twice.

## Types of changes

- [x] Test (adding missing tests or fixing existing tests)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works