### PR TITLE
refactor(core-event-emitter): expose all application events through an enum

### DIFF
--- a/__tests__/unit/core-blockchain/blockchain.test.ts
+++ b/__tests__/unit/core-blockchain/blockchain.test.ts
@@ -297,36 +297,6 @@ describe("Blockchain", () => {
         });
     });
 
-    describe("getEvents", () => {
-        it("should return the events", () => {
-            expect(blockchain.getEvents()).toEqual([
-                "block.applied",
-                "block.forged",
-                "block.reverted",
-                "block.received",
-                "block.disregarded",
-                "delegate.registered",
-                "delegate.resigned",
-                "forger.failed",
-                "forger.missing",
-                "forger.started",
-                "peer.added",
-                "peer.removed",
-                "round.created",
-                "state:started",
-                "transaction.applied",
-                "transaction.expired",
-                "transaction.forged",
-                "transaction.reverted",
-                "transaction.pool.added",
-                "transaction.pool.rejected",
-                "transaction.pool.removed",
-                "wallet.saved",
-                "wallet.created.cold",
-            ]);
-        });
-    });
-
     describe("constructor - networkStart", () => {
         it("should output log messages if launched in networkStart mode", async () => {
             const loggerWarn = jest.spyOn(logger, "warn");

--- a/__tests__/unit/core-database/database-service.test.ts
+++ b/__tests__/unit/core-database/database-service.test.ts
@@ -46,7 +46,7 @@ describe("Database Service", () => {
 
         databaseService = createService();
 
-        expect(emitter.on).toHaveBeenCalledWith("state:started", expect.toBeFunction());
+        expect(emitter.on).toHaveBeenCalledWith("state.started", expect.toBeFunction());
         expect(emitter.on).toHaveBeenCalledWith("wallet.created.cold", expect.toBeFunction());
     });
 

--- a/packages/core-blockchain/src/blockchain.ts
+++ b/packages/core-blockchain/src/blockchain.ts
@@ -533,36 +533,4 @@ export class Blockchain implements blockchain.IBlockchain {
     public pushPingBlock(block: models.IBlockData) {
         this.state.pushPingBlock(block);
     }
-
-    /**
-     * Get the list of events that are available.
-     * @return {Array}
-     */
-    public getEvents() {
-        return [
-            "block.applied",
-            "block.forged",
-            "block.reverted",
-            "block.received",
-            "block.disregarded",
-            "delegate.registered",
-            "delegate.resigned",
-            "forger.failed",
-            "forger.missing",
-            "forger.started",
-            "peer.added",
-            "peer.removed",
-            "round.created",
-            "state:started",
-            "transaction.applied",
-            "transaction.expired",
-            "transaction.forged",
-            "transaction.reverted",
-            "transaction.pool.added",
-            "transaction.pool.rejected",
-            "transaction.pool.removed",
-            "wallet.saved",
-            "wallet.created.cold",
-        ];
-    }
 }

--- a/packages/core-database/package.json
+++ b/packages/core-database/package.json
@@ -23,6 +23,7 @@
     },
     "dependencies": {
         "@arkecosystem/core-container": "^2.3.0-next.3",
+        "@arkecosystem/core-event-emitter": "^2.3.0-next.3",
         "@arkecosystem/core-interfaces": "^2.3.0-next.3",
         "@arkecosystem/core-transactions": "^2.3.0-next.3",
         "@arkecosystem/core-utils": "^2.3.0-next.3",

--- a/packages/core-database/src/database-service.ts
+++ b/packages/core-database/src/database-service.ts
@@ -1,4 +1,5 @@
 import { app } from "@arkecosystem/core-container";
+import { ApplicationEvents } from "@arkecosystem/core-event-emitter";
 import { Blockchain, Database, EventEmitter, Logger } from "@arkecosystem/core-interfaces";
 import { TransactionHandlerRegistry } from "@arkecosystem/core-transactions";
 import { roundCalculator } from "@arkecosystem/core-utils";
@@ -547,11 +548,11 @@ export class DatabaseService implements Database.IDatabaseService {
     }
 
     private registerListeners() {
-        this.emitter.on("state:started", () => {
+        this.emitter.on(ApplicationEvents.StateStarted, () => {
             this.stateStarted = true;
         });
 
-        this.emitter.on("wallet.created.cold", async coldWallet => {
+        this.emitter.on(ApplicationEvents.WalletColdCreated, async coldWallet => {
             try {
                 const wallet = await this.connection.walletsRepository.findByAddress(coldWallet.address);
 

--- a/packages/core-elasticsearch/package.json
+++ b/packages/core-elasticsearch/package.json
@@ -19,6 +19,7 @@
     },
     "dependencies": {
         "@arkecosystem/core-container": "^2.3.0-next.3",
+        "@arkecosystem/core-event-emitter": "^2.3.0-next.3",
         "@arkecosystem/core-http-utils": "^2.3.0-next.3",
         "@arkecosystem/core-interfaces": "^2.3.0-next.3",
         "@arkecosystem/crypto": "^2.3.0-next.3",

--- a/packages/core-elasticsearch/src/indices/rounds.ts
+++ b/packages/core-elasticsearch/src/indices/rounds.ts
@@ -1,3 +1,4 @@
+import { ApplicationEvents } from "@arkecosystem/core-event-emitter";
 import { storage } from "../storage";
 import { first, last } from "../utils";
 import { Index } from "./base";
@@ -36,6 +37,6 @@ export class Rounds extends Index {
     }
 
     public listen() {
-        this.emitter.on("round.created", () => this.index());
+        this.emitter.on(ApplicationEvents.RoundCreated, () => this.index());
     }
 }

--- a/packages/core-elasticsearch/src/indices/wallets.ts
+++ b/packages/core-elasticsearch/src/indices/wallets.ts
@@ -1,4 +1,4 @@
-import { client } from "../client";
+import { ApplicationEvents } from "@arkecosystem/core-event-emitter";
 import { Index } from "./base";
 
 export class Wallets extends Index {
@@ -33,6 +33,6 @@ export class Wallets extends Index {
     }
 
     public listen() {
-        this.emitter.on("round.applied", () => this.index());
+        this.emitter.on(ApplicationEvents.RoundApplied, () => this.index());
     }
 }

--- a/packages/core-event-emitter/src/index.ts
+++ b/packages/core-event-emitter/src/index.ts
@@ -7,3 +7,30 @@ export const plugin = {
         return new EventEmitter();
     },
 };
+
+export enum ApplicationEvents {
+    BlockApplied = "block.applied",
+    BlockDisregarded = "block.disregarded",
+    BlockForged = "block.forged",
+    BlockReceived = "block.received",
+    BlockReverted = "block.reverted",
+    DelegateRegistered = "delegate.registered",
+    DelegateResigned = "delegate.resigned",
+    ForgerFailed = "forger.failed",
+    ForgerMissing = "forger.missing",
+    ForgerStarted = "forger.started",
+    PeerAdded = "peer.added",
+    PeerRemoved = "peer.removed",
+    RoundApplied = "round.applied",
+    RoundCreated = "round.created",
+    StateStarted = "state.started",
+    TransactionApplied = "transaction.applied",
+    TransactionExpired = "transaction.expired",
+    TransactionForged = "transaction.forged",
+    TransactionPoolAdded = "transaction.pool.added",
+    TransactionPoolRejected = "transaction.pool.rejected",
+    TransactionPoolRemoved = "transaction.pool.removed",
+    TransactionReverted = "transaction.reverted",
+    WalletColdCreated = "wallet.created.cold",
+    WalletSaved = "wallet.saved",
+}

--- a/packages/core-interfaces/src/core-blockchain/blockchain.ts
+++ b/packages/core-interfaces/src/core-blockchain/blockchain.ts
@@ -173,10 +173,4 @@ export interface IBlockchain {
      * @return {Object}
      */
     pushPingBlock(block: models.IBlockData): void;
-
-    /**
-     * Get the list of events that are available.
-     * @return {Array}
-     */
-    getEvents(): string[];
 }

--- a/packages/core-webhooks/package.json
+++ b/packages/core-webhooks/package.json
@@ -20,6 +20,7 @@
     },
     "dependencies": {
         "@arkecosystem/core-container": "^2.3.0-next.3",
+        "@arkecosystem/core-event-emitter": "^2.3.0-next.3",
         "@arkecosystem/core-http-utils": "^2.3.0-next.3",
         "@arkecosystem/core-interfaces": "^2.3.0-next.3",
         "@arkecosystem/core-utils": "^2.3.0-next.3",

--- a/packages/core-webhooks/src/manager.ts
+++ b/packages/core-webhooks/src/manager.ts
@@ -1,5 +1,6 @@
 import { app } from "@arkecosystem/core-container";
-import { Blockchain, EventEmitter, Logger } from "@arkecosystem/core-interfaces";
+import { ApplicationEvents } from "@arkecosystem/core-event-emitter";
+import { EventEmitter, Logger } from "@arkecosystem/core-interfaces";
 import { httpie } from "@arkecosystem/core-utils";
 import * as conditions from "./conditions";
 import { database } from "./database";
@@ -7,10 +8,9 @@ import { database } from "./database";
 export class WebhookManager {
     private readonly logger: Logger.ILogger = app.resolvePlugin<Logger.ILogger>("logger");
     private readonly emitter: EventEmitter.EventEmitter = app.resolvePlugin<EventEmitter.EventEmitter>("event-emitter");
-    private readonly blockchain: Blockchain.IBlockchain = app.resolvePlugin<Blockchain.IBlockchain>("blockchain");
 
     public async setUp() {
-        for (const event of this.blockchain.getEvents()) {
+        for (const event of Object.values(ApplicationEvents)) {
             this.emitter.on(event, async payload => {
                 const { rows } = await database.findByEvent(event);
 


### PR DESCRIPTION
## Proposed changes

Export the `ApplicationEvents` enum from `core-event-emitter` to keep all event names in a single place to make changes and access to the event list easier.

## Types of changes

- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes