### PR TITLE
refactor: remove hacky use of 'global' in transaction builder tests

### DIFF
--- a/packages/crypto/__tests__/builder/builder.test.ts
+++ b/packages/crypto/__tests__/builder/builder.test.ts
@@ -1,9 +1,0 @@
-import "jest-extended";
-
-import { transactionBuilder } from "../../src/builder";
-
-describe("Builder", () => {
-    it("should be instantiated", () => {
-        expect(transactionBuilder).toBeObject();
-    });
-});

--- a/packages/crypto/__tests__/builder/transaction-builder-factory.test.ts
+++ b/packages/crypto/__tests__/builder/transaction-builder-factory.test.ts
@@ -1,0 +1,47 @@
+import "jest-extended";
+
+import { DelegateRegistrationBuilder, DelegateResignationBuilder, IPFSBuilder, MultiPaymentBuilder,
+    MultiSignatureBuilder, SecondSignatureBuilder, TimelockTransferBuilder, transactionBuilder as transactionBuilderFactory,
+    TransactionBuilderFactory, TransferBuilder, VoteBuilder } from "../../dist/builder";
+
+describe("Transaction Builder Factory", () => {
+    it("should be instantiated", () => {
+        expect(transactionBuilderFactory).toBeInstanceOf(TransactionBuilderFactory);
+    });
+
+    it('should create DelegateRegistrationBuilder', () => {
+        expect(transactionBuilderFactory.delegateRegistration()).toBeInstanceOf(DelegateRegistrationBuilder);
+    });
+
+    it('should create DelegateResignationBuilder', () => {
+        expect(transactionBuilderFactory.delegateResignation()).toBeInstanceOf(DelegateResignationBuilder);
+    });
+
+    it('should create IPFSBuilder', () => {
+        expect(transactionBuilderFactory.ipfs()).toBeInstanceOf(IPFSBuilder);
+    });
+
+    it('should create MultiPaymentBuilder', () => {
+        expect(transactionBuilderFactory.multiPayment()).toBeInstanceOf(MultiPaymentBuilder);
+    });
+
+    it('should create MultiSignatureBuilder', () => {
+        expect(transactionBuilderFactory.multiSignature()).toBeInstanceOf(MultiSignatureBuilder);
+    });
+
+    it('should create SecondSignatureBuilder', () => {
+        expect(transactionBuilderFactory.secondSignature()).toBeInstanceOf(SecondSignatureBuilder);
+    });
+
+    it('should create TimelockTransferBuilder', () => {
+        expect(transactionBuilderFactory.timelockTransfer()).toBeInstanceOf(TimelockTransferBuilder);
+    });
+
+    it('should create TransferBuilder', () => {
+        expect(transactionBuilderFactory.transfer()).toBeInstanceOf(TransferBuilder);
+    });
+
+    it('should create VoteBuilder', () => {
+        expect(transactionBuilderFactory.vote()).toBeInstanceOf(VoteBuilder);
+    });
+});

--- a/packages/crypto/__tests__/builder/transactions/__shared__/transaction-builder.ts
+++ b/packages/crypto/__tests__/builder/transactions/__shared__/transaction-builder.ts
@@ -1,197 +1,212 @@
-import { TransactionBuilder } from "../../../../src/builder/transactions/transaction";
-import { crypto, slots } from "../../../../src/crypto";
-import { configManager } from "../../../../src/managers/config";
-import { Transaction } from "../../../../src/models/transaction";
-import { Bignum } from "../../../../src/utils/bignum";
+import { TransactionBuilder } from "../../../../dist/builder/transactions/transaction";
+import { crypto, slots } from "../../../../dist/crypto";
+import { Transaction } from "../../../../dist/models/transaction";
+import { Bignum } from "../../../../dist/utils/bignum";
 
-export const transactionBuilder = () => {
-    let builder;
+export const transactionBuilder = (provider: () => TransactionBuilder) => {
 
-    beforeEach(() => {
-        // @ts-ignore
-        builder = global.builder;
-    });
+    describe('TransactionBuilder', () => {
 
-    describe("inherits = require(TransactionBuilder", () => {
-        it("as an instance", () => {
-            expect(builder).toBeInstanceOf(TransactionBuilder);
-        });
+        describe("inherits = require(TransactionBuilder", () => {
 
-        it("should have the essential properties", () => {
-            expect(builder).toHaveProperty("data.id", null);
-            expect(builder).toHaveProperty("data.timestamp");
-            expect(builder).toHaveProperty("data.version", 0x01);
+            it("should have the essential properties", () => {
+                const builder = provider();
 
-            expect(builder).toHaveProperty("data.type");
-            expect(builder).toHaveProperty("data.fee");
-        });
+                expect(builder).toHaveProperty("data.id", null);
+                expect(builder).toHaveProperty("data.timestamp");
+                expect(builder).toHaveProperty("data.version", 0x01);
 
-        describe("builder", () => {
-            let timestamp;
-            let data;
-
-            beforeEach(() => {
-                timestamp = slots.getTime();
-
-                data = {
-                    id: "fake-id",
-                    amount: 0,
-                    fee: 0,
-                    recipientId: "DK2v39r3hD9Lw8R5fFFHjUyCtXm1VETi42",
-                    senderPublicKey: "035440a82cb44faef75c3d7d881696530aac4d50da314b91795740cdbeaba9113c",
-                    timestamp,
-                    type: 0,
-                    version: 0x03,
-                };
+                expect(builder).toHaveProperty("data.type");
+                expect(builder).toHaveProperty("data.fee");
             });
 
-            it("should return a Transaction model with the builder data", () => {
-                builder.data = data;
+            describe("builder", () => {
 
-                const transaction = builder.build();
+                let timestamp;
+                let data;
 
-                expect(transaction).toBeInstanceOf(Transaction);
-                expect(transaction.amount).toEqual(Bignum.ZERO);
-                expect(transaction.fee).toEqual(Bignum.ZERO);
-                expect(transaction.recipientId).toBe("DK2v39r3hD9Lw8R5fFFHjUyCtXm1VETi42");
-                expect(transaction.senderPublicKey).toBe(
-                    "035440a82cb44faef75c3d7d881696530aac4d50da314b91795740cdbeaba9113c",
-                );
-                expect(transaction.timestamp).toBe(timestamp);
-                expect(transaction.type).toBe(0);
-                expect(transaction.version).toBe(0x03);
-            });
+                beforeEach(() => {
+                    timestamp = slots.getTime();
 
-            it("could merge and override the builder data", () => {
-                builder.data = data;
-
-                const transaction = builder.build({
-                    amount: 33,
-                    fee: 1000,
+                    data = {
+                        id: "fake-id",
+                        amount: 0,
+                        fee: 0,
+                        recipientId: "DK2v39r3hD9Lw8R5fFFHjUyCtXm1VETi42",
+                        senderPublicKey: "035440a82cb44faef75c3d7d881696530aac4d50da314b91795740cdbeaba9113c",
+                        timestamp,
+                        type: 0,
+                        version: 0x03,
+                    };
                 });
 
-                expect(transaction).toBeInstanceOf(Transaction);
-                expect(transaction.amount).toEqual(new Bignum(33));
-                expect(transaction.fee).toEqual(new Bignum(1000));
-                expect(transaction.recipientId).toBe("DK2v39r3hD9Lw8R5fFFHjUyCtXm1VETi42");
-                expect(transaction.senderPublicKey).toBe(
-                    "035440a82cb44faef75c3d7d881696530aac4d50da314b91795740cdbeaba9113c",
-                );
-                expect(transaction.timestamp).toBe(timestamp);
-                expect(transaction.version).toBe(0x03);
+                it("should return a Transaction model with the builder data", () => {
+                    const builder = provider();
+
+                    builder.data = data;
+
+                    const transaction = builder.build();
+
+                    expect(transaction).toBeInstanceOf(Transaction);
+                    expect(transaction.amount).toEqual(Bignum.ZERO);
+                    expect(transaction.fee).toEqual(Bignum.ZERO);
+                    expect(transaction.recipientId).toBe("DK2v39r3hD9Lw8R5fFFHjUyCtXm1VETi42");
+                    expect(transaction.senderPublicKey).toBe(
+                        "035440a82cb44faef75c3d7d881696530aac4d50da314b91795740cdbeaba9113c",
+                    );
+                    expect(transaction.timestamp).toBe(timestamp);
+                    expect(transaction.type).toBe(0);
+                    expect(transaction.version).toBe(0x03);
+                });
+
+                it("could merge and override the builder data", () => {
+                    const builder = provider();
+
+                    builder.data = data;
+
+                    const transaction = builder.build({
+                        amount: 33,
+                        fee: 1000,
+                    });
+
+                    expect(transaction).toBeInstanceOf(Transaction);
+                    expect(transaction.amount).toEqual(new Bignum(33));
+                    expect(transaction.fee).toEqual(new Bignum(1000));
+                    expect(transaction.recipientId).toBe("DK2v39r3hD9Lw8R5fFFHjUyCtXm1VETi42");
+                    expect(transaction.senderPublicKey).toBe(
+                        "035440a82cb44faef75c3d7d881696530aac4d50da314b91795740cdbeaba9113c",
+                    );
+                    expect(transaction.timestamp).toBe(timestamp);
+                    expect(transaction.version).toBe(0x03);
+                });
+            });
+
+            describe("fee", () => {
+                it("should set the fee", () => {
+                    const builder = provider();
+
+                    builder.fee(255);
+                    expect(builder.data.fee).toBe(255);
+                });
+            });
+
+            describe("amount", () => {
+                it("should set the amount", () => {
+                    const builder = provider();
+
+                    builder.amount(255);
+                    expect(builder.data.amount).toBe(255);
+                });
+            });
+
+            describe("recipientId", () => {
+                it("should set the recipient id", () => {
+                    const builder = provider();
+
+                    builder.recipientId("fake");
+                    expect(builder.data.recipientId).toBe("fake");
+                });
+            });
+
+            describe("senderPublicKey", () => {
+                it("should set the sender public key", () => {
+                    const builder = provider();
+
+                    builder.senderPublicKey("fake");
+                    expect(builder.data.senderPublicKey).toBe("fake");
+                });
             });
         });
 
-        describe("fee", () => {
-            it("should set the fee", () => {
-                builder.fee(255);
-                expect(builder.data.fee).toBe(255);
+        describe("sign", () => {
+            it("signs this transaction with the keys of the passphrase", () => {
+                const builder = provider();
+                const keys = {
+                    publicKey: "02d0d835266297f15c192be2636eb3fbc30b39b87fc583ff112062ef8ae1a1f2af",
+                };
+                crypto.getKeys = jest.fn(() => keys);
+                crypto.sign = jest.fn();
+
+                builder.sign("dummy pass");
+
+                expect(crypto.getKeys).toHaveBeenCalledWith("dummy pass");
+                expect(crypto.sign).toHaveBeenCalledWith(builder.__getSigningObject(), keys);
+            });
+
+            it("establishes the public key of the sender", () => {
+                const builder = provider();
+                const keys = {
+                    publicKey: "02d0d835266297f15c192be2636eb3fbc30b39b87fc583ff112062ef8ae1a1f2af",
+                };
+                crypto.getKeys = jest.fn(() => keys);
+                crypto.sign = jest.fn();
+                builder.sign("my real pass");
+                expect(builder.data.senderPublicKey).toBe(keys.publicKey);
             });
         });
 
-        describe("amount", () => {
-            it("should set the amount", () => {
-                builder.amount(255);
-                expect(builder.data.amount).toBe(255);
+        describe("signWithWif", () => {
+            it("signs this transaction with keys from a wif", () => {
+                const builder = provider();
+                const keys = {
+                    publicKey: "02d0d835266297f15c192be2636eb3fbc30b39b87fc583ff112062ef8ae1a1f2af",
+                };
+                crypto.getKeysFromWIF = jest.fn(() => keys);
+                crypto.sign = jest.fn();
+
+                builder.network(23).signWithWif("dummy pass");
+
+                expect(crypto.getKeysFromWIF).toHaveBeenCalledWith("dummy pass", {
+                    wif: 170,
+                });
+                expect(crypto.sign).toHaveBeenCalledWith(builder.__getSigningObject(), keys);
+            });
+
+            it("establishes the public key of the sender", () => {
+                const builder = provider();
+                const keys = {
+                    publicKey: "02d0d835266297f15c192be2636eb3fbc30b39b87fc583ff112062ef8ae1a1f2af",
+                };
+                crypto.getKeysFromWIF = jest.fn(() => keys);
+                crypto.sign = jest.fn();
+                builder.signWithWif("my real pass");
+                expect(builder.data.senderPublicKey).toBe(keys.publicKey);
             });
         });
 
-        describe("recipientId", () => {
-            it("should set the recipient id", () => {
-                builder.recipientId("fake");
-                expect(builder.data.recipientId).toBe("fake");
+        describe("secondSign", () => {
+            it("signs this transaction with the keys of the second passphrase", () => {
+                const builder = provider();
+                let keys;
+                crypto.getKeys = jest.fn(pass => {
+                    keys = { publicKey: `${pass} public key` };
+                    return keys;
+                });
+                crypto.secondSign = jest.fn();
+
+                builder.secondSign("my very real second pass");
+
+                expect(crypto.getKeys).toHaveBeenCalledWith("my very real second pass");
+                expect(crypto.secondSign).toHaveBeenCalledWith(builder.__getSigningObject(), keys);
             });
         });
 
-        describe("senderPublicKey", () => {
-            it("should set the sender public key", () => {
-                builder.senderPublicKey("fake");
-                expect(builder.data.senderPublicKey).toBe("fake");
+        describe("secondSignWithWif", () => {
+            it("signs this transaction with the keys of a second wif", () => {
+                const builder = provider();
+                let keys;
+                crypto.getKeysFromWIF = jest.fn(pass => {
+                    keys = { publicKey: `${pass} public key` };
+                    return keys;
+                });
+                crypto.secondSign = jest.fn();
+
+                builder.network(23).secondSignWithWif("my very real second pass", null);
+
+                expect(crypto.getKeysFromWIF).toHaveBeenCalledWith("my very real second pass", { wif: 170 });
+                expect(crypto.secondSign).toHaveBeenCalledWith(builder.__getSigningObject(), keys);
             });
         });
     });
 
-    describe("sign", () => {
-        it("signs this transaction with the keys of the passphrase", () => {
-            const keys = {
-                publicKey: "02d0d835266297f15c192be2636eb3fbc30b39b87fc583ff112062ef8ae1a1f2af",
-            };
-            crypto.getKeys = jest.fn(() => keys);
-            crypto.sign = jest.fn();
-
-            builder.sign("dummy pass");
-
-            expect(crypto.getKeys).toHaveBeenCalledWith("dummy pass");
-            expect(crypto.sign).toHaveBeenCalledWith(builder.__getSigningObject(), keys);
-        });
-
-        it("establishes the public key of the sender", () => {
-            const keys = {
-                publicKey: "02d0d835266297f15c192be2636eb3fbc30b39b87fc583ff112062ef8ae1a1f2af",
-            };
-            crypto.getKeys = jest.fn(() => keys);
-            crypto.sign = jest.fn();
-            builder.sign("my real pass");
-            expect(builder.data.senderPublicKey).toBe(keys.publicKey);
-        });
-    });
-
-    describe("signWithWif", () => {
-        it("signs this transaction with keys from a wif", () => {
-            const keys = {
-                publicKey: "02d0d835266297f15c192be2636eb3fbc30b39b87fc583ff112062ef8ae1a1f2af",
-            };
-            crypto.getKeysFromWIF = jest.fn(() => keys);
-            crypto.sign = jest.fn();
-
-            builder.network(23).signWithWif("dummy pass");
-
-            expect(crypto.getKeysFromWIF).toHaveBeenCalledWith("dummy pass", {
-                wif: 170,
-            });
-            expect(crypto.sign).toHaveBeenCalledWith(builder.__getSigningObject(), keys);
-        });
-
-        it("establishes the public key of the sender", () => {
-            const keys = {
-                publicKey: "02d0d835266297f15c192be2636eb3fbc30b39b87fc583ff112062ef8ae1a1f2af",
-            };
-            crypto.getKeysFromWIF = jest.fn(() => keys);
-            crypto.sign = jest.fn();
-            builder.signWithWif("my real pass");
-            expect(builder.data.senderPublicKey).toBe(keys.publicKey);
-        });
-    });
-
-    describe("secondSign", () => {
-        it("signs this transaction with the keys of the second passphrase", () => {
-            let keys;
-            crypto.getKeys = jest.fn(pass => {
-                keys = { publicKey: `${pass} public key` };
-                return keys;
-            });
-            crypto.secondSign = jest.fn();
-
-            builder.secondSign("my very real second pass");
-
-            expect(crypto.getKeys).toHaveBeenCalledWith("my very real second pass");
-            expect(crypto.secondSign).toHaveBeenCalledWith(builder.__getSigningObject(), keys);
-        });
-    });
-
-    describe("secondSignWithWif", () => {
-        it("signs this transaction with the keys of a second wif", () => {
-            let keys;
-            crypto.getKeysFromWIF = jest.fn(pass => {
-                keys = { publicKey: `${pass} public key` };
-                return keys;
-            });
-            crypto.secondSign = jest.fn();
-
-            builder.network(23).secondSignWithWif("my very real second pass");
-
-            expect(crypto.getKeysFromWIF).toHaveBeenCalledWith("my very real second pass", { wif: 170 });
-            expect(crypto.secondSign).toHaveBeenCalledWith(builder.__getSigningObject(), keys);
-        });
-    });
 };

--- a/packages/crypto/__tests__/builder/transactions/delegate-registration.test.ts
+++ b/packages/crypto/__tests__/builder/transactions/delegate-registration.test.ts
@@ -1,17 +1,15 @@
 import "jest-extended";
-import { client as ark } from "../../../src/client";
-import { TransactionTypes } from "../../../src/constants";
-import { crypto } from "../../../src/crypto/crypto";
-import { feeManager } from "../../../src/managers/fee";
+import { DelegateRegistrationBuilder } from "../../../dist/builder";
+import { client as ark } from "../../../dist/client";
+import { TransactionTypes } from "../../../dist/constants";
+import { crypto } from "../../../dist/crypto/crypto";
+import { feeManager } from "../../../dist/managers/fee";
 import { transactionBuilder } from "./__shared__/transaction-builder";
 
-let builder;
+let builder : DelegateRegistrationBuilder;
 
 beforeEach(() => {
     builder = ark.getBuilder().delegateRegistration();
-
-    // @ts-ignore
-    global.builder = builder;
 });
 
 describe("Delegate Registration Transaction", () => {
@@ -32,7 +30,7 @@ describe("Delegate Registration Transaction", () => {
         });
     });
 
-    transactionBuilder();
+    transactionBuilder(() => builder);
 
     it("should have its specific properties", () => {
         expect(builder).toHaveProperty("data.type", TransactionTypes.DelegateRegistration);

--- a/packages/crypto/__tests__/builder/transactions/delegate-resignation.test.ts
+++ b/packages/crypto/__tests__/builder/transactions/delegate-resignation.test.ts
@@ -1,20 +1,18 @@
 import "jest-extended";
-import { client as ark } from "../../../src/client";
-import { TransactionTypes } from "../../../src/constants";
-import { feeManager } from "../../../src/managers/fee";
+import { DelegateResignationBuilder } from "../../../dist/builder";
+import { client as ark } from "../../../dist/client";
+import { TransactionTypes } from "../../../dist/constants";
+import { feeManager } from "../../../dist/managers/fee";
 import { transactionBuilder } from "./__shared__/transaction-builder";
 
-let builder;
+let builder : DelegateResignationBuilder;
 
 beforeEach(() => {
     builder = ark.getBuilder().delegateResignation();
-
-    // @ts-ignore
-    global.builder = builder;
 });
 
 describe("Delegate Resignation Transaction", () => {
-    transactionBuilder();
+    transactionBuilder(() => builder);
 
     it("should have its specific properties", () => {
         expect(builder).toHaveProperty("data.type", TransactionTypes.DelegateResignation);

--- a/packages/crypto/__tests__/builder/transactions/ipfs.test.ts
+++ b/packages/crypto/__tests__/builder/transactions/ipfs.test.ts
@@ -1,20 +1,18 @@
 import "jest-extended";
-import { client as ark } from "../../../src/client";
-import { TransactionTypes } from "../../../src/constants";
-import { feeManager } from "../../../src/managers/fee";
+import { IPFSBuilder } from "../../../dist/builder";
+import { client as ark } from "../../../dist/client";
+import { TransactionTypes } from "../../../dist/constants";
+import { feeManager } from "../../../dist/managers/fee";
 import { transactionBuilder } from "./__shared__/transaction-builder";
 
-let builder;
+let builder : IPFSBuilder;
 
 beforeEach(() => {
     builder = ark.getBuilder().ipfs();
-
-    // @ts-ignore
-    global.builder = builder;
 });
 
 describe("IPFS Transaction", () => {
-    transactionBuilder();
+    transactionBuilder(() => builder);
 
     it("should have its specific properties", () => {
         expect(builder).toHaveProperty("data.type", TransactionTypes.Ipfs);
@@ -29,25 +27,21 @@ describe("IPFS Transaction", () => {
         expect(builder).not.toHaveProperty("data.ipfsHash");
     });
 
-    describe("ipfsHash", () => {
-        it("establishes the IPFS hash", () => {
-            builder.ipfsHash("zyx");
-            expect(builder.data.ipfsHash).toBe("zyx");
-        });
+    it("establishes the IPFS hash", () => {
+        builder.ipfsHash("zyx");
+        expect(builder.data.ipfsHash).toBe("zyx");
     });
 
-    describe("vendorField", () => {
-        // TODO This is test is OK, but the Subject Under Test might be wrong,
-        // so it is better to not assume that this is the desired behaviour
-        it("should generate and set the vendorFieldHex", () => {
-            const data = "hash";
-            // @ts-ignore
-            const hex: any = Buffer.from(data, 0).toString("hex");
-            const paddedHex = hex.padStart(128, "0");
+    // TODO This is test is OK, but the Subject Under Test might be wrong,
+    // so it is better to not assume that this is the desired behaviour
+    it("should generate and set the vendorFieldHex", () => {
+        const data = "hash";
+        // @ts-ignore
+        const hex: any = Buffer.from(data, 0).toString("hex");
+        const paddedHex = hex.padStart(128, "0");
 
-            builder.data.ipfsHash = data;
-            builder.vendorField(0);
-            expect(builder.data.vendorFieldHex).toBe(paddedHex);
-        });
+        builder.data.ipfsHash = data;
+        builder.vendorField(0);
+        expect(builder.data.vendorFieldHex).toBe(paddedHex);
     });
 });

--- a/packages/crypto/__tests__/builder/transactions/multi-payment.test.ts
+++ b/packages/crypto/__tests__/builder/transactions/multi-payment.test.ts
@@ -1,20 +1,18 @@
 import "jest-extended";
-import { client as ark } from "../../../src/client";
-import { TransactionTypes } from "../../../src/constants";
-import { feeManager } from "../../../src/managers/fee";
+import { client as ark } from "../../../dist/client";
+import { TransactionTypes } from "../../../dist/constants";
+import { feeManager } from "../../../dist/managers/fee";
 import { transactionBuilder } from "./__shared__/transaction-builder";
+import { MultiPaymentBuilder } from "../../../dist/builder";
 
-let builder;
+let builder : MultiPaymentBuilder;
 
 beforeEach(() => {
     builder = ark.getBuilder().multiPayment();
-
-    // @ts-ignore
-    global.builder = builder;
 });
 
 describe("Multi Payment Transaction", () => {
-    transactionBuilder();
+    transactionBuilder( () => builder);
 
     it("should have its specific properties", () => {
         expect(builder).toHaveProperty("data.type", TransactionTypes.MultiPayment);

--- a/packages/crypto/__tests__/builder/transactions/multi-signature.test.ts
+++ b/packages/crypto/__tests__/builder/transactions/multi-signature.test.ts
@@ -1,17 +1,15 @@
 import "jest-extended";
-import { client as ark } from "../../../src/client";
-import { TransactionTypes } from "../../../src/constants";
-import { crypto } from "../../../src/crypto/crypto";
-import { feeManager } from "../../../src/managers/fee";
+import { MultiSignatureBuilder } from "../../../dist/builder";
+import { client as ark } from "../../../dist/client";
+import { TransactionTypes } from "../../../dist/constants";
+import { crypto } from "../../../dist/crypto/crypto";
+import { feeManager } from "../../../dist/managers/fee";
 import { transactionBuilder } from "./__shared__/transaction-builder";
 
-let builder;
+let builder : MultiSignatureBuilder;
 
 beforeEach(() => {
     builder = ark.getBuilder().multiSignature();
-
-    // @ts-ignore
-    global.builder = builder;
 });
 
 describe("Multi Signature Transaction", () => {
@@ -36,7 +34,7 @@ describe("Multi Signature Transaction", () => {
         });
     });
 
-    transactionBuilder();
+    transactionBuilder(() => builder);
 
     it("should have its specific properties", () => {
         expect(builder).toHaveProperty("data.type", TransactionTypes.MultiSignature);

--- a/packages/crypto/__tests__/builder/transactions/second-signature.test.ts
+++ b/packages/crypto/__tests__/builder/transactions/second-signature.test.ts
@@ -1,17 +1,15 @@
 import "jest-extended";
-import { client as ark } from "../../../src/client";
-import { TransactionTypes } from "../../../src/constants";
-import { crypto } from "../../../src/crypto/crypto";
-import { feeManager } from "../../../src/managers/fee";
+import { SecondSignatureBuilder } from "../../../dist/builder";
+import { client as ark } from "../../../dist/client";
+import { TransactionTypes } from "../../../dist/constants";
+import { crypto } from "../../../dist/crypto/crypto";
+import { feeManager } from "../../../dist/managers/fee";
 import { transactionBuilder } from "./__shared__/transaction-builder";
 
-let builder;
+let builder : SecondSignatureBuilder;
 
 beforeEach(() => {
     builder = ark.getBuilder().secondSignature();
-
-    // @ts-ignore
-    global.builder = builder;
 });
 
 describe("Second Signature Transaction", () => {
@@ -23,7 +21,7 @@ describe("Second Signature Transaction", () => {
         });
     });
 
-    transactionBuilder();
+    transactionBuilder(() => builder);
 
     it("should have its specific properties", () => {
         expect(builder).toHaveProperty("data.type", TransactionTypes.SecondSignature);

--- a/packages/crypto/__tests__/builder/transactions/timelock-transfer.test.ts
+++ b/packages/crypto/__tests__/builder/transactions/timelock-transfer.test.ts
@@ -1,20 +1,18 @@
 import "jest-extended";
-import { client as ark } from "../../../src/client";
-import { TransactionTypes } from "../../../src/constants";
-import { feeManager } from "../../../src/managers/fee";
+import { TimelockTransferBuilder } from "../../../dist/builder";
+import { client as ark } from "../../../dist/client";
+import { TransactionTypes } from "../../../dist/constants";
+import { feeManager } from "../../../dist/managers/fee";
 import { transactionBuilder } from "./__shared__/transaction-builder";
 
-let builder;
+let builder : TimelockTransferBuilder;
 
 beforeEach(() => {
     builder = ark.getBuilder().timelockTransfer();
-
-    // @ts-ignore
-    global.builder = builder;
 });
 
 describe("Timelock Transfer Transaction", () => {
-    transactionBuilder();
+    transactionBuilder(() => builder);
 
     it("should have its specific properties", () => {
         expect(builder).toHaveProperty("data.type", TransactionTypes.TimelockTransfer);
@@ -27,13 +25,9 @@ describe("Timelock Transfer Transaction", () => {
     });
 
     describe("timelock", () => {
-        it("establishes the time lock", () => {
-            builder.timelock("time lock");
+        it("establishes the time-lock & time-lock type", () => {
+            builder.timelock("time lock", "time lock type");
             expect(builder.data.timelock).toBe("time lock");
-        });
-
-        it("establishes the time lock type", () => {
-            builder.timelock(null, "time lock type");
             expect(builder.data.timelockType).toBe("time lock type");
         });
     });

--- a/packages/crypto/__tests__/builder/transactions/transfer.test.ts
+++ b/packages/crypto/__tests__/builder/transactions/transfer.test.ts
@@ -1,17 +1,15 @@
 import "jest-extended";
-import { client as ark } from "../../../src/client";
-import { TransactionTypes } from "../../../src/constants";
-import { crypto } from "../../../src/crypto";
-import { feeManager } from "../../../src/managers/fee";
+import { TransactionBuilder } from "../../../dist/builder/transactions/transaction";
+import { client as ark } from "../../../dist/client";
+import { TransactionTypes } from "../../../dist/constants";
+import { crypto } from "../../../dist/crypto";
+import { feeManager } from "../../../dist/managers/fee";
 import { transactionBuilder } from "./__shared__/transaction-builder";
 
-let builder;
+let builder : TransactionBuilder;
 
 beforeEach(() => {
     builder = ark.getBuilder().transfer();
-
-    // @ts-ignore
-    global.builder = builder;
 });
 
 describe("Transfer Transaction", () => {
@@ -84,7 +82,7 @@ describe("Transfer Transaction", () => {
         });
     });
 
-    transactionBuilder();
+    transactionBuilder(() => builder);
 
     it("should have its specific properties", () => {
         expect(builder).toHaveProperty("data.type", TransactionTypes.Transfer);

--- a/packages/crypto/__tests__/builder/transactions/vote.test.ts
+++ b/packages/crypto/__tests__/builder/transactions/vote.test.ts
@@ -1,17 +1,15 @@
 import "jest-extended";
-import { client as ark } from "../../../src/client";
-import { TransactionTypes } from "../../../src/constants";
-import { crypto } from "../../../src/crypto";
-import { feeManager } from "../../../src/managers/fee";
+import { VoteBuilder } from "../../../dist/builder";
+import { client as ark } from "../../../dist/client";
+import { TransactionTypes } from "../../../dist/constants";
+import { crypto } from "../../../dist/crypto";
+import { feeManager } from "../../../dist/managers/fee";
 import { transactionBuilder } from "./__shared__/transaction-builder";
 
-let builder;
+let builder : VoteBuilder;
 
 beforeEach(() => {
     builder = ark.getBuilder().vote();
-
-    // @ts-ignore
-    global.builder = builder;
 });
 
 describe("Vote Transaction", () => {
@@ -34,7 +32,7 @@ describe("Vote Transaction", () => {
         });
     });
 
-    transactionBuilder();
+    transactionBuilder(() => builder);
 
     it("should have its specific properties", () => {
         expect(builder).toHaveProperty("data.type", TransactionTypes.Vote);

--- a/packages/crypto/__tests__/client.test.ts
+++ b/packages/crypto/__tests__/client.test.ts
@@ -1,8 +1,8 @@
 import "jest-extended";
-import { client } from "../src/client";
+import { client, Client } from "../dist/client";
 
 describe("Client", () => {
     it("should be instantiated", () => {
-        expect(client).toBeObject();
+        expect(client).toBeInstanceOf(Client);
     });
 });

--- a/packages/crypto/src/builder/index.ts
+++ b/packages/crypto/src/builder/index.ts
@@ -8,7 +8,7 @@ import { TimelockTransferBuilder } from "./transactions/timelock-transfer";
 import { TransferBuilder } from "./transactions/transfer";
 import { VoteBuilder } from "./transactions/vote";
 
-export class TransactionBuilderDirector {
+export class TransactionBuilderFactory {
     /**
      * Create new delegate transaction type.
      * @return {DelegateRegistrationBuilder}
@@ -82,7 +82,7 @@ export class TransactionBuilderDirector {
     }
 }
 
-const transactionBuilder = new TransactionBuilderDirector();
+const transactionBuilder = new TransactionBuilderFactory();
 export {
     transactionBuilder,
     DelegateRegistrationBuilder,

--- a/packages/crypto/src/builder/transactions/transaction.ts
+++ b/packages/crypto/src/builder/transactions/transaction.ts
@@ -183,7 +183,7 @@ export abstract class TransactionBuilder {
      * @param  {String} networkWif - value associated with network
      * @return {TransactionBuilder}
      */
-    public secondSignWithWif(wif, networkWif) {
+    public secondSignWithWif(wif, networkWif?) {
         if (wif) {
             const keys = crypto.getKeysFromWIF(wif, {
                 wif: networkWif || configManager.get("wif"),


### PR DESCRIPTION
## Proposed changes
Remove the hacky usage of global in builder tests, use a lambda function to implemented the needed functionality
Renamed TransactionBuilderDirector to TransactionBuilderFactory to more accurately describe what it is and what it's responsibilities are.
Added some coverage to said factory methods.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [ ] Docs (documentation only changes)
- [x] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
