### PR TITLE
refactor(core): replace pm2 with process manager

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,6 @@ jobs:
             - ./packages/core-logger-winston/node_modules
             - ./packages/core-p2p/node_modules
             - ./packages/core-snapshots/node_modules
-            - ./packages/core-snapshots-cli/node_modules
             - ./packages/core-test-utils/node_modules
             - ./packages/core-tester-cli/node_modules
             - ./packages/core-transaction-pool/node_modules
@@ -164,7 +163,6 @@ jobs:
             - ./packages/core-logger-winston/node_modules
             - ./packages/core-p2p/node_modules
             - ./packages/core-snapshots/node_modules
-            - ./packages/core-snapshots-cli/node_modules
             - ./packages/core-test-utils/node_modules
             - ./packages/core-tester-cli/node_modules
             - ./packages/core-transaction-pool/node_modules
@@ -272,7 +270,6 @@ jobs:
             - ./packages/core-logger-winston/node_modules
             - ./packages/core-p2p/node_modules
             - ./packages/core-snapshots/node_modules
-            - ./packages/core-snapshots-cli/node_modules
             - ./packages/core-test-utils/node_modules
             - ./packages/core-tester-cli/node_modules
             - ./packages/core-transaction-pool/node_modules
@@ -395,7 +392,6 @@ jobs:
             - ./packages/core-logger-winston/node_modules
             - ./packages/core-p2p/node_modules
             - ./packages/core-snapshots/node_modules
-            - ./packages/core-snapshots-cli/node_modules
             - ./packages/core-test-utils/node_modules
             - ./packages/core-tester-cli/node_modules
             - ./packages/core-transaction-pool/node_modules
@@ -513,7 +509,6 @@ jobs:
             - ./packages/core-logger-winston/node_modules
             - ./packages/core-p2p/node_modules
             - ./packages/core-snapshots/node_modules
-            - ./packages/core-snapshots-cli/node_modules
             - ./packages/core-test-utils/node_modules
             - ./packages/core-tester-cli/node_modules
             - ./packages/core-transaction-pool/node_modules
@@ -636,7 +631,6 @@ jobs:
             - ./packages/core-logger-winston/node_modules
             - ./packages/core-p2p/node_modules
             - ./packages/core-snapshots/node_modules
-            - ./packages/core-snapshots-cli/node_modules
             - ./packages/core-test-utils/node_modules
             - ./packages/core-tester-cli/node_modules
             - ./packages/core-transaction-pool/node_modules

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -86,7 +86,6 @@
         "latest-version": "^4.0.0",
         "listr": "^0.14.3",
         "ora": "^3.0.0",
-        "pm2": "^3.2.3",
         "pretty-bytes": "^5.1.0",
         "pretty-ms": "^4.0.0",
         "prompts": "^2.0.0",

--- a/packages/core/src/commands/command.ts
+++ b/packages/core/src/commands/command.ts
@@ -6,6 +6,7 @@ import Listr from "listr";
 import { join, resolve } from "path";
 import prompts from "prompts";
 import { configManager } from "../helpers/config";
+import { CommandFlags, Options } from "../types";
 
 // tslint:disable-next-line:no-var-requires
 const { version } = require("../../package.json");
@@ -68,7 +69,7 @@ export abstract class BaseCommand extends Command {
 
     protected tasks: Array<{ title: string; task: any }> = [];
 
-    protected buildPeerOptions(flags: Record<string, any>) {
+    protected buildPeerOptions(flags: CommandFlags) {
         const config = {
             networkStart: flags.networkStart,
             disableDiscovery: flags.disableDiscovery,
@@ -84,7 +85,7 @@ export abstract class BaseCommand extends Command {
         return config;
     }
 
-    protected async buildApplication(app, flags: Record<string, any>, config: Record<string, any>) {
+    protected async buildApplication(app, flags: CommandFlags, config: Options) {
         await app.setUp(version, flags, {
             ...{ skipPlugins: flags.skipPlugins },
             ...config,
@@ -93,7 +94,7 @@ export abstract class BaseCommand extends Command {
         return app;
     }
 
-    protected flagsToStrings(flags: Record<string, any>, ignoreKeys: string[] = []): string {
+    protected flagsToStrings(flags: CommandFlags, ignoreKeys: string[] = []): string {
         const mappedFlags = [];
 
         for (const [key, value] of Object.entries(flags)) {
@@ -120,7 +121,7 @@ export abstract class BaseCommand extends Command {
         }
     }
 
-    protected async getPaths(flags: Record<string, any>): Promise<envPaths.Paths> {
+    protected async getPaths(flags: CommandFlags): Promise<envPaths.Paths> {
         let paths: envPaths.Paths = this.getEnvPaths(flags);
 
         for (const [key, value] of Object.entries(paths)) {
@@ -214,7 +215,7 @@ export abstract class BaseCommand extends Command {
         this.error("Please enter valid data and try again!");
     }
 
-    protected async buildBIP38(flags: Record<string, any>): Promise<Record<string, string>> {
+    protected async buildBIP38(flags: CommandFlags): Promise<Record<string, string>> {
         // initial values
         let bip38 = flags.bip38 || process.env.CORE_FORGER_BIP38;
         let password = flags.password || process.env.CORE_FORGER_PASSWORD;
@@ -280,7 +281,7 @@ export abstract class BaseCommand extends Command {
         return this.getNetworks().map(network => ({ title: network, value: network }));
     }
 
-    private getEnvPaths(flags: Record<string, any>): envPaths.Paths {
+    private getEnvPaths(flags: CommandFlags): envPaths.Paths {
         return envPaths(flags.token, { suffix: "core" });
     }
 }

--- a/packages/core/src/commands/command.ts
+++ b/packages/core/src/commands/command.ts
@@ -4,7 +4,6 @@ import envPaths from "env-paths";
 import { existsSync, readdirSync } from "fs";
 import Listr from "listr";
 import { join, resolve } from "path";
-import pm2 from "pm2";
 import prompts from "prompts";
 import { configManager } from "../helpers/config";
 
@@ -213,28 +212,6 @@ export abstract class BaseCommand extends Command {
 
     protected abortWithInvalidInput(): void {
         this.error("Please enter valid data and try again!");
-    }
-
-    protected createPm2Connection(callback, noDaemonMode: boolean = false): void {
-        pm2.connect(noDaemonMode, error => {
-            if (error) {
-                this.error(error.message);
-            }
-
-            callback();
-        });
-    }
-
-    protected async describePm2Process(processName: string, callback): Promise<void> {
-        pm2.describe(processName, (error, apps) => {
-            if (error) {
-                pm2.disconnect();
-
-                this.error(error.message);
-            }
-
-            callback(apps[0]);
-        });
     }
 
     protected async buildBIP38(flags: Record<string, any>): Promise<Record<string, string>> {

--- a/packages/core/src/commands/config/cli.ts
+++ b/packages/core/src/commands/config/cli.ts
@@ -1,8 +1,8 @@
 import { flags } from "@oclif/command";
 import cli from "cli-ux";
-import { removeSync } from "fs-extra";
 import { configManager } from "../../helpers/config";
 import { installFromChannel } from "../../helpers/update";
+import { CommandFlags } from "../../types";
 import { BaseCommand } from "../command";
 
 export class CommandLineInterfaceCommand extends BaseCommand {
@@ -17,7 +17,7 @@ $ ark config:cli --channel=mine
 `,
     ];
 
-    public static flags: Record<string, any> = {
+    public static flags: CommandFlags = {
         token: flags.string({
             description: "the name of the token that should be used",
         }),

--- a/packages/core/src/commands/config/forger/bip38.ts
+++ b/packages/core/src/commands/config/forger/bip38.ts
@@ -5,6 +5,7 @@ import bip39 from "bip39";
 import fs from "fs-extra";
 import prompts from "prompts";
 import wif from "wif";
+import { CommandFlags } from "../../../types";
 import { BaseCommand } from "../../command";
 
 export class BIP38Command extends BaseCommand {
@@ -16,7 +17,7 @@ $ ark config:forger:bip38 --bip39="..." --password="..."
 `,
     ];
 
-    public static flags: Record<string, any> = {
+    public static flags: CommandFlags = {
         ...BaseCommand.flagsNetwork,
         bip39: flags.string({
             description: "the plain text bip39 passphrase",

--- a/packages/core/src/commands/config/forger/bip39.ts
+++ b/packages/core/src/commands/config/forger/bip39.ts
@@ -2,6 +2,7 @@ import { flags } from "@oclif/command";
 import bip39 from "bip39";
 import fs from "fs-extra";
 import prompts from "prompts";
+import { CommandFlags } from "../../../types";
 import { BaseCommand } from "../../command";
 
 export class BIP39Command extends BaseCommand {
@@ -13,7 +14,7 @@ $ ark config:forger:bip39 --bip39="..."
 `,
     ];
 
-    public static flags: Record<string, any> = {
+    public static flags: CommandFlags = {
         ...BaseCommand.flagsNetwork,
         bip39: flags.string({
             description: "the plain text bip39 passphrase",

--- a/packages/core/src/commands/config/forger/index.ts
+++ b/packages/core/src/commands/config/forger/index.ts
@@ -1,5 +1,6 @@
 import { flags } from "@oclif/command";
 import prompts from "prompts";
+import { CommandFlags } from "../../../types";
 import { BaseCommand } from "../../command";
 import { BIP38Command } from "./bip38";
 import { BIP39Command } from "./bip39";
@@ -16,7 +17,7 @@ $ ark config:forger --method=bip39
 `,
     ];
 
-    public static flags: Record<string, any> = {
+    public static flags: CommandFlags = {
         ...BaseCommand.flagsNetwork,
         ...BaseCommand.flagsForger,
         method: flags.string({

--- a/packages/core/src/commands/config/publish.ts
+++ b/packages/core/src/commands/config/publish.ts
@@ -3,6 +3,7 @@ import fs from "fs-extra";
 import { resolve } from "path";
 import prompts from "prompts";
 import { configManager } from "../../helpers/config";
+import { CommandFlags } from "../../types";
 import { BaseCommand } from "../command";
 
 export class PublishCommand extends BaseCommand {
@@ -14,7 +15,7 @@ $ ark config:publish --network=mainnet
 `,
     ];
 
-    public static flags: Record<string, any> = {
+    public static flags: CommandFlags = {
         ...BaseCommand.flagsNetwork,
     };
 
@@ -53,7 +54,7 @@ $ ark config:publish --network=mainnet
         }
     }
 
-    private async performPublishment(flags: Record<string, any>): Promise<void> {
+    private async performPublishment(flags: CommandFlags): Promise<void> {
         const { config } = await this.getPaths(flags);
 
         if (!this.isValidNetwork(flags.network)) {

--- a/packages/core/src/commands/config/reset.ts
+++ b/packages/core/src/commands/config/reset.ts
@@ -1,8 +1,7 @@
 import { flags } from "@oclif/command";
-import expandHomeDir from "expand-home-dir";
 import fs from "fs-extra";
-import { resolve } from "path";
 import prompts from "prompts";
+import { CommandFlags } from "../../types";
 import { BaseCommand } from "../command";
 import { PublishCommand } from "./publish";
 
@@ -15,7 +14,7 @@ $ ark config:reset --network=mainnet
 `,
     ];
 
-    public static flags: Record<string, any> = {
+    public static flags: CommandFlags = {
         ...BaseCommand.flagsNetwork,
         force: flags.boolean({
             description: "force the configuration to be reset",
@@ -43,7 +42,7 @@ $ ark config:reset --network=mainnet
         }
     }
 
-    private async performReset(flags: Record<string, any>): Promise<void> {
+    private async performReset(flags: CommandFlags): Promise<void> {
         const { config } = await this.getPaths(flags);
 
         this.addTask("Remove configuration", async () => {

--- a/packages/core/src/commands/core/log.ts
+++ b/packages/core/src/commands/core/log.ts
@@ -1,5 +1,6 @@
 import { flags } from "@oclif/command";
 import { AbstractLogCommand } from "../../shared/log";
+import { CommandFlags } from "../../types";
 import { BaseCommand } from "../command";
 
 export class LogCommand extends AbstractLogCommand {
@@ -7,7 +8,7 @@ export class LogCommand extends AbstractLogCommand {
 
     public static examples: string[] = [`$ ark core:log`];
 
-    public static flags: Record<string, any> = {
+    public static flags: CommandFlags = {
         ...BaseCommand.flagsNetwork,
         error: flags.boolean({
             description: "only show error output",

--- a/packages/core/src/commands/core/restart.ts
+++ b/packages/core/src/commands/core/restart.ts
@@ -1,4 +1,5 @@
 import { AbstractRestartCommand } from "../../shared/restart";
+import { CommandFlags } from "../../types";
 import { BaseCommand } from "../command";
 
 export class RestartCommand extends AbstractRestartCommand {
@@ -10,7 +11,7 @@ $ ark core:restart
 `,
     ];
 
-    public static flags: Record<string, any> = {
+    public static flags: CommandFlags = {
         ...BaseCommand.flagsNetwork,
     };
 

--- a/packages/core/src/commands/core/run.ts
+++ b/packages/core/src/commands/core/run.ts
@@ -1,4 +1,5 @@
 import { app } from "@arkecosystem/core-container";
+import { CommandFlags } from "../../types";
 import { BaseCommand } from "../command";
 
 export class RunCommand extends BaseCommand {
@@ -25,7 +26,7 @@ $ ark core:run --launchMode=seed
 `,
     ];
 
-    public static flags: Record<string, any> = {
+    public static flags: CommandFlags = {
         ...BaseCommand.flagsNetwork,
         ...BaseCommand.flagsBehaviour,
         ...BaseCommand.flagsForger,

--- a/packages/core/src/commands/core/start.ts
+++ b/packages/core/src/commands/core/start.ts
@@ -52,7 +52,7 @@ $ ark core:start --no-daemon
         try {
             const { bip38, password } = await this.buildBIP38(flags);
 
-            this.runWithPm2(
+            await this.runWithPm2(
                 {
                     name: `${flags.token}-core`,
                     // @ts-ignore

--- a/packages/core/src/commands/core/start.ts
+++ b/packages/core/src/commands/core/start.ts
@@ -1,5 +1,6 @@
 import { flags } from "@oclif/command";
 import { AbstractStartCommand } from "../../shared/start";
+import { CommandFlags } from "../../types";
 import { BaseCommand } from "../command";
 
 export class StartCommand extends AbstractStartCommand {
@@ -29,7 +30,7 @@ $ ark core:start --no-daemon
 `,
     ];
 
-    public static flags: Record<string, any> = {
+    public static flags: CommandFlags = {
         ...BaseCommand.flagsNetwork,
         ...BaseCommand.flagsBehaviour,
         ...BaseCommand.flagsForger,
@@ -44,7 +45,7 @@ $ ark core:start --no-daemon
         return StartCommand;
     }
 
-    protected async runProcess(flags: Record<string, any>): Promise<void> {
+    protected async runProcess(flags: CommandFlags): Promise<void> {
         this.abortWhenRunning(`${flags.token}-forger`);
         this.abortWhenRunning(`${flags.token}-relay`);
 

--- a/packages/core/src/commands/core/start.ts
+++ b/packages/core/src/commands/core/start.ts
@@ -45,34 +45,27 @@ $ ark core:start --no-daemon
     }
 
     protected async runProcess(flags: Record<string, any>): Promise<void> {
-        this.createPm2Connection(() => {
-            this.describePm2Process(`${flags.token}-forger`, forger => {
-                this.abortWhenRunning(`${flags.token}-forger`, forger);
+        this.abortWhenRunning(`${flags.token}-forger`);
+        this.abortWhenRunning(`${flags.token}-relay`);
 
-                this.describePm2Process(`${flags.token}-relay`, async relay => {
-                    this.abortWhenRunning(`${flags.token}-relay`, relay);
+        try {
+            const { bip38, password } = await this.buildBIP38(flags);
 
-                    try {
-                        const { bip38, password } = await this.buildBIP38(flags);
-
-                        this.runWithPm2(
-                            {
-                                name: `${flags.token}-core`,
-                                // @ts-ignore
-                                script: this.config.options.root,
-                                args: `core:run ${this.flagsToStrings(flags, ["daemon"])}`,
-                                env: {
-                                    CORE_FORGER_BIP38: bip38,
-                                    CORE_FORGER_PASSWORD: password,
-                                },
-                            },
-                            flags,
-                        );
-                    } catch (error) {
-                        this.error(error.message);
-                    }
-                });
-            });
-        });
+            this.runWithPm2(
+                {
+                    name: `${flags.token}-core`,
+                    // @ts-ignore
+                    script: this.config.options.root,
+                    args: `core:run ${this.flagsToStrings(flags, ["daemon"])}`,
+                    env: {
+                        CORE_FORGER_BIP38: bip38,
+                        CORE_FORGER_PASSWORD: password,
+                    },
+                },
+                flags,
+            );
+        } catch (error) {
+            this.error(error.message);
+        }
     }
 }

--- a/packages/core/src/commands/core/status.ts
+++ b/packages/core/src/commands/core/status.ts
@@ -1,4 +1,5 @@
 import { AbstractStatusCommand } from "../../shared/status";
+import { CommandFlags } from "../../types";
 import { BaseCommand } from "../command";
 
 export class StatusCommand extends AbstractStatusCommand {
@@ -6,7 +7,7 @@ export class StatusCommand extends AbstractStatusCommand {
 
     public static examples: string[] = [`$ ark core:status`];
 
-    public static flags: Record<string, any> = {
+    public static flags: CommandFlags = {
         ...BaseCommand.flagsNetwork,
     };
 

--- a/packages/core/src/commands/core/stop.ts
+++ b/packages/core/src/commands/core/stop.ts
@@ -1,5 +1,6 @@
 import { flags } from "@oclif/command";
 import { AbstractStopCommand } from "../../shared/stop";
+import { CommandFlags } from "../../types";
 import { BaseCommand } from "../command";
 
 export class StopCommand extends AbstractStopCommand {
@@ -14,7 +15,7 @@ $ ark core:stop --daemon
 `,
     ];
 
-    public static flags: Record<string, any> = {
+    public static flags: CommandFlags = {
         ...BaseCommand.flagsNetwork,
         daemon: flags.boolean({
             description: "stop the process or daemon",

--- a/packages/core/src/commands/env/get.ts
+++ b/packages/core/src/commands/env/get.ts
@@ -1,5 +1,6 @@
 import envfile from "envfile";
 import { existsSync } from "fs-extra";
+import { CommandFlags } from "../../types";
 import { BaseCommand } from "../command";
 
 export class GetCommand extends BaseCommand {
@@ -11,7 +12,7 @@ $ ark env:get CORE_LOG_LEVEL
 `,
     ];
 
-    public static flags: Record<string, any> = {
+    public static flags: CommandFlags = {
         ...BaseCommand.flagsNetwork,
     };
 

--- a/packages/core/src/commands/env/list.ts
+++ b/packages/core/src/commands/env/list.ts
@@ -1,6 +1,7 @@
 import Table from "cli-table3";
 import envfile from "envfile";
 import { existsSync } from "fs-extra";
+import { CommandFlags } from "../../types";
 import { renderTable } from "../../utils";
 import { BaseCommand } from "../command";
 
@@ -13,7 +14,7 @@ $ ark env:list
 `,
     ];
 
-    public static flags: Record<string, any> = {
+    public static flags: CommandFlags = {
         ...BaseCommand.flagsNetwork,
     };
 

--- a/packages/core/src/commands/env/paths.ts
+++ b/packages/core/src/commands/env/paths.ts
@@ -1,4 +1,5 @@
 import Table from "cli-table3";
+import { CommandFlags } from "../../types";
 import { renderTable } from "../../utils";
 import { BaseCommand } from "../command";
 
@@ -11,7 +12,7 @@ $ ark env:paths
 `,
     ];
 
-    public static flags: Record<string, any> = {
+    public static flags: CommandFlags = {
         ...BaseCommand.flagsNetwork,
     };
 

--- a/packages/core/src/commands/env/set.ts
+++ b/packages/core/src/commands/env/set.ts
@@ -1,7 +1,6 @@
-import { flags } from "@oclif/command";
 import envfile from "envfile";
-import expandHomeDir from "expand-home-dir";
 import { existsSync, writeFileSync } from "fs-extra";
+import { CommandFlags } from "../../types";
 import { BaseCommand } from "../command";
 
 export class SetCommand extends BaseCommand {
@@ -13,7 +12,7 @@ $ ark env:set CORE_LOG_LEVEL info
 `,
     ];
 
-    public static flags: Record<string, any> = {
+    public static flags: CommandFlags = {
         ...BaseCommand.flagsNetwork,
     };
 

--- a/packages/core/src/commands/forger/log.ts
+++ b/packages/core/src/commands/forger/log.ts
@@ -1,5 +1,6 @@
 import { flags } from "@oclif/command";
 import { AbstractLogCommand } from "../../shared/log";
+import { CommandFlags } from "../../types";
 import { BaseCommand } from "../command";
 
 export class LogCommand extends AbstractLogCommand {
@@ -7,7 +8,7 @@ export class LogCommand extends AbstractLogCommand {
 
     public static examples: string[] = [`$ ark forger:log`];
 
-    public static flags: Record<string, any> = {
+    public static flags: CommandFlags = {
         ...BaseCommand.flagsNetwork,
         error: flags.boolean({
             description: "only show error output",

--- a/packages/core/src/commands/forger/restart.ts
+++ b/packages/core/src/commands/forger/restart.ts
@@ -1,4 +1,5 @@
 import { AbstractRestartCommand } from "../../shared/restart";
+import { CommandFlags } from "../../types";
 import { BaseCommand } from "../command";
 
 export class RestartCommand extends AbstractRestartCommand {
@@ -10,7 +11,7 @@ $ ark forger:restart
 `,
     ];
 
-    public static flags: Record<string, any> = {
+    public static flags: CommandFlags = {
         ...BaseCommand.flagsNetwork,
     };
 

--- a/packages/core/src/commands/forger/run.ts
+++ b/packages/core/src/commands/forger/run.ts
@@ -1,4 +1,5 @@
 import { app } from "@arkecosystem/core-container";
+import { CommandFlags } from "../../types";
 import { BaseCommand } from "../command";
 
 export class RunCommand extends BaseCommand {
@@ -13,7 +14,7 @@ $ ark forger:run --bip38="..." --password="..."
 `,
     ];
 
-    public static flags: Record<string, any> = {
+    public static flags: CommandFlags = {
         ...BaseCommand.flagsNetwork,
         ...BaseCommand.flagsForger,
     };

--- a/packages/core/src/commands/forger/start.ts
+++ b/packages/core/src/commands/forger/start.ts
@@ -38,7 +38,7 @@ $ ark forger:start --no-daemon
         try {
             const { bip38, password } = await this.buildBIP38(flags);
 
-            this.runWithPm2(
+            await this.runWithPm2(
                 {
                     name: `${flags.token}-forger`,
                     // @ts-ignore

--- a/packages/core/src/commands/forger/start.ts
+++ b/packages/core/src/commands/forger/start.ts
@@ -1,5 +1,6 @@
 import { flags } from "@oclif/command";
 import { AbstractStartCommand } from "../../shared/start";
+import { CommandFlags } from "../../types";
 import { BaseCommand } from "../command";
 
 export class StartCommand extends AbstractStartCommand {
@@ -17,7 +18,7 @@ $ ark forger:start --no-daemon
 `,
     ];
 
-    public static flags: Record<string, any> = {
+    public static flags: CommandFlags = {
         ...BaseCommand.flagsNetwork,
         ...BaseCommand.flagsForger,
         daemon: flags.boolean({
@@ -31,7 +32,7 @@ $ ark forger:start --no-daemon
         return StartCommand;
     }
 
-    protected async runProcess(flags: Record<string, any>): Promise<void> {
+    protected async runProcess(flags: CommandFlags): Promise<void> {
         this.abortWhenRunning(`${flags.token}-core`);
 
         try {

--- a/packages/core/src/commands/forger/start.ts
+++ b/packages/core/src/commands/forger/start.ts
@@ -32,30 +32,26 @@ $ ark forger:start --no-daemon
     }
 
     protected async runProcess(flags: Record<string, any>): Promise<void> {
-        this.createPm2Connection(() => {
-            this.describePm2Process(`${flags.token}-core`, async core => {
-                this.abortWhenRunning(`${flags.token}-core`, core);
+        this.abortWhenRunning(`${flags.token}-core`);
 
-                try {
-                    const { bip38, password } = await this.buildBIP38(flags);
+        try {
+            const { bip38, password } = await this.buildBIP38(flags);
 
-                    this.runWithPm2(
-                        {
-                            name: `${flags.token}-forger`,
-                            // @ts-ignore
-                            script: this.config.options.root,
-                            args: `forger:run ${this.flagsToStrings(flags, ["daemon"])}`,
-                            env: {
-                                CORE_FORGER_BIP38: bip38,
-                                CORE_FORGER_PASSWORD: password,
-                            },
-                        },
-                        flags,
-                    );
-                } catch (error) {
-                    this.error(error.message);
-                }
-            });
-        });
+            this.runWithPm2(
+                {
+                    name: `${flags.token}-forger`,
+                    // @ts-ignore
+                    script: this.config.options.root,
+                    args: `forger:run ${this.flagsToStrings(flags, ["daemon"])}`,
+                    env: {
+                        CORE_FORGER_BIP38: bip38,
+                        CORE_FORGER_PASSWORD: password,
+                    },
+                },
+                flags,
+            );
+        } catch (error) {
+            this.error(error.message);
+        }
     }
 }

--- a/packages/core/src/commands/forger/status.ts
+++ b/packages/core/src/commands/forger/status.ts
@@ -1,4 +1,5 @@
 import { AbstractStatusCommand } from "../../shared/status";
+import { CommandFlags } from "../../types";
 import { BaseCommand } from "../command";
 
 export class StatusCommand extends AbstractStatusCommand {
@@ -6,7 +7,7 @@ export class StatusCommand extends AbstractStatusCommand {
 
     public static examples: string[] = [`$ ark forger:status`];
 
-    public static flags: Record<string, any> = {
+    public static flags: CommandFlags = {
         ...BaseCommand.flagsNetwork,
     };
 

--- a/packages/core/src/commands/forger/stop.ts
+++ b/packages/core/src/commands/forger/stop.ts
@@ -1,5 +1,6 @@
 import { flags } from "@oclif/command";
 import { AbstractStopCommand } from "../../shared/stop";
+import { CommandFlags } from "../../types";
 import { BaseCommand } from "../command";
 
 export class StopCommand extends AbstractStopCommand {
@@ -14,7 +15,7 @@ $ ark forger:stop --daemon
 `,
     ];
 
-    public static flags: Record<string, any> = {
+    public static flags: CommandFlags = {
         ...BaseCommand.flagsNetwork,
         daemon: flags.boolean({
             description: "stop the process or daemon",

--- a/packages/core/src/commands/relay/log.ts
+++ b/packages/core/src/commands/relay/log.ts
@@ -1,5 +1,6 @@
 import { flags } from "@oclif/command";
 import { AbstractLogCommand } from "../../shared/log";
+import { CommandFlags } from "../../types";
 import { BaseCommand } from "../command";
 
 export class LogCommand extends AbstractLogCommand {
@@ -7,7 +8,7 @@ export class LogCommand extends AbstractLogCommand {
 
     public static examples: string[] = [`$ ark relay:log`];
 
-    public static flags: Record<string, any> = {
+    public static flags: CommandFlags = {
         ...BaseCommand.flagsNetwork,
         error: flags.boolean({
             description: "only show error output",

--- a/packages/core/src/commands/relay/restart.ts
+++ b/packages/core/src/commands/relay/restart.ts
@@ -1,4 +1,5 @@
 import { AbstractRestartCommand } from "../../shared/restart";
+import { CommandFlags } from "../../types";
 import { BaseCommand } from "../command";
 
 export class RestartCommand extends AbstractRestartCommand {
@@ -10,7 +11,7 @@ $ ark relay:restart
 `,
     ];
 
-    public static flags: Record<string, any> = {
+    public static flags: CommandFlags = {
         ...BaseCommand.flagsNetwork,
     };
 

--- a/packages/core/src/commands/relay/run.ts
+++ b/packages/core/src/commands/relay/run.ts
@@ -1,4 +1,5 @@
 import { app } from "@arkecosystem/core-container";
+import { CommandFlags } from "../../types";
 import { BaseCommand } from "../command";
 
 export class RunCommand extends BaseCommand {
@@ -25,7 +26,7 @@ $ ark relay:run --launchMode=seed
 `,
     ];
 
-    public static flags: Record<string, any> = {
+    public static flags: CommandFlags = {
         ...BaseCommand.flagsNetwork,
         ...BaseCommand.flagsBehaviour,
     };

--- a/packages/core/src/commands/relay/start.ts
+++ b/packages/core/src/commands/relay/start.ts
@@ -1,5 +1,6 @@
 import { flags } from "@oclif/command";
 import { AbstractStartCommand } from "../../shared/start";
+import { CommandFlags } from "../../types";
 import { BaseCommand } from "../command";
 
 export class StartCommand extends AbstractStartCommand {
@@ -29,7 +30,7 @@ $ ark relay:start --no-daemon
 `,
     ];
 
-    public static flags: Record<string, any> = {
+    public static flags: CommandFlags = {
         ...BaseCommand.flagsNetwork,
         ...BaseCommand.flagsBehaviour,
         daemon: flags.boolean({
@@ -43,7 +44,7 @@ $ ark relay:start --no-daemon
         return StartCommand;
     }
 
-    protected async runProcess(flags: Record<string, any>): Promise<void> {
+    protected async runProcess(flags: CommandFlags): Promise<void> {
         this.abortWhenRunning(`${flags.token}-core`);
 
         this.runWithPm2(

--- a/packages/core/src/commands/relay/start.ts
+++ b/packages/core/src/commands/relay/start.ts
@@ -47,7 +47,7 @@ $ ark relay:start --no-daemon
     protected async runProcess(flags: CommandFlags): Promise<void> {
         this.abortWhenRunning(`${flags.token}-core`);
 
-        this.runWithPm2(
+        await this.runWithPm2(
             {
                 name: `${flags.token}-relay`,
                 // @ts-ignore

--- a/packages/core/src/commands/relay/start.ts
+++ b/packages/core/src/commands/relay/start.ts
@@ -44,20 +44,16 @@ $ ark relay:start --no-daemon
     }
 
     protected async runProcess(flags: Record<string, any>): Promise<void> {
-        this.createPm2Connection(() => {
-            this.describePm2Process(`${flags.token}-core`, core => {
-                this.abortWhenRunning(`${flags.token}-core`, core);
+        this.abortWhenRunning(`${flags.token}-core`);
 
-                this.runWithPm2(
-                    {
-                        name: `${flags.token}-relay`,
-                        // @ts-ignore
-                        script: this.config.options.root,
-                        args: `relay:run ${this.flagsToStrings(flags, ["daemon"])}`,
-                    },
-                    flags,
-                );
-            });
-        });
+        this.runWithPm2(
+            {
+                name: `${flags.token}-relay`,
+                // @ts-ignore
+                script: this.config.options.root,
+                args: `relay:run ${this.flagsToStrings(flags, ["daemon"])}`,
+            },
+            flags,
+        );
     }
 }

--- a/packages/core/src/commands/relay/status.ts
+++ b/packages/core/src/commands/relay/status.ts
@@ -1,4 +1,5 @@
 import { AbstractStatusCommand } from "../../shared/status";
+import { CommandFlags } from "../../types";
 import { BaseCommand } from "../command";
 
 export class StatusCommand extends AbstractStatusCommand {
@@ -6,7 +7,7 @@ export class StatusCommand extends AbstractStatusCommand {
 
     public static examples: string[] = [`$ ark relay:status`];
 
-    public static flags: Record<string, any> = {
+    public static flags: CommandFlags = {
         ...BaseCommand.flagsNetwork,
     };
 

--- a/packages/core/src/commands/relay/stop.ts
+++ b/packages/core/src/commands/relay/stop.ts
@@ -1,5 +1,6 @@
 import { flags } from "@oclif/command";
 import { AbstractStopCommand } from "../../shared/stop";
+import { CommandFlags } from "../../types";
 import { BaseCommand } from "../command";
 
 export class StopCommand extends AbstractStopCommand {
@@ -14,7 +15,7 @@ $ ark relay:stop --daemon
 `,
     ];
 
-    public static flags: Record<string, any> = {
+    public static flags: CommandFlags = {
         ...BaseCommand.flagsNetwork,
         daemon: flags.boolean({
             description: "stop the process or daemon",

--- a/packages/core/src/commands/snapshot/dump.ts
+++ b/packages/core/src/commands/snapshot/dump.ts
@@ -2,12 +2,13 @@ import { app } from "@arkecosystem/core-container";
 import { SnapshotManager } from "@arkecosystem/core-snapshots";
 import { flags } from "@oclif/command";
 import { setUpLite } from "../../helpers/snapshot";
+import { CommandFlags } from "../../types";
 import { BaseCommand } from "../command";
 
 export class DumpCommand extends BaseCommand {
     public static description: string = "create a full snapshot of the database";
 
-    public static flags = {
+    public static flags: CommandFlags = {
         ...BaseCommand.flagsSnapshot,
         blocks: flags.string({
             description: "blocks to append to, correlates to folder name",

--- a/packages/core/src/commands/snapshot/restore.ts
+++ b/packages/core/src/commands/snapshot/restore.ts
@@ -2,14 +2,15 @@ import { app } from "@arkecosystem/core-container";
 import { EventEmitter } from "@arkecosystem/core-interfaces";
 import { SnapshotManager } from "@arkecosystem/core-snapshots";
 import { flags } from "@oclif/command";
-import _cliProgress from "cli-progress";
+import cliProgress from "cli-progress";
 import { setUpLite } from "../../helpers/snapshot";
+import { CommandFlags } from "../../types";
 import { BaseCommand } from "../command";
 
 export class RestoreCommand extends BaseCommand {
     public static description: string = "import data from specified snapshot";
 
-    public static flags = {
+    public static flags: CommandFlags = {
         ...BaseCommand.flagsSnapshot,
         blocks: flags.string({
             description: "blocks to import, corelates to folder name",
@@ -37,11 +38,11 @@ export class RestoreCommand extends BaseCommand {
 
         const emitter = app.resolvePlugin<EventEmitter.EventEmitter>("event-emitter");
 
-        const progressBar = new _cliProgress.Bar(
+        const progressBar = new cliProgress.Bar(
             {
                 format: "{bar} {percentage}% | ETA: {eta}s | {value}/{total} | Duration: {duration}s",
             },
-            _cliProgress.Presets.shades_classic,
+            cliProgress.Presets.shades_classic,
         );
 
         emitter.on("start", data => {

--- a/packages/core/src/commands/snapshot/rollback.ts
+++ b/packages/core/src/commands/snapshot/rollback.ts
@@ -3,12 +3,13 @@ import { Logger } from "@arkecosystem/core-interfaces";
 import { SnapshotManager } from "@arkecosystem/core-snapshots";
 import { flags } from "@oclif/command";
 import { setUpLite } from "../../helpers/snapshot";
+import { CommandFlags } from "../../types";
 import { BaseCommand } from "../command";
 
 export class RollbackCommand extends BaseCommand {
     public static description: string = "rollback chain to specified height";
 
-    public static flags = {
+    public static flags: CommandFlags = {
         ...BaseCommand.flagsSnapshot,
         height: flags.integer({
             description: "block network height number to rollback",

--- a/packages/core/src/commands/snapshot/verify.ts
+++ b/packages/core/src/commands/snapshot/verify.ts
@@ -2,12 +2,13 @@ import { app } from "@arkecosystem/core-container";
 import { SnapshotManager } from "@arkecosystem/core-snapshots";
 import { flags } from "@oclif/command";
 import { setUpLite } from "../../helpers/snapshot";
+import { CommandFlags } from "../../types";
 import { BaseCommand } from "../command";
 
 export class VerifyCommand extends BaseCommand {
     public static description: string = "check validity of specified snapshot";
 
-    public static flags = {
+    public static flags: CommandFlags = {
         ...BaseCommand.flagsSnapshot,
         blocks: flags.string({
             description: "blocks to verify, corelates to folder name",

--- a/packages/core/src/commands/top.ts
+++ b/packages/core/src/commands/top.ts
@@ -1,8 +1,8 @@
 import Table from "cli-table3";
 import dayjs from "dayjs-ext";
-import pm2 from "pm2";
 import prettyBytes from "pretty-bytes";
 import prettyMs from "pretty-ms";
+import { processManager } from "../services/process-manager";
 import { renderTable } from "../utils";
 import { BaseCommand } from "./command";
 
@@ -22,38 +22,28 @@ $ ark top
     public async run(): Promise<void> {
         const { flags } = await this.parseWithNetwork(TopCommand);
 
-        this.createPm2Connection(() => {
-            pm2.list((error, processList) => {
-                pm2.disconnect();
+        const processes = processManager.list(flags.token);
 
-                if (error) {
-                    this.error(error.message);
-                }
+        if (!Object.keys(processes).length) {
+            this.warn("No processes are running.");
+            return;
+        }
 
-                const processes = Object.values(processList).filter(p => p.name.startsWith(flags.token as string));
-
-                if (!Object.keys(processes).length) {
-                    this.warn("No processes are running.");
-                    return;
-                }
-
-                renderTable(["ID", "Name", "Version", "Status", "Uptime", "CPU", "RAM"], (table: Table.Table) => {
-                    for (const process of processes) {
-                        // @ts-ignore
-                        table.push([
-                            process.pid,
-                            process.name,
-                            // @ts-ignore
-                            process.pm2_env.version,
-                            process.pm2_env.status,
-                            // @ts-ignore
-                            prettyMs(dayjs().diff(process.pm2_env.pm_uptime)),
-                            `${process.monit.cpu}%`,
-                            prettyBytes(process.monit.memory),
-                        ]);
-                    }
-                });
-            });
+        renderTable(["ID", "Name", "Version", "Status", "Uptime", "CPU", "RAM"], (table: Table.Table) => {
+            for (const process of processes) {
+                // @ts-ignore
+                table.push([
+                    process.pid,
+                    process.name,
+                    // @ts-ignore
+                    process.pm2_env.version,
+                    process.pm2_env.status,
+                    // @ts-ignore
+                    prettyMs(dayjs().diff(process.pm2_env.pm_uptime)),
+                    `${process.monit.cpu}%`,
+                    prettyBytes(process.monit.memory),
+                ]);
+            }
         });
     }
 }

--- a/packages/core/src/commands/top.ts
+++ b/packages/core/src/commands/top.ts
@@ -2,7 +2,7 @@ import Table from "cli-table3";
 import dayjs from "dayjs-ext";
 import prettyBytes from "pretty-bytes";
 import prettyMs from "pretty-ms";
-import { processManager } from "../services/process-manager";
+import { processManager } from "../process-manager";
 import { CommandFlags } from "../types";
 import { renderTable } from "../utils";
 import { BaseCommand } from "./command";

--- a/packages/core/src/commands/top.ts
+++ b/packages/core/src/commands/top.ts
@@ -3,6 +3,7 @@ import dayjs from "dayjs-ext";
 import prettyBytes from "pretty-bytes";
 import prettyMs from "pretty-ms";
 import { processManager } from "../services/process-manager";
+import { CommandFlags } from "../types";
 import { renderTable } from "../utils";
 import { BaseCommand } from "./command";
 
@@ -15,7 +16,7 @@ $ ark top
 `,
     ];
 
-    public static flags: Record<string, any> = {
+    public static flags: CommandFlags = {
         ...BaseCommand.flagsNetwork,
     };
 

--- a/packages/core/src/process-manager.ts
+++ b/packages/core/src/process-manager.ts
@@ -36,7 +36,7 @@ class ProcessManager {
 
     public exists(name: string): boolean {
         try {
-            const { stdout } = shellSync(`pm2 id ${name} | awk '{ print $2 }'`);
+            const { stdout } = this.exec(`pm2 id ${name} | awk '{ print $2 }'`);
 
             return !!stdout;
         } catch (error) {
@@ -60,7 +60,7 @@ class ProcessManager {
 
     private execWithHandler(command: string): boolean {
         try {
-            shellSync(command);
+            this.exec(command);
 
             return true;
         } catch (error) {

--- a/packages/core/src/process-manager.ts
+++ b/packages/core/src/process-manager.ts
@@ -1,5 +1,5 @@
 import { ExecaReturns, shellSync } from "execa";
-import { ProcessDescription } from "../types";
+import { ProcessDescription } from "./types";
 
 class ProcessManager {
     public start(opts: Record<string, any>, noDaemonMode: boolean): any {

--- a/packages/core/src/services/process-manager.ts
+++ b/packages/core/src/services/process-manager.ts
@@ -1,5 +1,5 @@
 import { ExecaReturns, shellSync } from "execa";
-import { ProcessDescription } from "pm2";
+import { ProcessDescription } from "../types";
 
 class ProcessManager {
     public start(opts: Record<string, any>, noDaemonMode: boolean): any {

--- a/packages/core/src/services/process-manager.ts
+++ b/packages/core/src/services/process-manager.ts
@@ -3,7 +3,13 @@ import { ProcessDescription } from "pm2";
 
 class ProcessManager {
     public start(opts: Record<string, any>, noDaemonMode: boolean): any {
-        // @TODO implement
+        const flags = ["--max-restarts=5", "--kill-timeout=30000"];
+
+        if (noDaemonMode) {
+            flags.push("--no-daemon");
+        }
+
+        return this.exec(`pm2 --name ${opts.name} ${flags.join(" ")} start ${opts.script} -- ${opts.args}`);
     }
 
     public stop(name: string): boolean {

--- a/packages/core/src/services/process-manager.ts
+++ b/packages/core/src/services/process-manager.ts
@@ -1,0 +1,66 @@
+import { ExecaReturns, shellSync } from "execa";
+import { ProcessDescription } from "pm2";
+
+class ProcessManager {
+    public start(opts: Record<string, any>, noDaemonMode: boolean): any {
+        // @TODO implement
+    }
+
+    public stop(name: string): boolean {
+        return this.execWithHandler(`pm2 stop ${name}`);
+    }
+
+    public restart(name: string): boolean {
+        return this.execWithHandler(`pm2 restart ${name}`);
+    }
+
+    public delete(name: string): boolean {
+        return this.execWithHandler(`pm2 delete ${name}`);
+    }
+
+    public describe(name: string): any {
+        try {
+            const { stdout } = this.exec("pm2 jlist");
+
+            return JSON.parse(stdout).find(p => p.name === name);
+        } catch (error) {
+            return false;
+        }
+    }
+
+    public exists(name: string): boolean {
+        try {
+            const { stdout } = shellSync(`pm2 id ${name} | awk '{ print $2 }'`);
+
+            return !!stdout;
+        } catch (error) {
+            return false;
+        }
+    }
+
+    public list(token: string): any {
+        try {
+            const { stdout } = this.exec("pm2 jlist");
+
+            return Object.values(JSON.parse(stdout)).filter((p: ProcessDescription) => p.name.startsWith(token));
+        } catch (error) {
+            return false;
+        }
+    }
+
+    private exec(command: string): ExecaReturns {
+        return shellSync(command);
+    }
+
+    private execWithHandler(command: string): boolean {
+        try {
+            shellSync(command);
+
+            return true;
+        } catch (error) {
+            return false;
+        }
+    }
+}
+
+export const processManager = new ProcessManager();

--- a/packages/core/src/shared/log.ts
+++ b/packages/core/src/shared/log.ts
@@ -1,7 +1,7 @@
 import cli from "cli-ux";
-import pm2, { ProcessDescription } from "pm2";
 import { Tail } from "tail";
 import { BaseCommand } from "../commands/command";
+import { processManager } from "../services/process-manager";
 
 export abstract class AbstractLogCommand extends BaseCommand {
     public async run(): Promise<void> {
@@ -9,37 +9,28 @@ export abstract class AbstractLogCommand extends BaseCommand {
 
         const processName = `${flags.token}-${this.getSuffix()}`;
 
-        this.createPm2Connection(() => {
-            pm2.describe(processName, (error, apps) => {
-                pm2.disconnect();
+        if (!processManager.exists(processName)) {
+            this.warn(`The "${processName}" process is not running.`);
+            return;
+        }
 
-                if (error) {
-                    this.error(error.message);
-                }
+        const { pm2_env } = processManager.describe(processName);
 
-                if (!apps[0]) {
-                    this.warn(`The "${processName}" process is not running.`);
-                    return;
-                }
+        const file = flags.error ? pm2_env.pm_err_log_path : pm2_env.pm_out_log_path;
 
-                const { pm2_env } = apps[0];
-                const file = flags.error ? pm2_env.pm_err_log_path : pm2_env.pm_out_log_path;
+        const log = new Tail(file);
 
-                const log = new Tail(file);
+        cli.action.start(`Waiting for ${file}`);
 
-                cli.action.start(`Waiting for ${file}`);
+        log.on("line", data => {
+            console.log(data);
 
-                log.on("line", data => {
-                    console.log(data);
-
-                    if (cli.action.running) {
-                        cli.action.stop();
-                    }
-                });
-
-                log.on("error", error => console.error("ERROR: ", error));
-            });
+            if (cli.action.running) {
+                cli.action.stop();
+            }
         });
+
+        log.on("error", error => console.error("ERROR: ", error));
     }
 
     public abstract getClass();

--- a/packages/core/src/shared/log.ts
+++ b/packages/core/src/shared/log.ts
@@ -1,7 +1,7 @@
 import cli from "cli-ux";
 import { Tail } from "tail";
 import { BaseCommand } from "../commands/command";
-import { processManager } from "../services/process-manager";
+import { processManager } from "../process-manager";
 
 export abstract class AbstractLogCommand extends BaseCommand {
     public async run(): Promise<void> {

--- a/packages/core/src/shared/restart.ts
+++ b/packages/core/src/shared/restart.ts
@@ -1,6 +1,6 @@
 import cli from "cli-ux";
 import { BaseCommand } from "../commands/command";
-import { processManager } from "../services/process-manager";
+import { processManager } from "../process-manager";
 
 export abstract class AbstractRestartCommand extends BaseCommand {
     public async run(): Promise<void> {

--- a/packages/core/src/shared/restart.ts
+++ b/packages/core/src/shared/restart.ts
@@ -14,8 +14,6 @@ export abstract class AbstractRestartCommand extends BaseCommand {
             processManager.restart(processName);
         } catch (error) {
             this.warn(`The "${processName}" process does not exist.`);
-
-            process.exit();
         } finally {
             cli.action.stop();
         }

--- a/packages/core/src/shared/restart.ts
+++ b/packages/core/src/shared/restart.ts
@@ -1,6 +1,6 @@
 import cli from "cli-ux";
-import pm2 from "pm2";
 import { BaseCommand } from "../commands/command";
+import { processManager } from "../services/process-manager";
 
 export abstract class AbstractRestartCommand extends BaseCommand {
     public async run(): Promise<void> {
@@ -8,26 +8,17 @@ export abstract class AbstractRestartCommand extends BaseCommand {
 
         const processName = `${flags.token}-${this.getSuffix()}`;
 
-        cli.action.start(`Restarting ${processName}`);
+        try {
+            cli.action.start(`Restarting ${processName}`);
 
-        this.createPm2Connection(() => {
-            pm2.reload(processName, error => {
-                pm2.disconnect();
+            processManager.restart(processName);
+        } catch (error) {
+            this.warn(`The "${processName}" process does not exist.`);
 
-                cli.action.stop();
-
-                if (error) {
-                    if (error.message === "process name not found") {
-                        this.warn(`The "${processName}" process does not exist.`);
-                        return;
-                    }
-
-                    throw error;
-                }
-
-                process.exit();
-            });
-        });
+            process.exit();
+        } finally {
+            cli.action.stop();
+        }
     }
 
     public abstract getClass();

--- a/packages/core/src/shared/start.ts
+++ b/packages/core/src/shared/start.ts
@@ -1,8 +1,8 @@
 import cli from "cli-ux";
-import { ProcessDescription } from "pm2";
 import prompts from "prompts";
 import { BaseCommand } from "../commands/command";
 import { processManager } from "../services/process-manager";
+import { ProcessDescription } from "../types";
 
 export abstract class AbstractStartCommand extends BaseCommand {
     public async run(): Promise<void> {

--- a/packages/core/src/shared/start.ts
+++ b/packages/core/src/shared/start.ts
@@ -20,20 +20,6 @@ export abstract class AbstractStartCommand extends BaseCommand {
 
         try {
             if (processManager.exists(processName)) {
-                cli.action.start(`Starting ${processName}`);
-
-                processManager.start(
-                    {
-                        ...{
-                            max_restarts: 5,
-                            min_uptime: "5m",
-                            kill_timeout: 30000,
-                        },
-                        ...options,
-                    },
-                    flags.daemon === false,
-                );
-            } else {
                 const app: ProcessDescription = processManager.describe(processName);
 
                 if (app.pm2_env.status === "online") {
@@ -50,6 +36,10 @@ export abstract class AbstractStartCommand extends BaseCommand {
                         return;
                     }
                 }
+            } else {
+                cli.action.start(`Starting ${processName}`);
+
+                processManager.start(options, flags.daemon === false);
             }
         } catch (error) {
             this.error(error.message);

--- a/packages/core/src/shared/start.ts
+++ b/packages/core/src/shared/start.ts
@@ -1,7 +1,7 @@
 import cli from "cli-ux";
 import prompts from "prompts";
 import { BaseCommand } from "../commands/command";
-import { processManager } from "../services/process-manager";
+import { processManager } from "../process-manager";
 import { CommandFlags, ProcessDescription } from "../types";
 
 export abstract class AbstractStartCommand extends BaseCommand {

--- a/packages/core/src/shared/start.ts
+++ b/packages/core/src/shared/start.ts
@@ -2,7 +2,7 @@ import cli from "cli-ux";
 import prompts from "prompts";
 import { BaseCommand } from "../commands/command";
 import { processManager } from "../services/process-manager";
-import { ProcessDescription } from "../types";
+import { CommandFlags, ProcessDescription } from "../types";
 
 export abstract class AbstractStartCommand extends BaseCommand {
     public async run(): Promise<void> {
@@ -13,9 +13,9 @@ export abstract class AbstractStartCommand extends BaseCommand {
 
     public abstract getClass();
 
-    protected abstract async runProcess(flags: Record<string, any>): Promise<void>;
+    protected abstract async runProcess(flags: CommandFlags): Promise<void>;
 
-    protected async runWithPm2(options: any, flags: Record<string, any>) {
+    protected async runWithPm2(options: any, flags: CommandFlags) {
         const processName = options.name;
 
         try {

--- a/packages/core/src/shared/status.ts
+++ b/packages/core/src/shared/status.ts
@@ -1,10 +1,10 @@
 import Table from "cli-table3";
 import dayjs from "dayjs-ext";
-import { ProcessDescription } from "pm2";
 import prettyBytes from "pretty-bytes";
 import prettyMs from "pretty-ms";
 import { BaseCommand } from "../commands/command";
 import { processManager } from "../services/process-manager";
+import { ProcessDescription } from "../types";
 import { renderTable } from "../utils";
 
 export abstract class AbstractStatusCommand extends BaseCommand {

--- a/packages/core/src/shared/status.ts
+++ b/packages/core/src/shared/status.ts
@@ -1,9 +1,10 @@
 import Table from "cli-table3";
 import dayjs from "dayjs-ext";
-import pm2, { ProcessDescription } from "pm2";
+import { ProcessDescription } from "pm2";
 import prettyBytes from "pretty-bytes";
 import prettyMs from "pretty-ms";
 import { BaseCommand } from "../commands/command";
+import { processManager } from "../services/process-manager";
 import { renderTable } from "../utils";
 
 export abstract class AbstractStatusCommand extends BaseCommand {
@@ -12,36 +13,26 @@ export abstract class AbstractStatusCommand extends BaseCommand {
 
         const processName = `${flags.token}-${this.getSuffix()}`;
 
-        this.createPm2Connection(() => {
-            pm2.describe(processName, (error, apps) => {
-                pm2.disconnect();
+        if (!processManager.exists(processName)) {
+            this.warn(`The "${processName}" process is not running.`);
+            return;
+        }
 
-                if (error) {
-                    this.error(error.message);
-                }
+        renderTable(["ID", "Name", "Version", "Status", "Uptime", "CPU", "RAM"], (table: Table.Table) => {
+            const app: ProcessDescription = processManager.describe(processName);
 
-                if (!apps[0]) {
-                    this.warn(`The "${processName}" process is not running.`);
-                    return;
-                }
-
-                renderTable(["ID", "Name", "Version", "Status", "Uptime", "CPU", "RAM"], (table: Table.Table) => {
-                    const process: ProcessDescription = apps[0];
-
-                    // @ts-ignore
-                    table.push([
-                        process.pid,
-                        process.name,
-                        // @ts-ignore
-                        process.pm2_env.version,
-                        process.pm2_env.status,
-                        // @ts-ignore
-                        prettyMs(dayjs().diff(process.pm2_env.pm_uptime)),
-                        `${process.monit.cpu}%`,
-                        prettyBytes(process.monit.memory),
-                    ]);
-                });
-            });
+            // @ts-ignore
+            table.push([
+                app.pid,
+                app.name,
+                // @ts-ignore
+                app.pm2_env.version,
+                app.pm2_env.status,
+                // @ts-ignore
+                prettyMs(dayjs().diff(app.pm2_env.pm_uptime)),
+                `${app.monit.cpu}%`,
+                prettyBytes(app.monit.memory),
+            ]);
         });
     }
 

--- a/packages/core/src/shared/status.ts
+++ b/packages/core/src/shared/status.ts
@@ -3,7 +3,7 @@ import dayjs from "dayjs-ext";
 import prettyBytes from "pretty-bytes";
 import prettyMs from "pretty-ms";
 import { BaseCommand } from "../commands/command";
-import { processManager } from "../services/process-manager";
+import { processManager } from "../process-manager";
 import { ProcessDescription } from "../types";
 import { renderTable } from "../utils";
 

--- a/packages/core/src/shared/stop.ts
+++ b/packages/core/src/shared/stop.ts
@@ -1,6 +1,6 @@
 import cli from "cli-ux";
 import { BaseCommand } from "../commands/command";
-import { processManager } from "../services/process-manager";
+import { processManager } from "../process-manager";
 
 export abstract class AbstractStopCommand extends BaseCommand {
     public async run(): Promise<void> {

--- a/packages/core/src/shared/stop.ts
+++ b/packages/core/src/shared/stop.ts
@@ -14,8 +14,6 @@ export abstract class AbstractStopCommand extends BaseCommand {
             processManager[flags.daemon ? "delete" : "stop"](processName);
         } catch (error) {
             this.warn(`The "${processName}" process does not exist.`);
-
-            process.exit();
         } finally {
             cli.action.stop();
         }

--- a/packages/core/src/shared/stop.ts
+++ b/packages/core/src/shared/stop.ts
@@ -1,6 +1,6 @@
 import cli from "cli-ux";
-import pm2 from "pm2";
 import { BaseCommand } from "../commands/command";
+import { processManager } from "../services/process-manager";
 
 export abstract class AbstractStopCommand extends BaseCommand {
     public async run(): Promise<void> {
@@ -8,28 +8,17 @@ export abstract class AbstractStopCommand extends BaseCommand {
 
         const processName = `${flags.token}-${this.getSuffix()}`;
 
-        this.createPm2Connection(() => {
-            const method = flags.daemon ? "delete" : "stop";
-
+        try {
             cli.action.start(`Stopping ${processName}`);
 
-            pm2[method](processName, error => {
-                pm2.disconnect();
+            processManager[flags.daemon ? "delete" : "stop"](processName);
+        } catch (error) {
+            this.warn(`The "${processName}" process does not exist.`);
 
-                cli.action.stop();
-
-                if (error) {
-                    if (error.message === "process name not found") {
-                        this.warn(`The "${processName}" process does not exist.`);
-                        return;
-                    }
-
-                    throw error;
-                }
-
-                process.exit();
-            });
-        });
+            process.exit();
+        } finally {
+            cli.action.stop();
+        }
     }
 
     public abstract getClass();

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,1 +1,7 @@
+import { flags } from "@oclif/command";
+
 export type ProcessDescription = Record<string, any>;
+
+export type CommandFlags = Record<string, any>;
+
+export type Options = Record<string, any>;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,5 +1,3 @@
-import { flags } from "@oclif/command";
-
 export type ProcessDescription = Record<string, any>;
 
 export type CommandFlags = Record<string, any>;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,0 +1,1 @@
+export type ProcessDescription = Record<string, any>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1634,60 +1634,6 @@
     universal-user-agent "^2.0.0"
     url-template "^2.0.8"
 
-"@pm2/agent-node@^1.0.9":
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/@pm2/agent-node/-/agent-node-1.1.5.tgz#b907e6605371063973f551595c43f36e2df95032"
-  integrity sha512-3mn0i2prHEYowc2mqSSxePFi/Oht+a0vtHDcrMUBeYJavt/8fyx6/B5jL3vrz1wKOZvUWe8xdknGVO8YLq94YA==
-  dependencies:
-    debug "^3.1.0"
-    eventemitter2 "^5.0.1"
-    proxy-agent "^3.0.3"
-    ws "^6.0.0"
-
-"@pm2/agent@^0.5.22":
-  version "0.5.23"
-  resolved "https://registry.yarnpkg.com/@pm2/agent/-/agent-0.5.23.tgz#1cb7b868e7f4d49c701506be1587bcbe791bccc0"
-  integrity sha512-mviwkRt51y3wY161uxiqXc0wyHTjgo+sIkJ/Mh6m400dYAnAGQ12LFlK56EbnQRwPfPog0q6txqncbFpn4L5zA==
-  dependencies:
-    async "^2.6.0"
-    chalk "^2.3.2"
-    eventemitter2 "^5.0.1"
-    fclone "^1.0.11"
-    moment "^2.21.0"
-    nssocket "^0.6.0"
-    pm2-axon "^3.2.0"
-    pm2-axon-rpc "^0.5.0"
-    semver "^5.5.0"
-    ws "^5.1.0"
-
-"@pm2/io@~2.4.2":
-  version "2.4.7"
-  resolved "https://registry.yarnpkg.com/@pm2/io/-/io-2.4.7.tgz#153ce2a3827a115c8437315d9da71aae36fc5558"
-  integrity sha512-01IQBBeIFUO6Gs3mVDfoDYcZ3cbaN66gPo6guVQTfhiTv1+ftQlSuZH64dO+41wKbUYgDrXnIvFHR99bnpqj8Q==
-  dependencies:
-    "@pm2/agent-node" "^1.0.9"
-    async "^2.6.1"
-    debug "3.1.0"
-    deep-metrics "0.0.2"
-    deepmerge "2.1.1"
-    event-loop-inspector "^1.2.0"
-    json-stringify-safe "5.0.1"
-    semver "5.5.0"
-    signal-exit "3.0.2"
-    tslib "1.9.3"
-    vxx "1.2.2"
-
-"@pm2/js-api@^0.5.43":
-  version "0.5.49"
-  resolved "https://registry.yarnpkg.com/@pm2/js-api/-/js-api-0.5.49.tgz#e6589a31f2cdf2c2e8dc45bd008674c80f9427b8"
-  integrity sha512-H5BP9aAYLadqqKzs8qWisb2Gt9rnWzYfocn42+UKFVSEsDrGpV18dNi8nexIJ3Lm+Z7vraxtQ42K7EQgslJwdA==
-  dependencies:
-    async "^2.4.1"
-    axios "^0.16.2"
-    debug "^2.6.8"
-    eventemitter2 "^4.1.0"
-    ws "^3.0.0"
-
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz#9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf"
@@ -2985,18 +2931,6 @@ ammo@3.x.x:
   dependencies:
     hoek "6.x.x"
 
-amp-message@~0.1.1:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/amp-message/-/amp-message-0.1.2.tgz#a78f1c98995087ad36192a41298e4db49e3dfc45"
-  integrity sha1-p48cmJlQh602GSpBKY5NtJ49/EU=
-  dependencies:
-    amp "0.3.1"
-
-amp@0.3.1, amp@~0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/amp/-/amp-0.3.1.tgz#6adf8d58a74f361e82c1fa8d389c079e139fc47d"
-  integrity sha1-at+NWKdPNh6CwfqNOJwHnhOfxH0=
-
 ansi-align@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ansi-align/-/ansi-align-2.0.0.tgz#c36aeccba563b89ceb556f3690f0b1d9e3547f7f"
@@ -3415,14 +3349,6 @@ async-limiter@~1.0.0:
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.0.tgz#78faed8c3d074ab81f22b4e985d79e8738f720f8"
   integrity sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==
 
-async-listener@^0.6.0:
-  version "0.6.10"
-  resolved "https://registry.yarnpkg.com/async-listener/-/async-listener-0.6.10.tgz#a7c97abe570ba602d782273c0de60a51e3e17cbc"
-  integrity sha512-gpuo6xOyF4D5DE5WvyqZdPA3NGhiT6Qf07l7DCB0wwDEsLvDIbCr6j9S5aj5Ch96dLace5tXVzWBZkxU/c5ohw==
-  dependencies:
-    semver "^5.3.0"
-    shimmer "^1.1.0"
-
 async-retry@^1.2.1:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/async-retry/-/async-retry-1.2.3.tgz#a6521f338358d322b1a0012b79030c6f411d1ce0"
@@ -3430,19 +3356,19 @@ async-retry@^1.2.1:
   dependencies:
     retry "0.12.0"
 
-async@2.6.1, async@^2.1.4, async@^2.5.0, async@^2.6.1:
+async@^1.4.0, async@~1.5:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
+  integrity sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=
+
+async@^2.1.4, async@^2.5.0, async@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.1.tgz#b245a23ca71930044ec53fa46aa00a3e87c6a610"
   integrity sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==
   dependencies:
     lodash "^4.17.10"
 
-async@^1.4.0, async@~1.5:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
-  integrity sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=
-
-async@^2.4.1, async@^2.6, async@^2.6.0, async@^2.6.2:
+async@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.2.tgz#18330ea7e6e313887f5d2f2a904bac6fe4dd5381"
   integrity sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==
@@ -3488,14 +3414,6 @@ axios-mock-adapter@^1.16.0:
   integrity sha512-m2D8ngMTQ5p4zZNBsPKoENgwz5rDfd0pZmXI/spdE2eeeKIcR3jquk+NRiBVFtb9UJlciBYplNzSUmgQ6X385Q==
   dependencies:
     deep-equal "^1.0.1"
-
-axios@^0.16.2:
-  version "0.16.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.16.2.tgz#ba4f92f17167dfbab40983785454b9ac149c3c6d"
-  integrity sha1-uk+S8XFn37q0CYN4VFS5rBScPG0=
-  dependencies:
-    follow-redirects "^1.2.3"
-    is-buffer "^1.1.5"
 
 axios@^0.18.0:
   version "0.18.0"
@@ -3828,11 +3746,6 @@ bl@~1.1.2:
   dependencies:
     readable-stream "~2.0.5"
 
-blessed@^0.1.81:
-  version "0.1.81"
-  resolved "https://registry.yarnpkg.com/blessed/-/blessed-0.1.81.tgz#f962d687ec2c369570ae71af843256e6d0ca1129"
-  integrity sha1-+WLWh+wsNpVwrnGvhDJW5tDKESk=
-
 block-stream@*:
   version "0.0.9"
   resolved "https://registry.yarnpkg.com/block-stream/-/block-stream-0.0.9.tgz#13ebfe778a03205cfe03751481ebb4b3300c126a"
@@ -3849,11 +3762,6 @@ bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.11.3, bn.js@^4.11.8, bn.js@^4
   version "4.11.8"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.8.tgz#2cde09eb5ee341f484746bb0309b3253b1b1442f"
   integrity sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==
-
-bodec@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/bodec/-/bodec-0.1.0.tgz#bc851555430f23c9f7650a75ef64c6a94c3418cc"
-  integrity sha1-vIUVVUMPI8n3ZQp172TGqUw0GMw=
 
 body-parser@1.18.3, body-parser@^1.18.3:
   version "1.18.3"
@@ -4384,12 +4292,7 @@ chardet@^0.7.0:
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
 
-charm@~0.1.1:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/charm/-/charm-0.1.2.tgz#06c21eed1a1b06aeb67553cdc53e23274bac2296"
-  integrity sha1-BsIe7RobBq62dVPNxT4jJ0usIpY=
-
-chokidar@^2.0.2, chokidar@^2.0.4:
+chokidar@^2.0.2:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.1.tgz#adc39ad55a2adf26548bd2afa048f611091f9184"
   integrity sha512-gfw3p2oQV2wEt+8VuMlNsPjCxDxvvgnm/kz+uATu805mWVF8IJN7uz9DN7iBz+RMJISmiVbCOBFs9qBGMjtPfQ==
@@ -4492,13 +4395,6 @@ cli-spinners@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-1.3.1.tgz#002c1990912d0d59580c93bd36c056de99e4259a"
   integrity sha512-1QL4544moEsDVH9T/l6Cemov/37iv1RtoKf7NJ04A60+4MREXNfx/QvavbH6QoGdsD4N4Mwy49cmaINR/o2mdg==
-
-cli-table-redemption@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/cli-table-redemption/-/cli-table-redemption-1.0.1.tgz#0359d8c34df74980029d76dff071a05a127c4fdd"
-  integrity sha512-SjVCciRyx01I4azo2K2rcc0NP/wOceXGzG1ZpYkEulbbIxDA/5YWv0oxG2HtQ4v8zPC6bgbRI7SbNaTZCxMNkg==
-  dependencies:
-    chalk "^1.1.3"
 
 cli-table3@^0.5.0, cli-table3@^0.5.1:
   version "0.5.1"
@@ -4751,11 +4647,6 @@ combined-stream@^1.0.5, combined-stream@^1.0.6, combined-stream@~1.0.5, combined
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@2.15.1:
-  version "2.15.1"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
-  integrity sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==
-
 commander@2.19.0, commander@^2.12.1, commander@^2.14.1, commander@^2.9.0:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
@@ -4852,14 +4743,6 @@ content@4.x.x:
   integrity sha512-lR9ND3dXiMdmsE84K6l02rMdgiBVmtYWu1Vr/gfSGHcIcznBj2QxmSdUgDuNFOA+G9yrb1IIWkZ7aKtB6hDGyA==
   dependencies:
     boom "7.x.x"
-
-continuation-local-storage@^3.1.4:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/continuation-local-storage/-/continuation-local-storage-3.2.1.tgz#11f613f74e914fe9b34c92ad2d28fe6ae1db7ffb"
-  integrity sha512-jx44cconVqkCEEyLSKWwkvUXwO561jXMa3LPjTPsm5QR22PA0/mhe33FT4Xb5y74JDvt/Cq+5lm8S8rskLv9ZA==
-  dependencies:
-    async-listener "^0.6.0"
-    emitter-listener "^1.1.1"
 
 conventional-changelog-angular@^5.0.2:
   version "5.0.2"
@@ -5075,13 +4958,6 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4, create-hmac@^1.1.7:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-cron@^1.3:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/cron/-/cron-1.6.0.tgz#15f92c1b5a930c5cdfcd53fe940064fa8ca2e72d"
-  integrity sha512-8OkXbeK3qF42ndzkIkCo3zfCDg2TxGjQiCQqVE+ZFFHa4vAcw0PdBc5i/6aJ9FppLncyKZmDuZdJ9/uuXEYZaw==
-  dependencies:
-    moment-timezone "^0.5.x"
-
 cross-env@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.2.0.tgz#6ecd4c015d5773e614039ee529076669b9d126f2"
@@ -5158,11 +5034,6 @@ cssstyle@^1.0.0:
   dependencies:
     cssom "0.3.x"
 
-culvert@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/culvert/-/culvert-0.1.2.tgz#9502f5f0154a2d5a22a023e79f71cc936fa6ef6f"
-  integrity sha1-lQL18BVKLVoioCPnn3HMk2+m728=
-
 currently-unhandled@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/currently-unhandled/-/currently-unhandled-0.4.1.tgz#988df33feab191ef799a61369dd76c17adf957ea"
@@ -5222,7 +5093,7 @@ data-urls@^1.0.0:
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
 
-date-fns@^1.27.2, date-fns@^1.29.0:
+date-fns@^1.27.2:
   version "1.30.1"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
   integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
@@ -5245,7 +5116,7 @@ dayjs-ext@^2.2.0:
     fast-plural-rules "^0.0.1"
     timezone-support "^1.8.0"
 
-debug@2, debug@2.6.9, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.3, debug@^2.6.8, debug@^2.6.9:
+debug@2, debug@2.6.9, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
@@ -5266,7 +5137,7 @@ debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   dependencies:
     ms "^2.1.1"
 
-debug@^3, debug@^3.0, debug@^3.1, debug@^3.1.0, debug@^3.2.5, debug@^3.2.6:
+debug@^3, debug@^3.1.0, debug@^3.2.5:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
@@ -5323,22 +5194,10 @@ deep-is@~0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
 
-deep-metrics@0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/deep-metrics/-/deep-metrics-0.0.2.tgz#180900dea82a2c4b976be2b7684914748f5a0931"
-  integrity sha512-2b4DO8YcPWSHrZ7XW9YjjJajmflw2EhKUMmeriZmGYsC8XvCWIyztsEjCQ3f5kIQO+ItzBK7BqVjSWlFZQtONQ==
-  dependencies:
-    semver "^5.3.0"
-
 deepmerge@*, deepmerge@3.1.0, deepmerge@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-3.1.0.tgz#a612626ce4803da410d77554bfd80361599c034d"
   integrity sha512-/TnecbwXEdycfbsM2++O3eGiatEFHjjNciHEwJclM+T5Kd94qD1AP+2elP/Mq0L5b9VZJao5znR01Mz6eX8Seg==
-
-deepmerge@2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.1.1.tgz#e862b4e45ea0555072bf51e7fd0d9845170ae768"
-  integrity sha512-urQxA1smbLZ2cBbXbaYObM1dJ82aJ2H57A1C/Kklfh/ZN1bgH4G/n5KWhdNfOK11W98gqZfyYj7W4frJJRwA2w==
 
 deepmerge@^3.0.0:
   version "3.2.0"
@@ -5695,13 +5554,6 @@ email-validator@^2.0.4:
   resolved "https://registry.yarnpkg.com/email-validator/-/email-validator-2.0.4.tgz#b8dfaa5d0dae28f1b03c95881d904d4e40bfe7ed"
   integrity sha512-gYCwo7kh5S3IDyZPLZf6hSS0MnZT8QmJFqYvbqlDZSbwdZlY6QZWxJ4i/6UhITOJ4XzyI647Bm2MXKCLqnJ4nQ==
 
-emitter-listener@^1.1.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/emitter-listener/-/emitter-listener-1.1.2.tgz#56b140e8f6992375b3d7cb2cab1cc7432d9632e8"
-  integrity sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==
-  dependencies:
-    shimmer "^1.2.0"
-
 emoji-regex@^7.0.1:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
@@ -5879,11 +5731,6 @@ escape-html@~1.0.3:
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
 
-escape-regexp@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/escape-regexp/-/escape-regexp-0.0.1.tgz#f44bda12d45bbdf9cb7f862ee7e4827b3dd32254"
-  integrity sha1-9EvaEtRbvfnLf4Yu5+SCez3TIlQ=
-
 escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.4, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
@@ -5945,26 +5792,6 @@ event-lite@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/event-lite/-/event-lite-0.1.2.tgz#838a3e0fdddef8cc90f128006c8e55a4e4e4c11b"
   integrity sha512-HnSYx1BsJ87/p6swwzv+2v6B4X+uxUteoDfRxsAb1S1BePzQqOLevVmkdA15GHJVd9A9Ok6wygUR18Hu0YeV9g==
-
-event-loop-inspector@^1.2.0:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/event-loop-inspector/-/event-loop-inspector-1.2.2.tgz#e56ed73f50a8b0b9193cc36be877fea18641aceb"
-  integrity sha512-v7OqIPmO0jqpmSH4Uc6IrY/H6lOidYzrXHE8vPHLDDOfV1Pw+yu+KEIE/AWnoFheWYlunZbxzKpZBAezVlrU9g==
-
-eventemitter2@5.0.1, eventemitter2@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/eventemitter2/-/eventemitter2-5.0.1.tgz#6197a095d5fb6b57e8942f6fd7eaad63a09c9452"
-  integrity sha1-YZegldX7a1folC9v1+qtY6CclFI=
-
-eventemitter2@^4.1.0:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/eventemitter2/-/eventemitter2-4.1.2.tgz#0e1a8477af821a6ef3995b311bf74c23a5247f15"
-  integrity sha1-DhqEd6+CGm7zmVsxG/dMI6UkfxU=
-
-eventemitter2@~0.4.14:
-  version "0.4.14"
-  resolved "https://registry.yarnpkg.com/eventemitter2/-/eventemitter2-0.4.14.tgz#8f61b75cde012b2e9eb284d4545583b5643b61ab"
-  integrity sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=
 
 eventemitter3@^3.1.0:
   version "3.1.0"
@@ -6150,7 +5977,7 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
-extend@3, extend@^3.0.0, extend@~3.0.0, extend@~3.0.2:
+extend@3, extend@~3.0.0, extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
@@ -6277,11 +6104,6 @@ fb-watchman@^2.0.0:
   integrity sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=
   dependencies:
     bser "^2.0.0"
-
-fclone@1.0.11, fclone@^1.0.11:
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/fclone/-/fclone-1.0.11.tgz#10e85da38bfea7fc599341c296ee1d77266ee640"
-  integrity sha1-EOhdo4v+p/xZk0HClu4ddyZu5kA=
 
 fecha@^2.3.3:
   version "2.3.3"
@@ -6430,13 +6252,6 @@ fn-name@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/fn-name/-/fn-name-2.0.1.tgz#5214d7537a4d06a4a301c0cc262feb84188002e7"
   integrity sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc=
-
-follow-redirects@^1.2.3:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.7.0.tgz#489ebc198dc0e7f64167bd23b03c4c19b5784c76"
-  integrity sha512-m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==
-  dependencies:
-    debug "^3.2.6"
 
 follow-redirects@^1.3.0:
   version "1.6.1"
@@ -6770,11 +6585,6 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
-git-node-fs@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/git-node-fs/-/git-node-fs-1.0.0.tgz#49b215e242ebe43aa4c7561bbba499521752080f"
-  integrity sha1-SbIV4kLr5Dqkx1Ybu6SZUhdSCA8=
-
 git-raw-commits@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/git-raw-commits/-/git-raw-commits-2.0.0.tgz#d92addf74440c14bcc5c83ecce3fb7f8a79118b5"
@@ -6802,11 +6612,6 @@ git-semver-tags@^2.0.2:
     meow "^4.0.0"
     semver "^5.5.0"
 
-git-sha1@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/git-sha1/-/git-sha1-0.1.2.tgz#599ac192b71875825e13a445f3a6e05118c2f745"
-  integrity sha1-WZrBkrcYdYJeE6RF86bgURjC90U=
-
 git-up@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/git-up/-/git-up-4.0.1.tgz#cb2ef086653640e721d2042fe3104857d89007c0"
@@ -6828,10 +6633,6 @@ gitconfiglocal@^1.0.0:
   integrity sha1-QdBF84UaXqiPA/JMocYXgRRGS5s=
   dependencies:
     ini "^1.3.2"
-
-"gkt@https://tgz.pm2.io/gkt-1.0.0.tgz":
-  version "1.0.0"
-  resolved "https://tgz.pm2.io/gkt-1.0.0.tgz#405502b007f319c3f47175c4474527300f2ab5ad"
 
 glob-base@^0.3.0:
   version "0.3.0"
@@ -8203,11 +8004,6 @@ is-wsl@^1.1.0:
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
   integrity sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
 
-is@^3.2.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/is/-/is-3.3.0.tgz#61cff6dd3c4193db94a3d62582072b44e5645d79"
-  integrity sha512-nW24QBoPcFGGHJGUwnfpI7Yc5CdqWNdsyHQszVE/z2pKHXzh7FZ5GWhJqSyaQ9wMkQnsTx+kAI8bHlCX4tKdbg==
-
 isarray@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
@@ -8710,16 +8506,6 @@ joi@^13.0.2:
     isemail "3.x.x"
     topo "3.x.x"
 
-js-git@^0.7.8:
-  version "0.7.8"
-  resolved "https://registry.yarnpkg.com/js-git/-/js-git-0.7.8.tgz#52fa655ab61877d6f1079efc6534b554f31e5444"
-  integrity sha1-UvplWrYYd9bxB578ZTS1VPMeVEQ=
-  dependencies:
-    bodec "^0.1.0"
-    culvert "^0.1.2"
-    git-sha1 "^0.1.2"
-    pako "^0.2.5"
-
 js-levenshtein@^1.1.3:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/js-levenshtein/-/js-levenshtein-1.1.6.tgz#c6cee58eb3550372df8deb85fad5ce66ce01d59d"
@@ -8822,7 +8608,7 @@ json-schema@0.2.3:
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
   integrity sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=
 
-json-stringify-safe@5.0.1, json-stringify-safe@5.x.x, json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
+json-stringify-safe@5.x.x, json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
@@ -8964,11 +8750,6 @@ lazy-cache@^0.2.3:
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-0.2.7.tgz#7feddf2dcb6edb77d11ef1d117ab5ffdf0ab1b65"
   integrity sha1-f+3fLctu23fRHvHRF6tf/fCrG2U=
-
-lazy@~1.0.11:
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/lazy/-/lazy-1.0.11.tgz#daa068206282542c088288e975c297c1ae77b690"
-  integrity sha1-2qBoIGKCVCwIgojpdcKXwa53tpA=
 
 lcid@^1.0.0:
   version "1.0.0"
@@ -9263,20 +9044,10 @@ lodash.fill@^3.4.0:
   resolved "https://registry.yarnpkg.com/lodash.fill/-/lodash.fill-3.4.0.tgz#a3c74ae640d053adf0dc2079f8720788e8bfef85"
   integrity sha1-o8dK5kDQU63w3CB5+HIHiOi/74U=
 
-lodash.findindex@^4.4.0, lodash.findindex@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.findindex/-/lodash.findindex-4.6.0.tgz#a3245dee61fb9b6e0624b535125624bb69c11106"
-  integrity sha1-oyRd7mH7m24GJLU1ElYku2nBEQY=
-
 lodash.flatten@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
   integrity sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=
-
-lodash.foreach@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.foreach/-/lodash.foreach-4.5.0.tgz#1a6a35eace401280c7f06dddec35165ab27e3e53"
-  integrity sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM=
 
 lodash.get@^4.4.2:
   version "4.4.2"
@@ -9298,7 +9069,7 @@ lodash.isempty@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.isempty/-/lodash.isempty-4.4.0.tgz#6f86cbedd8be4ec987be9aaf33c9684db1b31e7e"
   integrity sha1-b4bL7di+TsmHvpqvM8loTbGzHn4=
 
-lodash.isequal@^4.0.0, lodash.isequal@^4.5.0:
+lodash.isequal@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
   integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
@@ -9317,16 +9088,6 @@ lodash.isstring@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
   integrity sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=
-
-lodash.last@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/lodash.last/-/lodash.last-3.0.0.tgz#242f663112dd4c6e63728c60a3c909d1bdadbd4c"
-  integrity sha1-JC9mMRLdTG5jcoxgo8kJ0b2tvUw=
-
-lodash.merge@^4.6.0:
-  version "4.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.1.tgz#adc25d9cb99b9391c59624f379fbba60d7111d54"
-  integrity sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ==
 
 lodash.orderby@^4.6.0:
   version "4.6.0"
@@ -9750,7 +9511,7 @@ merge@^1.2.0:
   resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.1.tgz#38bebf80c3220a8a487b6fcfb3941bb11720c145"
   integrity sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==
 
-methods@^1.1.1, methods@~1.1.2:
+methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
@@ -9928,7 +9689,7 @@ mixin-object@^2.0.1:
     for-in "^0.1.3"
     is-extendable "^0.1.1"
 
-mkdirp@0.5.1, mkdirp@0.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
+mkdirp@0.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
@@ -9940,14 +9701,14 @@ modify-values@^1.0.0:
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
 
-moment-timezone@^0.5.14, moment-timezone@^0.5.x:
+moment-timezone@^0.5.14:
   version "0.5.23"
   resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.23.tgz#7cbb00db2c14c71b19303cb47b0fb0a6d8651463"
   integrity sha512-WHFH85DkCfiNMDX5D3X7hpNH3/PUhjTGcD0U1SgfBGZxJ3qUmJh5FdvaFjcClxOvB3rzdfj4oRffbI38jEnC1w==
   dependencies:
     moment ">= 2.9.0"
 
-moment@2.x.x, "moment@>= 2.9.0", moment@>=2.14.0, moment@^2.11.2, moment@^2.20.0, moment@^2.21.0, moment@^2.22.1, moment@^2.22.2:
+moment@2.x.x, "moment@>= 2.9.0", moment@>=2.14.0, moment@^2.11.2, moment@^2.20.0, moment@^2.22.1:
   version "2.24.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
   integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
@@ -10614,14 +10375,6 @@ npmlog@~4.0.0:
     gauge "~2.7.1"
     set-blocking "~2.0.0"
 
-nssocket@0.6.0, nssocket@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/nssocket/-/nssocket-0.6.0.tgz#59f96f6ff321566f33c70f7dbeeecdfdc07154fa"
-  integrity sha1-Wflvb/MhVm8zxw99vu7N/cBxVPo=
-  dependencies:
-    eventemitter2 "~0.4.14"
-    lazy "~1.0.11"
-
 number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
@@ -10991,20 +10744,6 @@ pac-proxy-agent@^2.0.1:
     raw-body "^2.2.0"
     socks-proxy-agent "^3.0.0"
 
-pac-proxy-agent@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/pac-proxy-agent/-/pac-proxy-agent-3.0.0.tgz#11d578b72a164ad74bf9d5bac9ff462a38282432"
-  integrity sha512-AOUX9jES/EkQX2zRz0AW7lSx9jD//hQS8wFXBvcnd/J2Py9KaMJMqV/LPqJssj1tgGufotb2mmopGPR15ODv1Q==
-  dependencies:
-    agent-base "^4.2.0"
-    debug "^3.1.0"
-    get-uri "^2.0.0"
-    http-proxy-agent "^2.1.0"
-    https-proxy-agent "^2.2.1"
-    pac-resolver "^3.0.0"
-    raw-body "^2.2.0"
-    socks-proxy-agent "^4.0.1"
-
 pac-resolver@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/pac-resolver/-/pac-resolver-3.0.0.tgz#6aea30787db0a891704deb7800a722a7615a6f26"
@@ -11073,11 +10812,6 @@ pacote@^9.4.1:
     tar "^4.4.8"
     unique-filename "^1.1.1"
     which "^1.3.1"
-
-pako@^0.2.5:
-  version "0.2.9"
-  resolved "https://registry.yarnpkg.com/pako/-/pako-0.2.9.tgz#f3f7522f4ef782348da8161bad9ecfd51bf83a75"
-  integrity sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=
 
 pako@~1.0.2, pako@~1.0.5:
   version "1.0.8"
@@ -11356,13 +11090,6 @@ pgpass@1.x:
   dependencies:
     split "^1.0.0"
 
-pidusage@^2.0.14:
-  version "2.0.17"
-  resolved "https://registry.yarnpkg.com/pidusage/-/pidusage-2.0.17.tgz#6b4a2b4a09026f0e9828f7e5627837e4c0672581"
-  integrity sha512-N8X5v18rBmlBoArfS83vrnD0gIFyZkXEo7a5pAS2aT0i2OLVymFb2AzVg+v8l/QcXnE1JwZcaXR8daJcoJqtjw==
-  dependencies:
-    safe-buffer "^5.1.2"
-
 pify@3.0.0, pify@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
@@ -11447,77 +11174,6 @@ pluralize@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"
   integrity sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==
-
-pm2-axon-rpc@^0.5.0, pm2-axon-rpc@^0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/pm2-axon-rpc/-/pm2-axon-rpc-0.5.1.tgz#ad3c43c43811c71f13e5eee2821194d03ceb03fe"
-  integrity sha512-hT8gN3/j05895QLXpwg+Ws8PjO4AVID6Uf9StWpud9HB2homjc1KKCcI0vg9BNOt56FmrqKDT1NQgheIz35+sA==
-  dependencies:
-    debug "^3.0"
-
-pm2-axon@3.3.0, pm2-axon@^3.2.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/pm2-axon/-/pm2-axon-3.3.0.tgz#a9badfdb8e083fbd5d7d24317b4a21eb708f0735"
-  integrity sha512-dAFlFYRuFbFjX7oAk41zT+dx86EuaFX/TgOp5QpUKRKwxb946IM6ydnoH5sSTkdI2pHSVZ+3Am8n/l0ocr7jdQ==
-  dependencies:
-    amp "~0.3.1"
-    amp-message "~0.1.1"
-    debug "^3.0"
-    escape-regexp "0.0.1"
-
-pm2-deploy@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/pm2-deploy/-/pm2-deploy-0.4.0.tgz#d543076919f7776c57eb75841a4320f547287661"
-  integrity sha512-3BdCghcGwMKwl3ffHZhc+j5JY5dldH9nq8m/I9W5wehJuSRZIyO96VOgKTMv3hYp7Yk5E+2lRGm8WFNlp65vOA==
-  dependencies:
-    async "^2.6"
-    tv4 "^1.3"
-
-pm2-multimeter@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/pm2-multimeter/-/pm2-multimeter-0.1.2.tgz#1a1e55153d41a05534cea23cfe860abaa0eb4ace"
-  integrity sha1-Gh5VFT1BoFU0zqI8/oYKuqDrSs4=
-  dependencies:
-    charm "~0.1.1"
-
-pm2@^3.2.3:
-  version "3.2.9"
-  resolved "https://registry.yarnpkg.com/pm2/-/pm2-3.2.9.tgz#6e0e009355fa089007689d97c6565f6b3e341476"
-  integrity sha512-dlNIwmbsRe+Ttculrjj776ILtP5rjDsykxCOhpZB+ioCsnOmRUGJHrWCdmoOjcyHgA5tvE/X0s9M1J/hYsRKGQ==
-  dependencies:
-    "@pm2/agent" "^0.5.22"
-    "@pm2/io" "~2.4.2"
-    "@pm2/js-api" "^0.5.43"
-    async "^2.6.1"
-    blessed "^0.1.81"
-    chalk "^2.4.1"
-    chokidar "^2.0.4"
-    cli-table-redemption "^1.0.0"
-    commander "2.15.1"
-    cron "^1.3"
-    date-fns "^1.29.0"
-    debug "^3.1"
-    eventemitter2 "5.0.1"
-    fclone "1.0.11"
-    mkdirp "0.5.1"
-    moment "^2.22.2"
-    needle "^2.2.1"
-    nssocket "0.6.0"
-    pidusage "^2.0.14"
-    pm2-axon "3.3.0"
-    pm2-axon-rpc "^0.5.1"
-    pm2-deploy "^0.4.0"
-    pm2-multimeter "^0.1.2"
-    promptly "^2"
-    semver "^5.5"
-    shelljs "~0.8.2"
-    source-map-support "^0.5.6"
-    sprintf-js "1.1.1"
-    v8-compile-cache "^2.0.0"
-    vizion "~2.0.2"
-    yamljs "^0.3.0"
-  optionalDependencies:
-    gkt "https://tgz.pm2.io/gkt-1.0.0.tgz"
 
 pn@^1.1.0:
   version "1.1.0"
@@ -11662,13 +11318,6 @@ promise-retry@^1.1.1:
   dependencies:
     asap "~2.0.3"
 
-promptly@^2:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/promptly/-/promptly-2.2.0.tgz#2a13fa063688a2a5983b161fff0108a07d26fc74"
-  integrity sha1-KhP6BjaIoqWYOxYf/wEIoH0m/HQ=
-  dependencies:
-    read "^1.0.4"
-
 prompts@^0.1.9:
   version "0.1.14"
   resolved "https://registry.yarnpkg.com/prompts/-/prompts-0.1.14.tgz#a8e15c612c5c9ec8f8111847df3337c9cbd443b2"
@@ -11754,20 +11403,6 @@ proxy-agent@2.3.1:
     pac-proxy-agent "^2.0.1"
     proxy-from-env "^1.0.0"
     socks-proxy-agent "^3.0.0"
-
-proxy-agent@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/proxy-agent/-/proxy-agent-3.0.3.tgz#1c1a33db60ef5f2e9e35b876fd63c2bc681c611d"
-  integrity sha512-PXVVVuH9tiQuxQltFJVSnXWuDtNr+8aNBP6XVDDCDiUuDN8eRCm+ii4/mFWmXWEA0w8jjJSlePa4LXlM4jIzNA==
-  dependencies:
-    agent-base "^4.2.0"
-    debug "^3.1.0"
-    http-proxy-agent "^2.1.0"
-    https-proxy-agent "^2.2.1"
-    lru-cache "^4.1.2"
-    pac-proxy-agent "^3.0.0"
-    proxy-from-env "^1.0.0"
-    socks-proxy-agent "^4.0.1"
 
 proxy-from-env@^1.0.0:
   version "1.0.0"
@@ -12078,7 +11713,7 @@ read-pkg@^4.0.1:
     parse-json "^4.0.0"
     pify "^3.0.0"
 
-read@1, read@^1.0.4, read@~1.0.1, read@~1.0.7:
+read@1, read@~1.0.1, read@~1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/read/-/read-1.0.7.tgz#b3da19bd052431a97671d44a42634adf710b40c4"
   integrity sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=
@@ -12679,11 +12314,6 @@ semver@4.3.2:
   resolved "https://registry.yarnpkg.com/semver/-/semver-4.3.2.tgz#c7a07158a80bedd052355b770d82d6640f803be7"
   integrity sha1-x6BxWKgL7dBSNVt3DYLWZA+AO+c=
 
-semver@5.5.0:
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
-  integrity sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==
-
 semver@^4.1.0:
   version "4.3.6"
   resolved "https://registry.yarnpkg.com/semver/-/semver-4.3.6.tgz#300bc6e0e86374f7ba61068b5b1ecd57fc6532da"
@@ -12824,7 +12454,7 @@ shebang-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
   integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
 
-shelljs@^0.8.2, shelljs@~0.8.2:
+shelljs@^0.8.2:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.3.tgz#a7f3319520ebf09ee81275b2368adb286659b097"
   integrity sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==
@@ -12838,7 +12468,7 @@ shellwords@^0.1.1:
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
-shimmer@^1.0.0, shimmer@^1.1.0, shimmer@^1.2.0:
+shimmer@^1.1.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/shimmer/-/shimmer-1.2.1.tgz#610859f7de327b587efebf501fb43117f9aff337"
   integrity sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==
@@ -12851,7 +12481,7 @@ shot@4.x.x:
     hoek "6.x.x"
     joi "14.x.x"
 
-signal-exit@3.0.2, signal-exit@^3.0.0, signal-exit@^3.0.2:
+signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
   integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
@@ -13167,7 +12797,7 @@ socks-proxy-agent@^3.0.0:
     agent-base "^4.1.0"
     socks "^1.1.10"
 
-socks-proxy-agent@^4.0.0, socks-proxy-agent@^4.0.1:
+socks-proxy-agent@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/socks-proxy-agent/-/socks-proxy-agent-4.0.1.tgz#5936bf8b707a993079c6f37db2091821bffa6473"
   integrity sha512-Kezx6/VBguXOsEe5oU3lXYyKMi4+gva72TwJ7pQY5JfqUx2nMk7NXA6z/mpNqIlfQjWYVfeuNvQjexiTaTn6Nw==
@@ -13327,11 +12957,6 @@ split@^1.0.0:
   integrity sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==
   dependencies:
     through "2"
-
-sprintf-js@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.1.1.tgz#36be78320afe5801f6cea3ee78b6e5aab940ea0c"
-  integrity sha1-Nr54Mgr+WAH2zqPueLblqrlA6gw=
 
 sprintf-js@~1.0.2:
   version "1.0.3"
@@ -14084,7 +13709,7 @@ ts-loader@^5.3.1, ts-loader@^5.3.3:
     micromatch "^3.1.4"
     semver "^5.0.1"
 
-tslib@1.9.3, tslib@^1, tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
+tslib@^1, tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
   integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
@@ -14135,11 +13760,6 @@ tunnel-agent@~0.4.1:
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.4.3.tgz#6373db76909fe570e08d73583365ed828a74eeeb"
   integrity sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=
-
-tv4@^1.3:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/tv4/-/tv4-1.3.0.tgz#d020c846fadd50c855abb25ebaecc68fc10f7963"
-  integrity sha1-0CDIRvrdUMhVq7JeuuzGj8EPeWM=
 
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
@@ -14228,11 +13848,6 @@ uid-number@0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/uid-number/-/uid-number-0.0.6.tgz#0ea10e8035e8eb5b8e4449f06da1c730663baa81"
   integrity sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=
-
-ultron@~1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.1.1.tgz#9fe1536a10a664a65266a1e3ccf85fd36302bc9c"
-  integrity sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==
 
 umask@^1.1.0, umask@~1.1.0:
   version "1.1.0"
@@ -14498,7 +14113,7 @@ uuid@^3.0.1, uuid@^3.1.0, uuid@^3.2.1, uuid@^3.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
-v8-compile-cache@^2.0.0, v8-compile-cache@^2.0.2:
+v8-compile-cache@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.0.2.tgz#a428b28bb26790734c4fc8bc9fa106fccebf6a6c"
   integrity sha512-1wFuMUIM16MDJRCrpbpuEPTUGmM5QMUg0cr3KFwra2XgOgFcPGDQHDh3CszSCD2Zewc/dh/pamNEW8CbfDebUw==
@@ -14561,20 +14176,6 @@ vision@^5.4.4:
     items "2.x.x"
     joi "14.x.x"
 
-vizion@~2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/vizion/-/vizion-2.0.2.tgz#fcc263f41a4543b02b655c1b6c4ff1406726d2fa"
-  integrity sha512-UGDB/UdC1iyPkwyQaI9AFMwKcluQyD4FleEXObrlu254MEf16MV8l+AZdpFErY/iVKZVWlQ+OgJlVVJIdeMUYg==
-  dependencies:
-    async "2.6.1"
-    git-node-fs "^1.0.0"
-    ini "^1.3.4"
-    js-git "^0.7.8"
-    lodash.findindex "^4.6.0"
-    lodash.foreach "^4.5.0"
-    lodash.get "^4.4.2"
-    lodash.last "^3.0.0"
-
 vm-browserify@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-0.0.4.tgz#5d7ea45bbef9e4a6ff65f95438e0a87c357d5a73"
@@ -14586,23 +14187,6 @@ vscode-languageserver-types@^3.5.0:
   version "3.14.0"
   resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.14.0.tgz#d3b5952246d30e5241592b6dde8280e03942e743"
   integrity sha512-lTmS6AlAlMHOvPQemVwo3CezxBp0sNB95KNPkqp3Nxd5VFEnuG1ByM0zlRWos0zjO3ZWtkvhal0COgiV1xIA4A==
-
-vxx@1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/vxx/-/vxx-1.2.2.tgz#741fb51c6f11d3383da6f9b92018a5d7ba807611"
-  integrity sha1-dB+1HG8R0zg9pvm5IBil17qAdhE=
-  dependencies:
-    continuation-local-storage "^3.1.4"
-    debug "^2.6.3"
-    extend "^3.0.0"
-    is "^3.2.0"
-    lodash.findindex "^4.4.0"
-    lodash.isequal "^4.0.0"
-    lodash.merge "^4.6.0"
-    methods "^1.1.1"
-    semver "^5.0.1"
-    shimmer "^1.0.0"
-    uuid "^3.0.1"
 
 w3c-hr-time@^1.0.1:
   version "1.0.1"
@@ -14948,16 +14532,7 @@ write-pkg@^3.1.0:
     sort-keys "^2.0.0"
     write-json-file "^2.2.0"
 
-ws@^3.0.0:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-3.3.3.tgz#f1cf84fe2d5e901ebce94efaece785f187a228f2"
-  integrity sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==
-  dependencies:
-    async-limiter "~1.0.0"
-    safe-buffer "~5.1.0"
-    ultron "~1.1.0"
-
-ws@^5.1.0, ws@^5.2.0:
+ws@^5.2.0:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/ws/-/ws-5.2.2.tgz#dffef14866b8e8dc9133582514d1befaf96e980f"
   integrity sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==
@@ -15038,14 +14613,6 @@ yallist@^3.0.0, yallist@^3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.3.tgz#b4b049e314be545e3ce802236d6cd22cd91c3de9"
   integrity sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==
-
-yamljs@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/yamljs/-/yamljs-0.3.0.tgz#dc060bf267447b39f7304e9b2bfbe8b5a7ddb03b"
-  integrity sha512-C/FsVVhht4iPQYXOInoxUM/1ELSf9EsgKH34FofQOp6hwCPrW4vG4w5++TED3xRUo8gD7l0P1J1dLlDYzODsTQ==
-  dependencies:
-    argparse "^1.0.7"
-    glob "^7.0.5"
 
 yargs-parser@10.x, yargs-parser@^10.0.0:
   version "10.1.0"


### PR DESCRIPTION
## Proposed changes

Replace the `pm2` dependency with a process manager that parses the output from the global `pm2` itself.

The `pm2` package itself is pure http://callbackhell.com/ which results in nasty code now that the CLI is bigger.

**To-Do**
- [ ] Implement `start` method with support for `--no-daemon` and `arguments`

## Types of changes

- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes