### PR TITLE
test(core-debugger-cli): increase coverage

### DIFF
--- a/packages/core-debugger-cli/__tests__/commands/identity.test.ts
+++ b/packages/core-debugger-cli/__tests__/commands/identity.test.ts
@@ -49,4 +49,8 @@ describe("Commands - Identity", () => {
             }),
         ).toEqual(expected);
     });
+
+    it("should not return anything for empty input", () => {
+        expect(identity({})).toEqual(undefined);
+    });
 });

--- a/packages/crypto/__tests__/builder/transactions/multi-payment.test.ts
+++ b/packages/crypto/__tests__/builder/transactions/multi-payment.test.ts
@@ -1,18 +1,18 @@
 import "jest-extended";
+import { MultiPaymentBuilder } from "../../../dist/builder";
 import { client as ark } from "../../../dist/client";
 import { TransactionTypes } from "../../../dist/constants";
 import { feeManager } from "../../../dist/managers/fee";
 import { transactionBuilder } from "./__shared__/transaction-builder";
-import { MultiPaymentBuilder } from "../../../dist/builder";
 
-let builder : MultiPaymentBuilder;
+let builder: MultiPaymentBuilder;
 
 beforeEach(() => {
     builder = ark.getBuilder().multiPayment();
 });
 
 describe("Multi Payment Transaction", () => {
-    transactionBuilder( () => builder);
+    transactionBuilder(() => builder);
 
     it("should have its specific properties", () => {
         expect(builder).toHaveProperty("data.type", TransactionTypes.MultiPayment);


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

There was one missing scenario for core-debugger-cli; where `identity({})` (blank options) wasn't tested and resulted in missing coverage.

Add needed test with this PR.

Also, added a file which was linted when committing.
## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [ ] Docs (documentation only changes)
- [x] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
