### PR TITLE
fix(core-api): Proper hex validation

### DIFF
--- a/packages/core-api/src/plugins/validation/formats/hex.ts
+++ b/packages/core-api/src/plugins/validation/formats/hex.ts
@@ -1,14 +1,6 @@
 export function registerHexFormat(ajv) {
     ajv.addFormat("hex", {
         type: "string",
-        validate: value => {
-            try {
-                Buffer.from(value, "hex");
-
-                return true;
-            } catch (e) {
-                return false;
-            }
-        },
+        validate: value => value.match(/^[0-9a-f]+$/i) !== null && value.length % 2 === 0
     });
 }


### PR DESCRIPTION
Buffer.from(value, "hex") will only throw an exception if value is not a
string, according to
https://nodejs.org/api/buffer.html#buffer_class_method_buffer_from_string_encoding
Indeed Buffer.from('foo', 'hex') does not throw. The schema has defined
`type: "string"`, which means that, in all cases when the validate
method is called, it will return true.

Use a proper validation using regular expression and a length check.

## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [ ] Docs (documentation only changes)
- [ ] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [ ] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
