### PR TITLE
refactor(core-logger-winston): add flag to disable extra spacing for readability

### DIFF
--- a/packages/core-logger-winston/src/defaults.ts
+++ b/packages/core-logger-winston/src/defaults.ts
@@ -6,7 +6,7 @@ export const defaults = {
             constructor: "Console",
             options: {
                 level: process.env.CORE_LOG_LEVEL || "debug",
-                format: formatter(true),
+                format: formatter(true, true),
                 stderrLevels: ["error", "warn"],
             },
         },
@@ -15,7 +15,7 @@ export const defaults = {
             constructor: "DailyRotateFile",
             options: {
                 level: process.env.CORE_LOG_LEVEL || "debug",
-                format: formatter(false),
+                format: formatter(false, true),
                 filename: process.env.CORE_LOG_FILE || `${process.env.CORE_PATH_LOG}/%DATE%.log`,
                 datePattern: "YYYY-MM-DD",
                 zippedArchive: true,

--- a/packages/core-logger-winston/src/formatter.ts
+++ b/packages/core-logger-winston/src/formatter.ts
@@ -5,7 +5,7 @@ import { format } from "winston";
 
 const { colorize, combine, timestamp, printf } = format;
 
-const formatter = (colorOutput: boolean = true) =>
+const formatter = (colorOutput: boolean = true, makeReadable: boolean = true) =>
     combine(
         colorize(),
         timestamp(),
@@ -39,7 +39,7 @@ const formatter = (colorOutput: boolean = true) =>
             const dateTime = dayjs(info.timestamp).format("YYYY-MM-DD HH:mm:ss");
 
             const dateTimeAndLevel = `[${dateTime}][${level}]:`;
-            const lineSpacer = " ".repeat(Math.abs(dateTimeAndLevel.length - 50) + 1);
+            const lineSpacer = makeReadable ? " ".repeat(Math.abs(dateTimeAndLevel.length - 50) + 1) : "";
 
             return `[${dateTime}][${level}]${lineSpacer}: ${message}`;
         }),

--- a/packages/core-logger-winston/src/index.ts
+++ b/packages/core-logger-winston/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./driver";
+export * from "./formatter";
 export * from "./plugin";

--- a/packages/core-logger-winston/src/plugin.ts
+++ b/packages/core-logger-winston/src/plugin.ts
@@ -13,19 +13,19 @@ export const plugin: Container.PluginDescriptor = {
         await logManager.makeDriver(new WinstonLogger(options));
 
         const driver = logManager.driver();
-        driver.debug(`Data Directory   => ${process.env.CORE_PATH_DATA}`);
+        driver.debug(`Data Directory => ${process.env.CORE_PATH_DATA}`);
         driver.debug(`Config Directory => ${process.env.CORE_PATH_CONFIG}`);
 
         if (process.env.CORE_PATH_CACHE) {
-            driver.debug(`Cache Directory  => ${process.env.CORE_PATH_CACHE}`);
+            driver.debug(`Cache Directory => ${process.env.CORE_PATH_CACHE}`);
         }
 
         if (process.env.CORE_PATH_LOG) {
-            driver.debug(`Log Directory  => ${process.env.CORE_PATH_LOG}`);
+            driver.debug(`Log Directory => ${process.env.CORE_PATH_LOG}`);
         }
 
         if (process.env.CORE_PATH_TEMP) {
-            driver.debug(`Temp Directory  => ${process.env.CORE_PATH_TEMP}`);
+            driver.debug(`Temp Directory => ${process.env.CORE_PATH_TEMP}`);
         }
 
         return driver;


### PR DESCRIPTION
## Proposed changes

Adds the `makeReadable` flag which enables extra spacing by default but can be set to false to remove that.

## Types of changes

- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes