### PR TITLE
feat(core-snapshots): rollback by a given amount of blocks

### DIFF
--- a/packages/core-snapshots/src/manager.ts
+++ b/packages/core-snapshots/src/manager.ts
@@ -79,7 +79,7 @@ export class SnapshotManager {
         this.database.close();
     }
 
-    public async rollbackChain(height) {
+    public async rollbackByHeight(height) {
         const lastBlock = await this.database.getLastBlock();
         const config = app.getConfig();
         const maxDelegates = config.getMilestone(lastBlock.height).activeDelegates;
@@ -109,6 +109,12 @@ export class SnapshotManager {
         );
 
         this.database.close();
+    }
+
+    public async rollbackByNumber(amount: number) {
+        const lastBlock = await this.database.getLastBlock();
+
+        return this.rollbackByHeight(lastBlock.height - amount);
     }
 
     /**

--- a/packages/core-snapshots/src/manager.ts
+++ b/packages/core-snapshots/src/manager.ts
@@ -80,31 +80,32 @@ export class SnapshotManager {
     }
 
     public async rollbackByHeight(height) {
-        const lastBlock = await this.database.getLastBlock();
-        const config = app.getConfig();
-        const maxDelegates = config.getMilestone(lastBlock.height).activeDelegates;
+        if (!height) {
+            app.forceExit(`Specified rollback block height: ${height.toLocaleString()} is not valid.`);
+        }
 
-        const rollBackHeight = height === -1 ? lastBlock.height : height;
-        if (rollBackHeight >= lastBlock.height || rollBackHeight < 1) {
+        const currentHeight = (await this.database.getLastBlock()).height;
+        const { activeDelegates } = app.getConfig().getMilestone(currentHeight);
+
+        if (height >= currentHeight) {
             app.forceExit(
-                `Specified rollback block height: ${rollBackHeight.toLocaleString()} is not valid. Current database height: ${lastBlock.height.toLocaleString()}. Exiting.`,
+                `Rollback height ${height.toLocaleString()} is greater than the current height ${currentHeight.toLocaleString()}.`,
             );
         }
 
-        if (height) {
-            const rollBackBlock = await this.database.getBlockByHeight(rollBackHeight);
-            const qTransactionBackup = await this.database.getTransactionsBackupQuery(rollBackBlock.timestamp);
-            await backupTransactionsToJSON(
-                `rollbackTransactionBackup.${+height + 1}.${lastBlock.height}.json`,
-                qTransactionBackup,
-                this.database,
-            );
-        }
+        const rollbackBlock = await this.database.getBlockByHeight(height);
+        const queryTransactionBackup = await this.database.getTransactionsBackupQuery(rollbackBlock.timestamp);
 
-        const newLastBlock = await this.database.rollbackChain(rollBackHeight);
+        await backupTransactionsToJSON(
+            `rollbackTransactionBackup.${+height + 1}.${currentHeight}.json`,
+            queryTransactionBackup,
+            this.database,
+        );
+
+        const newLastBlock = await this.database.rollbackChain(height);
         logger.info(
             `Rolling back chain to last finished round ${(
-                newLastBlock.height / maxDelegates
+                newLastBlock.height / activeDelegates
             ).toLocaleString()} with last block height ${newLastBlock.height.toLocaleString()}`,
         );
 
@@ -112,9 +113,9 @@ export class SnapshotManager {
     }
 
     public async rollbackByNumber(amount: number) {
-        const lastBlock = await this.database.getLastBlock();
+        const { height } = await this.database.getLastBlock();
 
-        return this.rollbackByHeight(lastBlock.height - amount);
+        return this.rollbackByHeight(height - amount);
     }
 
     /**

--- a/packages/core-snapshots/src/manager.ts
+++ b/packages/core-snapshots/src/manager.ts
@@ -80,8 +80,8 @@ export class SnapshotManager {
     }
 
     public async rollbackByHeight(height) {
-        if (!height) {
-            app.forceExit(`Specified rollback block height: ${height.toLocaleString()} is not valid.`);
+        if (!height || height <= 0) {
+            app.forceExit(`Rollback height ${height.toLocaleString()} is invalid.`);
         }
 
         const currentHeight = (await this.database.getLastBlock()).height;

--- a/packages/core/src/commands/snapshot/rollback.ts
+++ b/packages/core/src/commands/snapshot/rollback.ts
@@ -28,14 +28,6 @@ export class RollbackCommand extends BaseCommand {
             this.error("The @arkecosystem/core-snapshots plugin is not installed.");
         }
 
-        const logger = app.resolvePlugin<Logger.ILogger>("logger");
-
-        if (flags.height === -1) {
-            logger.warn("Rollback height is not specified. Rolling back to last completed round.");
-        }
-
-        logger.info(`Starting the process of blockchain rollback to block height of ${flags.height.toLocaleString()}`);
-
         if (flags.height) {
             await app.resolvePlugin<SnapshotManager>("snapshots").rollbackByHeight(flags.height);
         } else if (flags.number) {

--- a/packages/core/src/commands/snapshot/rollback.ts
+++ b/packages/core/src/commands/snapshot/rollback.ts
@@ -12,8 +12,10 @@ export class RollbackCommand extends BaseCommand {
     public static flags: CommandFlags = {
         ...BaseCommand.flagsSnapshot,
         height: flags.integer({
-            description: "block network height number to rollback",
-            default: -1,
+            description: "the height after the roll back",
+        }),
+        number: flags.integer({
+            description: "the number of blocks to roll back",
         }),
     };
 
@@ -34,6 +36,12 @@ export class RollbackCommand extends BaseCommand {
 
         logger.info(`Starting the process of blockchain rollback to block height of ${flags.height.toLocaleString()}`);
 
-        await app.resolvePlugin<SnapshotManager>("snapshots").rollbackChain(flags.height);
+        if (flags.height) {
+            await app.resolvePlugin<SnapshotManager>("snapshots").rollbackByHeight(flags.height);
+        } else if (flags.number) {
+            await app.resolvePlugin<SnapshotManager>("snapshots").rollbackByNumber(flags.number);
+        } else {
+            this.error("Please specify either a height or number of blocks to roll back.");
+        }
     }
 }


### PR DESCRIPTION
## Proposed changes

Allows to run `ark snapshot:rollback --number=51` instead of `ark snapshot:rollback --height=123456789` to perform a rollback.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes