### PR TITLE
feat(core-logger-pino): set different log levels for console and file

### DIFF
--- a/__tests__/unit/core-logger-pino/logger.test.ts
+++ b/__tests__/unit/core-logger-pino/logger.test.ts
@@ -10,7 +10,12 @@ let message;
 beforeAll(() => {
     process.env.CORE_PATH_LOG = tmpdir();
 
-    const driver = new PinoLogger({ level: "trace" });
+    const driver = new PinoLogger({
+        levels: {
+            console: "trace",
+            file: "trace",
+        },
+    });
 
     logger = driver.make();
 

--- a/packages/core-logger-pino/src/defaults.ts
+++ b/packages/core-logger-pino/src/defaults.ts
@@ -1,3 +1,6 @@
 export const defaults = {
-    level: process.env.CORE_LOG_LEVEL || "debug",
+    levels: {
+        console: process.env.CORE_LOG_LEVEL || "debug",
+        file: process.env.CORE_LOG_LEVEL_FILE || "trace",
+    },
 };

--- a/packages/core-logger-pino/src/driver.ts
+++ b/packages/core-logger-pino/src/driver.ts
@@ -11,20 +11,16 @@ export class PinoLogger extends AbstractLogger {
     public logger: pino.Logger;
     public silent: boolean = false;
 
-    constructor(readonly options) {
-        super(options);
-    }
-
     public make() {
         this.logger = pino(
             {
                 base: null,
                 safe: true,
-                level: this.options.level,
+                level: this.options.levels.console,
             },
             multistream([
-                { level: this.options.level, stream: this.getConsoleStream() },
-                { level: "trace", stream: this.getFileStream() },
+                { level: this.options.levels.console, stream: this.getConsoleStream() },
+                { level: this.options.levels.file, stream: this.getFileStream() },
             ]),
         );
 


### PR DESCRIPTION
## Proposed changes

Allow different log levels for the console and files.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes