### PR TITLE
chore(docker): changed forging secret and password handling

### DIFF
--- a/docker/production/devnet/enc.sh
+++ b/docker/production/devnet/enc.sh
@@ -1,28 +1,56 @@
 #!/usr/bin/env bash
-##########################################################################
-#                                                                        #
-# This script encrypts your forging secret as well as your password.     #
-# Put them in the corresponding variable names $SECRET="" and $BIP38="". #
-# Execute script after that. It will create a local folder named `enc`   #
-# containing all needed stuff. After starting your Docker container      #
-# it is desirable to delete that folder (`rm -rf enc`) and remove        #
-# previously entered secret and password.                                #	
-#                                                                        #
-##########################################################################
+##########################################################
+#                                                        #
+# This script encrypts your forging secret and password. #
+#                                                        #
+##########################################################
 
-SECRET="this is not a secret"   ### <= Your secret here
-BIP38="password"                ### <= Your password here
+type openssl >/dev/null 2>&1 || { echo >&2 "OpenSSL missing. Please install and run the script again."; exit 1; }
 
-### Stop edit here
+yellow=$(tput setaf 3)
+green=$(tput setaf 2)
+lila=$(tput setaf 4)
+bold=$(tput bold)
+reset=$(tput sgr0)
+
+warning ()
+{
+    echo "    ${yellow}==>${reset}${bold} $1${reset}"
+}
+
+success ()
+{
+    echo "    ${green}==>${reset}${bold} $1${reset}"
+}
+
+read -sp "Please enter your delegate secret: " inputSecret
+echo
+
+while true; do
+    read -sp "Please enter your password: " inputPass
+    echo
+    read -sp "Please enter password again: " inputPassA
+    echo
+    [ "${inputPass}" = "${inputPassA}" ] && break
+    echo "Password do not match! Please try again."
+done
+
+SECRET="${inputSecret}"
+BIP38="${inputPass}"
 
 rm -rf enc > /dev/null 2>&1
 mkdir enc; cd enc
 
+warning "Encrypting ..."
+
 openssl genrsa -out secret.key 2048
 openssl rsa -in secret.key -out secret.pub -outform PEM -pubout
-echo "${SECRET}" | openssl rsautl -encrypt -inkey secret.pub -pubin -out secret.dat 
+echo "${SECRET}" | openssl rsautl -encrypt -inkey secret.pub -pubin -out secret.dat
 
 openssl genrsa -out bip.key 2048
 openssl rsa -in bip.key -out bip.pub -outform PEM -pubout
 echo "${BIP38}" | openssl rsautl -encrypt -inkey bip.pub -pubin -out bip.dat
+
+success "Done! Created folder $(echo "${lila}enc${reset}") with all certificates and keys inside."
+success "You are now ready to run your docker $(echo "${yellow}forger")."
 

--- a/docker/production/mainnet/enc.sh
+++ b/docker/production/mainnet/enc.sh
@@ -1,28 +1,56 @@
 #!/usr/bin/env bash
-##########################################################################
-#                                                                        #
-# This script encrypts your forging secret as well as your password.     #
-# Put them in the corresponding variable names $SECRET="" and $BIP38="". #
-# Execute script after that. It will create a local folder named `enc`   #
-# containing all needed stuff. After starting your Docker container      #
-# it is desirable to delete that folder (`rm -rf enc`) and remove        #
-# previously entered secret and password.                                #	
-#                                                                        #
-##########################################################################
+##########################################################
+#                                                        #
+# This script encrypts your forging secret and password. #
+#                                                        #
+##########################################################
 
-SECRET="this is not a secret"   ### <= Your secret here
-BIP38="password"                ### <= Your password here
+type openssl >/dev/null 2>&1 || { echo >&2 "OpenSSL missing. Please install and run the script again."; exit 1; }
 
-### Stop edit here
+yellow=$(tput setaf 3)
+green=$(tput setaf 2)
+lila=$(tput setaf 4)
+bold=$(tput bold)
+reset=$(tput sgr0)
+
+warning ()
+{
+    echo "    ${yellow}==>${reset}${bold} $1${reset}"
+}
+
+success ()
+{
+    echo "    ${green}==>${reset}${bold} $1${reset}"
+}
+
+read -sp "Please enter your delegate secret: " inputSecret
+echo
+
+while true; do
+    read -sp "Please enter your password: " inputPass
+    echo
+    read -sp "Please enter password again: " inputPassA
+    echo
+    [ "${inputPass}" = "${inputPassA}" ] && break
+    echo "Password do not match! Please try again."
+done
+
+SECRET="${inputSecret}"
+BIP38="${inputPass}"
 
 rm -rf enc > /dev/null 2>&1
 mkdir enc; cd enc
 
+warning "Encrypting ..."
+
 openssl genrsa -out secret.key 2048
 openssl rsa -in secret.key -out secret.pub -outform PEM -pubout
-echo "${SECRET}" | openssl rsautl -encrypt -inkey secret.pub -pubin -out secret.dat 
+echo "${SECRET}" | openssl rsautl -encrypt -inkey secret.pub -pubin -out secret.dat
 
 openssl genrsa -out bip.key 2048
 openssl rsa -in bip.key -out bip.pub -outform PEM -pubout
 echo "${BIP38}" | openssl rsautl -encrypt -inkey bip.pub -pubin -out bip.dat
+
+success "Done! Created folder $(echo "${lila}enc${reset}") with all certificates and keys inside."
+success "You are now ready to run your docker $(echo "${yellow}forger")."
 


### PR DESCRIPTION
## Proposed changes
Changed script to interactively ask for forging secret and password instead of asking the user to put them manually in advance.

## Types of changes
- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist
- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
