### PR TITLE
test: fix coverage by registering current package plugin manually

### DIFF
--- a/packages/core-api/package.json
+++ b/packages/core-api/package.json
@@ -43,6 +43,7 @@
         "boom": "^7.3.0",
         "bs58check": "^2.1.2",
         "dayjs-ext": "^2.2.0",
+        "delay": "^4.1.0",
         "hapi-api-version": "^2.1.0",
         "hapi-pagination": "https://github.com/faustbrian/hapi-pagination",
         "hapi-rate-limit": "^3.0.0",

--- a/packages/core-blockchain/__tests__/__support__/setup.ts
+++ b/packages/core-blockchain/__tests__/__support__/setup.ts
@@ -1,12 +1,26 @@
 import { app } from "@arkecosystem/core-container";
-import { setUpContainer } from "@arkecosystem/core-test-utils/src/helpers/container";
+import { registerWithContainer, setUpContainer } from "../../../core-test-utils/src/helpers/container";
 
 jest.setTimeout(60000);
 
-export const setUpFull = async () =>
-    setUpContainer({
-        exit: "@arkecosystem/core-blockchain",
+export const setUpFull = async () => {
+    await setUpContainer({
+        exit: "@arkecosystem/core-p2p",
+        exclude: ["@arkecosystem/core-blockchain"],
     });
+
+    const { plugin } = require("../../src/plugin");
+    await registerWithContainer(plugin, {});
+
+    return app;
+};
+
+export const tearDownFull = async () => {
+    await app.tearDown();
+
+    const { plugin } = require("../../src/plugin");
+    await plugin.deregister(app, {});
+};
 
 export const setUp = async () =>
     setUpContainer({

--- a/packages/core-blockchain/__tests__/processor/block-processor.test.ts
+++ b/packages/core-blockchain/__tests__/processor/block-processor.test.ts
@@ -5,7 +5,7 @@ import { models } from "@arkecosystem/crypto";
 import { Blockchain } from "../../src/blockchain";
 import { BlockProcessor, BlockProcessorResult } from "../../src/processor";
 import * as handlers from "../../src/processor/handlers";
-import { setUpFull, tearDown } from "../__support__/setup";
+import { setUpFull, tearDownFull } from "../__support__/setup";
 
 const { Block } = models;
 const { delegates } = fixtures;
@@ -22,7 +22,7 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
-    await tearDown();
+    await tearDownFull();
 });
 
 const resetBlocks = async () => blockchain.removeBlocks(blockchain.getLastHeight() - 1); // reset to block height 1

--- a/packages/core-database-postgres/__tests__/__support__/setup.ts
+++ b/packages/core-database-postgres/__tests__/__support__/setup.ts
@@ -1,13 +1,36 @@
 import { app } from "@arkecosystem/core-container";
-import { setUpContainer } from "@arkecosystem/core-test-utils/src/helpers/container";
+import { registerWithContainer, setUpContainer } from "../../../core-test-utils/src/helpers/container";
 
 jest.setTimeout(60000);
 
-export const setUp = async () =>
-    setUpContainer({
+const options = {
+    connection: {
+        host: "localhost",
+        port: 5432,
+        database: "core_development",
+        user: "core",
+        password: "password",
+    },
+};
+
+export const setUp = async () => {
+    await setUpContainer({
         exit: "@arkecosystem/core-database-postgres",
+        exclude: ["@arkecosystem/core-database-postgres"],
     });
+
+    // register first core-database because core-database-postgres extends it
+    // (we might improve registerWithContainer to take care of extends)
+    const { plugin: pluginDatabase } = require("@arkecosystem/core-database");
+    await registerWithContainer(pluginDatabase, options);
+
+    const { plugin } = require("../../src/plugin");
+    await registerWithContainer(plugin, options);
+};
 
 export const tearDown = async () => {
     await app.tearDown();
+
+    const { plugin } = require("../../src/plugin");
+    await plugin.deregister(app, options);
 };

--- a/packages/core-database-postgres/__tests__/connection.test.ts
+++ b/packages/core-database-postgres/__tests__/connection.test.ts
@@ -1,6 +1,6 @@
 import { app } from "@arkecosystem/core-container";
-import genesisBlock from "@arkecosystem/core-test-utils/src/config/testnet/genesisBlock.json";
 import { models } from "@arkecosystem/crypto";
+import genesisBlock from "../../core-test-utils/src/config/testnet/genesisBlock.json";
 import { PostgresConnection } from "../src/connection";
 import { setUp, tearDown } from "./__support__/setup";
 

--- a/packages/core-database/__tests__/wallet-manager.test.ts
+++ b/packages/core-database/__tests__/wallet-manager.test.ts
@@ -27,14 +27,14 @@ beforeAll(async done => {
     // wrong network config.
     genesisBlock = new Block(genesisBlockTestnet);
 
-    const { WalletManager } = require("../dist/wallet-manager");
+    const { WalletManager } = require("../src/wallet-manager");
     walletManager = new WalletManager();
 
     done();
 });
 
 beforeEach(() => {
-    const { WalletManager } = require("../dist/wallet-manager");
+    const { WalletManager } = require("../src/wallet-manager");
     walletManager = new WalletManager();
 });
 

--- a/packages/core-graphql/__tests__/__support__/setup.ts
+++ b/packages/core-graphql/__tests__/__support__/setup.ts
@@ -1,18 +1,30 @@
 import { app } from "@arkecosystem/core-container";
-import { setUpContainer } from "@arkecosystem/core-test-utils/src/helpers/container";
+import { registerWithContainer, setUpContainer } from "../../../core-test-utils/src/helpers/container";
 
 jest.setTimeout(60000);
+
+const options = {
+    enabled: true,
+    host: "0.0.0.0",
+    port: 4005,
+};
 
 export const setUp = async () => {
     process.env.CORE_GRAPHQL_ENABLED = "true";
 
     await setUpContainer({
-        exclude: ["@arkecosystem/core-api", "@arkecosystem/core-forger"],
+        exclude: ["@arkecosystem/core-api", "@arkecosystem/core-forger", "@arkecosystem/core-graphql"],
     });
+
+    const { plugin } = require("../../src");
+    await registerWithContainer(plugin, options);
 
     return app;
 };
 
 export const tearDown = async () => {
     await app.tearDown();
+
+    const { plugin } = require("../../src");
+    await plugin.deregister(app, options);
 };

--- a/packages/core-json-rpc/__tests__/__support__/setup.ts
+++ b/packages/core-json-rpc/__tests__/__support__/setup.ts
@@ -1,17 +1,38 @@
 import { app } from "@arkecosystem/core-container";
-import { setUpContainer } from "@arkecosystem/core-test-utils/src/helpers/container";
+import { registerWithContainer, setUpContainer } from "../../../core-test-utils/src/helpers/container";
 
 jest.setTimeout(60000);
+
+const options = {
+    enabled: true,
+    host: "0.0.0.0",
+    port: 8080,
+    allowRemote: false,
+    whitelist: ["127.0.0.1", "::ffff:127.0.0.1"],
+};
 
 export async function setUp() {
     // @ts-ignore
     process.env.CORE_JSON_RPC_ENABLED = true;
 
-    return setUpContainer({
-        exclude: ["@arkecosystem/core-webhooks", "@arkecosystem/core-graphql", "@arkecosystem/core-forger"],
+    await setUpContainer({
+        exclude: [
+            "@arkecosystem/core-webhooks",
+            "@arkecosystem/core-graphql",
+            "@arkecosystem/core-forger",
+            "@arkecosystem/core-json-rpc",
+        ],
     });
+
+    const { plugin } = require("../../src");
+    await registerWithContainer(plugin, options);
+
+    return app;
 }
 
 export async function tearDown() {
-    return app.tearDown();
+    await app.tearDown();
+
+    const { plugin } = require("../../src");
+    await plugin.deregister(app, options);
 }

--- a/packages/core-p2p/__tests__/__support__/setup.ts
+++ b/packages/core-p2p/__tests__/__support__/setup.ts
@@ -1,14 +1,46 @@
 import { app } from "@arkecosystem/core-container";
-import { setUpContainer } from "@arkecosystem/core-test-utils/src/helpers/container";
+import delay from "delay";
+import { registerWithContainer, setUpContainer } from "../../../core-test-utils/src/helpers/container";
 
 jest.setTimeout(60000);
 
+const options = {
+    host: "0.0.0.0",
+    port: 4000,
+    minimumNetworkReach: 5,
+    coldStart: 5,
+};
+
 export const setUp = async () => {
     await setUpContainer({
-        exit: "@arkecosystem/core-blockchain",
+        exit: "@arkecosystem/core-p2p",
+        exclude: ["@arkecosystem/core-p2p"],
     });
+
+    // register p2p plugin
+    const { plugin } = require("../../src/plugin");
+    await registerWithContainer(plugin, options);
+
+    // and now register blockchain as it has to be registered after p2p
+    // a little trick here, we register blockchain plugin without starting it
+    // (it caused some issues where we waited eternally for blockchain to be up)
+    // instead, we start blockchain manually and check manually that it is up with getLastBlock()
+    process.env.CORE_SKIP_BLOCKCHAIN = "true";
+    const { plugin: pluginBlockchain } = require("@arkecosystem/core-blockchain");
+    const blockchain = await registerWithContainer(pluginBlockchain, {});
+    await blockchain.start(true);
+
+    while (!blockchain.getLastBlock()) {
+        await delay(1000);
+    }
 };
 
 export const tearDown = async () => {
+    const { plugin: pluginBlockchain } = require("@arkecosystem/core-blockchain");
+    await pluginBlockchain.deregister(app, {});
+
+    const { plugin } = require("../../src/plugin");
+    await plugin.deregister(app, options);
+
     await app.tearDown();
 };

--- a/packages/core-p2p/__tests__/court/guard.test.ts
+++ b/packages/core-p2p/__tests__/court/guard.test.ts
@@ -14,7 +14,7 @@ beforeAll(async () => {
 
     app.getConfig().set("milestoneHash", "dummy-milestone");
 
-    guard = require("../../dist/court/guard").guard;
+    guard = require("../../src/court/guard").guard;
 });
 
 afterAll(async () => {
@@ -114,7 +114,7 @@ describe("Guard", () => {
         const dummy = {
             nethash: "d9acd04bde4234a81addb8482333b4ac906bed7be5a9970ce8ada428bd083192",
             milestoneHash: "dummy-milestone",
-            version: "2.0.0",
+            version: "2.1.0",
             status: 200,
             state: {},
         };

--- a/packages/core-p2p/__tests__/monitor.test.ts
+++ b/packages/core-p2p/__tests__/monitor.test.ts
@@ -1,8 +1,8 @@
 /* tslint:disable:max-line-length  */
 import axios from "axios";
 import MockAdapter from "axios-mock-adapter";
-import { defaults } from "../dist/defaults";
-import { Peer } from "../dist/peer";
+import { defaults } from "../src/defaults";
+import { Peer } from "../src/peer";
 import { setUp, tearDown } from "./__support__/setup";
 
 const axiosMock = new MockAdapter(axios);
@@ -12,7 +12,7 @@ let monitor;
 
 beforeAll(async () => {
     await setUp();
-    monitor = require("../dist/monitor").monitor;
+    monitor = require("../src/monitor").monitor;
 });
 
 afterAll(async () => {

--- a/packages/core-p2p/__tests__/peer.test.ts
+++ b/packages/core-p2p/__tests__/peer.test.ts
@@ -1,7 +1,7 @@
 import { models } from "@arkecosystem/crypto";
 import axios from "axios";
 import MockAdapter from "axios-mock-adapter";
-import { Peer } from "../dist/peer";
+import { Peer } from "../src/peer";
 import { setUp, tearDown } from "./__support__/setup";
 
 const axiosMock = new MockAdapter(axios);

--- a/packages/core-test-utils/package.json
+++ b/packages/core-test-utils/package.json
@@ -36,10 +36,13 @@
         "@types/bip39": "^2.4.1",
         "@types/lodash.get": "^4.4.4",
         "@types/lodash.isequal": "^4.5.3",
+        "@types/lodash.isstring": "^4.0.4",
         "@types/lodash.sortby": "^4.7.4",
+        "awilix": "^4.0.1",
         "bip39": "^2.5.0",
         "lodash.get": "^4.4.2",
         "lodash.isequal": "^4.5.0",
+        "lodash.isstring": "^4.0.1",
         "lodash.sortby": "^4.7.0",
         "superheroes": "^2.0.0",
         "xstate": "^4.2.2"

--- a/packages/core-test-utils/src/helpers/container.ts
+++ b/packages/core-test-utils/src/helpers/container.ts
@@ -1,12 +1,14 @@
 import { app } from "@arkecosystem/core-container";
 import { Container } from "@arkecosystem/core-interfaces";
 import "@arkecosystem/core-jest-matchers";
+import { asValue } from "awilix";
+import isString from "lodash/isString";
 import * as path from "path";
 
 export async function setUpContainer(options: any): Promise<Container.IContainer> {
     options.network = options.network || "testnet";
     await app.setUp(
-        "2.0.0",
+        "2.1.0",
         {
             data: options.data || "~/.core",
             config: options.config ? options.config : path.resolve(__dirname, `../config/${options.network}`),
@@ -16,4 +18,55 @@ export async function setUpContainer(options: any): Promise<Container.IContainer
         options,
     );
     return app;
+}
+
+// copied from core-container registrars/plugin and slightly modified
+export async function registerWithContainer(plugin, options = {}) {
+    if (!plugin.register) {
+        return;
+    }
+
+    const name = plugin.name || plugin.pkg.name;
+    const version = plugin.version || plugin.pkg.version;
+    const defaults = plugin.defaults || plugin.pkg.defaults;
+    const alias = plugin.alias || plugin.pkg.alias;
+
+    options = applyToDefaults(name, defaults, options);
+
+    const pluginRegistered = await plugin.register(app, options || {});
+    app.register(
+        alias || name,
+        asValue({
+            name,
+            version,
+            plugin: pluginRegistered,
+            options,
+        }),
+    );
+
+    return pluginRegistered;
+}
+
+// copied from core-container registrars/plugin and slightly modified
+function applyToDefaults(name, defaults, options) {
+    if (defaults) {
+        options = Object.assign(defaults, options);
+    }
+
+    return castOptions(options);
+}
+
+// copied from core-container registrars/plugin
+function castOptions(options) {
+    const blacklist: any = [];
+    const regex = new RegExp(/^\d+$/);
+
+    Object.keys(options).forEach(key => {
+        const value = options[key];
+        if (isString(value) && !blacklist.includes(key) && regex.test(value)) {
+            options[key] = +value;
+        }
+    });
+
+    return options;
 }

--- a/packages/core-transaction-pool/__tests__/__support__/setup.ts
+++ b/packages/core-transaction-pool/__tests__/__support__/setup.ts
@@ -1,7 +1,30 @@
 import { app } from "@arkecosystem/core-container";
-import { setUpContainer } from "@arkecosystem/core-test-utils/src/helpers/container";
+import delay from "delay";
+import { registerWithContainer, setUpContainer } from "../../../core-test-utils/src/helpers/container";
 
 jest.setTimeout(60000);
+
+const options = {
+    enabled: true,
+    maxTransactionsPerSender: 300,
+    allowedSenders: [],
+    dynamicFees: {
+        enabled: true,
+        minFeePool: 1000,
+        minFeeBroadcast: 1000,
+        addonBytes: {
+            transfer: 100,
+            secondSignature: 250,
+            delegateRegistration: 400000,
+            vote: 100,
+            multiSignature: 500,
+            ipfs: 250,
+            timelockTransfer: 500,
+            multiPayment: 500,
+            delegateResignation: 400000,
+        },
+    },
+};
 
 export const setUp = async () => {
     return await setUpContainer({
@@ -12,12 +35,51 @@ export const setUp = async () => {
 };
 
 export const setUpFull = async () => {
-    return await setUpContainer({
-        exit: "@arkecosystem/core-blockchain",
+    await setUpContainer({
+        exit: "@arkecosystem/core-transaction-pool",
+        exclude: ["@arkecosystem/core-transaction-pool"],
         network: "unitnet",
     });
+
+    const { plugin } = require("../../src/plugin");
+    await registerWithContainer(plugin, options);
+
+    // now registering the plugins that need to be registered after transaction pool
+    // register p2p
+    const { plugin: pluginP2p } = require("@arkecosystem/core-p2p");
+    await registerWithContainer(pluginP2p, {
+        host: "0.0.0.0",
+        port: 4000,
+        minimumNetworkReach: 5,
+        coldStart: 5,
+    });
+
+    // register blockchain
+    // a little trick here, we register blockchain plugin without starting it
+    // (it caused some issues where we waited eternally for blockchain to be up)
+    // instead, we start blockchain manually and check manually that it is up with getLastBlock()
+    process.env.CORE_SKIP_BLOCKCHAIN = "true";
+    const { plugin: pluginBlockchain } = require("@arkecosystem/core-blockchain");
+    const blockchain = await registerWithContainer(pluginBlockchain, {});
+    await blockchain.start(true);
+
+    while (!blockchain.getLastBlock()) {
+        await delay(1000);
+    }
+
+    return app;
 };
 
 export const tearDown = async () => {
+    await app.tearDown();
+};
+
+export const tearDownFull = async () => {
+    const { plugin: pluginP2p } = require("@arkecosystem/core-p2p");
+    await pluginP2p.deregister(app, {});
+
+    const { plugin } = require("../../src/plugin");
+    await plugin.deregister(app, options);
+
     await app.tearDown();
 };

--- a/packages/core-transaction-pool/__tests__/connection.test.ts
+++ b/packages/core-transaction-pool/__tests__/connection.test.ts
@@ -9,7 +9,7 @@ import delay from "delay";
 import randomSeed from "random-seed";
 import { TransactionPool } from "../dist";
 import { transactions as mockData } from "./__fixtures__/transactions";
-import { setUpFull, tearDown } from "./__support__/setup";
+import { setUpFull, tearDownFull } from "./__support__/setup";
 
 const { ARKTOSHI, TransactionTypes } = constants;
 const { Transaction } = models;
@@ -39,7 +39,7 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
-    await tearDown();
+    await tearDownFull();
 });
 
 beforeEach(() => {

--- a/packages/core-transaction-pool/__tests__/dynamic-fee.test.ts
+++ b/packages/core-transaction-pool/__tests__/dynamic-fee.test.ts
@@ -1,20 +1,22 @@
 import { Blockchain, Container } from "@arkecosystem/core-interfaces";
-import { dynamicFeeMatcher } from "../dist/dynamic-fee";
-import { config } from "../src";
+import { dynamicFeeMatcher } from "../src/dynamic-fee";
 import { transactions } from "./__fixtures__/transactions";
-import { setUpFull, tearDown } from "./__support__/setup";
+import { setUpFull, tearDownFull } from "./__support__/setup";
 
+let config;
 let blockchain: Blockchain.IBlockchain;
 let container: Container.IContainer;
 
 beforeAll(async () => {
     container = await setUpFull();
+
+    config = require("../src").config;
     config.init(container.resolveOptions("transactionPool"));
     blockchain = container.resolvePlugin<Blockchain.IBlockchain>("blockchain");
 });
 
 afterAll(async () => {
-    await tearDown();
+    await tearDownFull();
 });
 
 describe("static fees", () => {

--- a/packages/core-transaction-pool/__tests__/pool-wallet-manager.test.ts
+++ b/packages/core-transaction-pool/__tests__/pool-wallet-manager.test.ts
@@ -4,25 +4,27 @@ import { generators } from "@arkecosystem/core-test-utils";
 import { delegates, genesisBlock } from "@arkecosystem/core-test-utils/src/fixtures/unitnet";
 import { crypto, models } from "@arkecosystem/crypto";
 import bip39 from "bip39";
-import { PoolWalletManager } from "../src";
-import { setUpFull, tearDown } from "./__support__/setup";
+import { setUpFull, tearDownFull } from "./__support__/setup";
 
 const { Block } = models;
 const { generateTransfers, generateWallets } = generators;
 
 const arktoshi = 10 ** 8;
 let container: Container.IContainer;
+let PoolWalletManager;
 let poolWalletManager;
 let blockchain: Blockchain.IBlockchain;
 
 beforeAll(async () => {
     container = await setUpFull();
+
+    PoolWalletManager = require("../src").PoolWalletManager;
     poolWalletManager = new PoolWalletManager();
     blockchain = container.resolvePlugin<Blockchain.IBlockchain>("blockchain");
 });
 
 afterAll(async () => {
-    await tearDown();
+    await tearDownFull();
 });
 
 describe("applyPoolTransactionToSender", () => {


### PR DESCRIPTION
## Proposed changes

Fixes the current coverage issue.

We had the issue because when testing some packages, we let core-container register all the needed plugins, including the one that we are currently testing.
By doing this, the container would simply call each package from its `dist` folder and register it (which is normal).
But as for testing we use `ts-jest` which transpiles on-the-fly our package, what `ts-jest` transpiled was not called and therefore we didn't have coverage.

See issue #1977 for the full discussion.

## Types of changes

- [x] Test (adding missing tests or fixing existing tests)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes