### PR TITLE
fix(core): reset configuration if --network is passed

### DIFF
--- a/packages/core/src/commands/config/reset.ts
+++ b/packages/core/src/commands/config/reset.ts
@@ -16,15 +16,12 @@ $ ark config:reset --network=mainnet
 
     public static flags: CommandFlags = {
         ...BaseCommand.flagsNetwork,
-        force: flags.boolean({
-            description: "force the configuration to be reset",
-        }),
     };
 
     public async run(): Promise<void> {
         const { flags } = await this.parseWithNetwork(ResetCommand);
 
-        if (flags.force) {
+        if (flags.network) {
             return this.performReset(flags);
         }
 


### PR DESCRIPTION
## Proposed changes

Remove the force flag and instead reset when the `--network` flag is provided.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes