### PR TITLE
fix(core-database): sort transactions by timestamp:desc by default

### DIFF
--- a/__tests__/unit/core-database/repositories/transactions-business-repository.test.ts
+++ b/__tests__/unit/core-database/repositories/transactions-business-repository.test.ts
@@ -117,6 +117,10 @@ describe("Transactions Business Repository", () => {
                     ],
                     orderBy: [
                         {
+                            field: "timestamp",
+                            direction: "desc",
+                        },
+                        {
                             field: "sequence",
                             direction: "asc",
                         },

--- a/packages/core-database/src/repositories/transactions-business-repository.ts
+++ b/packages/core-database/src/repositories/transactions-business-repository.ts
@@ -195,6 +195,14 @@ export class TransactionsBusinessRepository implements Database.ITransactionsBus
             };
         }
 
+        if (!searchParameters.orderBy.length) {
+            // default order-by
+            searchParameters.orderBy.push({
+                field: "timestamp",
+                direction: "desc",
+            });
+        }
+
         searchParameters.orderBy.push({
             field: "sequence",
             direction: sequenceOrder,


### PR DESCRIPTION
## Proposed changes

Default sorting by timestamps was missing for transactions.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes