### PR TITLE
chore: circleci restore caching + re-organize jobs for unit / integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,7 +151,7 @@ jobs:
           name: Unit tests
           command: >-
             cd ~/core && yarn test:unit:coverage --coverageDirectory
-            .coverage/unit/
+            .coverage/unit/ --maxWorkers=2
       - run:
           name: Last 1000 lines of test output
           when: on_fail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,47 +67,10 @@ jobs:
           name: Create .core/database directory
           command: mkdir -p $HOME/.core/database
       - run:
-          name: core-api - unit
+          name: Unit tests
           command: >-
-            cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-api/ --coverageDirectory
-            .coverage/unit/core-api
-      - run:
-          name: core-blockchain - unit
-          command: >-
-            cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-blockchain/ --coverageDirectory
-            .coverage/unit/core-blockchain
-      - run:
-          name: core-container - unit
-          command: >-
-            cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-container/ --coverageDirectory
-            .coverage/unit/core-container
-      - run:
-          name: core-database - unit
-          command: >-
-            cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-database/ --coverageDirectory
-            .coverage/unit/core-database
-      - run:
-          name: core-api - integration
-          command: >-
-            cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /integration/core-api/ --coverageDirectory
-            .coverage/integration/core-api
-      - run:
-          name: core-blockchain - integration
-          command: >-
-            cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /integration/core-blockchain/ --coverageDirectory
-            .coverage/integration/core-blockchain
-      - run:
-          name: core-database-postgres - integration
-          command: >-
-            cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /integration/core-database-postgres/
-            --coverageDirectory .coverage/integration/core-database-postgres
+            cd ~/core && yarn test:unit:coverage --coverageDirectory
+            .coverage/unit/
       - run:
           name: Last 1000 lines of test output
           when: on_fail
@@ -185,47 +148,10 @@ jobs:
           name: Create .core/database directory
           command: mkdir -p $HOME/.core/database
       - run:
-          name: core-api - unit
+          name: Unit tests
           command: >-
-            cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-api/ --coverageDirectory
-            .coverage/unit/core-api
-      - run:
-          name: core-blockchain - unit
-          command: >-
-            cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-blockchain/ --coverageDirectory
-            .coverage/unit/core-blockchain
-      - run:
-          name: core-container - unit
-          command: >-
-            cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-container/ --coverageDirectory
-            .coverage/unit/core-container
-      - run:
-          name: core-database - unit
-          command: >-
-            cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-database/ --coverageDirectory
-            .coverage/unit/core-database
-      - run:
-          name: core-api - integration
-          command: >-
-            cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /integration/core-api/ --coverageDirectory
-            .coverage/integration/core-api
-      - run:
-          name: core-blockchain - integration
-          command: >-
-            cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /integration/core-blockchain/ --coverageDirectory
-            .coverage/integration/core-blockchain
-      - run:
-          name: core-database-postgres - integration
-          command: >-
-            cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /integration/core-database-postgres/
-            --coverageDirectory .coverage/integration/core-database-postgres
+            cd ~/core && yarn test:unit:coverage --coverageDirectory
+            .coverage/unit/
       - run:
           name: Last 1000 lines of test output
           when: on_fail
@@ -303,53 +229,23 @@ jobs:
           name: Create .core/database directory
           command: mkdir -p $HOME/.core/database
       - run:
-          name: core-event-emitter - unit
+          name: core-api - integration
           command: >-
             cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-event-emitter/ --coverageDirectory
-            .coverage/unit/core-event-emitter
+            test:coverage /integration/core-api/ --coverageDirectory
+            .coverage/integration/core-api
       - run:
-          name: core-forger - unit
+          name: core-blockchain - integration
           command: >-
             cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-forger/ --coverageDirectory
-            .coverage/unit/core-forger
+            test:coverage /integration/core-blockchain/ --coverageDirectory
+            .coverage/integration/core-blockchain
       - run:
-          name: core-http-utils - unit
+          name: core-database-postgres - integration
           command: >-
             cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-http-utils/ --coverageDirectory
-            .coverage/unit/core-http-utils
-      - run:
-          name: core-jest-matchers - unit
-          command: >-
-            cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-jest-matchers/ --coverageDirectory
-            .coverage/unit/core-jest-matchers
-      - run:
-          name: core-logger - unit
-          command: >-
-            cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-logger/ --coverageDirectory
-            .coverage/unit/core-logger
-      - run:
-          name: core-logger-pino - unit
-          command: >-
-            cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-logger-pino/ --coverageDirectory
-            .coverage/unit/core-logger-pino
-      - run:
-          name: core-p2p - unit
-          command: >-
-            cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-p2p/ --coverageDirectory
-            .coverage/unit/core-p2p
-      - run:
-          name: core-snapshots - unit
-          command: >-
-            cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-snapshots/ --coverageDirectory
-            .coverage/unit/core-snapshots
+            test:coverage /integration/core-database-postgres/
+            --coverageDirectory .coverage/integration/core-database-postgres
       - run:
           name: core-forger - integration
           command: >-
@@ -362,12 +258,6 @@ jobs:
             cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
             test:coverage /integration/core-json-rpc/ --coverageDirectory
             .coverage/integration/core-json-rpc
-      - run:
-          name: core-p2p - integration
-          command: >-
-            cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /integration/core-p2p/ --coverageDirectory
-            .coverage/integration/core-p2p
       - run:
           name: Last 1000 lines of test output
           when: on_fail
@@ -444,36 +334,6 @@ jobs:
       - run:
           name: Create .core/database directory
           command: mkdir -p $HOME/.core/database
-      - run:
-          name: core-transaction-pool - unit
-          command: >-
-            cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-transaction-pool/ --coverageDirectory
-            .coverage/unit/core-transaction-pool
-      - run:
-          name: core-transactions - unit
-          command: >-
-            cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-transactions/ --coverageDirectory
-            .coverage/unit/core-transactions
-      - run:
-          name: core-utils - unit
-          command: >-
-            cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-utils/ --coverageDirectory
-            .coverage/unit/core-utils
-      - run:
-          name: core-webhooks - unit
-          command: >-
-            cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-webhooks/ --coverageDirectory
-            .coverage/unit/core-webhooks
-      - run:
-          name: crypto - unit
-          command: >-
-            cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/crypto/ --coverageDirectory
-            .coverage/unit/crypto
       - run:
           name: core-tester-cli - integration
           command: >-
@@ -575,53 +435,23 @@ jobs:
           name: Create .core/database directory
           command: mkdir -p $HOME/.core/database
       - run:
-          name: core-event-emitter - unit
+          name: core-api - integration
           command: >-
             cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-event-emitter/ --coverageDirectory
-            .coverage/unit/core-event-emitter
+            test:coverage /integration/core-api/ --coverageDirectory
+            .coverage/integration/core-api
       - run:
-          name: core-forger - unit
+          name: core-blockchain - integration
           command: >-
             cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-forger/ --coverageDirectory
-            .coverage/unit/core-forger
+            test:coverage /integration/core-blockchain/ --coverageDirectory
+            .coverage/integration/core-blockchain
       - run:
-          name: core-http-utils - unit
+          name: core-database-postgres - integration
           command: >-
             cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-http-utils/ --coverageDirectory
-            .coverage/unit/core-http-utils
-      - run:
-          name: core-jest-matchers - unit
-          command: >-
-            cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-jest-matchers/ --coverageDirectory
-            .coverage/unit/core-jest-matchers
-      - run:
-          name: core-logger - unit
-          command: >-
-            cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-logger/ --coverageDirectory
-            .coverage/unit/core-logger
-      - run:
-          name: core-logger-pino - unit
-          command: >-
-            cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-logger-pino/ --coverageDirectory
-            .coverage/unit/core-logger-pino
-      - run:
-          name: core-p2p - unit
-          command: >-
-            cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-p2p/ --coverageDirectory
-            .coverage/unit/core-p2p
-      - run:
-          name: core-snapshots - unit
-          command: >-
-            cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-snapshots/ --coverageDirectory
-            .coverage/unit/core-snapshots
+            test:coverage /integration/core-database-postgres/
+            --coverageDirectory .coverage/integration/core-database-postgres
       - run:
           name: core-forger - integration
           command: >-
@@ -634,12 +464,6 @@ jobs:
             cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
             test:coverage /integration/core-json-rpc/ --coverageDirectory
             .coverage/integration/core-json-rpc
-      - run:
-          name: core-p2p - integration
-          command: >-
-            cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /integration/core-p2p/ --coverageDirectory
-            .coverage/integration/core-p2p
       - run:
           name: Last 1000 lines of test output
           when: on_fail
@@ -717,36 +541,6 @@ jobs:
           name: Create .core/database directory
           command: mkdir -p $HOME/.core/database
       - run:
-          name: core-transaction-pool - unit
-          command: >-
-            cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-transaction-pool/ --coverageDirectory
-            .coverage/unit/core-transaction-pool
-      - run:
-          name: core-transactions - unit
-          command: >-
-            cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-transactions/ --coverageDirectory
-            .coverage/unit/core-transactions
-      - run:
-          name: core-utils - unit
-          command: >-
-            cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-utils/ --coverageDirectory
-            .coverage/unit/core-utils
-      - run:
-          name: core-webhooks - unit
-          command: >-
-            cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/core-webhooks/ --coverageDirectory
-            .coverage/unit/core-webhooks
-      - run:
-          name: crypto - unit
-          command: >-
-            cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
-            test:coverage /unit/crypto/ --coverageDirectory
-            .coverage/unit/crypto
-      - run:
           name: core-tester-cli - integration
           command: >-
             cd ~/core/.circleci && ./rebuild-db.sh && cd ~/core && yarn
@@ -785,8 +579,8 @@ workflows:
   build_and_test:
     jobs:
       - test-node10-0
+      - test-node11-0
       - test-node10-1
       - test-node10-2
-      - test-node11-0
       - test-node11-1
       - test-node11-2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
           key: 'core-node10-{{ checksum "checksum.txt" }}-1'
       - run:
           name: Install and build packages
-          command: yarn setup
+          command: yarn bootstrap && yarn build
       - save_cache:
           key: 'core-node10-{{ checksum "checksum.txt" }}-1'
           paths:
@@ -267,7 +267,7 @@ jobs:
           key: 'core-node10-{{ checksum "checksum.txt" }}-1'
       - run:
           name: Install and build packages
-          command: yarn setup
+          command: yarn bootstrap && yarn build
       - save_cache:
           key: 'core-node10-{{ checksum "checksum.txt" }}-1'
           paths:
@@ -409,7 +409,7 @@ jobs:
           key: 'core-node10-{{ checksum "checksum.txt" }}-1'
       - run:
           name: Install and build packages
-          command: yarn setup
+          command: yarn bootstrap && yarn build
       - save_cache:
           key: 'core-node10-{{ checksum "checksum.txt" }}-1'
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ jobs:
           name: Unit tests
           command: >-
             cd ~/core && yarn test:unit:coverage --coverageDirectory
-            .coverage/unit/
+            .coverage/unit/ --maxWorkers=2
       - run:
           name: Last 1000 lines of test output
           when: on_fail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,7 +149,7 @@ jobs:
           key: 'core-node11-{{ checksum "checksum.txt" }}-1'
       - run:
           name: Install and build packages
-          command: yarn setup
+          command: yarn bootstrap && yarn build
       - save_cache:
           key: 'core-node11-{{ checksum "checksum.txt" }}-1'
           paths:
@@ -539,7 +539,7 @@ jobs:
           key: 'core-node11-{{ checksum "checksum.txt" }}-1'
       - run:
           name: Install and build packages
-          command: yarn setup
+          command: yarn bootstrap && yarn build
       - save_cache:
           key: 'core-node11-{{ checksum "checksum.txt" }}-1'
           paths:
@@ -681,7 +681,7 @@ jobs:
           key: 'core-node11-{{ checksum "checksum.txt" }}-1'
       - run:
           name: Install and build packages
-          command: yarn setup
+          command: yarn bootstrap && yarn build
       - save_cache:
           key: 'core-node11-{{ checksum "checksum.txt" }}-1'
           paths:

--- a/.circleci/configTemplate.json
+++ b/.circleci/configTemplate.json
@@ -65,8 +65,8 @@
                 },
                 {
                     "run": {
-                        "name": "Test",
-                        "command": ""
+                        "name": "Unit tests",
+                        "command": "cd ~/core && yarn test:unit:coverage --coverageDirectory .coverage/unit/"
                     }
                 },
                 {
@@ -154,8 +154,8 @@
                 },
                 {
                     "run": {
-                        "name": "Test",
-                        "command": ""
+                        "name": "Unit tests",
+                        "command": "cd ~/core && yarn test:unit:coverage --coverageDirectory .coverage/unit/"
                     }
                 },
                 {
@@ -183,7 +183,7 @@
     "workflows": {
         "version": 2,
         "build_and_test": {
-            "jobs": []
+            "jobs": ["test-node10-0", "test-node11-0"]
         }
     }
 }

--- a/.circleci/configTemplate.json
+++ b/.circleci/configTemplate.json
@@ -155,7 +155,7 @@
                 {
                     "run": {
                         "name": "Unit tests",
-                        "command": "cd ~/core && yarn test:unit:coverage --coverageDirectory .coverage/unit/"
+                        "command": "cd ~/core && yarn test:unit:coverage --coverageDirectory .coverage/unit/ --maxWorkers=2"
                     }
                 },
                 {

--- a/.circleci/configTemplate.json
+++ b/.circleci/configTemplate.json
@@ -137,7 +137,7 @@
                 {
                     "run": {
                         "name": "Install and build packages",
-                        "command": "yarn setup"
+                        "command": "yarn bootstrap && yarn build"
                     }
                 },
                 {

--- a/.circleci/configTemplate.json
+++ b/.circleci/configTemplate.json
@@ -48,7 +48,7 @@
                 {
                     "run": {
                         "name": "Install and build packages",
-                        "command": "yarn setup"
+                        "command": "yarn bootstrap && yarn build"
                     }
                 },
                 {

--- a/.circleci/configTemplate.json
+++ b/.circleci/configTemplate.json
@@ -66,7 +66,7 @@
                 {
                     "run": {
                         "name": "Unit tests",
-                        "command": "cd ~/core && yarn test:unit:coverage --coverageDirectory .coverage/unit/"
+                        "command": "cd ~/core && yarn test:unit:coverage --coverageDirectory .coverage/unit/ --maxWorkers=2"
                     }
                 },
                 {


### PR DESCRIPTION
## Proposed changes

CircleCI builds were becoming slow, around 6-7min.

- Fixed caching : we were not using caching anymore because when doing `yarn setup` we'd basically remove all we had cached.
- Re-organized circleci jobs : 1 job for all unit tests, and 2 jobs for integration tests.

Now jobs are faster : 3-4min.

## Types of changes

- [x] Build (changes that affect the build system)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes