### PR TITLE
fix(core-transaction-pool): disallow multiple registrations for same delegate

### DIFF
--- a/packages/core-transaction-pool/__tests__/guard.test.ts
+++ b/packages/core-transaction-pool/__tests__/guard.test.ts
@@ -394,6 +394,33 @@ describe("Transaction Guard", () => {
             expect(result.errors).toBeNull();
         });
 
+        it("should not validate when multiple wallets register the same username in the same transaction payload", async () => {
+            const delegateRegistrations = [
+                generateDelegateRegistration("unitnet", wallets[14].passphrase, 1, false, "test_delegate")[0],
+                generateDelegateRegistration("unitnet", wallets[15].passphrase, 1, false, "test_delegate")[0],
+            ];
+
+            const result = await guard.validate(delegateRegistrations);
+            expect(result.invalid).toEqual(delegateRegistrations.map(transaction => transaction.id));
+
+            delegateRegistrations.forEach(tx => {
+                expect(guard.errors[tx.id]).toEqual([
+                    {
+                        type: "ERR_CONFLICT",
+                        message: `Multiple delegate registrations for "${
+                            tx.asset.delegate.username
+                        }" in transaction payload`,
+                    },
+                ]);
+            });
+
+            const wallet1 = transactionPool.walletManager.findByPublicKey(wallets[14].keys.publicKey);
+            const wallet2 = transactionPool.walletManager.findByPublicKey(wallets[15].keys.publicKey);
+
+            expect(wallet1.username).toBe(null);
+            expect(wallet2.username).toBe(null);
+        });
+
         describe("Sign a transaction then change some fields shouldn't pass validation", () => {
             const secondSignatureError = (id, address) => [
                 id,
@@ -889,6 +916,33 @@ describe("Transaction Guard", () => {
                     },
                 ],
             });
+        });
+
+        it("should not validate a delegate registration if an existing registration for the same username from a different wallet exists in the pool", async () => {
+            const delegateRegistrations = [
+                generateDelegateRegistration("unitnet", wallets[16].passphrase, 1, false, "test_delegate")[0],
+                generateDelegateRegistration("unitnet", wallets[17].passphrase, 1, false, "test_delegate")[0],
+            ];
+
+            expect(guard.__validateTransaction(delegateRegistrations[0])).toBeTrue();
+            guard.accept.set(delegateRegistrations[0].id, delegateRegistrations[0]);
+            guard.__addTransactionsToPool();
+            expect(guard.errors).toEqual({});
+            expect(guard.__validateTransaction(delegateRegistrations[1])).toBeFalse();
+            expect(guard.errors[delegateRegistrations[1].id]).toEqual([
+                {
+                    type: "ERR_PENDING",
+                    message: `Delegate registration for "${
+                        delegateRegistrations[1].asset.delegate.username
+                    }" already in the pool`,
+                },
+            ]);
+
+            const wallet1 = transactionPool.walletManager.findByPublicKey(wallets[16].keys.publicKey);
+            const wallet2 = transactionPool.walletManager.findByPublicKey(wallets[17].keys.publicKey);
+
+            expect(wallet1.username).toBe("test_delegate");
+            expect(wallet2.username).toBe(null);
         });
 
         it("should not validate when sender has same type transactions in the pool (only for 2nd sig, delegate registration, vote)", async () => {

--- a/packages/core-transaction-pool/src/connection.ts
+++ b/packages/core-transaction-pool/src/connection.ts
@@ -78,6 +78,17 @@ export class TransactionPool implements transactionPool.ITransactionPool {
     }
 
     /**
+     * Get all transactions of a given type from the pool.
+     * @param {Number} type of transaction
+     * @return {Set of MemPoolTransaction} all transactions of the given type, could be empty Set
+     */
+    public getTransactionsByType(type) {
+        this.__purgeExpired();
+
+        return this.mem.getByType(type);
+    }
+
+    /**
      * Get the number of transactions in the pool.
      * @return {Number}
      */


### PR DESCRIPTION
## Proposed changes

Only allow a single instance of a delegate registration in the pool per address.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes