### PR TITLE
chore(ci): explicitly name integration test jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -340,7 +340,7 @@ jobs:
       - run:
           name: Codecov
           command: ./node_modules/.bin/codecov
-  test-node10-0:
+  test-node10-integration-0:
     working_directory: ~/core
     environment:
       CORE_DB_DATABASE: core_unitnet
@@ -425,7 +425,7 @@ jobs:
       - run:
           name: Codecov
           command: ./node_modules/.bin/codecov
-  test-node11-0:
+  test-node11-integration-0:
     working_directory: ~/core
     environment:
       CORE_DB_DATABASE: core_unitnet
@@ -510,7 +510,7 @@ jobs:
       - run:
           name: Codecov
           command: ./node_modules/.bin/codecov
-  test-node10-1:
+  test-node10-integration-1:
     working_directory: ~/core
     environment:
       CORE_DB_DATABASE: core_unitnet
@@ -625,7 +625,7 @@ jobs:
       - run:
           name: Codecov
           command: ./node_modules/.bin/codecov
-  test-node10-2:
+  test-node10-integration-2:
     working_directory: ~/core
     environment:
       CORE_DB_DATABASE: core_unitnet
@@ -734,7 +734,7 @@ jobs:
       - run:
           name: Codecov
           command: ./node_modules/.bin/codecov
-  test-node11-1:
+  test-node11-integration-1:
     working_directory: ~/core
     environment:
       CORE_DB_DATABASE: core_unitnet
@@ -849,7 +849,7 @@ jobs:
       - run:
           name: Codecov
           command: ./node_modules/.bin/codecov
-  test-node11-2:
+  test-node11-integration-2:
     working_directory: ~/core
     environment:
       CORE_DB_DATABASE: core_unitnet
@@ -966,9 +966,9 @@ workflows:
       - test-node11-unit
       - test-node10-functional
       - test-node11-functional
-      - test-node10-0
-      - test-node11-0
-      - test-node10-1
-      - test-node10-2
-      - test-node11-1
-      - test-node11-2
+      - test-node10-integration-0
+      - test-node11-integration-0
+      - test-node10-integration-1
+      - test-node10-integration-2
+      - test-node11-integration-1
+      - test-node11-integration-2

--- a/.circleci/configTemplate.json
+++ b/.circleci/configTemplate.json
@@ -357,7 +357,7 @@
                 }
             ]
         },
-        "test-node10-0": {
+        "test-node10-integration-0": {
             "working_directory": "~/core",
             "environment": {
                 "CORE_DB_DATABASE": "core_unitnet",
@@ -446,7 +446,7 @@
                 }
             ]
         },
-        "test-node11-0": {
+        "test-node11-integration-0": {
             "working_directory": "~/core",
             "environment": {
                 "CORE_DB_DATABASE": "core_unitnet",
@@ -539,7 +539,7 @@
     "workflows": {
         "version": 2,
         "build_and_test": {
-            "jobs": ["test-node10-0", "test-node11-0"]
+            "jobs": ["test-node10-integration-0", "test-node11-integration-0"]
         }
     }
 }


### PR DESCRIPTION
## Proposed changes

Put `integration` into the name of the CircleCI jobs that run `integration` tests.

## Types of changes

- [x] Other

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes