### PR TITLE
fix(core-database): map block to transaction in findById

### DIFF
--- a/__tests__/unit/core-database/repositories/transactions-business-repository.test.ts
+++ b/__tests__/unit/core-database/repositories/transactions-business-repository.test.ts
@@ -226,13 +226,21 @@ describe("Transactions Business Repository", () => {
 
     describe("findById", () => {
         it("should invoke findById on db repository", async () => {
+            const expectedBlockId = "id";
+            const expectedHeight = 100;
             databaseService.connection.transactionsRepository = {
                 findById: async id => id,
                 getModel: () => new MockDatabaseModel(),
             } as Database.ITransactionsRepository;
-            jest.spyOn(databaseService.connection.transactionsRepository, "findById").mockImplementation(
-                async () => true,
-            );
+            jest.spyOn(databaseService.connection.transactionsRepository, "findById").mockImplementation(async () => ({
+                rows: [
+                    {
+                        blockId: expectedBlockId,
+                    },
+                ],
+            }));
+            databaseService.cache = new Map();
+            jest.spyOn(databaseService.cache, "get").mockReturnValue(expectedHeight);
 
             await transactionsBusinessRepository.findById("id");
 

--- a/packages/core-database/src/repositories/transactions-business-repository.ts
+++ b/packages/core-database/src/repositories/transactions-business-repository.ts
@@ -59,7 +59,8 @@ export class TransactionsBusinessRepository implements Database.ITransactionsBus
     }
 
     public async findById(id: string) {
-        return this.databaseServiceProvider().connection.transactionsRepository.findById(id);
+        const rows = return this.databaseServiceProvider().connection.transactionsRepository.findById(id);
+        return (await this.mapBlocksToTransactions(rows))[0];
     }
 
     public async findByTypeAndId(type: any, id: string) {

--- a/packages/core-database/src/repositories/transactions-business-repository.ts
+++ b/packages/core-database/src/repositories/transactions-business-repository.ts
@@ -59,7 +59,7 @@ export class TransactionsBusinessRepository implements Database.ITransactionsBus
     }
 
     public async findById(id: string) {
-        const rows = return this.databaseServiceProvider().connection.transactionsRepository.findById(id);
+        const rows = await this.databaseServiceProvider().connection.transactionsRepository.findById(id);
         return (await this.mapBlocksToTransactions(rows))[0];
     }
 


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

The `findById` method called by the `transactions/{id}` API endpoint does not map the block to the transaction.

[untested]

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes