### PR TITLE
fix: use the maxTransactionsPerRequest configuration for API validation

### DIFF
--- a/packages/core-api/src/versions/2/transactions/schema.ts
+++ b/packages/core-api/src/versions/2/transactions/schema.ts
@@ -1,3 +1,4 @@
+import { app } from "@arkecosystem/core-container";
 import joi from "joi";
 import { blockId } from "../shared/schemas/block-id";
 import { pagination } from "../shared/schemas/pagination";
@@ -58,7 +59,11 @@ export const store: object = {
     required: ["transactions"],
     additionalProperties: false,
     properties: {
-        transactions: { $ref: "transactions", minItems: 1, maxItems: 40 }, // TODO: use config
+        transactions: {
+            $ref: "transactions",
+            minItems: 1,
+            maxItems: app.resolveOptions("transaction-pool").maxTransactionsPerRequest,
+        },
     },
 };
 

--- a/packages/core-p2p/src/server/versions/1/schema.ts
+++ b/packages/core-p2p/src/server/versions/1/schema.ts
@@ -1,3 +1,5 @@
+import { app } from "@arkecosystem/core-container";
+
 /**
  * @type {Object}
  */
@@ -46,7 +48,11 @@ export const schema = {
         required: ["transactions"],
         additionalProperties: false,
         properties: {
-            transactions: { $ref: "transactions", minItems: 1, maxItems: 40 }, // TODO: use config
+            transactions: {
+                $ref: "transactions",
+                minItems: 1,
+                maxItems: app.resolveOptions("transaction-pool").maxTransactionsPerRequest,
+            },
         },
     },
     getTransactions: {


### PR DESCRIPTION
## Proposed changes

Use the configuration value `maxTransactionsPerRequest` from the transaction pool to validate API requests, resolves the todo in the comment.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes