### PR TITLE
fix(core-snapshots): always load core-database-postgres

### DIFF
--- a/packages/core-snapshots/package.json
+++ b/packages/core-snapshots/package.json
@@ -25,7 +25,6 @@
         "@arkecosystem/core-interfaces": "^2.3.0-next.1",
         "@arkecosystem/crypto": "^2.3.0-next.1",
         "JSONStream": "^1.3.5",
-        "bluebird": "^3.5.3",
         "cpy-cli": "^2.0.0",
         "create-hash": "^1.2.0",
         "fs-extra": "^7.0.1",
@@ -37,7 +36,6 @@
         "xcase": "^2.0.1"
     },
     "devDependencies": {
-        "@types/bluebird": "^3.5.26",
         "@types/create-hash": "^1.2.0",
         "@types/fs-extra": "^5.0.5",
         "@types/lodash.pick": "^4.4.6",

--- a/packages/core-snapshots/src/plugin.ts
+++ b/packages/core-snapshots/src/plugin.ts
@@ -16,6 +16,6 @@ export const plugin: Container.PluginDescriptor = {
 
         const databaseService = container.resolvePlugin<Database.IDatabaseService>("database");
         const connection = databaseService.connection as PostgresConnection;
-        return await manager.make(connection);
+        return manager.make(connection);
     },
 };

--- a/packages/core-snapshots/src/plugin.ts
+++ b/packages/core-snapshots/src/plugin.ts
@@ -15,10 +15,7 @@ export const plugin: Container.PluginDescriptor = {
         const manager = new SnapshotManager(options);
 
         const databaseService = container.resolvePlugin<Database.IDatabaseService>("database");
-        if (!!databaseService) {
-            const connection = databaseService.connection as any;
-            return await manager.make(connection as PostgresConnection);
-        }
-        return await manager.make(null);
+        const connection = databaseService.connection as PostgresConnection;
+        return await manager.make(connection);
     },
 };

--- a/packages/core/src/helpers/snapshot.ts
+++ b/packages/core/src/helpers/snapshot.ts
@@ -11,6 +11,7 @@ export async function setUpLite(options) {
             "@arkecosystem/core-logger",
             "@arkecosystem/core-logger-pino",
             "@arkecosystem/core-event-emitter",
+            "@arkecosystem/core-database-postgres",
             "@arkecosystem/core-snapshots",
         ],
     });


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
`core-snapshots` implemented migrations itself which corrupted the database. Now instead
always load the `core-database-postgres` plugin which already performs the migrations and properly checks wether they were already applied or not.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [ ] Docs (documentation only changes)
- [ ] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [ ] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
