### PR TITLE
docs: less noise in the GitHub PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,35 +1,41 @@
-## Proposed changes
+<!-- Please don't delete this template -->
+
+## Summary
+
 <!--
-Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
+Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to reference that issue with a keyword. https://help.github.com/en/articles/closing-issues-using-keywords
 -->
 
-## Types of changes
-<!--
-What types of changes does your code introduce?
-_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
--->
+## What kind of change does this PR introduce?
 
-- [ ] Bugfix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] Build (changes that affect the build system)
-- [ ] Docs (documentation only changes)
-- [ ] Test (adding missing tests or fixing existing tests)
-- [ ] Other... Please describe:
+<!-- _Put an `x` in the boxes that apply. -->
+
+- [ ] Bugfix
+- [ ] New feature
+- [ ] Refactoring / Performance Improvements
+- [ ] Build-related changes
+- [ ] Documentation
+- [ ] Tests / Continuous Integration
+- [ ] Other, please describe:
+
+## Does this PR introduce a breaking change?
+
+<!-- _Put an `x` in the boxes that apply. -->
+
+- [ ] Yes
+- [ ] No
 
 ## Checklist
-<!--
-_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
--->
+
+<!-- _Put an `x` in the boxes that apply. -->
 
 - [ ] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
 - [ ] Lint and unit tests pass locally with my changes
 - [ ] I have added tests that prove my fix is effective or that my feature works
-- [ ] I have added necessary documentation (if appropriate)
+- [ ] I have added necessary documentation _(if appropriate)_
+
+## Other information:
+
 <!--
-
-## Further comments
-
 If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,7 @@
 ## Summary
 
 <!--
-Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to reference that issue with a keyword. https://help.github.com/en/articles/closing-issues-using-keywords
+Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to reference the issue with a keyword. https://help.github.com/en/articles/closing-issues-using-keywords
 -->
 
 ## What kind of change does this PR introduce?
@@ -34,8 +34,8 @@ Describe the big picture of your changes here to communicate to the maintainers 
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] I have added necessary documentation _(if appropriate)_
 
-## Other information:
+## Other information
 
 <!--
-If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
+If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,8 @@
-<!-- Please don't delete this template -->
+<!-- Please don't delete this template and read our contribution guidelines at https://docs.ark.io/guidebook/contribution-guidelines/contributing.html -->
 
 ## Summary
 
-<!--
-Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to reference the issue with a keyword. https://help.github.com/en/articles/closing-issues-using-keywords
--->
+<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->
 
 ## What kind of change does this PR introduce?
 


### PR DESCRIPTION
## Proposed changes

Update the GitHub PR template to be less noisy and add an extra `breaking change` section.

## Types of changes

- [x] Other

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation