### PR TITLE
feat(crypto): implement error classes

### DIFF
--- a/packages/crypto/__tests__/crypto/crypto.test.ts
+++ b/packages/crypto/__tests__/crypto/crypto.test.ts
@@ -1,6 +1,7 @@
 import "jest-extended";
 import { TransactionTypes } from "../../src/constants";
 import { crypto } from "../../src/crypto/crypto";
+import { InvalidTransactionVersionError } from "../../src/errors";
 import { configManager } from "../../src/managers/config";
 import { ITransactionData } from "../../src/models";
 
@@ -112,7 +113,7 @@ describe("crypto.js", () => {
                 id: "13987348420913138422",
             };
 
-            expect(() => crypto.getBytes(transaction)).toThrow("not supported yet");
+            expect(() => crypto.getBytes(transaction)).toThrow(InvalidTransactionVersionError);
         });
     });
 
@@ -138,7 +139,9 @@ describe("crypto.js", () => {
         });
 
         it("should throw for unsupported versions", () => {
-            expect(() => crypto.getHash(Object.assign({}, transaction, { version: 110 }))).toThrow("not supported yet");
+            expect(() => crypto.getHash(Object.assign({}, transaction, { version: 110 }))).toThrow(
+                InvalidTransactionVersionError,
+            );
         });
     });
 
@@ -162,7 +165,9 @@ describe("crypto.js", () => {
         });
 
         it("should throw for unsupported version", () => {
-            expect(() => crypto.getId(Object.assign({}, transaction, { version: 110 }))).toThrow("not supported yet");
+            expect(() => crypto.getId(Object.assign({}, transaction, { version: 110 }))).toThrow(
+                InvalidTransactionVersionError,
+            );
         });
     });
 
@@ -197,7 +202,7 @@ describe("crypto.js", () => {
         it("should throw for unsupported versions", () => {
             expect(() => {
                 crypto.sign(Object.assign({}, transaction, { version: 110 }), keys);
-            }).toThrow("not supported yet");
+            }).toThrow(InvalidTransactionVersionError);
         });
     });
 

--- a/packages/crypto/src/builder/transactions/multi-payment.ts
+++ b/packages/crypto/src/builder/transactions/multi-payment.ts
@@ -1,4 +1,5 @@
 import { TransactionTypes } from "../../constants";
+import { MaximumPaymentsCountExceededError } from "../../errors";
 import { feeManager } from "../../managers";
 import { ITransactionData } from "../../models";
 import { Bignum } from "../../utils";
@@ -23,7 +24,7 @@ export class MultiPaymentBuilder extends TransactionBuilder<MultiPaymentBuilder>
      */
     public addPayment(recipientId: string, amount: number): MultiPaymentBuilder {
         if (this.data.asset.payments.length >= 2258) {
-            throw new Error("A maximum of 2258 outputs is allowed");
+            throw new MaximumPaymentsCountExceededError();
         }
 
         this.data.asset.payments.push({

--- a/packages/crypto/src/builder/transactions/transaction.ts
+++ b/packages/crypto/src/builder/transactions/transaction.ts
@@ -1,4 +1,5 @@
 import { crypto, slots } from "../../crypto";
+import { MissingTransactionSignatureError } from "../../errors";
 import { configManager } from "../../managers";
 import { ITransactionData, Transaction } from "../../models";
 import { INetwork } from "../../networks";
@@ -176,7 +177,7 @@ export abstract class TransactionBuilder<TBuilder extends TransactionBuilder<TBu
      */
     public getStruct(): ITransactionData {
         if (!this.data.senderPublicKey || !this.data.signature) {
-            throw new Error("The transaction is not signed yet");
+            throw new MissingTransactionSignatureError();
         }
 
         const struct = {

--- a/packages/crypto/src/crypto/crypto.ts
+++ b/packages/crypto/src/crypto/crypto.ts
@@ -4,6 +4,7 @@ import bs58check from "bs58check";
 import ByteBuffer from "bytebuffer";
 import secp256k1 from "secp256k1";
 
+import { InvalidTransactionVersionError } from "../errors";
 import { Address, KeyPair, Keys, PublicKey, WIF } from "../identities";
 import { configManager } from "../managers";
 import { feeManager } from "../managers";
@@ -30,7 +31,7 @@ class Crypto {
         skipSecondSignature: boolean = false,
     ): Buffer {
         if (transaction.version && transaction.version !== 1) {
-            throw new Error("not supported yet");
+            throw new InvalidTransactionVersionError(transaction.version);
         }
 
         let assetSize = 0;
@@ -177,7 +178,7 @@ class Crypto {
      */
     public getId(transaction: ITransactionData): string {
         if (transaction.version && transaction.version !== 1) {
-            throw new Error("not supported yet");
+            throw new InvalidTransactionVersionError(transaction.version);
         }
 
         return this.getHash(transaction).toString("hex");
@@ -192,7 +193,7 @@ class Crypto {
         skipSecondSignature: boolean = false,
     ): Buffer {
         if (transaction.version && transaction.version !== 1) {
-            throw new Error("not supported yet");
+            throw new InvalidTransactionVersionError(transaction.version);
         }
 
         const bytes = this.getBytes(transaction, skipSignature, skipSecondSignature);

--- a/packages/crypto/src/deserializers/transaction.ts
+++ b/packages/crypto/src/deserializers/transaction.ts
@@ -2,6 +2,7 @@ import bs58check from "bs58check";
 import ByteBuffer from "bytebuffer";
 import { TransactionTypes } from "../constants";
 import { crypto } from "../crypto";
+import { InvalidTransactionTypeError } from "../errors";
 import { configManager } from "../managers";
 import { Transaction } from "../models";
 import { IMultiSignatureAsset, ITransactionData } from "../models/transaction";
@@ -67,7 +68,7 @@ class TransactionDeserializer {
         } else if (transaction.type === TransactionTypes.DelegateResignation) {
             this.deserializeDelegateResignation(transaction, buf);
         } else {
-            throw new Error(`Type ${transaction.type} not supported.`);
+            throw new InvalidTransactionTypeError(transaction.type);
         }
     }
 

--- a/packages/crypto/src/errors.ts
+++ b/packages/crypto/src/errors.ts
@@ -1,0 +1,87 @@
+// tslint:disable:max-classes-per-file
+
+export class ExtendableError extends Error {
+    constructor(message: string) {
+        super(message);
+
+        Object.defineProperty(this, "message", {
+            enumerable: false,
+            value: message,
+        });
+
+        Object.defineProperty(this, "name", {
+            enumerable: false,
+            value: this.constructor.name,
+        });
+
+        Error.captureStackTrace(this, this.constructor);
+    }
+}
+
+export class CryptoError extends ExtendableError {}
+
+export class InvalidBip38CompressionError extends CryptoError {
+    constructor() {
+        super("Invalid BIP38 compression flag");
+    }
+}
+
+export class InvalidBip38LengthError extends CryptoError {
+    constructor() {
+        super("Invalid BIP38 data length");
+    }
+}
+
+export class InvalidBip38PrefixError extends CryptoError {
+    constructor() {
+        super("Invalid BIP38 prefix");
+    }
+}
+
+export class InvalidBip38TypeError extends CryptoError {
+    constructor() {
+        super("Invalid BIP38 type");
+    }
+}
+
+export class InvalidNetworkVersionError extends CryptoError {
+    constructor() {
+        super("Invalid network version");
+    }
+}
+
+export class InvalidPrivateKeyLengthError extends CryptoError {
+    constructor() {
+        super("Invalid private key length");
+    }
+}
+
+export class InvalidPublicKeyError extends CryptoError {
+    constructor(value: string) {
+        super(`publicKey '${value}' is invalid`);
+    }
+}
+
+export class InvalidTransactionTypeError extends CryptoError {
+    constructor(value: string) {
+        super(`Type ${value} not supported.`);
+    }
+}
+
+export class InvalidTransactionVersionError extends CryptoError {
+    constructor(value: number) {
+        super(`Version ${value} not supported.`);
+    }
+}
+
+export class MaximumPaymentsCountExceededError extends CryptoError {
+    constructor() {
+        super("A maximum of 2258 outputs is allowed");
+    }
+}
+
+export class MissingTransactionSignatureError extends CryptoError {
+    constructor() {
+        super("The transaction is not signed yet");
+    }
+}

--- a/packages/crypto/src/identities/address.ts
+++ b/packages/crypto/src/identities/address.ts
@@ -1,5 +1,6 @@
 import bs58check from "bs58check";
 import { HashAlgorithms } from "../crypto";
+import { InvalidPublicKeyError } from "../errors";
 import { configManager } from "../managers";
 import { PublicKey } from "./public-key";
 
@@ -11,7 +12,7 @@ export class Address {
     public static fromPublicKey(publicKey, networkVersion?: number): string {
         const pubKeyRegex = /^[0-9A-Fa-f]{66}$/;
         if (!pubKeyRegex.test(publicKey)) {
-            throw new Error(`publicKey '${publicKey}' is invalid`);
+            throw new InvalidPublicKeyError(publicKey);
         }
 
         if (!networkVersion) {

--- a/packages/crypto/src/identities/keys.ts
+++ b/packages/crypto/src/identities/keys.ts
@@ -2,6 +2,7 @@ import secp256k1 from "secp256k1";
 import wif from "wif";
 
 import { HashAlgorithms } from "../crypto";
+import { InvalidNetworkVersionError } from "../errors";
 import { configManager } from "../managers";
 import { INetwork } from "../networks";
 
@@ -40,7 +41,7 @@ export class Keys {
         const version = decoded.version;
 
         if (version !== network.wif) {
-            throw new Error("Invalid network version");
+            throw new InvalidNetworkVersionError();
         }
 
         const privateKey = decoded.privateKey;

--- a/packages/crypto/src/serializers/transaction.ts
+++ b/packages/crypto/src/serializers/transaction.ts
@@ -1,6 +1,7 @@
 import bs58check from "bs58check";
 import ByteBuffer from "bytebuffer";
 import { TransactionTypes } from "../constants";
+import { InvalidTransactionTypeError } from "../errors";
 import { configManager } from "../managers";
 import { Transaction } from "../models";
 import { ITransactionData } from "../models/transaction";
@@ -66,7 +67,7 @@ class TransactionSerializer {
         } else if (transaction.type === TransactionTypes.DelegateResignation) {
             this.serializeDelegateResignation(transaction, buffer);
         } else {
-            throw new Error(`Type ${transaction.type} not supported.`);
+            throw new InvalidTransactionTypeError(transaction.type);
         }
     }
 


### PR DESCRIPTION
## Proposed changes

First part of https://github.com/ArkEcosystem/core/issues/2028.

The crypto package now throws specific errors for specific issues rather then a generic `Error`. This allows us to assert types of errors in tests and the application itself rather then fiddling with the string messages of the generic error.

All of those errors extend the `CryptoError` class which is generic within the crypto package but still allows us to identify that the error came from the crypto package rather then guessing what happened.

Tests have been adjusted to assert instances of errors rather then messages.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes