### PR TITLE
fix(core-p2p): only log error if error object is not empty

### DIFF
--- a/packages/core-p2p/src/server/versions/1/handlers.ts
+++ b/packages/core-p2p/src/server/versions/1/handlers.ts
@@ -180,7 +180,10 @@ export const postBlock = {
 
             return { success: true };
         } catch (error) {
-            logger.error(error);
+            //  Only write the error to the log if the error object is not empty
+            if(!!Object.keys(error).length) {
+                logger.error(error);
+            }
             return { success: false };
         }
     },


### PR DESCRIPTION
## Proposed changes
Useless "undefined" errors could be written to the log when a malformed block is received because the error object is empty in these circumstances. This fixes it by checking that the error object is not empty before writing to the log.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [ ] Docs (documentation only changes)
- [ ] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [ ] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
