### PR TITLE
chore(ci): remove the postgres setup from unit test jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,16 +2,8 @@ version: 2
 jobs:
   test-node10-unit:
     working_directory: ~/core
-    environment:
-      CORE_DB_DATABASE: core_unitnet
-      CORE_DB_USERNAME: core
     docker:
       - image: 'circleci/node:10-browsers'
-      - image: 'postgres:alpine'
-        environment:
-          POSTGRES_PASSWORD: password
-          POSTGRES_DB: core_unitnet
-          POSTGRES_USER: core
     steps:
       - checkout
       - run:
@@ -20,8 +12,8 @@ jobs:
             sudo sh -c 'echo "deb http://ftp.debian.org/debian stable main
             contrib non-free" >> /etc/apt/sources.list' && sudo apt-get update
       - run:
-          name: Install xsel & postgresql-client
-          command: sudo apt-get install -q xsel postgresql-client
+          name: Install xsel
+          command: sudo apt-get install -q xsel
       - run:
           name: Generate cache key
           command: >-
@@ -88,16 +80,8 @@ jobs:
           command: ./node_modules/.bin/codecov
   test-node11-unit:
     working_directory: ~/core
-    environment:
-      CORE_DB_DATABASE: core_unitnet
-      CORE_DB_USERNAME: core
     docker:
       - image: 'circleci/node:11-browsers'
-      - image: 'postgres:alpine'
-        environment:
-          POSTGRES_PASSWORD: password
-          POSTGRES_DB: core_unitnet
-          POSTGRES_USER: core
     steps:
       - checkout
       - run:
@@ -106,8 +90,8 @@ jobs:
             sudo sh -c 'echo "deb http://ftp.debian.org/debian stable main
             contrib non-free" >> /etc/apt/sources.list' && sudo apt-get update
       - run:
-          name: Install xsel & postgresql-client
-          command: sudo apt-get install -q xsel postgresql-client
+          name: Install xsel
+          command: sudo apt-get install -q xsel
       - run:
           name: Generate cache key
           command: >-

--- a/.circleci/configTemplate.json
+++ b/.circleci/configTemplate.json
@@ -3,21 +3,9 @@
     "jobs": {
         "test-node10-unit": {
             "working_directory": "~/core",
-            "environment": {
-                "CORE_DB_DATABASE": "core_unitnet",
-                "CORE_DB_USERNAME": "core"
-            },
             "docker": [
                 {
                     "image": "circleci/node:10-browsers"
-                },
-                {
-                    "image": "postgres:alpine",
-                    "environment": {
-                        "POSTGRES_PASSWORD": "password",
-                        "POSTGRES_DB": "core_unitnet",
-                        "POSTGRES_USER": "core"
-                    }
                 }
             ],
             "steps": [
@@ -30,8 +18,8 @@
                 },
                 {
                     "run": {
-                        "name": "Install xsel & postgresql-client",
-                        "command": "sudo apt-get install -q xsel postgresql-client"
+                        "name": "Install xsel",
+                        "command": "sudo apt-get install -q xsel"
                     }
                 },
                 {
@@ -92,21 +80,9 @@
         },
         "test-node11-unit": {
             "working_directory": "~/core",
-            "environment": {
-                "CORE_DB_DATABASE": "core_unitnet",
-                "CORE_DB_USERNAME": "core"
-            },
             "docker": [
                 {
                     "image": "circleci/node:11-browsers"
-                },
-                {
-                    "image": "postgres:alpine",
-                    "environment": {
-                        "POSTGRES_PASSWORD": "password",
-                        "POSTGRES_DB": "core_unitnet",
-                        "POSTGRES_USER": "core"
-                    }
                 }
             ],
             "steps": [
@@ -119,8 +95,8 @@
                 },
                 {
                     "run": {
-                        "name": "Install xsel & postgresql-client",
-                        "command": "sudo apt-get install -q xsel postgresql-client"
+                        "name": "Install xsel",
+                        "command": "sudo apt-get install -q xsel"
                     }
                 },
                 {


### PR DESCRIPTION
## Proposed changes

Remove all postgres steps from the unit test jobs as there is no need for pg, cuts off a bit of runtime.

## Types of changes

- [x] Other... Please describe:

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes