### PR TITLE
fix(core-database-postgres): add EQ operator to block height

### DIFF
--- a/packages/core-database-postgres/src/models/block.ts
+++ b/packages/core-database-postgres/src/models/block.ts
@@ -27,7 +27,11 @@ export class Block extends Model {
             },
             {
                 name: "height",
-                supportedOperators: [Database.SearchOperator.OP_LTE, Database.SearchOperator.OP_GTE],
+                supportedOperators: [
+                    Database.SearchOperator.OP_EQ,
+                    Database.SearchOperator.OP_LTE,
+                    Database.SearchOperator.OP_GTE,
+                ],
             },
             {
                 name: "number_of_transactions",


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

The block model does currently not allow the `equals` operator, passing a blockheight to the `blocks/{id}` endpoint will therefore result in a 404 error.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes