### PR TITLE
fix(core-p2p): getNetworkHeight() was sorting incorrectly peer heights

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,7 @@ jobs:
             - ./packages/core-container/node_modules
             - ./packages/core-database/node_modules
             - ./packages/core-database-postgres/node_modules
+            - ./packages/core-debugger-cli/node_modules
             - ./packages/core-elasticsearch/node_modules
             - ./packages/core-error-tracker-airbrake/node_modules
             - ./packages/core-error-tracker-bugsnag/node_modules
@@ -126,6 +127,7 @@ jobs:
             - ./packages/core-container/node_modules
             - ./packages/core-database/node_modules
             - ./packages/core-database-postgres/node_modules
+            - ./packages/core-debugger-cli/node_modules
             - ./packages/core-elasticsearch/node_modules
             - ./packages/core-error-tracker-airbrake/node_modules
             - ./packages/core-error-tracker-bugsnag/node_modules
@@ -211,6 +213,7 @@ jobs:
             - ./packages/core-container/node_modules
             - ./packages/core-database/node_modules
             - ./packages/core-database-postgres/node_modules
+            - ./packages/core-debugger-cli/node_modules
             - ./packages/core-elasticsearch/node_modules
             - ./packages/core-error-tracker-airbrake/node_modules
             - ./packages/core-error-tracker-bugsnag/node_modules
@@ -321,6 +324,7 @@ jobs:
             - ./packages/core-container/node_modules
             - ./packages/core-database/node_modules
             - ./packages/core-database-postgres/node_modules
+            - ./packages/core-debugger-cli/node_modules
             - ./packages/core-elasticsearch/node_modules
             - ./packages/core-error-tracker-airbrake/node_modules
             - ./packages/core-error-tracker-bugsnag/node_modules
@@ -425,6 +429,7 @@ jobs:
             - ./packages/core-container/node_modules
             - ./packages/core-database/node_modules
             - ./packages/core-database-postgres/node_modules
+            - ./packages/core-debugger-cli/node_modules
             - ./packages/core-elasticsearch/node_modules
             - ./packages/core-error-tracker-airbrake/node_modules
             - ./packages/core-error-tracker-bugsnag/node_modules
@@ -535,6 +540,7 @@ jobs:
             - ./packages/core-container/node_modules
             - ./packages/core-database/node_modules
             - ./packages/core-database-postgres/node_modules
+            - ./packages/core-debugger-cli/node_modules
             - ./packages/core-elasticsearch/node_modules
             - ./packages/core-error-tracker-airbrake/node_modules
             - ./packages/core-error-tracker-bugsnag/node_modules

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,6 @@ jobs:
             - ./packages/core-container/node_modules
             - ./packages/core-database/node_modules
             - ./packages/core-database-postgres/node_modules
-            - ./packages/core-debugger-cli/node_modules
             - ./packages/core-elasticsearch/node_modules
             - ./packages/core-error-tracker-airbrake/node_modules
             - ./packages/core-error-tracker-bugsnag/node_modules
@@ -127,7 +126,6 @@ jobs:
             - ./packages/core-container/node_modules
             - ./packages/core-database/node_modules
             - ./packages/core-database-postgres/node_modules
-            - ./packages/core-debugger-cli/node_modules
             - ./packages/core-elasticsearch/node_modules
             - ./packages/core-error-tracker-airbrake/node_modules
             - ./packages/core-error-tracker-bugsnag/node_modules
@@ -213,7 +211,6 @@ jobs:
             - ./packages/core-container/node_modules
             - ./packages/core-database/node_modules
             - ./packages/core-database-postgres/node_modules
-            - ./packages/core-debugger-cli/node_modules
             - ./packages/core-elasticsearch/node_modules
             - ./packages/core-error-tracker-airbrake/node_modules
             - ./packages/core-error-tracker-bugsnag/node_modules
@@ -324,7 +321,6 @@ jobs:
             - ./packages/core-container/node_modules
             - ./packages/core-database/node_modules
             - ./packages/core-database-postgres/node_modules
-            - ./packages/core-debugger-cli/node_modules
             - ./packages/core-elasticsearch/node_modules
             - ./packages/core-error-tracker-airbrake/node_modules
             - ./packages/core-error-tracker-bugsnag/node_modules
@@ -429,7 +425,6 @@ jobs:
             - ./packages/core-container/node_modules
             - ./packages/core-database/node_modules
             - ./packages/core-database-postgres/node_modules
-            - ./packages/core-debugger-cli/node_modules
             - ./packages/core-elasticsearch/node_modules
             - ./packages/core-error-tracker-airbrake/node_modules
             - ./packages/core-error-tracker-bugsnag/node_modules
@@ -540,7 +535,6 @@ jobs:
             - ./packages/core-container/node_modules
             - ./packages/core-database/node_modules
             - ./packages/core-database-postgres/node_modules
-            - ./packages/core-debugger-cli/node_modules
             - ./packages/core-elasticsearch/node_modules
             - ./packages/core-error-tracker-airbrake/node_modules
             - ./packages/core-error-tracker-bugsnag/node_modules

--- a/__tests__/unit/core-p2p/monitor.test.ts
+++ b/__tests__/unit/core-p2p/monitor.test.ts
@@ -211,4 +211,16 @@ describe("Monitor", () => {
             expect(blocks.length).toBe(2);
         });
     });
+
+    describe("getNetworkHeight", () => {
+        it("should return correct network height", () => {
+            monitor.peers = {
+                "1.1.1.1": { state: { height: 1 } },
+                "1.1.1.2": { state: { height: 7 } },
+                "1.1.1.3": { state: { height: 10 } },
+            };
+
+            expect(monitor.getNetworkHeight()).toBe(7);
+        });
+    });
 });

--- a/packages/core-p2p/src/monitor.ts
+++ b/packages/core-p2p/src/monitor.ts
@@ -348,7 +348,7 @@ export class Monitor implements P2P.IMonitor {
         const medians = this.getPeers()
             .filter(peer => peer.state.height)
             .map(peer => peer.state.height)
-            .sort();
+            .sort((a, b) => a - b);
 
         return medians[Math.floor(medians.length / 2)] || 0;
     }


### PR DESCRIPTION
## Proposed changes

p2p getNetworkHeight() was sorting peer height with default array sort() method, but this method sorts using string representation, not actual numbers.
Which means that `[1, 30, 4, 21, 100000]` is sorted as `[1, 100000, 21, 30, 4]`.

Fixed by just sorting using custom method, comparing actual numbers.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works