### PR TITLE
fix(core-blockchain): node stuck during sync 

### DIFF
--- a/packages/core-blockchain/src/state-machine.ts
+++ b/packages/core-blockchain/src/state-machine.ts
@@ -353,8 +353,10 @@ blockchainMachine.actionMap = (blockchain: Blockchain) => ({
                 blockchain.processQueue.clear();
             }
 
-            stateStorage.noBlockCounter++;
-            stateStorage.lastDownloadedBlock = stateStorage.getLastBlock();
+            if (blockchain.processQueue.length() === 0) {
+                stateStorage.noBlockCounter++;
+                stateStorage.lastDownloadedBlock = stateStorage.getLastBlock();
+            }
 
             blockchain.dispatch("NOBLOCK");
         }

--- a/packages/core-transaction-pool/src/connection.ts
+++ b/packages/core-transaction-pool/src/connection.ts
@@ -482,7 +482,7 @@ export class TransactionPool implements transactionPool.ITransactionPool {
 
             const senderWallet = this.walletManager.findByPublicKey(transaction.senderPublicKey);
             const errors = [];
-            if (senderWallet && senderWallet.canApply(transaction, errors)) {
+            if (senderWallet && senderWallet.canApply(transaction.data, errors)) {
                 senderWallet.applyTransactionToSender(transaction);
             } else {
                 logger.error(`BuildWallets from pool: ${JSON.stringify(errors)}`);


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Fixes a regression introduced by #2216.

```
ark-core  | [2019-03-10 05:19:57][DEBUG]: Delegate arkx (03bbfb43ecb5a54a1e227bb37b5812b5321213838d376e2b455b6af78442621dec) allowed to forge block 1,735,171 👍
0|ark-core  | [2019-03-10 05:19:57][DEBUG]: Delegate genesis_31 (027b320c5429334ecf846122492d12b898a756bf1347aa61f7bf1dcd706315a9fb) allowed to forge block 1,735,172 👍
0|ark-core  | [2019-03-10 05:19:57][DEBUG]: Delegate genesis_2 (0259d9ca7922c277b0e7407a88703bbb98f5da43a335b0eefa6c4642f072acfe79) allowed to forge block 1,735,173 👍
0|ark-core  | [2019-03-10 05:19:57][INFO]: Starting Round 34,024 🕊️
0|ark-core  | [2019-03-10 05:19:57][DEBUG]: Updating delegate statistics
0|ark-core  | [2019-03-10 05:19:57][DEBUG]: Delegate lol (03b383f3cb3c74d77ce0384412d996f9b617013758b38983f8ffa4115cc952cc62) just missed a block. Total: 71
0|ark-core  | [2019-03-10 05:19:57][DEBUG]: Delegate stevenhop (0304d0c477d634cc85d89c1a4afee8f51168d1747fe8fd79cabc26565e49eb8a7a) just missed a block. Total: 2685
0|ark-core  | [2019-03-10 05:19:57][DEBUG]: Delegate itsanametoo (0236d5232cdbd1e7ab87fad10ebe689c4557bc9d0c408b6773be964c837231d5f0) just missed a block. Total: 1588
0|ark-core  | [2019-03-10 05:19:57][DEBUG]: Delegate xillion (02d2a18dcb0dd7abd0a91ca70cb79d04e1ff7a4e77d1d8beda3d6c0a51b55a5db1) just missed a block. Total: 1483
0|ark-core  | [2019-03-10 05:19:57][DEBUG]: Delegate darkdel (03990f3668e883501ad3d583809f3420e2206176ccbb63ff242dd053e9ea5e8e4a) just missed a block. Total: 162
0|ark-core  | [2019-03-10 05:19:57][DEBUG]: Delegate dafty (03459978b705ff16949113189ba4306e7edcdeda015f1d7fe3f8864659f703014c) just missed a block. Total: 3300
0|ark-core  | [2019-03-10 05:19:57][DEBUG]: Delegate bioly (0284a88da69cc04439633217c6961d2800df0f7dff7f85b9803848ee02d0743f1d) just missed a block. Total: 5461
0|ark-core  | [2019-03-10 05:19:57][DEBUG]: Delegate darktoons (03a02b9d5fdd1307c2ee4652ba54d492d1fd11a7d1bb3f3a44c4a05e79f19de933) just missed a block. Total: 5475
0|ark-core  | [2019-03-10 05:19:57][INFO]: No new block found on this peer
0|ark-core  | [2019-03-10 05:19:57][DEBUG]: event 'NOBLOCK': {"syncWithNetwork":"downloadBlocks"} -> {"syncWithNetwork":"syncing"} -> actions: [checkLastDownloadedBlockSynced]
0|ark-core  | [2019-03-10 05:19:57][DEBUG]: Queued blocks (rebuild: 0 process: 42)
0|ark-core  | [2019-03-10 05:19:57][DEBUG]: event 'NOTSYNCED': {"syncWithNetwork":"syncing"} -> {"syncWithNetwork":"downloadBlocks"} -> actions: [downloadBlocks]
0|ark-core  | [2019-03-10 05:19:57][INFO]: Downloading blocks from height 1,735,172 via 167.114.29.57
0|ark-core  | [2019-03-10 05:19:57][INFO]: 43 modified wallets committed to database
0|ark-core  | [2019-03-10 05:19:57][DEBUG]: Loaded 51 active delegates
```

What basically happened is that when `downloadBlocks` returns no blocks, the last downloaded block is reset to the last chained block which in principle is fine, provided the process queue is empty otherwise the relay tries to download an already chained block which makes no sense.

<sub>Also fixes another oversight related to #2217.<sub>

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [ ] Docs (documentation only changes)
- [ ] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [ ] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
