### PR TITLE
build(docker): create symbolic link for ark bin

### DIFF
--- a/docker/production/entrypoint.sh
+++ b/docker/production/entrypoint.sh
@@ -4,6 +4,7 @@ sudo /usr/sbin/ntpd -s
 sudo rm -rf /home/node/.config/ark-core/*
 sudo rm -rf /home/node/.local/state/ark-core/*
 sudo chown node:node -R /home/node
+sudo ln -s /home/node/.yarn/bin/ark /usr/bin/ark
 ark config:publish --network=$NETWORK
 sudo rm -f /home/node/.config/ark-core/$NETWORK/.env
 


### PR DESCRIPTION
## Proposed changes
Make symbolic link instead of exporting path to `ark`.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
