### PR TITLE
fix(core-utils): handle NSect edge case

### DIFF
--- a/__tests__/unit/core-utils/nsect.test.ts
+++ b/__tests__/unit/core-utils/nsect.test.ts
@@ -108,6 +108,20 @@ describe("N-section (8-ary search)", () => {
         expect(numberOfProbeCalls).toBe(3);
     });
 
+    it("search in a narrow range", async () => {
+        numberOfProbeCalls = 0;
+        searchCondition = element => element <= 4000;
+        expect(data[await nSect.find(398, 402)]).toBe(4000);
+        expect(numberOfProbeCalls).toBe(1);
+    });
+
+    it("search in a range with length 9", async () => {
+        numberOfProbeCalls = 0;
+        searchCondition = element => element <= 4000;
+        expect(data[await nSect.find(398, 407)]).toBe(4000);
+        expect(numberOfProbeCalls).toBe(1);
+    });
+
     it("nonexistent", async () => {
         numberOfProbeCalls = 0;
         searchCondition = element => false;

--- a/packages/core-utils/src/nsect.ts
+++ b/packages/core-utils/src/nsect.ts
@@ -75,6 +75,20 @@ export class NSect {
             assert.notStrictEqual(indexOfHighestMatching, -1);
             assert(indexOfHighestMatching < indexesToProbe.length - 1);
 
+            if (indexesToProbe[indexOfHighestMatching] + 1 === indexesToProbe[indexOfHighestMatching + 1]) {
+                // In a narrow range, it may happen that:
+                // highestMatching = 1100
+                // indexesToProbe[0] = 1099, is a match
+                // indexesToProbe[1] = 1100, is a match
+                // indexesToProbe[2] = 1101, is not a match
+                // indexesToProbe[3] = 1103, is not a match
+                // indexOfHighestMatching = 1
+                // Then we know highestMatching is the definitive result because the probe
+                // declared that the data at index 1100 matches and the data at index 1101
+                // does not match.
+                break;
+            }
+
             low = highestMatching + 1;
             high = indexesToProbe[indexOfHighestMatching + 1] - 1;
         }


### PR DESCRIPTION
If the search range is narrowed too much then the condition
"if (low + this.nAry >= high) {" would catch it and return. But it could
happen that we still have neighboring elements and that condition is not
true.

Check whether the probe declared that the highest match is at some
height and if we have probed the next height - the fact that the next
height was not declared a match, implicitly means that it is not a
match. And if we have two neighboring heights, the lower one a match and
the higher one not, then we don't need to search further and have the
final result.