### PR TITLE
chore(docker): rename development to unitnet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,8 +61,7 @@ packages/**/dist/
 *.sqlite
 
 # Random
-peers_backup.json
-docker
+docker/development
 
 #Webstorm/Intellij
 .idea

--- a/install.sh
+++ b/install.sh
@@ -325,12 +325,12 @@ fi
 
 cd "$HOME"
 
-if [ -d "core" ]; then
+if [ -d "ark-core" ]; then
    heading "Removing existing folder..."
-   rm -rf core
+   rm -rf ark-core
 fi
 
-git clone https://github.com/ArkEcosystem/core.git -b develop
-cd core
+git clone https://github.com/ArkEcosystem/core.git ~/ark-core -b develop
+cd ark-core
 yarn setup
 

--- a/scripts/docker/templates/development/purge.sh
+++ b/scripts/docker/templates/development/purge.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env sh
-
-docker stop {token}-development-postgres
-docker rm -v {token}-development-postgres
-docker volume rm development_postgres
-docker network rm development_default

--- a/scripts/docker/templates/mainnet/docker-compose.yml
+++ b/scripts/docker/templates/mainnet/docker-compose.yml
@@ -1,6 +1,3 @@
-#
-# For running some services on development without tainting your system
-#
 version: '2'
 services:
 

--- a/scripts/docker/templates/unitnet/docker-compose.yml
+++ b/scripts/docker/templates/unitnet/docker-compose.yml
@@ -1,19 +1,16 @@
-#
-# For running some services on development without tainting your system
-#
 version: '2'
 services:
 
   postgres:
     image: "postgres:alpine"
-    container_name: {token}-development-postgres
+    container_name: {token}-unitnet-postgres
     ports:
       - '127.0.0.1:5432:5432'
     volumes:
       - 'postgres:/var/lib/postgresql/data'
     environment:
      POSTGRES_PASSWORD: password
-     POSTGRES_DB: {token}_development
+     POSTGRES_DB: {token}_unitnet
      POSTGRES_USER: {token}
 
 volumes:

--- a/scripts/docker/templates/unitnet/purge.sh
+++ b/scripts/docker/templates/unitnet/purge.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+
+docker stop {token}-unitnet-postgres
+docker rm -v {token}-unitnet-postgres
+docker volume rm unitnet_postgres
+docker network rm unitnet_default


### PR DESCRIPTION
## Proposed changes

Renamed `development` to `unitnet` to make it clear that it is meant to run the test suite together with the `unitnet` network.

## Types of changes

- [x] Other

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes