### PR TITLE
fix(core-p2p): return an empty array if the peers cache parsing fails

### DIFF
--- a/packages/core-p2p/src/utils/restore-peers.ts
+++ b/packages/core-p2p/src/utils/restore-peers.ts
@@ -21,16 +21,20 @@ export const restorePeers = (): any[] => {
         return [];
     }
 
-    const peers = JSON.parse(readFileSync(path, { encoding: "utf8" }));
-    const { value, error } = Joi.validate(peers, schema);
+    try {
+        const peers = JSON.parse(readFileSync(path, { encoding: "utf8" }));
+        const { value, error } = Joi.validate(peers, schema);
 
-    if (error) {
-        const logger = app.resolvePlugin<Logger.ILogger>("logger");
-        if (logger) {
-            logger.warn("Ignoring corrupt peers from cache.");
+        if (error) {
+            const logger = app.resolvePlugin<Logger.ILogger>("logger");
+            if (logger) {
+                logger.warn("Ignoring corrupt peers from cache.");
+            }
+            return [];
         }
+
+        return value;
+    } catch (error) {
         return [];
     }
-
-    return value;
 };


### PR DESCRIPTION
## Proposed changes

If the `~/.cache/ark-core/devnet/peers.json` file is malformed the `JSON.parse` will fail as only Joi errors are currently handled.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes