### PR TITLE
chore: update circleci config to fix coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,10 +53,8 @@ jobs:
             - ./packages/core-json-rpc/node_modules
             - ./packages/core-logger/node_modules
             - ./packages/core-logger-pino/node_modules
-            - ./packages/core-logger-winston/node_modules
             - ./packages/core-p2p/node_modules
             - ./packages/core-snapshots/node_modules
-            - ./packages/core-test-utils/node_modules
             - ./packages/core-tester-cli/node_modules
             - ./packages/core-transaction-pool/node_modules
             - ./packages/core-utils/node_modules
@@ -71,42 +69,50 @@ jobs:
           name: core-api - unit
           command: >-
             cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-api/
+            test:coverage /unit/core-api/ --coverageDirectory
+            .coverage/unit/core-api
       - run:
           name: core-blockchain - unit
           command: >-
             cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-blockchain/
+            test:coverage /unit/core-blockchain/ --coverageDirectory
+            .coverage/unit/core-blockchain
       - run:
           name: core-container - unit
           command: >-
             cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-container/
+            test:coverage /unit/core-container/ --coverageDirectory
+            .coverage/unit/core-container
       - run:
           name: core-database - unit
           command: >-
             cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-database/
+            test:coverage /unit/core-database/ --coverageDirectory
+            .coverage/unit/core-database
       - run:
           name: core-database-postgres - unit
           command: >-
             cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-database-postgres/
+            test:coverage /unit/core-database-postgres/ --coverageDirectory
+            .coverage/unit/core-database-postgres
       - run:
           name: core-debugger-cli - unit
           command: >-
             cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-debugger-cli/
+            test:coverage /unit/core-debugger-cli/ --coverageDirectory
+            .coverage/unit/core-debugger-cli
       - run:
           name: core-api - integration
           command: >-
             cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /integration/core-api/
+            test:coverage /integration/core-api/ --coverageDirectory
+            .coverage/integration/core-api
       - run:
           name: core-blockchain - integration
           command: >-
             cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /integration/core-blockchain/
+            test:coverage /integration/core-blockchain/ --coverageDirectory
+            .coverage/integration/core-blockchain
       - run:
           name: Last 1000 lines of test output
           when: on_fail
@@ -170,10 +176,8 @@ jobs:
             - ./packages/core-json-rpc/node_modules
             - ./packages/core-logger/node_modules
             - ./packages/core-logger-pino/node_modules
-            - ./packages/core-logger-winston/node_modules
             - ./packages/core-p2p/node_modules
             - ./packages/core-snapshots/node_modules
-            - ./packages/core-test-utils/node_modules
             - ./packages/core-tester-cli/node_modules
             - ./packages/core-transaction-pool/node_modules
             - ./packages/core-utils/node_modules
@@ -188,42 +192,50 @@ jobs:
           name: core-api - unit
           command: >-
             cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-api/
+            test:coverage /unit/core-api/ --coverageDirectory
+            .coverage/unit/core-api
       - run:
           name: core-blockchain - unit
           command: >-
             cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-blockchain/
+            test:coverage /unit/core-blockchain/ --coverageDirectory
+            .coverage/unit/core-blockchain
       - run:
           name: core-container - unit
           command: >-
             cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-container/
+            test:coverage /unit/core-container/ --coverageDirectory
+            .coverage/unit/core-container
       - run:
           name: core-database - unit
           command: >-
             cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-database/
+            test:coverage /unit/core-database/ --coverageDirectory
+            .coverage/unit/core-database
       - run:
           name: core-database-postgres - unit
           command: >-
             cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-database-postgres/
+            test:coverage /unit/core-database-postgres/ --coverageDirectory
+            .coverage/unit/core-database-postgres
       - run:
           name: core-debugger-cli - unit
           command: >-
             cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-debugger-cli/
+            test:coverage /unit/core-debugger-cli/ --coverageDirectory
+            .coverage/unit/core-debugger-cli
       - run:
           name: core-api - integration
           command: >-
             cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /integration/core-api/
+            test:coverage /integration/core-api/ --coverageDirectory
+            .coverage/integration/core-api
       - run:
           name: core-blockchain - integration
           command: >-
             cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /integration/core-blockchain/
+            test:coverage /integration/core-blockchain/ --coverageDirectory
+            .coverage/integration/core-blockchain
       - run:
           name: Last 1000 lines of test output
           when: on_fail
@@ -287,10 +299,8 @@ jobs:
             - ./packages/core-json-rpc/node_modules
             - ./packages/core-logger/node_modules
             - ./packages/core-logger-pino/node_modules
-            - ./packages/core-logger-winston/node_modules
             - ./packages/core-p2p/node_modules
             - ./packages/core-snapshots/node_modules
-            - ./packages/core-test-utils/node_modules
             - ./packages/core-tester-cli/node_modules
             - ./packages/core-transaction-pool/node_modules
             - ./packages/core-utils/node_modules
@@ -305,47 +315,62 @@ jobs:
           name: core-event-emitter - unit
           command: >-
             cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-event-emitter/
+            test:coverage /unit/core-event-emitter/ --coverageDirectory
+            .coverage/unit/core-event-emitter
       - run:
           name: core-forger - unit
           command: >-
             cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-forger/
+            test:coverage /unit/core-forger/ --coverageDirectory
+            .coverage/unit/core-forger
       - run:
           name: core-http-utils - unit
           command: >-
             cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-http-utils/
+            test:coverage /unit/core-http-utils/ --coverageDirectory
+            .coverage/unit/core-http-utils
       - run:
           name: core-jest-matchers - unit
           command: >-
             cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-jest-matchers/
+            test:coverage /unit/core-jest-matchers/ --coverageDirectory
+            .coverage/unit/core-jest-matchers
       - run:
           name: core-logger - unit
           command: >-
             cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-logger/
+            test:coverage /unit/core-logger/ --coverageDirectory
+            .coverage/unit/core-logger
       - run:
           name: core-logger-pino - unit
           command: >-
             cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-logger-pino/
+            test:coverage /unit/core-logger-pino/ --coverageDirectory
+            .coverage/unit/core-logger-pino
       - run:
           name: core-p2p - unit
           command: >-
             cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-p2p/
+            test:coverage /unit/core-p2p/ --coverageDirectory
+            .coverage/unit/core-p2p
+      - run:
+          name: core-snapshots - unit
+          command: >-
+            cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
+            test:coverage /unit/core-snapshots/ --coverageDirectory
+            .coverage/unit/core-snapshots
       - run:
           name: core-json-rpc - integration
           command: >-
             cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /integration/core-json-rpc/
+            test:coverage /integration/core-json-rpc/ --coverageDirectory
+            .coverage/integration/core-json-rpc
       - run:
           name: core-p2p - integration
           command: >-
             cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /integration/core-p2p/
+            test:coverage /integration/core-p2p/ --coverageDirectory
+            .coverage/integration/core-p2p
       - run:
           name: Last 1000 lines of test output
           when: on_fail
@@ -409,10 +434,8 @@ jobs:
             - ./packages/core-json-rpc/node_modules
             - ./packages/core-logger/node_modules
             - ./packages/core-logger-pino/node_modules
-            - ./packages/core-logger-winston/node_modules
             - ./packages/core-p2p/node_modules
             - ./packages/core-snapshots/node_modules
-            - ./packages/core-test-utils/node_modules
             - ./packages/core-tester-cli/node_modules
             - ./packages/core-transaction-pool/node_modules
             - ./packages/core-utils/node_modules
@@ -424,45 +447,47 @@ jobs:
           name: Create .core/database directory
           command: mkdir -p $HOME/.core/database
       - run:
-          name: core-snapshots - unit
-          command: >-
-            cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-snapshots/
-      - run:
           name: core-tester-cli - unit
           command: >-
             cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-tester-cli/
+            test:coverage /unit/core-tester-cli/ --coverageDirectory
+            .coverage/unit/core-tester-cli
       - run:
           name: core-transaction-pool - unit
           command: >-
             cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-transaction-pool/
+            test:coverage /unit/core-transaction-pool/ --coverageDirectory
+            .coverage/unit/core-transaction-pool
       - run:
           name: core-utils - unit
           command: >-
             cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-utils/
+            test:coverage /unit/core-utils/ --coverageDirectory
+            .coverage/unit/core-utils
       - run:
           name: core-vote-report - unit
           command: >-
             cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-vote-report/
+            test:coverage /unit/core-vote-report/ --coverageDirectory
+            .coverage/unit/core-vote-report
       - run:
           name: core-webhooks - unit
           command: >-
             cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-webhooks/
+            test:coverage /unit/core-webhooks/ --coverageDirectory
+            .coverage/unit/core-webhooks
       - run:
           name: crypto - unit
           command: >-
             cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/crypto/
+            test:coverage /unit/crypto/ --coverageDirectory
+            .coverage/unit/crypto
       - run:
           name: core-transaction-pool - integration
           command: >-
             cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
             test:coverage /integration/core-transaction-pool/
+            --coverageDirectory .coverage/integration/core-transaction-pool
       - run:
           name: Last 1000 lines of test output
           when: on_fail
@@ -526,10 +551,8 @@ jobs:
             - ./packages/core-json-rpc/node_modules
             - ./packages/core-logger/node_modules
             - ./packages/core-logger-pino/node_modules
-            - ./packages/core-logger-winston/node_modules
             - ./packages/core-p2p/node_modules
             - ./packages/core-snapshots/node_modules
-            - ./packages/core-test-utils/node_modules
             - ./packages/core-tester-cli/node_modules
             - ./packages/core-transaction-pool/node_modules
             - ./packages/core-utils/node_modules
@@ -544,47 +567,62 @@ jobs:
           name: core-event-emitter - unit
           command: >-
             cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-event-emitter/
+            test:coverage /unit/core-event-emitter/ --coverageDirectory
+            .coverage/unit/core-event-emitter
       - run:
           name: core-forger - unit
           command: >-
             cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-forger/
+            test:coverage /unit/core-forger/ --coverageDirectory
+            .coverage/unit/core-forger
       - run:
           name: core-http-utils - unit
           command: >-
             cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-http-utils/
+            test:coverage /unit/core-http-utils/ --coverageDirectory
+            .coverage/unit/core-http-utils
       - run:
           name: core-jest-matchers - unit
           command: >-
             cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-jest-matchers/
+            test:coverage /unit/core-jest-matchers/ --coverageDirectory
+            .coverage/unit/core-jest-matchers
       - run:
           name: core-logger - unit
           command: >-
             cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-logger/
+            test:coverage /unit/core-logger/ --coverageDirectory
+            .coverage/unit/core-logger
       - run:
           name: core-logger-pino - unit
           command: >-
             cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-logger-pino/
+            test:coverage /unit/core-logger-pino/ --coverageDirectory
+            .coverage/unit/core-logger-pino
       - run:
           name: core-p2p - unit
           command: >-
             cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-p2p/
+            test:coverage /unit/core-p2p/ --coverageDirectory
+            .coverage/unit/core-p2p
+      - run:
+          name: core-snapshots - unit
+          command: >-
+            cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
+            test:coverage /unit/core-snapshots/ --coverageDirectory
+            .coverage/unit/core-snapshots
       - run:
           name: core-json-rpc - integration
           command: >-
             cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /integration/core-json-rpc/
+            test:coverage /integration/core-json-rpc/ --coverageDirectory
+            .coverage/integration/core-json-rpc
       - run:
           name: core-p2p - integration
           command: >-
             cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /integration/core-p2p/
+            test:coverage /integration/core-p2p/ --coverageDirectory
+            .coverage/integration/core-p2p
       - run:
           name: Last 1000 lines of test output
           when: on_fail
@@ -648,10 +686,8 @@ jobs:
             - ./packages/core-json-rpc/node_modules
             - ./packages/core-logger/node_modules
             - ./packages/core-logger-pino/node_modules
-            - ./packages/core-logger-winston/node_modules
             - ./packages/core-p2p/node_modules
             - ./packages/core-snapshots/node_modules
-            - ./packages/core-test-utils/node_modules
             - ./packages/core-tester-cli/node_modules
             - ./packages/core-transaction-pool/node_modules
             - ./packages/core-utils/node_modules
@@ -663,45 +699,47 @@ jobs:
           name: Create .core/database directory
           command: mkdir -p $HOME/.core/database
       - run:
-          name: core-snapshots - unit
-          command: >-
-            cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-snapshots/
-      - run:
           name: core-tester-cli - unit
           command: >-
             cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-tester-cli/
+            test:coverage /unit/core-tester-cli/ --coverageDirectory
+            .coverage/unit/core-tester-cli
       - run:
           name: core-transaction-pool - unit
           command: >-
             cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-transaction-pool/
+            test:coverage /unit/core-transaction-pool/ --coverageDirectory
+            .coverage/unit/core-transaction-pool
       - run:
           name: core-utils - unit
           command: >-
             cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-utils/
+            test:coverage /unit/core-utils/ --coverageDirectory
+            .coverage/unit/core-utils
       - run:
           name: core-vote-report - unit
           command: >-
             cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-vote-report/
+            test:coverage /unit/core-vote-report/ --coverageDirectory
+            .coverage/unit/core-vote-report
       - run:
           name: core-webhooks - unit
           command: >-
             cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-webhooks/
+            test:coverage /unit/core-webhooks/ --coverageDirectory
+            .coverage/unit/core-webhooks
       - run:
           name: crypto - unit
           command: >-
             cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/crypto/
+            test:coverage /unit/crypto/ --coverageDirectory
+            .coverage/unit/crypto
       - run:
           name: core-transaction-pool - integration
           command: >-
             cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
             test:coverage /integration/core-transaction-pool/
+            --coverageDirectory .coverage/integration/core-transaction-pool
       - run:
           name: Last 1000 lines of test output
           when: on_fail

--- a/.circleci/generateConfig.js
+++ b/.circleci/generateConfig.js
@@ -42,7 +42,7 @@ fs.readdir("./packages", (_, packages) => {
                     .map(pkg => ({
                             run: {
                                 name: `${pkg} - ${testType}`,
-                                command: `${resetSqlCommand} && cd ~/core && yarn test:coverage /${testType}/${pkg}/`,
+                                command: `${resetSqlCommand} && cd ~/core && yarn test:coverage /${testType}/${pkg}/ --coverageDirectory .coverage/${testType}/${pkg}`,
                             },
                         })
                     )


### PR DESCRIPTION
## Proposed changes

Update circleci config to generate coverage for each package and each test type (unit / integration) in a different folder.
This fixes recent coverage issue as all coverage was generated in the same directory, each test step was overriding previous test step coverage.

## Types of changes

- [x] Build (changes that affect the build system)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes