### PR TITLE
misc(crypto): Update devnet blockid milestone

### DIFF
--- a/packages/crypto/src/networks/devnet/milestones.json
+++ b/packages/crypto/src/networks/devnet/milestones.json
@@ -53,7 +53,7 @@
         "vendorFieldLength": 255
     },
     {
-        "height": 1840000,
+        "height": 1895000,
         "block": {
             "idFullSha256": true
         }


### PR DESCRIPTION
Height 1895000 at Mon Mar 25 16:56:22 CET 2019