### PR TITLE
fix(tests): Reference the home directory via HOME, not ~

### DIFF
--- a/__tests__/utils/helpers/container.ts
+++ b/__tests__/utils/helpers/container.ts
@@ -8,7 +8,7 @@ import * as path from "path";
 export async function setUpContainer(options: any): Promise<Container.IContainer> {
     options.network = options.network || "testnet";
 
-    process.env.CORE_PATH_DATA = options.data || "~/.core";
+    process.env.CORE_PATH_DATA = options.data || `${process.env.HOME}/.core`;
     process.env.CORE_PATH_CONFIG = options.config
         ? options.config
         : path.resolve(__dirname, `../config/${options.network}`);


### PR DESCRIPTION
"~" is expanded by the shell, if we use it in JavaScript it will end up
creating directories like "./packages/core-p2p/~/.core/"

Use HOME from the environment instead. If it is not set, then trying
"/.core/..." is fine.