### PR TITLE
chore: add publish script for the next channel

### DIFF
--- a/deprecated/core-snapshots-cli/package.json
+++ b/deprecated/core-snapshots-cli/package.json
@@ -17,10 +17,6 @@
     },
     "scripts": {
         "snapshot": "./bin/run",
-        "publish:alpha": "npm publish --tag alpha",
-        "publish:beta": "npm publish --tag beta",
-        "publish:rc": "npm publish --tag rc",
-        "publish:latest": "npm publish --tag latest",
         "prepublishOnly": "yarn build",
         "prepack": "oclif-dev manifest && npm shrinkwrap",
         "postpack": "rm -f oclif.manifest.json",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
         "publish:alpha": "cross-env-shell ./scripts/publish/alpha.sh",
         "publish:beta": "cross-env-shell ./scripts/publish/beta.sh",
         "publish:rc": "cross-env-shell ./scripts/publish/rc.sh",
+        "publish:next": "cross-env-shell ./scripts/publish/next.sh",
         "publish:latest": "cross-env-shell ./scripts/publish/latest.sh",
         "upgrade": "cross-env-shell ./scripts/upgrade.sh",
         "version": "cross-env-shell ./scripts/version.sh",

--- a/packages/core-logger-pino/package.json
+++ b/packages/core-logger-pino/package.json
@@ -12,10 +12,6 @@
         "dist"
     ],
     "scripts": {
-        "publish:alpha": "npm publish --tag alpha",
-        "publish:beta": "npm publish --tag beta",
-        "publish:rc": "npm publish --tag rc",
-        "publish:stable": "npm publish --tag latest",
         "prepublishOnly": "yarn build",
         "compile": "../../node_modules/typescript/bin/tsc",
         "build": "yarn clean && yarn compile",

--- a/packages/core-tester-cli/package.json
+++ b/packages/core-tester-cli/package.json
@@ -18,10 +18,6 @@
     },
     "scripts": {
         "tester": "./bin/run",
-        "publish:alpha": "npm publish --tag alpha",
-        "publish:beta": "npm publish --tag beta",
-        "publish:rc": "npm publish --tag rc",
-        "publish:latest": "npm publish --tag latest",
         "prepublishOnly": "yarn build",
         "pretest": "bash ../../scripts/pre-test.sh",
         "prepack": "oclif-dev manifest && npm shrinkwrap",

--- a/packages/core-transactions/package.json
+++ b/packages/core-transactions/package.json
@@ -12,13 +12,9 @@
         "dist"
     ],
     "scripts": {
-        "publish:alpha": "npm publish --tag alpha",
-        "publish:beta": "npm publish --tag beta",
-        "publish:rc": "npm publish --tag rc",
-        "publish:stable": "npm publish --tag latest",
         "prepublishOnly": "yarn build",
         "compile": "../../node_modules/typescript/bin/tsc",
-        "build": "yarn clean && tsc",
+        "build": "yarn clean && yarn compile",
         "build:watch": "yarn clean && yarn compile -w",
         "clean": "del dist"
     },

--- a/scripts/publish/next.sh
+++ b/scripts/publish/next.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+for dir in `find packages -mindepth 1 -maxdepth 1 -type d`; do
+    cd $dir
+    echo $PWD
+    cd ../..
+    npm publish --tag next
+done


### PR DESCRIPTION
## Proposed changes

Adds a `next` channel so people don't need to switch channels on devnet between alpha/beta/rc.

## Types of changes

- [x] Other... Please describe:

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes