### PR TITLE
feat(core-api): add active delegates endpoint

### DIFF
--- a/__tests__/integration/core-api/v2/handlers/delegates.test.ts
+++ b/__tests__/integration/core-api/v2/handlers/delegates.test.ts
@@ -136,6 +136,25 @@ describe("API 2.0 - Delegates", () => {
         );
     });
 
+    describe("GET /delegates/active", () => {
+        describe.each([["API-Version", "request"], ["Accept", "requestWithAcceptHeader"]])(
+            "using the %s header",
+            (header, request) => {
+                it("should GET all the active delegates at a specified height", async () => {
+                    const activeDelegates = app.getConfig().getMilestone(1).activeDelegates;
+
+                    const response = await utils[request]("GET", "delegates/active", { height: 1 });
+                    expect(response).toBeSuccessfulResponse();
+                    expect(response.data.data).toBeArray();
+                    expect(response.data.data).toHaveLength(activeDelegates);
+
+                    response.data.data.forEach(utils.expectDelegate);
+                    expect(response.data.data.sort((a, b) => a.rank < b.rank)).toEqual(response.data.data);
+                });
+            },
+        );
+    });
+
     describe("GET /delegates/:id", () => {
         describe.each([["API-Version", "request"], ["Accept", "requestWithAcceptHeader"]])(
             "using the %s header",

--- a/__tests__/integration/core-api/v2/handlers/delegates.test.ts
+++ b/__tests__/integration/core-api/v2/handlers/delegates.test.ts
@@ -140,7 +140,19 @@ describe("API 2.0 - Delegates", () => {
         describe.each([["API-Version", "request"], ["Accept", "requestWithAcceptHeader"]])(
             "using the %s header",
             (header, request) => {
-                it("should GET all the active delegates at a specified height", async () => {
+                it("should GET all the active delegates at the current network height", async () => {
+                    const activeDelegates = app.getConfig().getMilestone().activeDelegates;
+
+                    const response = await utils[request]("GET", "delegates/active");
+                    expect(response).toBeSuccessfulResponse();
+                    expect(response.data.data).toBeArray();
+                    expect(response.data.data).toHaveLength(activeDelegates);
+
+                    response.data.data.forEach(utils.expectDelegate);
+                    expect(response.data.data.sort((a, b) => a.rank < b.rank)).toEqual(response.data.data);
+                });
+
+                it("should GET all the active delegates at the specified height", async () => {
                     const activeDelegates = app.getConfig().getMilestone(1).activeDelegates;
 
                     const response = await utils[request]("GET", "delegates/active", { height: 1 });

--- a/__tests__/unit/core-database/repositories/delegates-business-repository.test.ts
+++ b/__tests__/unit/core-database/repositories/delegates-business-repository.test.ts
@@ -405,10 +405,7 @@ describe("Delegate Repository", () => {
 
             expect(results).toBeArray();
             expect(results[0].username).toBeString();
-            expect(results[0].approval).toBeNumber();
-            expect(results[0].productivity).toBeNumber();
-            expect(results[0].approval).toBe(delegateCalculator.calculateApproval(delegate, height));
-            expect(results[0].productivity).toBe(delegateCalculator.calculateProductivity(delegate));
+            expect(results[0].username).toEqual(delegate.username);
         });
     });
 });

--- a/packages/core-api/src/versions/2/delegates/controller.ts
+++ b/packages/core-api/src/versions/2/delegates/controller.ts
@@ -14,6 +14,17 @@ export class DelegatesController extends Controller {
         }
     }
 
+    public async active(request: Hapi.Request, h: Hapi.ResponseToolkit) {
+        try {
+            // @ts-ignore
+            const data = await request.server.methods.v2.delegates.active(request);
+
+            return super.respondWithCache(data, h);
+        } catch (error) {
+            return Boom.badImplementation(error);
+        }
+    }
+
     public async show(request: Hapi.Request, h: Hapi.ResponseToolkit) {
         try {
             // @ts-ignore

--- a/packages/core-api/src/versions/2/delegates/methods.ts
+++ b/packages/core-api/src/versions/2/delegates/methods.ts
@@ -19,7 +19,9 @@ const index = async request => {
 };
 
 const active = async request => {
-    const delegates = await databaseService.delegates.getActiveAtHeight(request.query.height);
+    const delegates = await databaseService.delegates.getActiveAtHeight(
+        request.query.height || this.blockchain.getLastHeight()
+    );
 
     if (!delegates.length) {
         return Boom.notFound("Delegates not found");

--- a/packages/core-api/src/versions/2/delegates/methods.ts
+++ b/packages/core-api/src/versions/2/delegates/methods.ts
@@ -93,15 +93,14 @@ const voterBalances = async request => {
 };
 
 export function registerMethods(server) {
-    const blockTime = config.getMilestone().blocktime;
-    const activeDelegates = config.getMilestone().activeDelegates;
+    const { activeDelegates, blocktime } = config.getMilestone();
 
     ServerCache.make(server)
         .method("v2.delegates.index", index, 8, request => ({
             ...request.query,
             ...paginate(request),
         }))
-        .method("v2.delegates.active", active, blockTime * activeDelegates, request => ({
+        .method("v2.delegates.active", active, activeDelegates * blocktime, request => ({
             ...request.query
         }))
         .method("v2.delegates.show", show, 8, request => ({ id: request.params.id }))

--- a/packages/core-api/src/versions/2/delegates/methods.ts
+++ b/packages/core-api/src/versions/2/delegates/methods.ts
@@ -1,5 +1,5 @@
 import { app } from "@arkecosystem/core-container";
-import { Database } from "@arkecosystem/core-interfaces";
+import { Blockchain, Database } from "@arkecosystem/core-interfaces";
 import { orderBy } from "@arkecosystem/utils";
 import Boom from "boom";
 import { blocksRepository } from "../../../repositories";
@@ -8,6 +8,7 @@ import { paginate, respondWithResource, respondWithCollection, toPagination } fr
 
 const config = app.getConfig();
 const databaseService = app.resolvePlugin<Database.IDatabaseService>("database");
+const blockchain = app.resolvePlugin<Blockchain.IBlockchain>("blockchain");
 
 const index = async request => {
     const delegates = await databaseService.delegates.findAll({
@@ -20,7 +21,7 @@ const index = async request => {
 
 const active = async request => {
     const delegates = await databaseService.delegates.getActiveAtHeight(
-        request.query.height || this.blockchain.getLastHeight()
+        request.query.height || blockchain.getLastHeight()
     );
 
     if (!delegates.length) {

--- a/packages/core-api/src/versions/2/delegates/methods.ts
+++ b/packages/core-api/src/versions/2/delegates/methods.ts
@@ -6,6 +6,7 @@ import { blocksRepository } from "../../../repositories";
 import { ServerCache } from "../../../services";
 import { paginate, respondWithResource, respondWithCollection, toPagination } from "../utils";
 
+const config = app.getConfig();
 const databaseService = app.resolvePlugin<Database.IDatabaseService>("database");
 
 const index = async request => {
@@ -92,12 +93,15 @@ const voterBalances = async request => {
 };
 
 export function registerMethods(server) {
+    const blockTime = config.getMilestone().blocktime;
+    const activeDelegates = config.getMilestone().activeDelegates;
+
     ServerCache.make(server)
         .method("v2.delegates.index", index, 8, request => ({
             ...request.query,
             ...paginate(request),
         }))
-        .method("v2.delegates.active", active, 30, request => ({
+        .method("v2.delegates.active", active, blockTime * activeDelegates, request => ({
             ...request.query
         }))
         .method("v2.delegates.show", show, 8, request => ({ id: request.params.id }))

--- a/packages/core-api/src/versions/2/delegates/routes.ts
+++ b/packages/core-api/src/versions/2/delegates/routes.ts
@@ -17,6 +17,15 @@ export function registerRoutes(server: Hapi.Server): void {
 
     server.route({
         method: "GET",
+        path: "/delegates/active",
+        handler: controller.active,
+        options: {
+            validate: Schema.active,
+        },
+    });
+
+    server.route({
+        method: "GET",
         path: "/delegates/{id}",
         handler: controller.show,
         options: {

--- a/packages/core-api/src/versions/2/delegates/schema.ts
+++ b/packages/core-api/src/versions/2/delegates/schema.ts
@@ -78,8 +78,7 @@ export const active: object = {
     query: {
         height: Joi.number()
             .integer()
-            .min(1)
-            .required(),
+            .min(1),
     }
 };
 

--- a/packages/core-api/src/versions/2/delegates/schema.ts
+++ b/packages/core-api/src/versions/2/delegates/schema.ts
@@ -74,6 +74,15 @@ export const index: object = {
     },
 };
 
+export const active: object = {
+    query: {
+        height: Joi.number()
+            .integer()
+            .min(1)
+            .required(),
+    }
+};
+
 export const show: object = {
     params: {
         id: schemaIdentifier,

--- a/packages/core-database/src/repositories/delegates-business-repository.ts
+++ b/packages/core-database/src/repositories/delegates-business-repository.ts
@@ -150,13 +150,7 @@ export class DelegatesBusinessRepository implements Database.IDelegatesBusinessR
         const delegates = await this.databaseServiceProvider().getActiveDelegates(height);
 
         return delegates.map(delegate => {
-            const wallet = this.databaseServiceProvider().wallets.findById(delegate.publicKey);
-
-            return {
-                username: wallet.username,
-                approval: delegateCalculator.calculateApproval(delegate, height),
-                productivity: delegateCalculator.calculateProductivity(wallet),
-            };
+            return this.databaseServiceProvider().wallets.findById(delegate.publicKey);
         });
     }
 

--- a/packages/core-interfaces/src/core-database/business-repository/delegates-business-repository.ts
+++ b/packages/core-interfaces/src/core-database/business-repository/delegates-business-repository.ts
@@ -10,5 +10,5 @@ export interface IDelegatesBusinessRepository {
 
     findById(id: string): models.Wallet;
 
-    getActiveAtHeight(height: number): Promise<Array<{ username: string; approval: number; productivity: number }>>;
+    getActiveAtHeight(height: number): Promise<models.Wallet[]>;
 }

--- a/packages/core-p2p/src/peer-verifier.ts
+++ b/packages/core-p2p/src/peer-verifier.ts
@@ -300,7 +300,7 @@ export class PeerVerifier {
         // the last block in a round (so that the delegates calculations are still the same for
         // both chains).
 
-        const delegates = await this.getDelegates(round);
+        const delegates = await this.getDelegatesByRound(round);
 
         const hisBlocksByHeight = {};
 
@@ -327,7 +327,7 @@ export class PeerVerifier {
      * @param {Object} round to get delegates for
      * @return {Object} a map of { publicKey: delegate, ... } of all delegates for the given round
      */
-    private async getDelegates(round: any): Promise<any> {
+    private async getDelegatesByRound(round: any): Promise<any> {
         const numDelegates = round.maxDelegates;
 
         const heightOfFirstBlockInRound = (round.round - 1) * numDelegates + 1;

--- a/packages/core-p2p/src/peer-verifier.ts
+++ b/packages/core-p2p/src/peer-verifier.ts
@@ -324,7 +324,7 @@ export class PeerVerifier {
 
     /**
      * Get the delegates for the given round.
-     * @param {Object} round round to get delegates for
+     * @param {Object} round to get delegates for
      * @return {Object} a map of { publicKey: delegate, ... } of all delegates for the given round
      */
     private async getDelegates(round: any): Promise<any> {


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

Adds an additional endpoint to the delegates API to retrieve the active delegates at a certain height (use case: display rank changes in the explorer).

The `getActiveAtHeight` method was not being used anywhere, hence it took the liberty to modify it to the needs of this PR.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works