### PR TITLE
chore: store development docker files in docker/development

### DIFF
--- a/scripts/docker/generate-docker.js
+++ b/scripts/docker/generate-docker.js
@@ -14,11 +14,11 @@ const token = process.argv[2];
 console.log(`Generating docker files for '${token}':`)
 
 templateDirs.forEach(templateDir => {
-    ensureDirSync(`./docker/${templateDir}`)
+    ensureDirSync(`./docker/development/${templateDir}`)
     const templateFiles = fs.readdirSync(`${templateRoot}/${templateDir}`)
     templateFiles.forEach(templateFile => {
         const template = fs.readFileSync(`${templateRoot}/${templateDir}/${templateFile}`, { encoding: "utf8" })
-        const target = `./docker/${templateDir}/${templateFile}`
+        const target = `./docker/development/${templateDir}/${templateFile}`
         console.log(`${target}`)
         fs.writeFileSync(target, template.replace(regex, token));
         if (templateFile.endsWith(".sh")) {


### PR DESCRIPTION
## Proposed changes

Moves the development docker files so @adrian69 can store the production files in a sub-directory.

## Types of changes

- [x] Build (changes that affect the build system)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes