### PR TITLE
fix(core-webhooks): return an empty array if no webhooks exist for a …

### DIFF
--- a/packages/core-database/src/repositories/delegates-business-repository.ts
+++ b/packages/core-database/src/repositories/delegates-business-repository.ts
@@ -155,7 +155,7 @@ export class DelegatesBusinessRepository implements Database.IDelegatesBusinessR
         });
     }
 
-    private applyOrder(params): [CallbackFunctionVariadicVoidReturn|string, string] {
+    private applyOrder(params): [CallbackFunctionVariadicVoidReturn | string, string] {
         const assignOrder = (params, value) => (params.orderBy = value);
 
         if (!params.orderBy) {

--- a/packages/core-webhooks/src/database.ts
+++ b/packages/core-webhooks/src/database.ts
@@ -34,10 +34,12 @@ class Database {
     }
 
     public findByEvent(event) {
-        return this.database
-            .get("webhooks")
-            .find({ event })
-            .value();
+        return (
+            this.database
+                .get("webhooks")
+                .find({ event })
+                .value() || []
+        );
     }
 
     public create(data) {

--- a/packages/core-webhooks/src/index.ts
+++ b/packages/core-webhooks/src/index.ts
@@ -1,7 +1,7 @@
 import { Container, Logger } from "@arkecosystem/core-interfaces";
 import { database } from "./database";
 import { defaults } from "./defaults";
-import { webhookManager } from "./manager";
+import { WebhookManager } from "./manager";
 import { startServer } from "./server";
 
 export const plugin: Container.PluginDescriptor = {
@@ -16,7 +16,8 @@ export const plugin: Container.PluginDescriptor = {
 
         database.make();
 
-        await webhookManager.setUp();
+        const manager = new WebhookManager();
+        await manager.setUp();
 
         return startServer(options.server);
     },

--- a/packages/core-webhooks/src/manager.ts
+++ b/packages/core-webhooks/src/manager.ts
@@ -4,7 +4,7 @@ import { httpie } from "@arkecosystem/core-utils";
 import * as conditions from "./conditions";
 import { database } from "./database";
 
-class WebhookManager {
+export class WebhookManager {
     private readonly logger: Logger.ILogger = app.resolvePlugin<Logger.ILogger>("logger");
     private readonly emitter: EventEmitter.EventEmitter = app.resolvePlugin<EventEmitter.EventEmitter>("event-emitter");
     private readonly blockchain: Blockchain.IBlockchain = app.resolvePlugin<Blockchain.IBlockchain>("blockchain");
@@ -68,5 +68,3 @@ class WebhookManager {
         return matches;
     }
 }
-
-export const webhookManager = new WebhookManager();


### PR DESCRIPTION
## Proposed changes

Fixes `UnhandledPromiseRejectionWarning: TypeError: webhooks is not iterable` caused by `database.findByEvent` returning `undefined` instead of an empty array if the event doesn't exist.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
