### PR TITLE
fix: quorum issues

### DIFF
--- a/packages/core-blockchain/src/blockchain.ts
+++ b/packages/core-blockchain/src/blockchain.ts
@@ -244,7 +244,7 @@ export class Blockchain implements blockchain.IBlockchain {
             return;
         }
 
-        if (this.state.started && this.state.blockchain.value === "idle") {
+        if (this.state.started) {
             this.dispatch("NEWBLOCK");
             this.enqueueBlocks([block]);
         } else {

--- a/packages/core-forger/src/manager.ts
+++ b/packages/core-forger/src/manager.ts
@@ -99,8 +99,6 @@ export class ForgerManager {
             await this.__loadUsernames();
 
             round = await this.client.getRound();
-            const delayTime = +this.config.getMilestone(round.lastBlock.height).blocktime * 1000 - 2000;
-
             if (!round.canForge) {
                 // this.logger.debug('Block already forged in current slot')
                 // technically it is possible to compute doing shennanigan with arkjs.slots lib
@@ -111,7 +109,6 @@ export class ForgerManager {
             }
 
             const delegate = this.__isDelegateActivated(round.currentForger.publicKey);
-
             if (!delegate) {
                 // this.logger.debug(`Current forging delegate ${
                 //  round.currentForger.publicKey
@@ -125,7 +122,7 @@ export class ForgerManager {
                     await this.client.syncCheck();
                 }
 
-                await delay(delayTime); // we will check at next slot
+                await delay(slots.getTimeInMsUntilNextSlot()); // we will check at next slot
 
                 return this.__monitor(round);
             }
@@ -133,14 +130,14 @@ export class ForgerManager {
             const networkState = await this.client.getNetworkState();
 
             if (!this.__parseNetworkState(networkState, delegate)) {
-                await delay(delayTime); // we will check at next slot
+                await delay(slots.getTimeInMsUntilNextSlot()); // we will check at next slot
 
                 return this.__monitor(round);
             }
 
             await this.__forgeNewBlock(delegate, round);
 
-            await delay(delayTime); // we will check at next slot
+            await delay(slots.getTimeInMsUntilNextSlot()); // we will check at next slot
 
             return this.__monitor(round);
         } catch (error) {

--- a/packages/core-forger/src/manager.ts
+++ b/packages/core-forger/src/manager.ts
@@ -129,13 +129,9 @@ export class ForgerManager {
 
             const networkState = await this.client.getNetworkState();
 
-            if (!this.__parseNetworkState(networkState, delegate)) {
-                await delay(slots.getTimeInMsUntilNextSlot()); // we will check at next slot
-
-                return this.__monitor(round);
+            if (this.__parseNetworkState(networkState, delegate)) {
+                await this.__forgeNewBlock(delegate, round);
             }
-
-            await this.__forgeNewBlock(delegate, round);
 
             await delay(slots.getTimeInMsUntilNextSlot()); // we will check at next slot
 

--- a/packages/core-p2p/src/network-state.ts
+++ b/packages/core-p2p/src/network-state.ts
@@ -59,11 +59,6 @@ class QuorumDetails {
      * Number of peers with a different slot.
      */
     public peersDifferentSlot = 0;
-
-    /**
-     * Number of peers where forging is not allowed.
-     */
-    public peersForgingNotAllowed = 0;
 }
 
 export enum NetworkStateStatus {
@@ -167,11 +162,6 @@ export class NetworkState {
             if (peer.state.currentSlot !== currentSlot) {
                 quorum = false;
                 this.quorumDetails.peersDifferentSlot++;
-            }
-
-            if (!peer.state.forgingAllowed) {
-                quorum = false;
-                this.quorumDetails.peersForgingNotAllowed++;
             }
 
             quorum ? this.quorumDetails.peersQuorum++ : this.quorumDetails.peersNoQuorum++;

--- a/packages/core-p2p/src/network-state.ts
+++ b/packages/core-p2p/src/network-state.ts
@@ -59,6 +59,11 @@ class QuorumDetails {
      * Number of peers with a different slot.
      */
     public peersDifferentSlot = 0;
+
+    /**
+     * Number of peers where forging is not allowed.
+     */
+    public peersForgingNotAllowed = 0;
 }
 
 export enum NetworkStateStatus {
@@ -162,6 +167,11 @@ export class NetworkState {
             if (peer.state.currentSlot !== currentSlot) {
                 quorum = false;
                 this.quorumDetails.peersDifferentSlot++;
+            }
+
+            if (!peer.state.forgingAllowed) {
+                quorum = false;
+                this.quorumDetails.peersForgingNotAllowed++;
             }
 
             quorum ? this.quorumDetails.peersQuorum++ : this.quorumDetails.peersNoQuorum++;

--- a/packages/crypto/__tests__/crypto/slots.test.ts
+++ b/packages/crypto/__tests__/crypto/slots.test.ts
@@ -99,4 +99,13 @@ describe("Slots", () => {
             expect(slots.isForgingAllowed()).toBeDefined();
         });
     });
+
+    describe("getTimeInMsUntilNextSlot", () => {
+        it("should be ok", () => {
+            const nextSlotTime = slots.getSlotTime(slots.getNextSlot());
+            const now = slots.getTime();
+
+            expect(slots.getTimeInMsUntilNextSlot()).toEqual((nextSlotTime - now) * 1000);
+        });
+    });
 });

--- a/packages/crypto/src/crypto/slots.ts
+++ b/packages/crypto/src/crypto/slots.ts
@@ -61,7 +61,7 @@ class Slots {
     /**
      * Get real time from relative epoch time.
      */
-    public getRealTime(epochTime: number): number {
+    public getRealTime(epochTime?: number): number {
         if (epochTime === undefined) {
             epochTime = this.getTime();
         }
@@ -69,6 +69,15 @@ class Slots {
         const start = Math.floor(this.beginEpochTime().valueOf() / 1000) * 1000;
 
         return start + epochTime * 1000;
+    }
+
+    /**
+     * Time left until next slot.
+     */
+    public getTimeInMsUntilNextSlot(): number {
+        const nextSlotTime = this.getSlotTime(this.getNextSlot());
+        const now = this.getTime();
+        return (nextSlotTime - now) * 1000;
     }
 
     /**


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
This PR resolves two different issues related to quorum.
1) Do not discard incoming blocks when syncing with network. See:
```
019-02-11 23:56:08][DEBUG]: Sending wake-up check to relay node http://127.0.0.1:4000
[2019-02-11 23:56:08][DEBUG]: Blockchain sync check WAKEUP requested by forger 🛏
[2019-02-11 23:56:08][DEBUG]: event 'WAKEUP': "idle" -> {"syncWithNetwork":"syncing"} -> actions: [checkLastDownloadedBlockSynced]
[2019-02-11 23:56:08][DEBUG]: Queued blocks (rebuild: 0 process: 0)
[2019-02-11 23:56:08][DEBUG]: event 'SYNCED': {"syncWithNetwork":"syncing"} -> {"syncWithNetwork":"downloadFinished"} -> actions: [downloadFinished]
[2019-02-11 23:56:08][INFO]: Block 130,749 pinged blockchain 19 times
[2019-02-11 23:56:08][INFO]: Received new block at height 130,750 with 0 transactions from
[2019-02-11 23:56:08][INFO]: Block disregarded because blockchain is not ready ❗️
[2019-02-11 23:56:08][INFO]: Block download finished 🚀
[2019-02-11 23:56:08][DEBUG]: event 'PROCESSFINISHED': {"syncWithNetwork":"downloadFinished"} -> {"syncWithNetwork":"processFinished"} -> actions: [checkLastBlockSynced]
[2019-02-11 23:56:08][DEBUG]: event 'SYNCED': {"syncWithNetwork":"processFinished"} -> {"syncWithNetwork":"end"} -> actions: [syncingComplete]
[2019-02-11 23:56:08][INFO]: Blockchain 100% in sync 💯
[2019-02-11 23:56:08][DEBUG]: event 'SYNCFINISHED': {"syncWithNetwork":"end"} -> "idle" -> actions: [checkLater, blockchainReady]
[2019-02-11 23:56:14][INFO]: Next forging delegate genesis_1 (03287bfebba4c7881a0509717e71b34b63f31e40021c321f89ae04f84be6d6ac37) is active on this node.
[2019-02-11 23:56:14][DEBUG]: Sending wake-up check to relay node http://127.0.0.1:4000
[2019-02-11 23:56:14][DEBUG]: Blockchain sync check WAKEUP requested by forger 🛏
[2019-02-11 23:56:14][DEBUG]: event 'WAKEUP': "idle" -> {"syncWithNetwork":"syncing"} -> actions: [checkLastDownloadedBlockSynced]
[2019-02-11 23:56:14][DEBUG]: Queued blocks (rebuild: 0 process: 0)
[2019-02-11 23:56:14][DEBUG]: event 'SYNCED': {"syncWithNetwork":"syncing"} -> {"syncWithNetwork":"downloadFinished"} -> actions: [downloadFinished]
[2019-02-11 23:56:14][INFO]: Block download finished 🚀
[2019-02-11 23:56:14][DEBUG]: event 'PROCESSFINISHED': {"syncWithNetwork":"downloadFinished"} -> {"syncWithNetwork":"processFinished"} -> actions: [checkLastBlockSynced]
[2019-02-11 23:56:14][DEBUG]: event 'SYNCED': {"syncWithNetwork":"processFinished"} -> {"syncWithNetwork":"end"} -> actions: [syncingComplete]
[2019-02-11 23:56:14][INFO]: Blockchain 100% in sync 💯
[2019-02-11 23:56:14][DEBUG]: event 'SYNCFINISHED': {"syncWithNetwork":"end"} -> "idle" -> actions: [checkLater, blockchainReady]
[2019-02-11 23:56:20][INFO]: Checking 31 peers 🔭
[2019-02-11 23:56:20][INFO]: Detected 1 distinct overheight block 1 header.
[2019-02-11 23:56:20][INFO]: Fork 6 - Not enough quorum to forge next block.
[2019-02-11 23:56:20][DEBUG]: Network State: {
  "quorum": 0,
  "quorumDetails": {
    "peersQuorum": 0,
    "peersNoQuorum": 31,
    "peersOverHeight": 31,
    "peersOverHeightBlockHeaders": {
      "10250198326393091911": {
        "version": 0,
        "timestamp": 59846168,
        "height": 130750,
        "previousBlockHex": "47bb66c613f01084",
        "previousBlock": "5168837998261833860",
        "numberOfTransactions": 0,
        "totalAmount": "0",
        "totalFee": "0",
        "reward": "200000000",
        "payloadLength": 0,
        "payloadHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
        "generatorPublicKey": "0363550e2a3fe2153526effd4302045fa2c3027d0d9b30b19821a4870c8cb134bc",
        "blockSignature": "3044022039db19c9351f011d89d15e8c959bb8bc1ced66a3e0a62dfab8cff47519d838d1022019f6657fb9b0c4237ad7f3713cac9494e535a2cf0bcf11fbf9aae2cf6878bef3",
        "idHex": "8e400511e9f6b747",
        "id": "10250198326393091911"
      }
    },
...
```

When the forger requests the relay to sync, it can happen that it downloads no blocks from a peer. It's possible to receive a block via broadcast during this time frame. What then happens is that the block is rejected, because the state machine is in sync state. Which then thinks it is in sync. Afterwards all peers are pinged to get their height, but since it just refused a block it lags behind. Quorum fails.

2) Sometimes a forger wakes up twice (also seen in the log above)

This happens at random as the wake-up timer is firing "randomly" (sleeping for 6s) without checking how 
much time until the next slot is actually left.  One problem of this is that the `forgingAllowed` flag is only true in the first half of a slot.

So after sleeping 6s `__monitor` is called again while possibly still in the same(!) slot... it therefore decides to sleep again for 6s but by the time it wakes up its most likely way too late so `forgingAllowed = false` and quorum fails. Doesn't happen always, because it depends on the actual timing.

Now instead of (over)sleeping 6s, only sleep for the actual time left. I kept the `forgingAllowed` check for now, though we can probably remove it (2.2 material).

Been running this on a few forgers without issues so far.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [ ] Docs (documentation only changes)
- [ ] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [ ] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
