### PR TITLE
feat(core): add restart flags to update command

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -63,6 +63,7 @@
         "@arkecosystem/core-p2p": "^2.2.0-rc.0",
         "@arkecosystem/core-snapshots": "^2.2.0-rc.0",
         "@arkecosystem/core-transaction-pool": "^2.2.0-rc.0",
+        "@arkecosystem/core-utils": "^2.2.0-rc.0",
         "@arkecosystem/core-webhooks": "^2.2.0-rc.0",
         "@arkecosystem/crypto": "^2.2.0-rc.0",
         "@faustbrian/dato": "^0.1.0",

--- a/packages/core/src/commands/command.ts
+++ b/packages/core/src/commands/command.ts
@@ -284,19 +284,26 @@ export abstract class BaseCommand extends Command {
         return this.getNetworks().map(network => ({ title: network, value: network }));
     }
 
-    protected async restartProcess(processName: string) {
+    protected async restartProcess(processName: string, showPrompt: boolean = true) {
         if (processManager.isRunning(processName)) {
-            await confirm(`Would you like to restart the ${processName} process?`, () => {
-                try {
-                    cli.action.start(`Restarting ${processName}`);
+            if (showPrompt) {
+                await confirm(`Would you like to restart the ${processName} process?`, () => {
+                    this.restartRunningProcess(processName);
+                });
+            } else {
+                this.restartRunningProcess(processName);    
+            }
+        }
+    }
 
-                    processManager.restart(processName);
-                } catch (error) {
-                    this.error(error.message);
-                } finally {
-                    cli.action.stop();
-                }
-            });
+    protected restartRunningProcess(processName: string) {
+        try {
+            cli.action.start(`Restarting ${processName}`);
+            processManager.restart(processName);
+        } catch (error) {
+            this.error(error.message);
+        } finally {
+            cli.action.stop();
         }
     }
 

--- a/packages/core/src/commands/command.ts
+++ b/packages/core/src/commands/command.ts
@@ -291,12 +291,12 @@ export abstract class BaseCommand extends Command {
                     this.restartRunningProcess(processName);
                 });
             } else {
-                this.restartRunningProcess(processName);    
+                this.restartRunningProcess(processName);
             }
         }
     }
 
-    protected restartRunningProcess(processName: string) {
+    protected restartRunningProcess(processName: string): void {
         try {
             cli.action.start(`Restarting ${processName}`);
             processManager.restart(processName);

--- a/packages/core/src/commands/command.ts
+++ b/packages/core/src/commands/command.ts
@@ -284,19 +284,19 @@ export abstract class BaseCommand extends Command {
         return this.getNetworks().map(network => ({ title: network, value: network }));
     }
 
-    protected async restartProcess(processName: string, showPrompt: boolean = true) {
+    protected async restartRunningProcessPrompt(processName: string, showPrompt: boolean = true) {
         if (processManager.isRunning(processName)) {
             if (showPrompt) {
                 await confirm(`Would you like to restart the ${processName} process?`, () => {
-                    this.restartRunningProcess(processName);
+                    this.restartProcess(processName);
                 });
             } else {
-                this.restartRunningProcess(processName);
+                this.restartProcess(processName);
             }
         }
     }
 
-    protected restartRunningProcess(processName: string): void {
+    protected restartProcess(processName: string): void {
         try {
             cli.action.start(`Restarting ${processName}`);
             processManager.restart(processName);

--- a/packages/core/src/commands/config/cli.ts
+++ b/packages/core/src/commands/config/cli.ts
@@ -62,9 +62,9 @@ $ ark config:cli --channel=mine
 
             const { flags } = await this.parseWithNetwork(CommandLineInterfaceCommand);
 
-            await this.restartProcess(`${flags.token}-core`);
-            await this.restartProcess(`${flags.token}-relay`);
-            await this.restartProcess(`${flags.token}-forger`);
+            await this.restartRunningProcessPrompt(`${flags.token}-core`);
+            await this.restartRunningProcessPrompt(`${flags.token}-relay`);
+            await this.restartRunningProcessPrompt(`${flags.token}-forger`);
         } catch (err) {
             this.error(err.message);
         } finally {

--- a/packages/core/src/commands/reinstall.ts
+++ b/packages/core/src/commands/reinstall.ts
@@ -47,8 +47,8 @@ export class ReinstallCommand extends BaseCommand {
 
         this.warn(`Version ${this.config.version} has been installed.`);
 
-        await this.restartProcess(`${flags.token}-core`);
-        await this.restartProcess(`${flags.token}-relay`);
-        await this.restartProcess(`${flags.token}-forger`);
+        await this.restartRunningProcessPrompt(`${flags.token}-core`);
+        await this.restartRunningProcessPrompt(`${flags.token}-relay`);
+        await this.restartRunningProcessPrompt(`${flags.token}-forger`);
     }
 }

--- a/packages/core/src/commands/update.ts
+++ b/packages/core/src/commands/update.ts
@@ -83,26 +83,26 @@ export class UpdateCommand extends BaseCommand {
 
         if (this.hasRestartFlag(flags)) {
             if (flags.restart) {
-                this.restartProcess(`${flags.token}-core`, false);
-                this.restartProcess(`${flags.token}-relay`, false);
-                this.restartProcess(`${flags.token}-forger`, false);
+                this.restartRunningProcessPrompt(`${flags.token}-core`, false);
+                this.restartRunningProcessPrompt(`${flags.token}-relay`, false);
+                this.restartRunningProcessPrompt(`${flags.token}-forger`, false);
             } else {
                 if (flags.restartCore) {
-                    this.restartProcess(`${flags.token}-core`, false);
+                    this.restartRunningProcessPrompt(`${flags.token}-core`, false);
                 }
 
                 if (flags.restartRelay) {
-                    this.restartProcess(`${flags.token}-relay`, false);
+                    this.restartRunningProcessPrompt(`${flags.token}-relay`, false);
                 }
 
                 if (flags.restartForger) {
-                    this.restartProcess(`${flags.token}-forger`, false);
+                    this.restartRunningProcessPrompt(`${flags.token}-forger`, false);
                 }
             }
         } else {
-            await this.restartProcess(`${flags.token}-core`);
-            await this.restartProcess(`${flags.token}-relay`);
-            await this.restartProcess(`${flags.token}-forger`);
+            await this.restartRunningProcessPrompt(`${flags.token}-core`);
+            await this.restartRunningProcessPrompt(`${flags.token}-relay`);
+            await this.restartRunningProcessPrompt(`${flags.token}-forger`);
         }
     }
 

--- a/packages/core/src/commands/update.ts
+++ b/packages/core/src/commands/update.ts
@@ -6,6 +6,7 @@ import { confirm } from "../helpers/prompts";
 import { checkForUpdates, installFromChannel } from "../helpers/update";
 import { CommandFlags } from "../types";
 import { BaseCommand } from "./command";
+import { hasSomeProperty } from "@arkecosystem/core-utils";
 
 export class UpdateCommand extends BaseCommand {
     public static description: string = "Update the core installation";
@@ -13,6 +14,20 @@ export class UpdateCommand extends BaseCommand {
     public static flags: CommandFlags = {
         force: flags.boolean({
             description: "force an update",
+        }),
+        restart: flags.boolean({
+            description: "restart all running processes",
+            exclusive: ["restartCore", "restartRelay", "restartForger"],
+            allowNo: true,
+        }),
+        restartCore: flags.boolean({
+            description: "restart the core process",
+        }),
+        restartRelay: flags.boolean({
+            description: "restart the relay process",
+        }),
+        restartForger: flags.boolean({
+            description: "restart the forger process",
         }),
     };
 
@@ -66,8 +81,32 @@ export class UpdateCommand extends BaseCommand {
 
         this.warn(`Version ${state.newVersion} has been installed.`);
 
-        await this.restartProcess(`${flags.token}-core`);
-        await this.restartProcess(`${flags.token}-relay`);
-        await this.restartProcess(`${flags.token}-forger`);
+        if (this.hasRestartFlag(flags)) {
+            if (flags.restart) {
+                this.restartProcess(`${flags.token}-core`, false);
+                this.restartProcess(`${flags.token}-relay`, false);
+                this.restartProcess(`${flags.token}-forger`, false);
+            } else {
+                if (flags.restartCore) {
+                    this.restartProcess(`${flags.token}-core`, false);
+                }
+
+                if (flags.restartRelay) {
+                    this.restartProcess(`${flags.token}-relay`, false);
+                }
+
+                if (flags.restartForger) {
+                    this.restartProcess(`${flags.token}-forger`, false);
+                }
+            }
+        } else {
+            await this.restartProcess(`${flags.token}-core`);
+            await this.restartProcess(`${flags.token}-relay`);
+            await this.restartProcess(`${flags.token}-forger`);
+        }
+    }
+
+    private hasRestartFlag(flags: CommandFlags): boolean {
+        return hasSomeProperty(flags, ["restart", "restartCore", "restartRelay", "restartForger"]);
     }
 }


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

Adds the option to pass flags to the update command to specify the restart behaviour without prompting for user input:

- `--restart`: restarts all (running) processes
- `--no-restart`: no process will be restarted
- `--restart-core`: restarts the core process
- `--restart-relay`: restarts the relay process
- `--restart-forger`: restarts the forger process

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes