### PR TITLE
chore: import lodash functions from function packages instead of the full lodash

### DIFF
--- a/__tests__/unit/core-database/repositories/wallets-business-repository.test.ts
+++ b/__tests__/unit/core-database/repositories/wallets-business-repository.test.ts
@@ -2,8 +2,8 @@ import "../mocks/core-container";
 
 import { Database } from "@arkecosystem/core-interfaces";
 import { Bignum, crypto } from "@arkecosystem/crypto";
-import compact from "lodash/compact";
-import uniq from "lodash/uniq";
+import compact from "lodash.compact";
+import uniq from "lodash.uniq";
 import { genesisBlock } from "../../../utils/fixtures/testnet/block-model";
 
 import { Wallet, WalletsBusinessRepository } from "../../../../packages/core-database/src";

--- a/__tests__/unit/core-snapshots/transport/codec/core/core.test.ts
+++ b/__tests__/unit/core-snapshots/transport/codec/core/core.test.ts
@@ -1,6 +1,6 @@
 /* tslint:disable:no-console */
 
-import pick from "lodash/pick";
+import pick from "lodash.pick";
 import msgpack from "msgpack-lite";
 
 import { blocks } from "../../../fixtures/blocks";

--- a/__tests__/utils/helpers/container.ts
+++ b/__tests__/utils/helpers/container.ts
@@ -2,7 +2,7 @@ import { app } from "@arkecosystem/core-container";
 import { Container } from "@arkecosystem/core-interfaces";
 import "@arkecosystem/core-jest-matchers";
 import { asValue } from "awilix";
-import isString from "lodash/isString";
+import isString from "lodash.isstring";
 import * as path from "path";
 
 export async function setUpContainer(options: any): Promise<Container.IContainer> {

--- a/deprecated/core-logger-winston/src/driver.ts
+++ b/deprecated/core-logger-winston/src/driver.ts
@@ -1,6 +1,6 @@
 import { AbstractLogger } from "@arkecosystem/core-logger";
 import "colors";
-import isEmpty from "lodash/isEmpty";
+import isEmpty from "lodash.isempty";
 import { inspect } from "util";
 import * as winston from "winston";
 

--- a/packages/core-api/src/repositories/repository.ts
+++ b/packages/core-api/src/repositories/repository.ts
@@ -1,6 +1,6 @@
 import { app } from "@arkecosystem/core-container";
 import { Database, TransactionPool } from "@arkecosystem/core-interfaces";
-import snakeCase from "lodash/snakeCase";
+import snakeCase from "lodash.snakecase";
 import { IRepository } from "../interfaces";
 
 // TODO: Deprecate this with v1

--- a/packages/core-api/src/repositories/transactions.ts
+++ b/packages/core-api/src/repositories/transactions.ts
@@ -1,7 +1,7 @@
 import { constants, slots } from "@arkecosystem/crypto";
 import { dato } from "@faustbrian/dato";
-import partition from "lodash/partition";
-import snakeCase from "lodash/snakeCase";
+import partition from "lodash.partition";
+import snakeCase from "lodash.snakecase";
 import { IRepository } from "../interfaces";
 import { Repository } from "./repository";
 import { buildFilterQuery } from "./utils/build-filter-query";

--- a/packages/core-container/src/config/index.ts
+++ b/packages/core-container/src/config/index.ts
@@ -1,6 +1,6 @@
 import { configManager as crypto, HashAlgorithms } from "@arkecosystem/crypto";
-import get from "lodash/get";
-import set from "lodash/set";
+import get from "lodash.get";
+import set from "lodash.set";
 import { fileLoader } from "./loaders";
 import { Network } from "./network";
 

--- a/packages/core-container/src/registrars/plugin.ts
+++ b/packages/core-container/src/registrars/plugin.ts
@@ -1,6 +1,6 @@
 import { asValue } from "awilix";
 import Hoek from "hoek";
-import isString from "lodash/isString";
+import isString from "lodash.isstring";
 import semver from "semver";
 
 export class PluginRegistrar {

--- a/packages/core-database-postgres/src/repositories/transactions.ts
+++ b/packages/core-database-postgres/src/repositories/transactions.ts
@@ -1,7 +1,7 @@
 import { Database } from "@arkecosystem/core-interfaces";
 import { slots } from "@arkecosystem/crypto";
 import { dato } from "@faustbrian/dato";
-import partition from "lodash/partition";
+import partition from "lodash.partition";
 import { Transaction } from "../models";
 import { queries } from "../queries";
 import { Repository } from "./repository";

--- a/packages/core-database/src/database-service.ts
+++ b/packages/core-database/src/database-service.ts
@@ -4,7 +4,7 @@ import { TransactionHandlerRegistry } from "@arkecosystem/core-transactions";
 import { roundCalculator } from "@arkecosystem/core-utils";
 import { Bignum, crypto, HashAlgorithms, models, Transaction } from "@arkecosystem/crypto";
 import assert from "assert";
-import cloneDeep from "lodash/cloneDeep";
+import cloneDeep from "lodash.clonedeep";
 
 import { WalletManager } from "./wallet-manager";
 

--- a/packages/core-database/src/repositories/utils/search-parameter-converter.ts
+++ b/packages/core-database/src/repositories/utils/search-parameter-converter.ts
@@ -1,5 +1,5 @@
 import { Database } from "@arkecosystem/core-interfaces";
-import snakeCase from "lodash/snakeCase";
+import snakeCase from "lodash.snakecase";
 
 export class SearchParameterConverter implements Database.ISearchParameterConverter {
     constructor(private databaseModel: Database.IDatabaseModel) {}

--- a/packages/core-forger/src/client.ts
+++ b/packages/core-forger/src/client.ts
@@ -3,7 +3,7 @@ import { Logger } from "@arkecosystem/core-interfaces";
 import { NetworkState, NetworkStateStatus } from "@arkecosystem/core-p2p";
 import { httpie } from "@arkecosystem/core-utils";
 import delay from "delay";
-import sample from "lodash/sample";
+import sample from "lodash.sample";
 import { URL } from "url";
 
 export class Client {

--- a/packages/core-forger/src/manager.ts
+++ b/packages/core-forger/src/manager.ts
@@ -3,8 +3,8 @@ import { Logger } from "@arkecosystem/core-interfaces";
 import { NetworkState, NetworkStateStatus } from "@arkecosystem/core-p2p";
 import { configManager, ITransactionData, models, slots, Transaction } from "@arkecosystem/crypto";
 import delay from "delay";
-import isEmpty from "lodash/isEmpty";
-import uniq from "lodash/uniq";
+import isEmpty from "lodash.isempty";
+import uniq from "lodash.uniq";
 import pluralize from "pluralize";
 
 import { Client } from "./client";

--- a/packages/core-interfaces/src/shared/config.ts
+++ b/packages/core-interfaces/src/shared/config.ts
@@ -1,5 +1,5 @@
-import get from "lodash/get";
-import set from "lodash/set";
+import get from "lodash.get";
+import set from "lodash.set";
 
 export class Config {
     private config: any;

--- a/packages/core-jest-matchers/src/api/block.ts
+++ b/packages/core-jest-matchers/src/api/block.ts
@@ -1,5 +1,5 @@
 import { sortBy } from "@arkecosystem/utils";
-import isEqual from "lodash/isEqual";
+import isEqual from "lodash.isequal";
 
 export {};
 

--- a/packages/core-jest-matchers/src/api/peer.ts
+++ b/packages/core-jest-matchers/src/api/peer.ts
@@ -1,5 +1,5 @@
 import { sortBy } from "@arkecosystem/utils";
-import isEqual from "lodash/isEqual";
+import isEqual from "lodash.isequal";
 
 export {};
 

--- a/packages/core-jest-matchers/src/api/transaction.ts
+++ b/packages/core-jest-matchers/src/api/transaction.ts
@@ -1,5 +1,5 @@
 import { sortBy } from "@arkecosystem/utils";
-import isEqual from "lodash/isEqual";
+import isEqual from "lodash.isequal";
 
 export {};
 

--- a/packages/core-jest-matchers/src/blockchain/execute-on-entry.ts
+++ b/packages/core-jest-matchers/src/blockchain/execute-on-entry.ts
@@ -1,5 +1,5 @@
-import get from "lodash/get";
-import isEqual from "lodash/isEqual";
+import get from "lodash.get";
+import isEqual from "lodash.isequal";
 
 export {};
 

--- a/packages/core-jest-matchers/src/models/delegate.ts
+++ b/packages/core-jest-matchers/src/models/delegate.ts
@@ -1,5 +1,5 @@
 import { sortBy } from "@arkecosystem/utils";
-import isEqual from "lodash/isEqual";
+import isEqual from "lodash.isequal";
 
 export {};
 

--- a/packages/core-jest-matchers/src/models/transaction.ts
+++ b/packages/core-jest-matchers/src/models/transaction.ts
@@ -1,5 +1,5 @@
 import { sortBy } from "@arkecosystem/utils";
-import isEqual from "lodash/isEqual";
+import isEqual from "lodash.isequal";
 
 export {};
 

--- a/packages/core-jest-matchers/src/models/wallet.ts
+++ b/packages/core-jest-matchers/src/models/wallet.ts
@@ -1,5 +1,5 @@
 import { sortBy } from "@arkecosystem/utils";
-import isEqual from "lodash/isEqual";
+import isEqual from "lodash.isequal";
 
 export {};
 

--- a/packages/core-json-rpc/src/server/services/network.ts
+++ b/packages/core-json-rpc/src/server/services/network.ts
@@ -3,7 +3,7 @@ import { Logger, P2P } from "@arkecosystem/core-interfaces";
 import { httpie } from "@arkecosystem/core-utils";
 import { configManager } from "@arkecosystem/crypto";
 import isReachable from "is-reachable";
-import sample from "lodash/sample";
+import sample from "lodash.sample";
 
 class Network {
     private peers: any;

--- a/packages/core-json-rpc/src/server/services/processor.ts
+++ b/packages/core-json-rpc/src/server/services/processor.ts
@@ -1,5 +1,5 @@
 import Joi from "joi";
-import get from "lodash/get";
+import get from "lodash.get";
 import { network } from "./network";
 
 export class Processor {

--- a/packages/core-logger-pino/src/driver.ts
+++ b/packages/core-logger-pino/src/driver.ts
@@ -1,6 +1,6 @@
 import { AbstractLogger } from "@arkecosystem/core-logger";
 import { WriteStream } from "fs";
-import isEmpty from "lodash/isEmpty";
+import isEmpty from "lodash.isempty";
 import pino, { PrettyOptions } from "pino";
 import PinoPretty from "pino-pretty";
 import pump from "pump";

--- a/packages/core-p2p/src/court/guard.ts
+++ b/packages/core-p2p/src/court/guard.ts
@@ -1,8 +1,8 @@
 import { app } from "@arkecosystem/core-container";
 import { Logger } from "@arkecosystem/core-interfaces";
 import { dato, Dato } from "@faustbrian/dato";
-import head from "lodash/head";
-import sumBy from "lodash/sumBy";
+import head from "lodash.head";
+import sumBy from "lodash.sumby";
 import prettyMs from "pretty-ms";
 import semver from "semver";
 

--- a/packages/core-p2p/src/monitor.ts
+++ b/packages/core-p2p/src/monitor.ts
@@ -6,10 +6,10 @@ import { slots } from "@arkecosystem/crypto";
 import { dato, Dato } from "@faustbrian/dato";
 import delay from "delay";
 import fs from "fs";
-import groupBy from "lodash/groupBy";
-import sample from "lodash/sample";
-import shuffle from "lodash/shuffle";
-import take from "lodash/take";
+import groupBy from "lodash.groupby";
+import sample from "lodash.sample";
+import shuffle from "lodash.shuffle";
+import take from "lodash.take";
 import pluralize from "pluralize";
 import prettyMs from "pretty-ms";
 

--- a/packages/core-p2p/src/utils/check-dns.ts
+++ b/packages/core-p2p/src/utils/check-dns.ts
@@ -1,7 +1,7 @@
 import { app } from "@arkecosystem/core-container";
 import { Logger } from "@arkecosystem/core-interfaces";
 import dns from "dns";
-import shuffle from "lodash/shuffle";
+import shuffle from "lodash.shuffle";
 import util from "util";
 
 export const checkDNS = async hosts => {

--- a/packages/core-p2p/src/utils/check-ntp.ts
+++ b/packages/core-p2p/src/utils/check-ntp.ts
@@ -1,6 +1,6 @@
 import { app } from "@arkecosystem/core-container";
 import { Logger } from "@arkecosystem/core-interfaces";
-import shuffle from "lodash/shuffle";
+import shuffle from "lodash.shuffle";
 import Sntp from "sntp";
 
 /**

--- a/packages/core-snapshots/src/manager.ts
+++ b/packages/core-snapshots/src/manager.ts
@@ -3,7 +3,7 @@
 import { app } from "@arkecosystem/core-container";
 import { PostgresConnection } from "@arkecosystem/core-database-postgres";
 import { Logger } from "@arkecosystem/core-interfaces";
-import pick from "lodash/pick";
+import pick from "lodash.pick";
 
 const logger = app.resolvePlugin<Logger.ILogger>("logger");
 import { database } from "./db";

--- a/packages/core-transaction-pool/src/dynamic-fee/matcher.ts
+++ b/packages/core-transaction-pool/src/dynamic-fee/matcher.ts
@@ -1,7 +1,7 @@
 import { app } from "@arkecosystem/core-container";
 import { Logger } from "@arkecosystem/core-interfaces";
 import { Bignum, constants, feeManager, formatSatoshi, Transaction } from "@arkecosystem/crypto";
-import camelCase from "lodash/camelCase";
+import camelCase from "lodash.camelcase";
 import { config as localConfig } from "../config";
 
 /**

--- a/packages/core-vote-report/src/handler.ts
+++ b/packages/core-vote-report/src/handler.ts
@@ -2,7 +2,7 @@ import { app } from "@arkecosystem/core-container";
 import { Blockchain, Database } from "@arkecosystem/core-interfaces";
 import { delegateCalculator, supplyCalculator } from "@arkecosystem/core-utils";
 import { Bignum, configManager } from "@arkecosystem/crypto";
-import sumBy from "lodash/sumBy";
+import sumBy from "lodash.sumby";
 
 export function handler(request, h) {
     const config = app.getConfig();

--- a/packages/core/src/hooks/command_not_found/suggest.ts
+++ b/packages/core/src/hooks/command_not_found/suggest.ts
@@ -3,7 +3,7 @@
 import { Hook } from "@oclif/config";
 import Chalk from "chalk";
 import * as Levenshtein from "fast-levenshtein";
-import minBy from "lodash/minBy";
+import minBy from "lodash.minby";
 import { confirm } from "../../helpers/prompts";
 
 function closest(commandIDs: string[], cmd: string) {

--- a/packages/crypto/src/managers/config.ts
+++ b/packages/crypto/src/managers/config.ts
@@ -1,7 +1,7 @@
 import deepmerge from "deepmerge";
-import camelCase from "lodash/camelCase";
-import get from "lodash/get";
-import set from "lodash/set";
+import camelCase from "lodash.camelcase";
+import get from "lodash.get";
+import set from "lodash.set";
 
 import { TransactionTypes } from "../constants";
 import * as networks from "../networks";

--- a/packages/crypto/src/managers/network.ts
+++ b/packages/crypto/src/managers/network.ts
@@ -1,4 +1,4 @@
-import get from "lodash/get";
+import get from "lodash.get";
 import * as networks from "../networks";
 import { NetworkName } from "./config";
 

--- a/packages/crypto/src/transactions/registry.ts
+++ b/packages/crypto/src/transactions/registry.ts
@@ -1,4 +1,4 @@
-import camelCase from "lodash/camelCase";
+import camelCase from "lodash.camelcase";
 import { TransactionTypes } from "../constants";
 import {
     MissingMilestoneFeeError,


### PR DESCRIPTION
## Proposed changes

lodash functions were imported from a full lodash installation that is not present outside of lerna instead of using the single function dependencies.

## Types of changes

- [x] Other... Please describe:

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes