### PR TITLE
fix(core-p2p): two-way ban

### DIFF
--- a/packages/core-interfaces/src/core-p2p/monitor.ts
+++ b/packages/core-interfaces/src/core-p2p/monitor.ts
@@ -20,7 +20,7 @@ export interface IMonitor {
      * @param  {IPeer} peer
      * @throws {Error} If invalid peer
      */
-    acceptNewPeer(peer: any): Promise<void>;
+    acceptNewPeer(peer: any): Promise<boolean>;
 
     /**
      * Remove peer from monitor.

--- a/packages/core-p2p/src/server/plugins/accept-request.ts
+++ b/packages/core-p2p/src/server/plugins/accept-request.ts
@@ -1,6 +1,6 @@
 import Boom from "boom";
 import { monitor } from "../../monitor";
-import { isWhitelisted } from "../../utils";
+import { isLocalHost, isWhitelisted } from "../../utils";
 
 /**
  * The register method used by hapi.js.
@@ -41,8 +41,10 @@ const register = async (server, options) => {
                 });
 
                 try {
-                    if (!(await monitor.acceptNewPeer(peer))) {
-                        return Boom.forbidden();
+                    if (!isLocalHost(peer.ip)) {
+                        if (!(await monitor.acceptNewPeer(peer))) {
+                            return Boom.forbidden();
+                        }
                     }
                 } catch (error) {
                     return Boom.badImplementation(error.message);

--- a/packages/core-p2p/src/server/plugins/accept-request.ts
+++ b/packages/core-p2p/src/server/plugins/accept-request.ts
@@ -41,7 +41,9 @@ const register = async (server, options) => {
                 });
 
                 try {
-                    await monitor.acceptNewPeer(peer);
+                    if (!(await monitor.acceptNewPeer(peer))) {
+                        return Boom.forbidden();
+                    }
                 } catch (error) {
                     return Boom.badImplementation(error.message);
                 }

--- a/packages/core-p2p/src/server/plugins/accept-request.ts
+++ b/packages/core-p2p/src/server/plugins/accept-request.ts
@@ -42,7 +42,8 @@ const register = async (server, options) => {
 
                 try {
                     if (!isLocalHost(peer.ip)) {
-                        if (!(await monitor.acceptNewPeer(peer))) {
+                        const accepted = await monitor.acceptNewPeer(peer);
+                        if (!accepted && request.method === "post") {
                             return Boom.forbidden();
                         }
                     }

--- a/packages/core-p2p/src/utils/index.ts
+++ b/packages/core-p2p/src/utils/index.ts
@@ -2,4 +2,4 @@ export { checkDNS } from "./check-dns";
 export { checkNTP } from "./check-ntp";
 export { isWhitelisted } from "./is-whitelisted";
 export { restorePeers } from "./restore-peers";
-export { isValidPeer } from "./is-valid-peer";
+export { isValidPeer, isLocalHost } from "./is-valid-peer";

--- a/packages/core-p2p/src/utils/is-valid-peer.ts
+++ b/packages/core-p2p/src/utils/is-valid-peer.ts
@@ -24,15 +24,7 @@ export const isValidPeer = (peer: { ip: string; status?: string | number }): boo
     return true;
 };
 
-const sanitizeRemoteAddress = (ip: string): string | null => {
-    try {
-        return process(ip).toString();
-    } catch (error) {
-        return null;
-    }
-};
-
-const isLocalHost = (ip: string): boolean => {
+export const isLocalHost = (ip: string): boolean => {
     try {
         const parsed = parse(ip);
         if (parsed.range() === "loopback") {
@@ -47,5 +39,13 @@ const isLocalHost = (ip: string): boolean => {
         return Object.keys(interfaces).some(ifname => interfaces[ifname].some(iface => iface.address === ip));
     } catch (error) {
         return false;
+    }
+};
+
+const sanitizeRemoteAddress = (ip: string): string | null => {
+    try {
+        return process(ip).toString();
+    } catch (error) {
+        return null;
     }
 };


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
A node would still accept blocks from a banned peer:
```
[INFO]: Received new block at height 7,816,623 with 0 transactions from 82.223.100.85
[2019-03-27 15:53:40][DEBUG]: Delegate calidelegate (037b4730e7c63252912825510423487e9ee507e1a5719dfeef52187d8ababe3048) allowed to forge block 7,816,623 👍
[2019-03-27 15:53:40][DEBUG]: event 'PROCESSFINISHED': "newBlock" -> "idle" -> actions: [checkLater, blockchainReady]
[2019-03-27 15:53:40][INFO]: Broadcasting block 7,816,623 to 0 peers
[2019-03-27 15:53:47][INFO]: Block 7,816,623 pinged blockchain 20 times
[2019-03-27 15:53:47][INFO]: Received new block at height 7,816,624 with 0 transactions from 82.223.100.85
[2019-03-27 15:53:47][DEBUG]: Delegate civseed (02b02cae6c53adcbbe2b88e3f21fff9e3ceb8c2f028fdfaecff9d393696eaa3d07) allowed to forge block 7,816,624 👍
[2019-03-27 15:53:47][DEBUG]: event 'PROCESSFINISHED': "newBlock" -> "idle" -> actions: [checkLater, blockchainReady]
[2019-03-27 15:53:47][INFO]: Broadcasting block 7,816,624 to 85 peers
[2019-03-27 15:53:50][INFO]: 82.223.100.85 has downloaded 400 blocks from height 7,655,720
[2019-03-27 15:53:51][DEBUG]: Rejected peer 82.223.100.85 as it doesn't meet the minimum version requirements. Expected: >=2.1.0,>=2.2.0-alpha.0,>=2.2.0-beta.0,>=2.2.0-rc.0 - Received: 2.0.19
[2019-03-27 15:53:51][DEBUG]: Suspended 82.223.100.85 for 5 minutes because of "Invalid Version"
[2019-03-27 15:53:55][DEBUG]: 82.223.100.85 still suspended for 4 minutes 56.1 seconds because of "Invalid Version".
[2019-03-27 15:53:55][INFO]: Block 7,816,624 pinged blockchain 18 times
[2019-03-27 15:53:55][INFO]: Received new block at height 7,816,625 with 0 transactions from 82.223.100.85
[2019-03-27 15:53:55][DEBUG]: Delegate tibonos (02bd74ba354e4533cbbb0d03076622c15917e2e1d65fe4c4c8294d6b4c57d667b4) allowed to forge block 7,816,625 👍
[2019-03-27 15:53:55][DEBUG]: event 'PROCESSFINISHED': "newBlock" -> "idle" -> actions: [checkLater, blockchainReady]
[2019-03-27 15:53:56][INFO]: Broadcasting block 7,816,625 to 0 peers
[2019-03-27 15:54:03][INFO]: Block 7,816,625 pinged blockchain 20 times
[2019-03-27 15:54:03][INFO]: Received new block at height 7,816,626 with 0 transactions from 82.223.100.85
[2019-03-27 15:54:03][DEBUG]: Delegate ghostfaceuk (0344f455358055213235a21eff6deffa4d8ded38e43b9103e10184cc4c108ee81c) allowed to forge block 7,816,626 👍
[2019-03-27 15:54:03][INFO]: Broadcasting block 7,816,626 to 0 peers
[2019-03-27 15:54:03][DEBUG]: event 'PROCESSFINISHED': "newBlock" -> "idle" -> actions: [checkLater, blockchainReady]
[2019-03-27 15:55:03][DEBUG]: event 'WAKEUP': "idle" -> {"syncWithNetwork":"syncing"} -> actions: [checkLastDownloadedBlockSynced]
[2019-03-27 15:55:03][DEBUG]: Queued blocks (rebuild: 0 process: 0)
[2019-03-27 15:55:03][DEBUG]: event 'NOTSYNCED': {"syncWithNetwork":"syncing"} -> {"syncWithNetwork":"downloadBlocks"} -> actions: [downloadBlocks]
[2019-03-27 15:55:03][INFO]: Downloading blocks from height 7,816,626 via 178.32.65.143
[2019-03-27 15:55:03][INFO]: Downloaded 7 new blocks accounting for a total of 0 transactions
[2019-03-27 15:55:03][DEBUG]: event 'DOWNLOADED': {"syncWithNetwork":"downloadBlocks"} -> {"syncWithNetwork":"syncing"} -> actions: [checkLastDownloadedBlockSynced]
[2019-03-27 15:55:03][DEBUG]: Delegate del (03d9ed6e7f29daf12ef925d4ce5753aade23c8cfd52a0427240fb30ad6ec232fed) allowed to forge block 7,816,627 👍
[2019-03-27 15:55:03][DEBUG]: Queued blocks (rebuild: 0 process: 6)
[2019-03-27 15:55:03][DEBUG]: event 'SYNCED': {"syncWithNetwork":"syncing"} -> {"syncWithNetwork":"downloadFinished"} -> actions: [downloadFinished]
[2019-03-27 15:55:03][INFO]: Block download finished 🚀
[2019-03-27 15:55:03][DEBUG]: event 'PROCESSFINISHED': {"syncWithNetwork":"downloadFinished"} -> {"syncWithNetwork":"processFinished"} -> actions: [checkLastBlockSynced]
[2019-03-27 15:55:03][DEBUG]: event 'NOTSYNCED': {"syncWithNetwork":"processFinished"} -> {"syncWithNetwork":"downloadBlocks"} -> actions: [downloadBlocks]
[2019-03-27 15:55:03][INFO]: Downloading blocks from height 7,816,633 via 193.31.27.160
[2019-03-27 15:55:04][DEBUG]: Delegate deadlock (036efbf08c18a338a0475920317c7c771dcd73fc1966cf9f2036ece3fb4ed5bad0) allowed to forge block 7,816,628 👍
[2019-03-27 15:55:04][DEBUG]: Delegate fun (02618fd3094afc436742a1e47dab922a1d8892ae791d1b426d125f6bd691634427) allowed to forge block 7,816,629 👍
[2019-03-27 15:55:04][DEBUG]: Delegate goose (03c5d32dedf5441b3aafb2e0c6ad3e5568bb0b3e822807b133e2276e014d830e3c) allowed to forge block 7,816,630 👍
```
With this PR a node will now properly drop requests from banned peers.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [ ] Docs (documentation only changes)
- [ ] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [ ] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
