### PR TITLE
fix(core-api): use the supply calculator in the v1 API

### DIFF
--- a/packages/core-api/src/versions/1/blocks/controller.ts
+++ b/packages/core-api/src/versions/1/blocks/controller.ts
@@ -1,3 +1,4 @@
+import { supplyCalculator } from "@arkecosystem/core-utils";
 import { bignumify } from "@arkecosystem/core-utils";
 import Boom from "boom";
 import Hapi from "hapi";
@@ -105,14 +106,8 @@ export class BlocksController extends Controller {
 
     public async supply(request: Hapi.Request, h: Hapi.ResponseToolkit) {
         try {
-            const lastBlock = this.blockchain.getLastBlock();
-            const constants = this.config.getMilestone(lastBlock.data.height);
-            const rewards = bignumify(constants.reward).times(lastBlock.data.height - constants.height);
-
             return super.respondWith({
-                supply: +bignumify(this.config.get("genesisBlock.totalAmount"))
-                    .plus(rewards)
-                    .toFixed(),
+                supply: supplyCalculator.calculate(this.blockchain.getLastBlock().data.height),
             });
         } catch (error) {
             return Boom.badImplementation(error);


### PR DESCRIPTION
## Proposed changes

The v1 API was not using the supply calculator which caused a different result then the v2 API.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes