### PR TITLE
refactor(core): require the user to take action for updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,6 @@ jobs:
             - ./packages/core-logger-winston/node_modules
             - ./packages/core-p2p/node_modules
             - ./packages/core-snapshots/node_modules
-            - ./packages/core-snapshots-cli/node_modules
             - ./packages/core-test-utils/node_modules
             - ./packages/core-tester-cli/node_modules
             - ./packages/core-transaction-pool/node_modules
@@ -164,7 +163,6 @@ jobs:
             - ./packages/core-logger-winston/node_modules
             - ./packages/core-p2p/node_modules
             - ./packages/core-snapshots/node_modules
-            - ./packages/core-snapshots-cli/node_modules
             - ./packages/core-test-utils/node_modules
             - ./packages/core-tester-cli/node_modules
             - ./packages/core-transaction-pool/node_modules
@@ -272,7 +270,6 @@ jobs:
             - ./packages/core-logger-winston/node_modules
             - ./packages/core-p2p/node_modules
             - ./packages/core-snapshots/node_modules
-            - ./packages/core-snapshots-cli/node_modules
             - ./packages/core-test-utils/node_modules
             - ./packages/core-tester-cli/node_modules
             - ./packages/core-transaction-pool/node_modules
@@ -395,7 +392,6 @@ jobs:
             - ./packages/core-logger-winston/node_modules
             - ./packages/core-p2p/node_modules
             - ./packages/core-snapshots/node_modules
-            - ./packages/core-snapshots-cli/node_modules
             - ./packages/core-test-utils/node_modules
             - ./packages/core-tester-cli/node_modules
             - ./packages/core-transaction-pool/node_modules
@@ -513,7 +509,6 @@ jobs:
             - ./packages/core-logger-winston/node_modules
             - ./packages/core-p2p/node_modules
             - ./packages/core-snapshots/node_modules
-            - ./packages/core-snapshots-cli/node_modules
             - ./packages/core-test-utils/node_modules
             - ./packages/core-tester-cli/node_modules
             - ./packages/core-transaction-pool/node_modules
@@ -636,7 +631,6 @@ jobs:
             - ./packages/core-logger-winston/node_modules
             - ./packages/core-p2p/node_modules
             - ./packages/core-snapshots/node_modules
-            - ./packages/core-snapshots-cli/node_modules
             - ./packages/core-test-utils/node_modules
             - ./packages/core-tester-cli/node_modules
             - ./packages/core-transaction-pool/node_modules

--- a/packages/core/src/commands/config/cli.ts
+++ b/packages/core/src/commands/config/cli.ts
@@ -1,6 +1,5 @@
 import { flags } from "@oclif/command";
 import cli from "cli-ux";
-import { removeSync } from "fs-extra";
 import { configManager } from "../../helpers/config";
 import { installFromChannel } from "../../helpers/update";
 import { BaseCommand } from "../command";

--- a/packages/core/src/commands/update.ts
+++ b/packages/core/src/commands/update.ts
@@ -1,10 +1,58 @@
-import { checkForUpdates } from "../helpers/update";
+import Chalk from "chalk";
+import cli from "cli-ux";
+import { removeSync } from "fs-extra";
+import { requestConfirmation } from "../helpers/prompts";
+import { checkForUpdates, installFromChannel } from "../helpers/update";
 import { BaseCommand } from "./command";
 
 export class UpdateCommand extends BaseCommand {
     public static description: string = "Update the core installation";
 
     public async run(): Promise<void> {
-        await checkForUpdates(this);
+        const state = await checkForUpdates(this);
+
+        if (!state.ready) {
+            this.log(`You already have the latest version (${state.currentVersion})`);
+
+            return;
+        }
+
+        try {
+            const currentVersion = state.currentVersion;
+            const newVersion = state.updateVersion;
+
+            this.warn(
+                `${state.name} update available from ${Chalk.greenBright(currentVersion)} to ${Chalk.greenBright(
+                    newVersion,
+                )}.`,
+            );
+
+            await requestConfirmation("Would you like to update?", async () => {
+                try {
+                    cli.action.start(`Updating from ${currentVersion} to ${newVersion}`);
+
+                    await installFromChannel(state.name, state.channel);
+
+                    cli.action.stop();
+
+                    removeSync(state.cache);
+
+                    this.warn(`Version ${newVersion} has been installed.`);
+                    this.warn(
+                        'Respectively run "ark relay:restart", "ark forger:restart" or "ark core:restart" to restart your processes.',
+                    );
+
+                    // @TODO ask the user if he wants to restart the core
+                    // @TODO ask the user if he wants to restart the relay
+                    // @TODO ask the user if he wants to restart the forger
+
+                    process.exit();
+                } catch (err) {
+                    this.error(err.message);
+                }
+            });
+        } catch (err) {
+            this.error(err.message);
+        }
     }
 }

--- a/packages/core/src/helpers/prompts.ts
+++ b/packages/core/src/helpers/prompts.ts
@@ -1,0 +1,15 @@
+import prompts from "prompts";
+
+export async function requestConfirmation(message: string, callback: any): Promise<void> {
+    const { confirm } = await prompts([
+        {
+            type: "confirm",
+            name: "confirm",
+            message,
+        },
+    ]);
+
+    if (confirm) {
+        await callback();
+    }
+}

--- a/packages/core/src/helpers/update.ts
+++ b/packages/core/src/helpers/update.ts
@@ -1,17 +1,15 @@
 import { IConfig } from "@oclif/config";
-import Chalk from "chalk";
 import cli from "cli-ux";
 import { shell } from "execa";
 import { closeSync, openSync, statSync } from "fs";
 import { existsSync } from "fs-extra";
-import { ensureDirSync, removeSync } from "fs-extra";
+import { ensureDirSync } from "fs-extra";
 import latestVersion from "latest-version";
 import { join } from "path";
-import prompts from "prompts";
 import semver from "semver";
 import { configManager } from "./config";
 
-async function getVersionFromNode(name: string, channel: string): Promise<string> {
+async function getLatestVersion(name: string, channel: string): Promise<string> {
     try {
         const version = await latestVersion(name, { version: channel });
 
@@ -24,7 +22,21 @@ async function getVersionFromNode(name: string, channel: string): Promise<string
 function ensureCacheFile(config: IConfig): string {
     ensureDirSync(config.cacheDir);
 
-    return join(config.cacheDir, "update");
+    const fileName = join(config.cacheDir, "update");
+
+    closeSync(openSync(fileName, "w"));
+
+    return fileName;
+}
+
+export async function installFromChannel(pkg, channel) {
+    const { stdout, stderr } = await shell(`yarn global add ${pkg}@${channel}`);
+
+    if (stderr) {
+        console.error(stderr);
+    }
+
+    console.log(stdout);
 }
 
 export function getRegistryChannel(config: IConfig): string {
@@ -53,22 +65,19 @@ export function needsRefresh(config: IConfig): boolean {
     }
 }
 
-export async function installFromChannel(pkg, channel) {
-    const { stdout, stderr } = await shell(`yarn global add ${pkg}@${channel}`);
+export async function checkForUpdates({ config, error, warn }): Promise<any> {
+    const initialState = {
+        ready: false,
+        name: config.name,
+        currentVersion: config.version,
+    };
 
-    if (stderr) {
-        console.error(stderr);
-    }
-
-    console.log(stdout);
-}
-
-export async function checkForUpdates({ config, error, log, warn }): Promise<void> {
     if (existsSync(join(__dirname, "../../../..", ".git"))) {
         if (!process.env.CORE_DEVELOPER_MODE) {
             warn(`You are using a git clone for developers. Please install core via yarn for auto-updates.`);
         }
-        return;
+
+        return initialState;
     }
 
     try {
@@ -76,49 +85,28 @@ export async function checkForUpdates({ config, error, log, warn }): Promise<voi
         const cacheFile = ensureCacheFile(config);
 
         cli.action.start(`Checking for updates`);
-        const remoteVersion = await getVersionFromNode(config.name, channel);
+        const latestVersion = await getLatestVersion(config.name, channel);
         cli.action.stop();
 
-        closeSync(openSync(cacheFile, "w"));
-
-        if (remoteVersion === undefined) {
+        if (latestVersion === undefined) {
             error(`We were unable to find any releases for the "${channel}" channel.`);
+
+            return initialState;
         }
 
-        if (semver.gt(remoteVersion, config.version)) {
-            warn(
-                `${config.name} update available from ${Chalk.greenBright(config.version)} to ${Chalk.greenBright(
-                    remoteVersion,
-                )}.`,
-            );
-
-            const response = await prompts([
-                {
-                    type: "confirm",
-                    name: "confirm",
-                    message: `Would you like to update?`,
+        if (semver.gt(latestVersion, config.version)) {
+            return {
+                ...initialState,
+                ...{
+                    ready: true,
+                    updateVersion: latestVersion,
+                    cache: cacheFile,
                 },
-            ]);
-
-            if (response.confirm) {
-                try {
-                    cli.action.start(`Updating from ${config.version} to ${remoteVersion}`);
-
-                    await installFromChannel(config.name, channel);
-
-                    removeSync(cacheFile);
-
-                    cli.action.stop();
-
-                    warn(`Version ${remoteVersion} has been installed. Please restart your relay and forger.`);
-                } catch (err) {
-                    error(err.message);
-                }
-            }
-        } else {
-            log(`You already have the latest version (${config.version})`);
+            };
         }
     } catch (err) {
         error(err.message);
     }
+
+    return initialState;
 }

--- a/packages/core/src/hooks/init/update.ts
+++ b/packages/core/src/hooks/init/update.ts
@@ -22,9 +22,16 @@ export const init: Hook<"init"> = async function({ id, config }) {
             )}. Review the latest release and run "ark update" once you wish to update.`,
         );
 
+        const branch = {
+            alpha: "develop",
+            beta: "develop",
+            rc: "develop",
+            latest: "master",
+        }[state.channel];
+
         await cli.url(
-            `Click here to read the changelog for v${state.currentVersion}`,
-            "https://github.com/ArkEcosystem/core/blob/master/CHANGELOG.md",
+            `Click here to read the changelog for ${state.currentVersion}.`,
+            `https://github.com/ArkEcosystem/core/blob/${branch}/CHANGELOG.md`,
         );
     }
 };

--- a/packages/core/src/hooks/init/update.ts
+++ b/packages/core/src/hooks/init/update.ts
@@ -1,4 +1,6 @@
 import { Hook } from "@oclif/config";
+import Chalk from "chalk";
+import cli from "cli-ux";
 import { checkForUpdates, needsRefresh } from "../../helpers/update";
 
 // tslint:disable-next-line:only-arrow-functions
@@ -11,5 +13,18 @@ export const init: Hook<"init"> = async function({ id, config }) {
         return;
     }
 
-    await checkForUpdates(this);
+    const state = await checkForUpdates(this);
+
+    if (!state.ready) {
+        this.warn(
+            `${state.name} update available from ${Chalk.greenBright(state.currentVersion)} to ${Chalk.greenBright(
+                state.updateVersion,
+            )}. Review the latest release and run "ark update" once you wish to update.`,
+        );
+
+        await cli.url(
+            `Click here to read the changelog for v${state.currentVersion}`,
+            "https://github.com/ArkEcosystem/core/blob/master/CHANGELOG.md",
+        );
+    }
 };


### PR DESCRIPTION
## Proposed changes

The `init` hook for updates now only gives a notification if an update is available together with a link to the changelog instead of also performing the update.

_Until 2.2 is on mainnet we won't have a changelog for the non-stable releases so the link will be not of interest until then._

## Types of changes

- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes