### PR TITLE
fix(core-event-emitter): ensure the event listener won’t exceed the max listener count

### DIFF
--- a/__tests__/unit/core-event-emitter/emitter.test.ts
+++ b/__tests__/unit/core-event-emitter/emitter.test.ts
@@ -1,4 +1,4 @@
-import EventEmitter from "eventemitter3";
+import { EventEmitter } from "events";
 import { plugin } from "../../../packages/core-event-emitter/src";
 
 const emitter = plugin.register();

--- a/__tests__/unit/core-event-emitter/emitter.test.ts
+++ b/__tests__/unit/core-event-emitter/emitter.test.ts
@@ -1,5 +1,5 @@
-import { EventEmitter } from "events";
 import { plugin } from "../../../packages/core-event-emitter/src";
+import { EventEmitter } from "../../../packages/core-event-emitter/src/emitter";
 
 const emitter = plugin.register();
 

--- a/packages/core-event-emitter/package.json
+++ b/packages/core-event-emitter/package.json
@@ -17,9 +17,6 @@
         "build:watch": "yarn clean && yarn compile -w",
         "clean": "del dist"
     },
-    "dependencies": {
-        "eventemitter3": "^3.1.0"
-    },
     "publishConfig": {
         "access": "public"
     },

--- a/packages/core-event-emitter/src/emitter.ts
+++ b/packages/core-event-emitter/src/emitter.ts
@@ -3,17 +3,17 @@ import { EventEmitter as NativeEmitter } from "events";
 export class EventEmitter {
     private readonly emitter: NativeEmitter = new NativeEmitter();
 
-    public emit(event: string | symbol, ...args: any[]): void {
+    public emit(event: string | symbol, args: any[]): void {
         this.emitter.emit(event, args);
     }
 
-    public on(event: string | symbol, listener: (...args: any[]) => void): void {
+    public on(event: string | symbol, listener: (args: any[]) => void): void {
         this.ensureMaxListenerCount(event);
 
         this.emitter.on(event, listener);
     }
 
-    public once(event: string | symbol, listener: (...args: any[]) => void): void {
+    public once(event: string | symbol, listener: (args: any[]) => void): void {
         this.ensureMaxListenerCount(event);
 
         this.emitter.once(event, listener);

--- a/packages/core-event-emitter/src/emitter.ts
+++ b/packages/core-event-emitter/src/emitter.ts
@@ -3,8 +3,8 @@ import { EventEmitter as NativeEmitter } from "events";
 export class EventEmitter {
     private readonly emitter: NativeEmitter = new NativeEmitter();
 
-    public emit(event: string | symbol, args: any[]): void {
-        this.emitter.emit(event, args);
+    public emit(event: string | symbol, args: any[]): boolean {
+        return this.emitter.emit(event, args);
     }
 
     public on(event: string | symbol, listener: (args: any[]) => void): void {

--- a/packages/core-event-emitter/src/emitter.ts
+++ b/packages/core-event-emitter/src/emitter.ts
@@ -1,0 +1,30 @@
+import { EventEmitter as NativeEmitter } from "events";
+
+export class EventEmitter {
+    private readonly emitter: NativeEmitter = new NativeEmitter();
+
+    public emit(event: string | symbol, ...args: any[]): void {
+        this.emitter.emit(event, args);
+    }
+
+    public on(event: string | symbol, listener: (...args: any[]) => void): void {
+        this.ensureMaxListenerCount(event);
+
+        this.emitter.on(event, listener);
+    }
+
+    public once(event: string | symbol, listener: (...args: any[]) => void): void {
+        this.ensureMaxListenerCount(event);
+
+        this.emitter.once(event, listener);
+    }
+
+    private ensureMaxListenerCount(event): void {
+        const maxListeners = this.emitter.getMaxListeners();
+        const listenerCount = this.emitter.listenerCount(event);
+
+        if (listenerCount >= maxListeners) {
+            this.emitter.setMaxListeners(maxListeners + 1);
+        }
+    }
+}

--- a/packages/core-event-emitter/src/emitter.ts
+++ b/packages/core-event-emitter/src/emitter.ts
@@ -3,17 +3,17 @@ import { EventEmitter as NativeEmitter } from "events";
 export class EventEmitter {
     private readonly emitter: NativeEmitter = new NativeEmitter();
 
-    public emit(event: string | symbol, args: any[]): boolean {
+    public emit(event: string | symbol, args: any): boolean {
         return this.emitter.emit(event, args);
     }
 
-    public on(event: string | symbol, listener: (args: any[]) => void): void {
+    public on(event: string | symbol, listener: (args: any) => void): void {
         this.ensureMaxListenerCount(event);
 
         this.emitter.on(event, listener);
     }
 
-    public once(event: string | symbol, listener: (args: any[]) => void): void {
+    public once(event: string | symbol, listener: (args: any) => void): void {
         this.ensureMaxListenerCount(event);
 
         this.emitter.once(event, listener);

--- a/packages/core-event-emitter/src/emitter.ts
+++ b/packages/core-event-emitter/src/emitter.ts
@@ -7,13 +7,13 @@ export class EventEmitter {
         return this.emitter.emit(event, args);
     }
 
-    public on(event: string | symbol, listener: (args: any) => void): void {
+    public on(event: string | symbol, listener: (...args: any) => void): void {
         this.ensureMaxListenerCount(event);
 
         this.emitter.on(event, listener);
     }
 
-    public once(event: string | symbol, listener: (args: any) => void): void {
+    public once(event: string | symbol, listener: (...args: any) => void): void {
         this.ensureMaxListenerCount(event);
 
         this.emitter.once(event, listener);

--- a/packages/core-event-emitter/src/index.ts
+++ b/packages/core-event-emitter/src/index.ts
@@ -1,4 +1,4 @@
-import EventEmitter from "eventemitter3";
+import { EventEmitter } from "./emitter";
 
 export const plugin = {
     pkg: require("../package.json"),

--- a/packages/core-interfaces/package.json
+++ b/packages/core-interfaces/package.json
@@ -24,8 +24,7 @@
     },
     "dependencies": {
         "@arkecosystem/crypto": "^2.3.0-next.2",
-        "awilix": "^4.2.1",
-        "eventemitter3": "^3.1.0"
+        "awilix": "^4.2.1"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/core-interfaces/src/core-event-emitter/index.ts
+++ b/packages/core-interfaces/src/core-event-emitter/index.ts
@@ -1,2 +1,3 @@
-import EventEmitter from "eventemitter3";
+import { EventEmitter } from "events";
+
 export { EventEmitter };

--- a/yarn.lock
+++ b/yarn.lock
@@ -5577,11 +5577,6 @@ event-lite@^0.1.1:
   resolved "https://registry.yarnpkg.com/event-lite/-/event-lite-0.1.2.tgz#838a3e0fdddef8cc90f128006c8e55a4e4e4c11b"
   integrity sha512-HnSYx1BsJ87/p6swwzv+2v6B4X+uxUteoDfRxsAb1S1BePzQqOLevVmkdA15GHJVd9A9Ok6wygUR18Hu0YeV9g==
 
-eventemitter3@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.0.tgz#090b4d6cdbd645ed10bf750d4b5407942d7ba163"
-  integrity sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA==
-
 events@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/events/-/events-3.0.0.tgz#9a0a0dfaf62893d92b875b8f2698ca4114973e88"


### PR DESCRIPTION
## Proposed changes

Ensure that we tell node.js that we have a new listener by increasing the max listener count to avoid warnings.

**Also drops `eventemitter3` as there isn't that big of a difference between it and the node 11 emitter.**

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes