### PR TITLE
fix(core-transaction-pool): invalid transactions after rollback

### DIFF
--- a/packages/core-blockchain/src/state-storage.ts
+++ b/packages/core-blockchain/src/state-storage.ts
@@ -20,7 +20,7 @@ let _cachedTransactionIds: immutable.OrderedSet<string> = immutable.OrderedSet()
 
 // Map Block instances to block data.
 const _mapToBlockData = (blocks: immutable.Seq<number, models.Block>): immutable.Seq<number, models.IBlockData> =>
-    blocks.map(block => ({ ...block.data, transactions: block.transactions }));
+    blocks.map(block => ({ ...block.data, transactions: block.transactions.map(tx => tx.data) }));
 
 /**
  * Represents an in-memory storage for state machine data.

--- a/packages/core-transaction-pool/__tests__/connection.test.ts
+++ b/packages/core-transaction-pool/__tests__/connection.test.ts
@@ -161,9 +161,10 @@ describe("Connection", () => {
         it("should not add not-appliable transactions", () => {
             // This should be skipped due to insufficient funds
             const highFeeTransaction = new Transaction(mockData.dummy3);
-            highFeeTransaction.fee = bignumify(1e9 * SATOSHI);
+            highFeeTransaction.data.fee = bignumify(1e9 * SATOSHI);
             // changing public key as fixture transactions have the same one
-            highFeeTransaction.senderPublicKey = "000000000000000000000000000000000000000420000000000000000000000000";
+            highFeeTransaction.data.senderPublicKey =
+                "000000000000000000000000000000000000000420000000000000000000000000";
 
             const transactions = [
                 mockData.dummy1,

--- a/packages/core-transaction-pool/src/connection.ts
+++ b/packages/core-transaction-pool/src/connection.ts
@@ -181,7 +181,7 @@ export class TransactionPool implements transactionPool.ITransactionPool {
         const senderWallet = this.walletManager.findByPublicKey(transaction.senderPublicKey);
 
         const errors = [];
-        if (this.walletManager.canApply(transaction, errors)) {
+        if (this.walletManager.canApply(transaction.data, errors)) {
             senderWallet.applyTransactionToSender(transaction);
         } else {
             // Remove tx again from the pool


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
After a rollback, the transaction pool could end up with transactions where the block timestamp is used, therefore failing verification and resulting in invalid blocks:

_This does not apply to `develop`, because of the much stricter separation of the transaction data introduced with AIP29._

```
|ark-relay  | [2019-03-08 08:15:32][INFO]: Received new block at height 1,714,194 with 5 transactions from 127.0.0.1
8|ark-relay  | [2019-03-08 08:15:32][WARN]: Block 1,714,194 (2420495039909631961) disregarded because verification failed 📜
8|ark-relay  | [2019-03-08 08:15:32][WARN]: {
8|ark-relay  |     "verified": false,
8|ark-relay  |     "errors": [
8|ark-relay  |         "One or more transactions are not verified:",
8|ark-relay  |         "=> ff011e009ae4b0030296893488d335ff818391da7c450cfeb7821a4eb535b15b95808ea733915fbfb140420f00000000001862656e63686461726b202d204461696c79207061796f757440db740300000000000000001efd043bfbbd454d510a07fdb28907d789292fc1b1304402201acf15e55b974242b3745322bfdf311115dbf86602eae238710a6f03787d2e95022053250abcd98a8a4b186603d3753daaa9fb71663c62a8dc915745914406d9c110",
8|ark-relay  |         "=> ff011e009ae4b0030296893488d335ff818391da7c450cfeb7821a4eb535b15b95808ea733915fbfb140420f00000000001862656e63686461726b202d204461696c79207061796f7574fa15290500000000000000001e0d54486c57a8d4ca4852233e8d9c83bb86bec001304402204ad339493098dc3b38d99359ca6a49c610f85d0e0aec778c64002c74a7278e6102205860098a29feab87d001af95b0fc8503a3075375f7958b9b2513048636c69752",
8|ark-relay  |         "=> ff011e009ae4b0030296893488d335ff818391da7c450cfeb7821a4eb535b15b95808ea733915fbfb140420f00000000001b62656e63686461726b202d2064656c6567617465207061796f7574fd0d270700000000000000001e0d54486c57a8d4ca4852233e8d9c83bb86bec00130450221008d4ef5df30af086c92d55719d7bb4d7bf5e6ceafe911b437275acf5bf981dc40022072b2cda839a3f8a95a6b7172faef16ec3be57b0f611d8f6c13ac494a907ff9db",
8|ark-relay  |         "=> ff011e009ae4b0030296893488d335ff818391da7c450cfeb7821a4eb535b15b95808ea733915fbfb140420f00000000001862656e63686461726b202d204461696c79207061796f757474a45d0b00000000000000001ed9a13631caf6b663916aa0a776e36429830584aa304402204c2f27aa2b8cf3dd9e1fc4d6aefd62bd9cffabff10e46662c1c1b5779ec30df00220418684a5819d166d5a38bbac62dafb4fa3e0966844882ef0ffbf66b8c26abdc3",
8|ark-relay  |         "=> ff011e009ae4b0030296893488d335ff818391da7c450cfeb7821a4eb535b15b95808ea733915fbfb140420f00000000001862656e63686461726b202d204461696c79207061796f75740657540800000000000000001e9e40641d8999099d05c03c9bca79e95c36ea5f2f3045022100d0843aa21985b8bf71649c8f830c30eb8aabd7545a8bb30a8e04cff4c00468fb02200725cb3fd58070b3f4087096dc84fc0145cd011f62b7a1c59e3a7d97152ee961"
8|ark-relay  |     ]
8|ark-relay  | }
```

This also caused the following errors:
```
[2019-03-08 00:35:28][INFO]: Undoing block 1,713,199
[2019-03-08 00:35:28][INFO]: Undoing block 1,713,198
[2019-03-08 00:35:28][ERROR]: [PoolWalletManager] Can't apply transaction id:1208867d04c014381017e701574de1f51e7329258ceb8d0640e81628897c9f3c from sender:DJpFwW39QnQvQRQJF2MCfAoKvsX4DJ28jq due to ["Failed to verify second-signature"]
[2019-03-08 00:35:28][ERROR]: [PoolWalletManager] Can't apply transaction id:03b468516ac6659066b52d4a2bdd047099183170125fa248d6277bf85a483cc5 from sender:DJpFwW39QnQvQRQJF2MCfAoKvsX4DJ28jq due to ["Failed to verify second-signature"]
[2019-03-08 00:35:28][ERROR]: [PoolWalletManager] Can't apply transaction id:26eeb5ff0f11100cfbc2fde2ce0af38d7e779549b3f9adfd91a3fb174c0eda3d from sender:DJpFwW39QnQvQRQJF2MCfAoKvsX4DJ28jq due to ["Failed to verify second-signature"]
[2019-03-08 00:35:28][ERROR]: [PoolWalletManager] Can't apply transaction id:b633991f2d2ec85ec29cf48f9c54590ed3ca6e3c4211645a33031fe13cc05e60 from sender:DJpFwW39QnQvQRQJF2MCfAoKvsX4DJ28jq due to ["Failed to verify second-signature"]
[2019-03-08 00:35:28][ERROR]: [PoolWalletManager] Can't apply transaction id:ea77d055825472c1086abaca63a291328edd58f54ae49d7d00b51105c3d15be1 from sender:DJpFwW39QnQvQRQJF2MCfAoKvsX4DJ28jq due to ["Failed to verify second-signature"]
[2019-03-08 00:35:28][ERROR]: [PoolWalletManager] Can't apply transaction id:da9e0054e68ee2077a75c8dac10459d020453ddc21fe9c3f0e2c09cff25034ae from sender:DJpFwW39QnQvQRQJF2MCfAoKvsX4DJ28jq due to ["Failed to verify second-signature"]
[2019-03-08 00:35:28][INFO]: Undoing block 1,713,197
[2019-03-08 00:35:28][INFO]: Undoing block 1,713,196
[2019-03-08 00:35:28][INFO]: Undoing block 1,713,195
```

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [ ] Docs (documentation only changes)
- [ ] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [ ] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
