### PR TITLE
fix(core): pass the bip38 and password flags to the forger:run command

### DIFF
--- a/packages/core/src/commands/forger/start.ts
+++ b/packages/core/src/commands/forger/start.ts
@@ -37,6 +37,8 @@ $ ark forger:start --no-daemon
 
         try {
             const { bip38, password } = await this.buildBIP38(flags);
+            flags.bip38 = bip38;
+            flags.password = password;
 
             await this.runWithPm2(
                 {


### PR DESCRIPTION
## Proposed changes

`forger:run` would enter the interactive mode via `forger:start` as the required flags for non-interactive mode were missing.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes