### PR TITLE
fix(core-api): adjust schema validation of blocks show

### DIFF
--- a/__tests__/integration/core-api/v2/handlers/blocks.test.ts
+++ b/__tests__/integration/core-api/v2/handlers/blocks.test.ts
@@ -55,8 +55,8 @@ describe("API 2.0 - Blocks", () => {
                     expect(response).toBePaginated();
                     expect(response.data.data).toBeArray();
 
-                    const block = response.data.data[0];
-                    utils.expectBlock(block);
+                    response.data.data.forEach(utils.expectBlock);
+                    expect(response.data.data.sort((a, b) => a.height > b.height)).toEqual(response.data.data);
                 });
             },
         );

--- a/packages/core-api/src/versions/2/blocks/schema.ts
+++ b/packages/core-api/src/versions/2/blocks/schema.ts
@@ -44,7 +44,7 @@ export const index: object = {
 
 export const show: object = {
     params: {
-        id: Joi.string().regex(/^[0-9]+$/, "numbers"),
+        id: blockId,
     },
 };
 


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

The blocks/show endpoint does currently not accept block ids of the new sha256 format. There are no fixtures for blocks with the new id format i believe?

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
