### PR TITLE
fix(crypto): keep old vendor field padding

### DIFF
--- a/packages/crypto/src/transactions/serializers/transaction.ts
+++ b/packages/crypto/src/transactions/serializers/transaction.ts
@@ -6,7 +6,7 @@ import { TransactionTypes } from "../../constants";
 import { TransactionVersionError } from "../../errors";
 import { Address } from "../../identities";
 import { configManager } from "../../managers";
-import { Bignum, maxVendorFieldLength } from "../../utils";
+import { Bignum } from "../../utils";
 import { ITransactionData } from "../interfaces";
 import { Transaction } from "../types";
 
@@ -149,11 +149,11 @@ export class TransactionSerializer {
             for (let i = 0; i < fillstart; i++) {
                 bb.writeByte(vf[i]);
             }
-            for (let i = fillstart; i < maxVendorFieldLength(); i++) {
+            for (let i = fillstart; i < 64; i++) {
                 bb.writeByte(0);
             }
         } else {
-            for (let i = 0; i < maxVendorFieldLength(); i++) {
+            for (let i = 0; i < 64; i++) {
                 bb.writeByte(0);
             }
         }


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Don't touch the vendor field padding of the legacy serialization format. Unbreaks devnet for nodes on `develop` now that the vendorfield length milestone has been reached.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [ ] Docs (documentation only changes)
- [ ] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [ ] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
