### PR TITLE
fix(core-tester-cli): Don't hide errors from HTTP failures

### DIFF
--- a/packages/core-tester-cli/src/http-client.ts
+++ b/packages/core-tester-cli/src/http-client.ts
@@ -1,4 +1,5 @@
 import axios from "axios";
+import { logger } from "./logger";
 
 export class HttpClient {
     private baseURL: any;
@@ -8,22 +9,24 @@ export class HttpClient {
     }
 
     public async get(path: string, params?: Record<string, any>, headers?: Record<string, any>): Promise<any> {
+        const fullURL = this.baseURL + path
         try {
-            const { data } = await axios.get(`${this.baseURL}${path}`, { params, headers });
+            const { data } = await axios.get(fullURL, { params, headers });
 
             return data;
         } catch (error) {
-            // do nothing...
+            logger.error(`${fullURL}: ${error.message}`);
         }
     }
 
     public async post(path: string, payload: Record<string, any>): Promise<any> {
+        const fullURL = this.baseURL + path
         try {
-            const { data } = await axios.post(`${this.baseURL}${path}`, payload);
+            const { data } = await axios.post(fullURL, payload);
 
             return data;
         } catch (error) {
-            // do nothing...
+            logger.error(`${fullURL}: ${error.message}`);
         }
     }
 }


### PR DESCRIPTION
Before this patch we would just get the following error, leaving one to
wonder what went wrong:

  [1552298227459] ERROR (core-tester-cli/40747 on smle): Cannot destructure property `data` of 'undefined' or 'null'.

After this patch:

  [1552299329734] ERROR (core-tester-cli/3408 on smle): http://localhost:4003/api/v2/node/configuration: connect ECONNREFUSED 127.0.0.1:4003
  [1552299329735] ERROR (core-tester-cli/3408 on smle): Cannot destructure property `data` of 'undefined' or 'null'.