### PR TITLE
fix(core-p2p): pass all opts to the http client instead of just headers

### DIFF
--- a/packages/core-p2p/src/peer.ts
+++ b/packages/core-p2p/src/peer.ts
@@ -330,12 +330,12 @@ export class Peer implements P2P.IPeer {
      * Perform POST request.
      * @param  {String} endpoint
      * @param  {Object} body
-     * @param  {Object} headers
+     * @param  {Object} opts
      * @return {(Object|undefined)}
      */
-    public async __post(endpoint, body, headers) {
+    public async __post(endpoint, body, opts) {
         try {
-            const response = await httpie.post(`${this.url}${endpoint}`, { body, headers });
+            const response = await httpie.post(`${this.url}${endpoint}`, { body, ...opts });
 
             this.__parseHeaders(response);
 


### PR DESCRIPTION
## Proposed changes

The http client needs all options instead of just the headers which were passed in wrongly.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes