### PR TITLE
fix(core-database): search a block ID if there is no height match

### DIFF
--- a/packages/core-database/src/repositories/blocks-business-repository.ts
+++ b/packages/core-database/src/repositories/blocks-business-repository.ts
@@ -30,7 +30,7 @@ export class BlocksBusinessRepository implements Database.IBlocksBusinessReposit
         try {
             const block = await this.findByHeight(idOrHeight);
 
-            return block;
+            return block || this.findById(idOrHeight);
         } catch (error) {
             return this.findById(idOrHeight);
         }


### PR DESCRIPTION
## Proposed changes

The `try catch` only triggers when a legacy block ID (bigint) is passed as it exceeds the postgres int size but we also want to search by ID if the height was a valid int but didn't yield a result.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes