### PR TITLE
test(core-jest-matchers): increase coverage

### DIFF
--- a/packages/core-jest-matchers/__tests__/api/block.test.ts
+++ b/packages/core-jest-matchers/__tests__/api/block.test.ts
@@ -1,0 +1,49 @@
+import "../../src/api/block";
+
+let block;
+
+beforeEach(() => {
+    block = {
+        blockSignature: "",
+        createdAt: "",
+        generatorPublicKey: "",
+        height: "",
+        id: "",
+        numberOfTransactions: "",
+        payloadHash: "",
+        payloadLength: "",
+        previousBlock: "",
+        reward: "",
+        timestamp: "",
+        totalAmount: "",
+        totalFee: "",
+        transactions: "",
+        updatedAt: "",
+        version: "",
+    };
+});
+describe(".toBeValidBlock", () => {
+    test("passes when given a valid block", () => {
+        expect(block).toBeValidBlock();
+    });
+
+    test("fails given an invalid block", () => {
+        delete block.reward;
+        expect(expect(block).toBeValidBlock).toThrowError(/Expected .* to be a valid block/);
+    });
+});
+
+describe(".toBeValidArrayOfBlocks", () => {
+    test("passes given a valid array of blocks", () => {
+        expect([block, block]).toBeValidArrayOfBlocks();
+    });
+
+    test("fails given an array with an invalid block", () => {
+        delete block.reward;
+        expect(expect([block, block]).toBeValidArrayOfBlocks).toThrowError(/Expected .* to be a valid array of blocks/);
+    });
+
+    test("fails when not given an array of blocks", () => {
+        expect(expect(block).toBeValidArrayOfBlocks).toThrowError(/Expected .* to be a valid array of blocks/);
+    });
+});

--- a/packages/core-jest-matchers/__tests__/api/peer.test.ts
+++ b/packages/core-jest-matchers/__tests__/api/peer.test.ts
@@ -1,0 +1,33 @@
+import "../../src/api/peer";
+
+let peer;
+
+beforeEach(() => {
+    peer = { ip: "", port: "" };
+});
+
+describe(".toBeValidPeer", () => {
+    test("passes pass given a valid peer", () => {
+        expect(peer).toBeValidPeer();
+    });
+
+    test("fails given an invalid peer", () => {
+        delete peer.ip;
+        expect(expect(peer).toBeValidPeer).toThrowError(/Expected .* to be a valid peer/);
+    });
+});
+
+describe(".toBeValidArrayOfPeers", () => {
+    test("passes given an array of valid peers", () => {
+        expect([peer, peer]).toBeValidArrayOfPeers();
+    });
+
+    test("fails given an array with an invalid peer", () => {
+        delete peer.ip;
+        expect(expect([peer, peer]).toBeValidArrayOfPeers).toThrowError(/Expected .* to be a valid array of peers/);
+    });
+
+    test("fails when not given an array of peers", () => {
+        expect(expect(peer).toBeValidArrayOfPeers).toThrowError(/Expected .* to be a valid array of peers/);
+    });
+});

--- a/packages/core-jest-matchers/__tests__/api/response.test.ts
+++ b/packages/core-jest-matchers/__tests__/api/response.test.ts
@@ -1,0 +1,48 @@
+import "../../src/api/response";
+
+let response;
+
+beforeEach(() => {
+    response = {
+        status: 200,
+        headers: {},
+        data: {
+            meta: {
+                pageCount: "",
+                totalCount: "",
+                next: "",
+                previous: "",
+                self: "",
+                first: "",
+                last: "",
+            },
+        },
+    };
+});
+
+describe(".toBeSuccessfulResponse", () => {
+    test("passes when given a successful response", () => {
+        expect(response).toBeSuccessfulResponse();
+    });
+
+    test("fails when given an unsuccessful response", () => {
+        response.status = 404;
+        expect(expect(response).toBeSuccessfulResponse).toThrowError(/Expected .* to be a successful response/);
+    });
+
+    test("fails when not given a response object", () => {
+        response = "invalid";
+        expect(expect(response).toBeSuccessfulResponse).toThrowError(/Expected .* to be a successful response/);
+    });
+});
+
+describe(".toBePaginated", () => {
+    test("passes when given a paginated response", () => {
+        expect(response).toBePaginated();
+    });
+
+    test("fails when not given a paginated response", () => {
+        delete response.data.meta.pageCount;
+        expect(expect(response).toBePaginated).toThrowError(/Expected .* to be a paginated response/);
+    });
+});

--- a/packages/core-jest-matchers/__tests__/api/transaction.test.ts
+++ b/packages/core-jest-matchers/__tests__/api/transaction.test.ts
@@ -1,0 +1,26 @@
+import "../../src/api/transaction";
+
+const transaction = {
+    id: "",
+    blockid: "",
+    type: "",
+    timestamp: "",
+    amount: "",
+    fee: "",
+    senderId: "",
+    senderPublicKey: "",
+    signature: "",
+    asset: "",
+    confirmations: "",
+};
+
+describe(".toBeApiTransaction", () => {
+    test("passes pass given a valid transaction", () => {
+        expect(transaction).toBeApiTransaction();
+    });
+
+    test("fails given an invalid transaction", () => {
+        delete transaction.id;
+        expect(expect(transaction).toBeApiTransaction).toThrowError(/Expected .* to be a valid transaction/);
+    });
+});

--- a/packages/core-jest-matchers/__tests__/fields/address.test.ts
+++ b/packages/core-jest-matchers/__tests__/fields/address.test.ts
@@ -6,6 +6,6 @@ describe(".toBeArkAddress", () => {
     });
 
     test("fails when not given a valid address", () => {
-        expect("invalid-address").not.toBeArkAddress();
+        expect(expect("invalid-address").toBeArkAddress).toThrowError("Expected value to be a valid address");
     });
 });

--- a/packages/core-jest-matchers/__tests__/fields/public-key.test.ts
+++ b/packages/core-jest-matchers/__tests__/fields/public-key.test.ts
@@ -4,4 +4,8 @@ describe(".toBeArkPublicKey", () => {
     test("passes when given a valid public key", () => {
         expect("022cca9529ec97a772156c152a00aad155ee6708243e65c9d211a589cb5d43234d").toBeArkPublicKey();
     });
+
+    test("fails when not given a valid public key", () => {
+        expect(expect("invalid-pubkey").toBeArkPublicKey).toThrowError("Expected value to be a valid public key");
+    });
 });

--- a/packages/core-jest-matchers/__tests__/models/delegate.test.ts
+++ b/packages/core-jest-matchers/__tests__/models/delegate.test.ts
@@ -12,6 +12,6 @@ describe(".toBeDelegate", () => {
     });
 
     test("fails when given an invalid delegate", () => {
-        expect({ fake: "news" }).not.toBeDelegate();
+        expect(expect({ fake: "news" }).toBeDelegate).toThrowError("Expected value to be a valid delegate");
     });
 });

--- a/packages/core-jest-matchers/__tests__/models/transaction.test.ts
+++ b/packages/core-jest-matchers/__tests__/models/transaction.test.ts
@@ -23,6 +23,6 @@ describe(".toBeTransaction", () => {
     });
 
     test("fails when given an invalid transaction", () => {
-        expect({ fake: "news" }).not.toBeTransaction();
+        expect(expect({ fake: "news" }).toBeTransaction).toThrowError("Expected value to be a valid transaction");
     });
 });

--- a/packages/core-jest-matchers/__tests__/models/wallet.test.ts
+++ b/packages/core-jest-matchers/__tests__/models/wallet.test.ts
@@ -11,6 +11,6 @@ describe(".toBeWallet", () => {
     });
 
     test("fails when given an invalid wallet", () => {
-        expect({ fake: "news" }).not.toBeWallet();
+        expect(expect({ fake: "news" }).toBeWallet).toThrowError("Expected value to be a valid wallet");
     });
 });

--- a/packages/core-jest-matchers/__tests__/transactions/types/delegate-resignation.test.ts
+++ b/packages/core-jest-matchers/__tests__/transactions/types/delegate-resignation.test.ts
@@ -11,6 +11,8 @@ describe(".toBeDelegateResignationType", () => {
     });
 
     test("fails when given an invalid transaction", () => {
-        expect({ type: "invalid" }).not.toBeDelegateResignationType();
+        expect(expect({ type: "invalid" }).toBeDelegateResignationType).toThrowError(
+            "Expected value to be a valid DelegateResignation transaction.",
+        );
     });
 });

--- a/packages/core-jest-matchers/__tests__/transactions/types/delegate.test.ts
+++ b/packages/core-jest-matchers/__tests__/transactions/types/delegate.test.ts
@@ -11,6 +11,8 @@ describe(".toBeDelegateType", () => {
     });
 
     test("fails when given an invalid transaction", () => {
-        expect({ type: "invalid" }).not.toBeDelegateType();
+        expect(expect({ type: "invalid" }).toBeDelegateType).toThrowError(
+            "Expected value to be a valid DELEGATE transaction.",
+        );
     });
 });

--- a/packages/core-jest-matchers/__tests__/transactions/types/ipfs.test.ts
+++ b/packages/core-jest-matchers/__tests__/transactions/types/ipfs.test.ts
@@ -9,6 +9,6 @@ describe(".toBeIpfsType", () => {
     });
 
     test("fails when given an invalid transaction", () => {
-        expect({ type: "invalid" }).not.toBeIpfsType();
+        expect(expect({ type: "invalid" }).toBeIpfsType).toThrowError("Expected value to be a valid IPFS transaction.");
     });
 });

--- a/packages/core-jest-matchers/__tests__/transactions/types/multi-payment.test.ts
+++ b/packages/core-jest-matchers/__tests__/transactions/types/multi-payment.test.ts
@@ -9,6 +9,8 @@ describe(".toBeMultiPaymentType", () => {
     });
 
     test("fails when given an invalid transaction", () => {
-        expect({ type: "invalid" }).not.toBeMultiPaymentType();
+        expect(expect({ type: "invalid" }).toBeMultiPaymentType).toThrowError(
+            "Expected value to be a valid MultiPayment transaction.",
+        );
     });
 });

--- a/packages/core-jest-matchers/__tests__/transactions/types/multi-signature.test.ts
+++ b/packages/core-jest-matchers/__tests__/transactions/types/multi-signature.test.ts
@@ -11,6 +11,8 @@ describe(".toBeMultiSignatureType", () => {
     });
 
     test("fails when given an invalid transaction", () => {
-        expect({ type: "invalid" }).not.toBeMultiSignatureType();
+        expect(expect({ type: "invalid" }).toBeMultiSignatureType).toThrowError(
+            "Expected value to be a valid MultiSignature transaction.",
+        );
     });
 });

--- a/packages/core-jest-matchers/__tests__/transactions/types/second-signature.test.ts
+++ b/packages/core-jest-matchers/__tests__/transactions/types/second-signature.test.ts
@@ -11,6 +11,8 @@ describe(".toBeSecondSignatureType", () => {
     });
 
     test("fails when given an invalid transaction", () => {
-        expect({ type: "invalid" }).not.toBeSecondSignatureType();
+        expect(expect({ type: "invalid" }).toBeSecondSignatureType).toThrowError(
+            "Expected value to be a valid SecondSignature transaction.",
+        );
     });
 });

--- a/packages/core-jest-matchers/__tests__/transactions/types/timelock-transfer.test.ts
+++ b/packages/core-jest-matchers/__tests__/transactions/types/timelock-transfer.test.ts
@@ -11,6 +11,8 @@ describe(".toBeTimelockTransferType", () => {
     });
 
     test("fails when given an invalid transaction", () => {
-        expect({ type: "invalid" }).not.toBeTimelockTransferType();
+        expect(expect({ type: "invalid" }).toBeTimelockTransferType).toThrowError(
+            "Expected value to be a valid TimelockTransfer transaction.",
+        );
     });
 });

--- a/packages/core-jest-matchers/__tests__/transactions/types/transfer.test.ts
+++ b/packages/core-jest-matchers/__tests__/transactions/types/transfer.test.ts
@@ -9,6 +9,8 @@ describe(".toBeTransferType", () => {
     });
 
     test("fails when given an invalid transaction", () => {
-        expect({ type: "invalid" }).not.toBeTransferType();
+        expect(expect({ type: "invalid" }).toBeTransferType).toThrowError(
+            "Expected value to be a valid Transfer transaction.",
+        );
     });
 });

--- a/packages/core-jest-matchers/__tests__/transactions/types/vote.test.ts
+++ b/packages/core-jest-matchers/__tests__/transactions/types/vote.test.ts
@@ -9,6 +9,6 @@ describe(".toBeVoteType", () => {
     });
 
     test("fails when given an invalid transaction", () => {
-        expect({ type: "invalid" }).not.toBeVoteType();
+        expect(expect({ type: "invalid" }).toBeVoteType).toThrowError("Expected value to be a valid VOTE transaction.");
     });
 });

--- a/packages/core-jest-matchers/__tests__/transactions/valid-second-signature.test.ts
+++ b/packages/core-jest-matchers/__tests__/transactions/valid-second-signature.test.ts
@@ -80,4 +80,12 @@ describe(".toHaveValidSecondSignature", () => {
             "Expected value to have a valid second signature",
         );
     });
+
+    test("fails when it does not match", () => {
+        transaction.secondSignature = "invalid";
+        transaction.signSignature = "invalid";
+        expect(transaction).not.toHaveValidSecondSignature({
+            publicKey: wallets[1].publicKey,
+        });
+    });
 });

--- a/packages/core-jest-matchers/__tests__/transactions/valid-second-signature.test.ts
+++ b/packages/core-jest-matchers/__tests__/transactions/valid-second-signature.test.ts
@@ -76,9 +76,8 @@ describe(".toHaveValidSecondSignature", () => {
     test("fails when given an invalid transaction", () => {
         transaction.secondSignature = "invalid";
         transaction.signSignature = "invalid";
-
-        expect(transaction).not.toHaveValidSecondSignature({
-            publicKey: wallets[1].publicKey,
-        });
+        expect(expect(transaction).toHaveValidSecondSignature).toThrowError(
+            "Expected value to have a valid second signature",
+        );
     });
 });

--- a/packages/core-jest-matchers/__tests__/transactions/valid.test.ts
+++ b/packages/core-jest-matchers/__tests__/transactions/valid.test.ts
@@ -24,6 +24,6 @@ describe(".toBeValidTransaction", () => {
 
     test("fails when given an invalid transaction", () => {
         transaction.fee = "invalid" as any;
-        expect(transaction).not.toBeValidTransaction();
+        expect(expect(transaction).toBeValidTransaction).toThrowError("Expected value to be a valid transaction");
     });
 });


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

#1967

I've added tests following the existing implementations for the api/ source files.

I've also added or changed existing tests to also check that upon failure the message is as defined in the source files.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [ ] Docs (documentation only changes)
- [x] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
