### PR TITLE
refactor(core-p2p): dont dump the reply when /peer/list validation fails

### DIFF
--- a/packages/core-p2p/src/peer.ts
+++ b/packages/core-p2p/src/peer.ts
@@ -422,9 +422,13 @@ export class Peer implements P2P.IPeer {
         const result = Joi.validate(reply, schema, { allowUnknown: true, convert: false });
 
         if (result.error) {
-            this.logger.error(
-                `Got unexpected reply from ${this.url}${endpoint}: ${JSON.stringify(reply)}: ` + result.error.message,
-            );
+            let errorMessage = result.error.message;
+            if (result.error.details && result.error.details.length > 0) {
+                const context = result.error.details[0].context;
+                errorMessage += ` - ${context.key}: ${context.value}`;
+            }
+
+            this.logger.error(`Got unexpected reply from ${this.url}${endpoint}: ${errorMessage}`);
             return false;
         }
 


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

```
[INFO]: Fetching a fresh peer list from http://185.170.115.40:4002
[ERROR]: Got unexpected reply from http://185.170.115.40:4002/peer/list: child "peers" fails because ["peers" at position 1 fails because [child "ip" fails because ["ip" must be a valid ip address with a forbidden CIDR]]] - ip: 2130706433
```

vs

```
[INFO]: Fetching a fresh peer list from http://185.170.115.40:4002
[ERROR]: Got unexpected reply from http://185.170.115.40:4002/peer/list: 
{"success":true,"peers":[{"ip":"2130706435","port":4002,"nethash":"2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867","milestoneHash":"3b7ee0793e2ddf23","version":"2.1.0","os":"linux","status":200,
    "height":1571996,"delay":3,"hashid":"fb0491af"},{"ip":"2130706433","port":4002,"nethash":"2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867","milestoneHash":"3b7ee0793e2ddf23","version":"2.1.0","os":"linux","status":200,
    "height":1571996,"delay":43,"hashid":"fb0491af"},{"ip":"2130706434","port":4002,"nethash":"2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867","milestoneHash":"3b7ee0793e2ddf23","version":"2.1.0","os":"linux","status":200,
    "height":1571996,"delay":43,"hashid":"fb0491af"},{"ip":"localhost","port":4002,"nethash":"2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867","milestoneHash":"3b7ee0793e2ddf23","version":"2.1.0","os":"linux","status":200,
    "height":1571996,"delay":48,"hashid":"fb0491af"},{"ip":"2130706436","port":4002,"nethash":"2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867","milestoneHash":"3b7ee0793e2ddf23","version":"2.1.0","os":"linux","status":200,
    "height":1571996,"delay":48,"hashid":"fb0491af"},{"ip":"94.16.113.187","port":4002,"nethash":"2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867","milestoneHash":"3b7ee0793e2ddf23","version":"2.1.0","os":"linux","status":200,
    "height":1264592,"delay":68,"hashid":"1c254aa0"},{"ip":"185.170.115.40","port":4002,"nethash":"2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867","milestoneHash":"3b7ee0793e2ddf23","version":"2.1.0","os":"linux","status":200,
    "height":1274218,"delay":70,"hashid":"1c254aa0"},{"ip":"37.59.70.165","port":4002,"nethash":"2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867","version":"2.2.0","os":"linux","status":200,
    "height":1720051,"delay":84,"hashid":"a3a98837"},{"ip":"213.32.9.98","port":4002,"nethash":"2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867","version":"2.2.0","os":"linux","status":200,
    "height":1720051,"delay":91,"hashid":"a3a98837"},{"ip":"213.32.9.97","port":4002,"nethash":"2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867","version":"2.2.0","os":"linux","status":200,
    "height":1720051,"delay":91,"hashid":"a3a98837"},{"ip":"167.114.29.43","port":4002,"nethash":"2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867","version":"2.2.0","os":"linux","status":200,
    "height":1720060,"delay":209,"hashid":"a3a98837"},{"ip":"167.114.29.53","port":4002,"nethash":"2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867","version":"2.2.0","os":"linux","status":200,
    "height":1720060,"delay":209,"hashid":"a3a98837"},{"ip":"167.114.43.33","port":4002,"nethash":"2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867","version":"2.2.0","os":"linux","status":200,
    "height":1720059,"delay":216,"hashid":"a3a98837"},{"ip":"167.114.29.47","port":4002,"nethash":"2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867","version":"2.2.0","os":"linux","status":200,
    "height":1720051,"delay":235,"hashid":"a3a98837"},{"ip":"167.114.29.33","port":4002,"nethash":"2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867","version":"2.2.0","os":"linux","status":200,
    "height":1720051,"delay":239,"hashid":"a3a98837"},{"ip":"167.114.43.38","port":4002,"nethash":"2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867","version":"2.2.0","os":"linux","status":200,
    "height":1720051,"delay":239,"hashid":"a3a98837"},{"ip":"167.114.29.45","port":4002,"nethash":"2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867","version":"2.2.0","os":"linux","status":200,
    "height":1720051,"delay":239,"hashid":"a3a98837"},{"ip":"167.114.29.42","port":4002,"nethash":"2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867","version":"2.2.0","os":"linux","status":200,
    "height":1720051,"delay":240,"hashid":"a3a98837"},{"ip":"167.114.29.37","port":4002,"nethash":"2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867","version":"2.2.0","os":"linux","status":200,
    "height":1720051,"delay":240,"hashid":"a3a98837"},{"ip":"167.114.43.34","port":4002,"nethash":"2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867","version":"2.2.0","os":"linux","status":200,
    "height":1720051,"delay":240,"hashid":"a3a98837"},{"ip":"167.114.29.38","port":4002,"nethash":"2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867","version":"2.2.0","os":"linux","status":200,
    "height":1720051,"delay":240,"hashid":"a3a98837"},{"ip":"167.114.43.36","port":4002,"nethash":"2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867","version":"2.2.0","os":"linux","status":200,
    "height":1720051,"delay":241,"hashid":"a3a98837"},{"ip":"167.114.29.40","port":4002,"nethash":"2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867","version":"2.2.0","os":"linux","status":200,
    "height":1720051,"delay":241,"hashid":"a3a98837"},{"ip":"167.114.43.42","port":4002,"nethash":"2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867","version":"2.2.0","os":"linux","status":200,
    "height":1720051,"delay":241,"hashid":"a3a98837"},{"ip":"167.114.29.50","port":4002,"nethash":"2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867","version":"2.2.0","os":"linux","status":200,
    "height":1720051,"delay":241,"hashid":"a3a98837"},{"ip":"167.114.43.40","port":4002,"nethash":"2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867","version":"2.2.0","os":"linux","status":200,
    "height":1720051,"delay":242,"hashid":"a3a98837"},{"ip":"167.114.43.41","port":4002,"nethash":"2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867","version":"2.2.0","os":"linux","status":200,
    "height":1720051,"delay":242,"hashid":"a3a98837"},{"ip":"167.114.29.34","port":4002,"nethash":"2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867","version":"2.2.0","os":"linux","status":200,
    "height":1720051,"delay":242,"hashid":"a3a98837"},{"ip":"167.114.29.55","port":4002,"nethash":"2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867","version":"2.2.0","os":"linux","status":200,
    "height":1720051,"delay":242,"hashid":"a3a98837"},{"ip":"167.114.29.60","port":4002,"nethash":"2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867","version":"2.2.0","os":"linux","status":200,
    "height":1720051,"delay":243,"hashid":"a3a98837"},{"ip":"167.114.43.37","port":4002,"nethash":"2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867","version":"2.2.0","os":"linux","status":200,
    "height":1720051,"delay":243,"hashid":"a3a98837"},{"ip":"167.114.29.41","port":4002,"nethash":"2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867","version":"2.2.0","os":"linux","status":200,
    "height":1720051,"delay":244,"hashid":"a3a98837"},{"ip":"167.114.29.51","port":4002,"nethash":"2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867","version":"2.2.0","os":"linux","status":200,
    "height":1720051,"delay":244,"hashid":"a3a98837"},{"ip":"167.114.29.36","port":4002,"nethash":"2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867","version":"2.2.0","os":"linux","status":200,
    "height":1720051,"delay":244,"hashid":"a3a98837"},{"ip":"167.114.29.58","port":4002,"nethash":"2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867","version":"2.2.0","os":"linux","status":200,
    "height":1720051,"delay":244,"hashid":"a3a98837"},{"ip":"167.114.43.39","port":4002,"nethash":"2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867","version":"2.2.0","os":"linux","status":200,
    "height":1720051,"delay":245,"hashid":"a3a98837"},{"ip":"167.114.43.43","port":4002,"nethash":"2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867","version":"2.2.0","os":"linux","status":200,
    "height":1720051,"delay":245,"hashid":"a3a98837"},{"ip":"167.114.29.46","port":4002,"nethash":"2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867","version":"2.2.0","os":"linux","status":200,
    "height":1720051,"delay":245,"hashid":"a3a98837"},{"ip":"167.114.29.57","port":4002,"nethash":"2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867","version":"2.2.0","os":"linux","status":200,
    "height":1720051,"delay":245,"hashid":"a3a98837"},{"ip":"167.114.29.54","port":4002,"nethash":"2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867","version":"2.2.0","os":"linux","status":200,
    "height":1720051,"delay":245,"hashid":"a3a98837"},{"ip":"167.114.29.59","port":4002,"nethash":"2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867","version":"2.2.0","os":"linux","status":200,
    "height":1720051,"delay":246,"hashid":"a3a98837"},{"ip":"167.114.29.44","port":4002,"nethash":"2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867","version":"2.2.0","os":"linux","status":200,
    "height":1720051,"delay":246,"hashid":"a3a98837"},{"ip":"167.114.29.39","port":4002,"nethash":"2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867","version":"2.2.0","os":"linux","status":200,
    "height":1720051,"delay":246,"hashid":"a3a98837"},{"ip":"167.114.29.56","port":4002,"nethash":"2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867","version":"2.2.0","os":"linux","status":200,
    "height":1720051,"delay":246,"hashid":"a3a98837"},{"ip":"167.114.29.49","port":4002,"nethash":"2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867","version":"2.2.0","os":"linux","status":200,
    "height":1720051,"delay":247,"hashid":"a3a98837"},{"ip":"167.114.29.61","port":4002,"nethash":"2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867","version":"2.2.0","os":"linux","status":200,
    "height":1720051,"delay":247,"hashid":"a3a98837"},{"ip":"167.114.29.48","port":4002,"nethash":"2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867","version":"2.2.0","os":"linux","status":200,
    "height":1720051,"delay":247,"hashid":"a3a98837"},{"ip":"167.114.29.52","port":4002,"nethash":"2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867","version":"2.2.0","os":"linux","status":200,
    "height":1720051,"delay":248,"hashid":"a3a98837"},{"ip":"167.114.43.35","port":4002,"nethash":"2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867","version":"2.2.0","os":"linux","status":200,
    "height":1720051,"delay":248,"hashid":"a3a98837"},{"ip":"167.114.29.35","port":4002,"nethash":"2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867","version":"2.2.0","os":"linux","status":200,
    "height":1720051,"delay":249,"hashid":"a3a98837"},{"ip":"138.197.79.32","port":4002,"nethash":"2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867","version":"2.2.0","os":"linux","status":200,
    "height":1720051,"delay":258,"hashid":"3bfaff3f"},{"ip":"167.114.43.44","port":4002,"nethash":"2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867","version":"2.2.0","os":"linux","status":200,
    "height":1720052,"delay":362,"hashid":"a3a98837"},{"ip":"167.114.43.46","port":4002,"nethash":"2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867","version":"2.2.0","os":"linux","status":200,
    "height":1720060,"delay":362,"hashid":"a3a98837"},{"ip":"167.114.43.49","port":4002,"nethash":"2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867","version":"2.2.0","os":"linux","status":200,
    "height":1720052,"delay":363,"hashid":"a3a98837"},{"ip":"104.223.26.36","port":4002,"nethash":"2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867","milestoneHash":"3b7ee0793e2ddf23","version":"2.1.2","os":"linux","status":200,
    "height":1720051,"delay":364,"hashid":"6c847f7f"},{"ip":"167.114.43.52","port":4002,"nethash":"2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867","version":"2.2.0","os":"linux","status":200,
    "height":1720052,"delay":366,"hashid":"a3a98837"},{"ip":"167.114.43.48","port":4002,"nethash":"2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867","version":"2.2.0","os":"linux","status":200,
    "height":1720051,"delay":392,"hashid":"a3a98837"},{"ip":"167.114.43.45","port":4002,"nethash":"2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867","version":"2.2.0","os":"linux","status":200,
    "height":1720051,"delay":396,"hashid":"a3a98837"},{"ip":"167.114.43.50","port":4002,"nethash":"2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867","version":"2.2.0","os":"linux","status":200,
    "height":1720051,"delay":397,"hashid":"a3a98837"},{"ip":"167.114.43.53","port":4002,"nethash":"2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867","version":"2.2.0","os":"linux","status":200,
    "height":1720051,"delay":397,"hashid":"a3a98837"},{"ip":"167.114.43.47","port":4002,"nethash":"2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867","version":"2.2.0","os":"linux","status":200,
    "height":1720051,"delay":399,"hashid":"a3a98837"},{"ip":"167.114.43.51","port":4002,"nethash":"2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867","version":"2.2.0","os":"linux","status":200,
    "height":1720051,"delay":401,"hashid":"a3a98837"},{"ip":"167.114.43.54","port":4002,"nethash":"2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867","version":"2.2.0","os":"linux","status":200,
    "height":1720059,"delay":2581,"hashid":"a3a98837"}]}: child "peers" fails because ["peers" at position 0 fails because [child "ip" fails because ["ip" must be a valid ip address with a forbidden CIDR]]]

```
## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [ ] Docs (documentation only changes)
- [ ] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [ ] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
