### PR TITLE
refactor(core-p2p): allow multiple minimum versions for alpha/beta/rc releases

### DIFF
--- a/packages/core-p2p/__tests__/court/guard.test.ts
+++ b/packages/core-p2p/__tests__/court/guard.test.ts
@@ -15,6 +15,7 @@ beforeAll(async () => {
     app.getConfig().set("milestoneHash", "dummy-milestone");
 
     guard = require("../../src/court/guard").guard;
+    guard.config.set("minimumVersions", [">=2.0.0"]);
 });
 
 afterAll(async () => {
@@ -79,20 +80,12 @@ describe("Guard", () => {
 
     describe("isValidVersion", () => {
         it("should be a valid version", () => {
-            const get = guard.config.get;
-            guard.config.get = jest.fn(() => ">=2.0.0");
-
             expect(guard.isValidVersion({ version: "2.0.0" })).toBeTrue();
             expect(guard.isValidVersion({ version: "2.1.39" })).toBeTrue();
             expect(guard.isValidVersion({ version: "3.0.0" })).toBeTrue();
-
-            guard.config.get = get;
         });
 
         it("should be an invalid version", () => {
-            const get = guard.config.get;
-            guard.config.get = jest.fn(() => ">=2.0.0");
-
             expect(guard.isValidVersion({ version: "1.0.0" })).toBeFalse();
             expect(guard.isValidVersion({ version: "1.0" })).toBeFalse();
             expect(guard.isValidVersion({ version: "---aaa" })).toBeFalse();
@@ -103,8 +96,6 @@ describe("Guard", () => {
             expect(guard.isValidVersion({ version: true })).toBeFalse();
             expect(guard.isValidVersion({ version: () => "1" })).toBeFalse();
             expect(guard.isValidVersion({ version: "2.0.0.0" })).toBeFalse();
-
-            guard.config.get = get;
         });
     });
 

--- a/packages/core-p2p/src/court/guard.ts
+++ b/packages/core-p2p/src/court/guard.ts
@@ -183,7 +183,9 @@ export class Guard {
             return false;
         }
 
-        return semver.satisfies(version, this.config.get("minimumVersion"));
+        return this.config
+            .get("minimumVersions")
+            .some((minimumVersion: string) => semver.satisfies(version, minimumVersion));
     }
 
     /**

--- a/packages/core-p2p/src/defaults.ts
+++ b/packages/core-p2p/src/defaults.ts
@@ -4,7 +4,7 @@ export const defaults = {
     /**
      * The minimum peer version we expect
      */
-    minimumVersion: ">=2.1.0",
+    minimumVersions: [">=2.1.0", ">=2.2.0-rc.1"],
     /**
      * The number of peers we expect to be available to start a relay
      */

--- a/packages/core-p2p/src/monitor.ts
+++ b/packages/core-p2p/src/monitor.ts
@@ -159,12 +159,12 @@ export class Monitor implements P2P.IMonitor {
         }
 
         if (!this.guard.isValidVersion(peer) && !this.guard.isWhitelisted(peer)) {
-            const minimumVersion: string = localConfig.get("minimumVersion");
+            const minimumVersions: string[] = localConfig.get("minimumVersions");
 
             logger.debug(
                 `Rejected peer ${
                     peer.ip
-                } as it doesn't meet the minimum version requirements. Expected: ${minimumVersion} - Received: ${
+                } as it doesn't meet the minimum version requirements. Expected: ${minimumVersions} - Received: ${
                     peer.version
                 }`,
             );

--- a/packages/core-test-utils/src/config/testnet/plugins.js
+++ b/packages/core-test-utils/src/config/testnet/plugins.js
@@ -38,7 +38,7 @@ module.exports = {
     "@arkecosystem/core-p2p": {
         host: process.env.CORE_P2P_HOST || "0.0.0.0",
         port: process.env.CORE_P2P_PORT || 4000,
-        minimumVersion: ">=2.0.0",
+        minimumVersions: [">=2.0.0"],
         minimumNetworkReach: 5,
         coldStart: 5,
     },

--- a/packages/core-test-utils/src/config/unitnet/plugins.js
+++ b/packages/core-test-utils/src/config/unitnet/plugins.js
@@ -38,7 +38,7 @@ module.exports = {
     "@arkecosystem/core-p2p": {
         host: process.env.CORE_P2P_HOST || "0.0.0.0",
         port: process.env.CORE_P2P_PORT || 4000,
-        minimumVersion: ">=2.0.0",
+        minimumVersions: [">=2.0.0"],
         minimumNetworkReach: 5,
         coldStart: 5,
     },


### PR DESCRIPTION
## Proposed changes

Allow multiple minimum versions to allow testing of alpha/beta/rc releases alongside stable ones.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes