### PR TITLE
refactor(core-forger): always use latest available height

### DIFF
--- a/__tests__/unit/core-forger/manager.test.ts
+++ b/__tests__/unit/core-forger/manager.test.ts
@@ -68,7 +68,10 @@ describe("Forger Manager", () => {
                 reward: 2 * 1e8,
             };
 
-            await forgeManager.__forgeNewBlock(del, round);
+            await forgeManager.__forgeNewBlock(del, round, {
+                lastBlockId: round.lastBlock.id,
+                nodeHeight: round.lastBlock.height,
+            });
 
             expect(forgeManager.client.broadcast).toHaveBeenCalledWith(
                 expect.objectContaining({

--- a/packages/core-p2p/src/network-state.ts
+++ b/packages/core-p2p/src/network-state.ts
@@ -39,7 +39,7 @@ class QuorumDetails {
      */
 
     /**
-     * Number of peers with a different last block id.
+     * Number of peers that are on a different chain (forked).
      */
     public peersForked = 0;
 

--- a/packages/core-p2p/src/network-state.ts
+++ b/packages/core-p2p/src/network-state.ts
@@ -34,18 +34,6 @@ class QuorumDetails {
     public peersOverHeightBlockHeaders: { [id: string]: any } = {};
 
     /**
-     * Number of peers which are up to N (=3) blocks below `nodeHeight`.
-     * In other words peers lower than `nodeHeight` - N are not considered for quorum.
-     */
-    public peersBelowHeightElasticity = 0;
-
-    /**
-     * Number of ignored peers (i.e height far below `nodeHeight`). Ignored peers
-     * are not used for quorum.
-     */
-    public peersQuorumIgnored = 0;
-
-    /**
      * The following properties are not mutual exclusive for a peer
      * and imply a peer is on the same `nodeHeight`.
      */
@@ -53,7 +41,7 @@ class QuorumDetails {
     /**
      * Number of peers with a different last block id.
      */
-    public peersDifferentBlockId = 0;
+    public peersForked = 0;
 
     /**
      * Number of peers with a different slot.
@@ -75,8 +63,8 @@ export enum NetworkStateStatus {
 }
 
 export class NetworkState {
-    private nodeHeight: number;
-    private lastBlockId: string;
+    public nodeHeight: number;
+    public lastBlockId: string;
     private quorumDetails: QuorumDetails;
 
     public constructor(readonly status: NetworkStateStatus, lastBlock?: any) {
@@ -157,34 +145,26 @@ export class NetworkState {
     }
 
     private update(peer: Peer, currentSlot: number) {
-        if (peer.state.height === this.nodeHeight) {
-            let quorum = true;
-            if (peer.state.header.id !== this.lastBlockId) {
-                quorum = false;
-                this.quorumDetails.peersDifferentBlockId++;
-            }
-
-            if (peer.state.currentSlot !== currentSlot) {
-                quorum = false;
-                this.quorumDetails.peersDifferentSlot++;
-            }
-
-            if (!peer.state.forgingAllowed) {
-                this.quorumDetails.peersForgingNotAllowed++;
-            }
-
-            quorum ? this.quorumDetails.peersQuorum++ : this.quorumDetails.peersNoQuorum++;
-        } else if (peer.state.height > this.nodeHeight) {
+        if (peer.state.height > this.nodeHeight) {
             this.quorumDetails.peersNoQuorum++;
             this.quorumDetails.peersOverHeight++;
             this.quorumDetails.peersOverHeightBlockHeaders[peer.state.header.id] = peer.state.header;
-        } else if (this.nodeHeight - peer.state.height < 3) {
-            // suppose the max network elasticity accross 3 blocks
-            this.quorumDetails.peersNoQuorum++;
-            this.quorumDetails.peersBelowHeightElasticity++;
         } else {
-            // Peers far below own height are ignored for quorum
-            this.quorumDetails.peersQuorumIgnored++;
+            if (peer.verification.forked) {
+                this.quorumDetails.peersNoQuorum++;
+                this.quorumDetails.peersForked++;
+            } else {
+                this.quorumDetails.peersQuorum++;
+            }
+        }
+
+        // Just statistics in case something goes wrong.
+        if (peer.state.currentSlot !== currentSlot) {
+            this.quorumDetails.peersDifferentSlot++;
+        }
+
+        if (!peer.state.forgingAllowed) {
+            this.quorumDetails.peersForgingNotAllowed++;
         }
     }
 }


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Always use the height as reported by the network state and simplify quorum calculation.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [ ] Docs (documentation only changes)
- [ ] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [ ] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
