### PR TITLE
fix(core): parse the network for the snapshot restore command

### DIFF
--- a/packages/core/src/commands/snapshot/restore.ts
+++ b/packages/core/src/commands/snapshot/restore.ts
@@ -31,7 +31,7 @@ export class RestoreCommand extends BaseCommand {
     };
 
     public async run(): Promise<void> {
-        const { flags } = this.parse(RestoreCommand);
+        const { flags } = await this.parseWithNetwork(RestoreCommand);
 
         await setUpLite(flags);
 


### PR DESCRIPTION
## Proposed changes

The `snapshot:restore` was not deciding what network to use if the `--network` flag was missing.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes