### PR TITLE
feat(core): add support for reinstalling the current version

### DIFF
--- a/packages/core/src/commands/reinstall.ts
+++ b/packages/core/src/commands/reinstall.ts
@@ -20,13 +20,13 @@ export class ReinstallCommand extends BaseCommand {
         const { flags } = await this.parseWithNetwork(ReinstallCommand);
 
         if (flags.force) {
-            return this.execute(flags);
+            return this.performInstall(flags);
         }
 
         try {
             await confirm("Are you sure you want to reinstall?", async () => {
                 try {
-                    await this.execute(flags);
+                    await this.performInstall(flags);
                 } catch (err) {
                     this.error(err.message);
                 } finally {
@@ -38,7 +38,7 @@ export class ReinstallCommand extends BaseCommand {
         }
     }
     
-    private async execute(flags: CommandFlags, state: Record<string, any>): Promise<void> {
+    private async performInstall(flags: CommandFlags, state: Record<string, any>): Promise<void> {
         cli.action.start(`Reinstalling ${this.config.version}`);
 
         await installFromChannel(this.config.name, this.config.version);

--- a/packages/core/src/commands/reinstall.ts
+++ b/packages/core/src/commands/reinstall.ts
@@ -1,0 +1,54 @@
+import Chalk from "chalk";
+import cli from "cli-ux";
+import { removeSync } from "fs-extra";
+import { confirm } from "../helpers/prompts";
+import { checkForUpdates, installFromChannel } from "../helpers/update";
+import { BaseCommand } from "./command";
+import { CommandFlags } from "../types";
+import { flags } from "@oclif/command";
+
+export class ReinstallCommand extends BaseCommand {
+    public static description: string = "Reinstall the core";
+
+    public static flags: CommandFlags = {
+        force: flags.boolean({
+            description: "force a reinstall",
+        }),
+    };
+
+    public async run(): Promise<void> {
+        const { flags } = await this.parseWithNetwork(ReinstallCommand);
+
+        if (flags.force) {
+            return this.execute(flags);
+        }
+
+        try {
+            await confirm("Are you sure you want to reinstall?", async () => {
+                try {
+                    await this.execute(flags);
+                } catch (err) {
+                    this.error(err.message);
+                } finally {
+                    cli.action.stop();
+                }
+            });
+        } catch (err) {
+            this.error(err.message);
+        }
+    }
+    
+    private async execute(flags: CommandFlags, state: Record<string, any>): Promise<void> {
+        cli.action.start(`Reinstalling ${this.config.version}`);
+
+        await installFromChannel(this.config.name, this.config.version);
+        
+        cli.action.stop();
+
+        this.warn(`Version ${this.config.version} has been installed.`);
+
+        await this.restartProcess(`${flags.token}-core`);
+        await this.restartProcess(`${flags.token}-relay`);
+        await this.restartProcess(`${flags.token}-forger`);
+    }
+}

--- a/packages/core/src/commands/reinstall.ts
+++ b/packages/core/src/commands/reinstall.ts
@@ -38,7 +38,7 @@ export class ReinstallCommand extends BaseCommand {
         }
     }
     
-    private async performInstall(flags: CommandFlags, state: Record<string, any>): Promise<void> {
+    private async performInstall(flags: CommandFlags): Promise<void> {
         cli.action.start(`Reinstalling ${this.config.version}`);
 
         await installFromChannel(this.config.name, this.config.version);


### PR DESCRIPTION
## Proposed changes

Allow to reinstall the currently installed version in case something breaks.

**Fiddled this together on mobile, will test and finish it on monday.**

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes