### PR TITLE
fix(core-database-postgres): support PG9.5 for asset column migration

### DIFF
--- a/packages/core-database-postgres/src/migrations/20190313000000-add-asset-column-to-transactions-table.sql
+++ b/packages/core-database-postgres/src/migrations/20190313000000-add-asset-column-to-transactions-table.sql
@@ -1,1 +1,2 @@
-ALTER TABLE transactions ADD COLUMN IF NOT EXISTS asset JSONB;
+ALTER TABLE transactions DROP COLUMN IF EXISTS asset;
+ALTER TABLE transactions ADD COLUMN asset JSONB;


### PR DESCRIPTION
## Proposed changes

Support PG9.5 for asset column migration

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
