### PR TITLE
refactor(core-database-postgres): add findByHeight to avoid confusion with the misleading findByHeights

### DIFF
--- a/__tests__/unit/core-database/database-service.test.ts
+++ b/__tests__/unit/core-database/database-service.test.ts
@@ -86,7 +86,7 @@ describe("Database Service", () => {
             databaseService = createService();
 
             connection.blocksRepository = {
-                findByHeight: heights => heights.map(h => ({ height: Number(h), fromDb: true })),
+                findByHeights: heights => heights.map(h => ({ height: Number(h), fromDb: true })),
             } as Database.IBlocksRepository;
 
             let requestHeights = requestHeightsHigh;

--- a/__tests__/unit/core-database/database-service.test.ts
+++ b/__tests__/unit/core-database/database-service.test.ts
@@ -86,7 +86,7 @@ describe("Database Service", () => {
             databaseService = createService();
 
             connection.blocksRepository = {
-                findByHeights: heights => heights.map(h => ({ height: Number(h), fromDb: true })),
+                findByHeights: (heights: number[]) => heights.map(h => ({ height: Number(h), fromDb: true })),
             } as Database.IBlocksRepository;
 
             let requestHeights = requestHeightsHigh;

--- a/__tests__/unit/core-database/database-service.test.ts
+++ b/__tests__/unit/core-database/database-service.test.ts
@@ -87,7 +87,7 @@ describe("Database Service", () => {
 
             connection.blocksRepository = {
                 findByHeights: (heights: number[]) => heights.map(h => ({ height: Number(h), fromDb: true })),
-            } as Database.IBlocksRepository;
+            } as any; // FIXME: use Database.IBlocksRepository
 
             let requestHeights = requestHeightsHigh;
 

--- a/packages/core-database-postgres/src/plugin.ts
+++ b/packages/core-database-postgres/src/plugin.ts
@@ -17,7 +17,7 @@ export const plugin: Container.PluginDescriptor = {
 
         const connection = await databaseManager.makeConnection(new PostgresConnection(options, walletManager));
 
-        return await databaseServiceFactory(options, walletManager, connection);
+        return databaseServiceFactory(options, walletManager, connection);
     },
     async deregister(container: Container.IContainer, options) {
         container.resolvePlugin<Logger.ILogger>("logger").info("Closing Database Connection");

--- a/packages/core-database-postgres/src/queries/blocks/find-by-height.sql
+++ b/packages/core-database-postgres/src/queries/blocks/find-by-height.sql
@@ -1,3 +1,3 @@
 SELECT *
 FROM blocks
-WHERE height IN (${heights:list})
+WHERE height = ${height}

--- a/packages/core-database-postgres/src/queries/blocks/find-by-heights.sql
+++ b/packages/core-database-postgres/src/queries/blocks/find-by-heights.sql
@@ -1,0 +1,3 @@
+SELECT *
+FROM blocks
+WHERE height IN (${heights:list})

--- a/packages/core-database-postgres/src/queries/index.ts
+++ b/packages/core-database-postgres/src/queries/index.ts
@@ -7,6 +7,7 @@ export const queries = {
         delete: loadQueryFile(__dirname, "./blocks/delete.sql"),
         findById: loadQueryFile(__dirname, "./blocks/find-by-id.sql"),
         findByHeight: loadQueryFile(__dirname, "./blocks/find-by-height.sql"),
+        findByHeights: loadQueryFile(__dirname, "./blocks/find-by-heights.sql"),
         headers: loadQueryFile(__dirname, "./blocks/headers.sql"),
         heightRange: loadQueryFile(__dirname, "./blocks/height-range.sql"),
         latest: loadQueryFile(__dirname, "./blocks/latest.sql"),

--- a/packages/core-database-postgres/src/repositories/blocks.ts
+++ b/packages/core-database-postgres/src/repositories/blocks.ts
@@ -15,13 +15,27 @@ export class BlocksRepository extends Repository implements Database.IBlocksRepo
         return this.db.oneOrNone(sql.findById, { id });
     }
 
+    /**
+     * Find many blocks by their IDs.
+     * @param {String[]} ids
+     */
     public async findByIds(ids: string[]) {
-        const query = this.query
-            .select()
-            .from(this.query)
-            .where(this.query.id.in(ids))
-            .group(this.query.id);
-        return await this.findMany(query);
+        return this.findMany(
+            this.query
+                .select()
+                .from(this.query)
+                .where(this.query.id.in(ids))
+                .group(this.query.id),
+        );
+    }
+
+    /**
+     * Get a block at the given height.
+     * @param  {Number} height the height of the blocks to retrieve
+     * @return {Promise}
+     */
+    public async findByHeight(height: number) {
+        return this.db.oneOrNone(sql.findByHeight, { height });
     }
 
     /**
@@ -29,7 +43,7 @@ export class BlocksRepository extends Repository implements Database.IBlocksRepo
      * @param  {Array} heights the heights of the blocks to retrieve
      * @return {Promise}
      */
-    public async findByHeight(heights) {
+    public async findByHeights(heights) {
         return this.db.manyOrNone(sql.findByHeight, { heights });
     }
 
@@ -136,7 +150,7 @@ export class BlocksRepository extends Repository implements Database.IBlocksRepo
             }
         }
 
-        return await this.findManyWithCount(selectQuery, params.paginate, params.orderBy);
+        return this.findManyWithCount(selectQuery, params.paginate, params.orderBy);
     }
 
     public async search(params: Database.SearchParameters) {
@@ -159,6 +173,6 @@ export class BlocksRepository extends Repository implements Database.IBlocksRepo
             }
         }
 
-        return await this.findManyWithCount(selectQuery, params.paginate, params.orderBy);
+        return this.findManyWithCount(selectQuery, params.paginate, params.orderBy);
     }
 }

--- a/packages/core-database-postgres/src/repositories/blocks.ts
+++ b/packages/core-database-postgres/src/repositories/blocks.ts
@@ -43,7 +43,7 @@ export class BlocksRepository extends Repository implements Database.IBlocksRepo
      * @param  {Array} heights the heights of the blocks to retrieve
      * @return {Promise}
      */
-    public async findByHeights(heights) {
+    public async findByHeights(heights: number[]) {
         return this.db.manyOrNone(sql.findByHeight, { heights });
     }
 

--- a/packages/core-database-postgres/src/repositories/blocks.ts
+++ b/packages/core-database-postgres/src/repositories/blocks.ts
@@ -44,7 +44,7 @@ export class BlocksRepository extends Repository implements Database.IBlocksRepo
      * @return {Promise}
      */
     public async findByHeights(heights: number[]) {
-        return this.db.manyOrNone(sql.findByHeight, { heights });
+        return this.db.manyOrNone(sql.findByHeights, { heights });
     }
 
     /**

--- a/packages/core-database-postgres/src/repositories/transactions.ts
+++ b/packages/core-database-postgres/src/repositories/transactions.ts
@@ -107,13 +107,15 @@ export class TransactionsRepository extends Repository implements Database.ITran
     }
 
     public async findAllByWallet(wallet: any, paginate?: Database.SearchPaginate, orderBy?: Database.SearchOrderBy[]) {
-        const selectQuery = this.query
-            .select()
-            .from(this.query)
-            .where(this.query.sender_public_key.equals(wallet.publicKey))
-            .or(this.query.recipient_id.equals(wallet.address));
-
-        return await this.findManyWithCount(selectQuery, paginate, orderBy);
+        return this.findManyWithCount(
+            this.query
+                .select()
+                .from(this.query)
+                .where(this.query.sender_public_key.equals(wallet.publicKey))
+                .or(this.query.recipient_id.equals(wallet.address)),
+            paginate,
+            orderBy,
+        );
     }
 
     public async findWithVendorField() {

--- a/packages/core-database/src/database-service.ts
+++ b/packages/core-database/src/database-service.ts
@@ -245,7 +245,7 @@ export class DatabaseService implements Database.IDatabaseService {
             }
         }
 
-        const heightsToGetFromDB = Object.keys(toGetFromDB);
+        const heightsToGetFromDB = Object.keys(toGetFromDB).map(height => +height);
         if (heightsToGetFromDB.length > 0) {
             const blocksByHeights = await this.connection.blocksRepository.findByHeights(heightsToGetFromDB);
 

--- a/packages/core-database/src/database-service.ts
+++ b/packages/core-database/src/database-service.ts
@@ -247,10 +247,11 @@ export class DatabaseService implements Database.IDatabaseService {
 
         const heightsToGetFromDB = Object.keys(toGetFromDB);
         if (heightsToGetFromDB.length > 0) {
-            for (const blockFromDB of await this.connection.blocksRepository.findByHeights(heightsToGetFromDB)) {
-                const h = blockFromDB.height;
-                const i = toGetFromDB[h];
-                blocks[i] = blockFromDB;
+            const blocksByHeights = await this.connection.blocksRepository.findByHeights(heightsToGetFromDB);
+
+            for (const blockFromDB of blocksByHeights) {
+                const index = toGetFromDB[blockFromDB.height];
+                blocks[index] = blockFromDB;
             }
         }
 

--- a/packages/core-database/src/database-service.ts
+++ b/packages/core-database/src/database-service.ts
@@ -247,7 +247,7 @@ export class DatabaseService implements Database.IDatabaseService {
 
         const heightsToGetFromDB = Object.keys(toGetFromDB);
         if (heightsToGetFromDB.length > 0) {
-            for (const blockFromDB of await this.connection.blocksRepository.findByHeight(heightsToGetFromDB)) {
+            for (const blockFromDB of await this.connection.blocksRepository.findByHeights(heightsToGetFromDB)) {
                 const h = blockFromDB.height;
                 const i = toGetFromDB[h];
                 blocks[i] = blockFromDB;

--- a/packages/core-database/src/repositories/blocks-business-repository.ts
+++ b/packages/core-database/src/repositories/blocks-business-repository.ts
@@ -10,24 +10,24 @@ export class BlocksBusinessRepository implements Database.IBlocksBusinessReposit
     }
 
     public async findAllByGenerator(generatorPublicKey: string, paginate: Database.SearchPaginate) {
-        return await this.findAll({ ...{ generatorPublicKey }, ...paginate });
+        return this.findAll({ ...{ generatorPublicKey }, ...paginate });
     }
 
     public async findLastByPublicKey(generatorPublicKey: string) {
         // we order by height,desc by default
-        return await this.findAll({ generatorPublicKey });
+        return this.findAll({ generatorPublicKey });
     }
 
     public async findByHeight(height: number) {
-        return await this.findAll({ ...{ height } });
+        return this.findAll({ ...{ height } });
     }
 
     public async findById(id: string) {
-        return await this.databaseServiceProvider().connection.blocksRepository.findById(id);
+        return this.databaseServiceProvider().connection.blocksRepository.findById(id);
     }
 
     public async search(params: Database.IParameters) {
-        return await this.databaseServiceProvider().connection.blocksRepository.search(this.parseSearchParams(params));
+        return this.databaseServiceProvider().connection.blocksRepository.search(this.parseSearchParams(params));
     }
 
     private parseSearchParams(params: Database.IParameters): Database.SearchParameters {

--- a/packages/core-database/src/repositories/transactions-business-repository.ts
+++ b/packages/core-database/src/repositories/transactions-business-repository.ts
@@ -51,7 +51,7 @@ export class TransactionsBusinessRepository implements Database.ITransactionsBus
             searchParameters.paginate,
             searchParameters.orderBy,
         );
-        return await this.mapBlocksToTransactions(result.rows);
+        return this.mapBlocksToTransactions(result.rows);
     }
 
     public async findAllLegacy(parameters: any) {
@@ -74,9 +74,8 @@ export class TransactionsBusinessRepository implements Database.ITransactionsBus
     }
 
     public async getFeeStatistics() {
-        const opts = app.resolveOptions("transaction-pool");
-        return await this.databaseServiceProvider().connection.transactionsRepository.getFeeStatistics(
-            opts.dynamicFees.minFeeBroadcast,
+        return this.databaseServiceProvider().connection.transactionsRepository.getFeeStatistics(
+            app.resolveOptions("transaction-pool").dynamicFees.minFeeBroadcast,
         );
     }
 

--- a/packages/core-interfaces/src/core-database/database-repository/blocks-repository.ts
+++ b/packages/core-interfaces/src/core-database/database-repository/blocks-repository.ts
@@ -8,14 +8,25 @@ export interface IBlocksRepository extends IRepository {
      */
     findById(id: string): Promise<any>;
 
+    /**
+     * Find many blocks by their IDs.
+     * @param {String[]} ids
+     */
     findByIds(id: string[]): Promise<any[]>;
+
+    /**
+     * Get a block at the given height.
+     * @param  {Number} height the height of the blocks to retrieve
+     * @return {Promise}
+     */
+    findByHeight(heights): Promise<any>;
 
     /**
      * Get all of the blocks at the given heights.
      * @param {Array} heights the heights of the blocks to retrieve
      * @return {Promise}
      */
-    findByHeight(heights): Promise<any>;
+    findByHeights(heights): Promise<any>;
 
     /**
      * Count the number of records in the database.

--- a/packages/core-interfaces/src/core-database/database-repository/blocks-repository.ts
+++ b/packages/core-interfaces/src/core-database/database-repository/blocks-repository.ts
@@ -19,14 +19,14 @@ export interface IBlocksRepository extends IRepository {
      * @param  {Number} height the height of the blocks to retrieve
      * @return {Promise}
      */
-    findByHeight(heights): Promise<any>;
+    findByHeight(height: number): Promise<any>;
 
     /**
      * Get all of the blocks at the given heights.
      * @param {Array} heights the heights of the blocks to retrieve
      * @return {Promise}
      */
-    findByHeights(heights): Promise<any>;
+    findByHeights(heights: number[]): Promise<any>;
 
     /**
      * Count the number of records in the database.


### PR DESCRIPTION
## Proposed changes

The `findByHeight` method in `core-database-postgres` at the moment has a very misleading name as the singular `height` in the same indicates that you will received a single block but it executes `manyOrNone` which means the result will be an array.

https://github.com/ArkEcosystem/core/blob/develop/packages/core-database-postgres/src/repositories/blocks.ts#L32

This PR provides a `findByHeight` and `findByHeights` method which return a single and multiple blocks. This will avoid confusion and unexpected behaviour like there currently is with the `findByHeight` method based on its name.

## Types of changes

- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes