### PR TITLE
refactor(core): exit start commands if the process is already running

### DIFF
--- a/packages/core/src/commands/command.ts
+++ b/packages/core/src/commands/command.ts
@@ -285,7 +285,7 @@ export abstract class BaseCommand extends Command {
     }
 
     protected async restartProcess(processName: string) {
-        if (processManager.isOnline(processName)) {
+        if (processManager.isRunning(processName)) {
             await confirm(`Would you like to restart the ${processName} process?`, () => {
                 try {
                     cli.action.start(`Restarting ${processName}`);

--- a/packages/core/src/process-manager.ts
+++ b/packages/core/src/process-manager.ts
@@ -43,11 +43,11 @@ class ProcessManager {
         }
     }
 
-    public isOnline(name: string): boolean {
+    public isRunning(name: string): boolean {
         return this.status(name) === ProcessState.Online;
     }
 
-    public isStopped(name: string): boolean {
+    public hasStopped(name: string): boolean {
         return this.status(name) === ProcessState.Stopped;
     }
 

--- a/packages/core/src/shared/start.ts
+++ b/packages/core/src/shared/start.ts
@@ -31,27 +31,15 @@ export abstract class AbstractStartCommand extends BaseCommand {
                     return;
                 }
 
-                if (processManager.isOnline(processName)) {
-                    const response = await prompts({
-                        type: "confirm",
-                        name: "confirm",
-                        message: "A process is already running, would you like to restart it?",
-                    });
-
-                    if (!response.confirm) {
-                        this.warn(`The "${processName}" process has not been restarted.`);
-                        return;
-                    }
+                if (processManager.isRunning(processName)) {
+                    this.warn(`The "${processName}" process is already running.`);
+                    return;
                 }
-
-                cli.action.start(`Restarting ${processName}`);
-
-                processManager.restart(processName);
-            } else {
-                cli.action.start(`Starting ${processName}`);
-
-                processManager.start(options, flags.daemon === false);
             }
+
+            cli.action.start(`Starting ${processName}`);
+
+            processManager.start(options, flags.daemon === false);
         } catch (error) {
             this.error(error.message);
         } finally {
@@ -60,7 +48,7 @@ export abstract class AbstractStartCommand extends BaseCommand {
     }
 
     protected abortWhenRunning(processName: string): void {
-        if (processManager.isOnline(processName)) {
+        if (processManager.isRunning(processName)) {
             this.warn(`The "${processName}" process is already running.`);
             process.exit();
         }

--- a/packages/core/src/shared/start.ts
+++ b/packages/core/src/shared/start.ts
@@ -22,12 +22,12 @@ export abstract class AbstractStartCommand extends BaseCommand {
         try {
             if (processManager.exists(processName)) {
                 if (processManager.hasUnknownState(processName)) {
-                    this.warn(`The "${processName}" process has entered an unknown state, aborting restart.`);
+                    this.warn(`The "${processName}" process has entered an unknown state, aborting start.`);
                     return;
                 }
 
                 if (processManager.hasErrored(processName)) {
-                    this.warn(`The "${processName}" process has previously errored, aborting restart.`);
+                    this.warn(`The "${processName}" process has previously errored, aborting start.`);
                     return;
                 }
 


### PR DESCRIPTION
## Proposed changes

Exit the start command if a process is already running, restart should be used instead for those cases.

Follow up to https://github.com/ArkEcosystem/core/pull/2178

## Types of changes

- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes