### PR TITLE
refactor(core-logger-winston): do not log empty values and stringify non-string values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ packages/**/dist/
 
 # Random
 peers_backup.json
+docker
 
 #Webstorm/Intellij
 .idea

--- a/packages/core-logger-winston/package.json
+++ b/packages/core-logger-winston/package.json
@@ -34,6 +34,7 @@
         "chalk": "^2.4.1",
         "colors": "^1.3.3",
         "dayjs-ext": "^2.2.0",
+        "lodash.isempty": "^4.4.0",
         "node-emoji": "^1.8.1",
         "winston": "^3.1.0",
         "winston-daily-rotate-file": "^3.5.1"

--- a/packages/core-logger-winston/src/driver.ts
+++ b/packages/core-logger-winston/src/driver.ts
@@ -1,5 +1,7 @@
 import { AbstractLogger } from "@arkecosystem/core-logger";
 import "colors";
+import isEmpty from "lodash/isEmpty";
+import { inspect } from "util";
 import * as winston from "winston";
 
 let tracker = null;
@@ -24,47 +26,47 @@ export class WinstonLogger extends AbstractLogger {
 
     /**
      * Log an error message.
-     * @param  {String} message
+     * @param  {*} message
      * @return {void}
      */
-    public error(message: string): void {
-        this.logger.error(message);
+    public error(message: any): void {
+        this.createLog("error", message);
     }
 
     /**
      * Log a warning message.
-     * @param  {String} message
+     * @param  {*} message
      * @return {void}
      */
-    public warn(message: string): void {
-        this.logger.warn(message);
+    public warn(message: any): void {
+        this.createLog("warn", message);
     }
 
     /**
      * Log an info message.
-     * @param  {String} message
+     * @param  {*} message
      * @return {void}
      */
-    public info(message: string): void {
-        this.logger.info(message);
+    public info(message: any): void {
+        this.createLog("info", message);
     }
 
     /**
      * Log a debug message.
-     * @param  {String} message
+     * @param  {*} message
      * @return {void}
      */
-    public debug(message: string): void {
-        this.logger.debug(message);
+    public debug(message: any): void {
+        this.createLog("debug", message);
     }
 
     /**
      * Log a verbose message.
-     * @param  {String} message
+     * @param  {*} message
      * @return {void}
      */
-    public verbose(message: string): void {
-        this.logger.verbose(message);
+    public verbose(message: any): void {
+        this.createLog("verbose", message);
     }
 
     /**
@@ -155,5 +157,23 @@ export class WinstonLogger extends AbstractLogger {
                 new winston.transports[transport.constructor](transport.options),
             );
         }
+    }
+
+    /**
+     * Log a message with the given method.
+     * @param  {String} method
+     * @param  {*} message
+     * @return {void}
+     */
+    private createLog(method: string, message: any): void {
+        if (isEmpty(message)) {
+            return;
+        }
+
+        if (typeof message !== "string") {
+            message = inspect(message, { depth: 1 });
+        }
+
+        this.logger[method](message);
     }
 }

--- a/packages/core-logger/src/logger.ts
+++ b/packages/core-logger/src/logger.ts
@@ -15,38 +15,38 @@ export abstract class AbstractLogger implements Logger.ILogger {
 
     /**
      * Log an error message.
-     * @param  {String} message
+     * @param  {*} message
      * @return {void}
      */
-    public abstract error(message: string): void;
+    public abstract error(message: any): void;
 
     /**
      * Log a warning message.
-     * @param  {String} message
+     * @param  {*} message
      * @return {void}
      */
-    public abstract warn(message: string): void;
+    public abstract warn(message: any): void;
 
     /**
      * Log an info message.
-     * @param  {String} message
+     * @param  {*} message
      * @return {void}
      */
-    public abstract info(message: string): void;
+    public abstract info(message: any): void;
 
     /**
      * Log a debug message.
-     * @param  {String} message
+     * @param  {*} message
      * @return {void}
      */
-    public abstract debug(message: string): void;
+    public abstract debug(message: any): void;
 
     /**
      * Log a verbose message.
-     * @param  {String} message
+     * @param  {*} message
      * @return {void}
      */
-    public abstract verbose(message: string): void;
+    public abstract verbose(message: any): void;
 
     /**
      * Print the progress tracker.


### PR DESCRIPTION
## Proposed changes

An improved version of https://github.com/ArkEcosystem/core/pull/2010 to handle the issue everywhere on the logger level.

## Types of changes

- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes