### PR TITLE
refactor(core-p2p): remove height difference ban

### DIFF
--- a/__tests__/unit/core-p2p/guard.test.ts
+++ b/__tests__/unit/core-p2p/guard.test.ts
@@ -153,22 +153,6 @@ describe("Guard", () => {
             expect(convertToMinutes(until)).toBe(5);
         });
 
-        it('should return a 10 minutes suspension for "Node is not at height"', () => {
-            guard.monitor.getNetworkHeight = jest.fn(() => 154);
-
-            guard.suspend({
-                ...dummy,
-                state: {
-                    height: 1,
-                },
-            });
-
-            const { until, reason } = guard.get(dummy.ip);
-
-            expect(reason).toBe("Node is not at height");
-            expect(convertToMinutes(until)).toBe(10);
-        });
-
         it('should return a 2 minutes suspension for "Timeout"', () => {
             guard.suspend({
                 ...dummy,

--- a/packages/core-p2p/src/guard.ts
+++ b/packages/core-p2p/src/guard.ts
@@ -47,18 +47,6 @@ export class Guard {
             reason: "Invalid Version",
             weight: 2,
         },
-        INVALID_MILESTONE_HASH: {
-            number: 5,
-            period: "addMinutes",
-            reason: "Invalid Milestones",
-            weight: 2,
-        },
-        INVALID_HEIGHT: {
-            number: 10,
-            period: "addMinutes",
-            reason: "Node is not at height",
-            weight: 3,
-        },
         INVALID_NETWORK: {
             number: 5,
             period: "addMinutes",
@@ -310,14 +298,6 @@ export class Guard {
 
         if (!this.isValidVersion(peer)) {
             return this.determinePunishment(peer, this.offences.INVALID_VERSION);
-        }
-
-        // NOTE: Suspending this peer only means that we no longer
-        // will download blocks from him but he can still download blocks from us.
-        const heightDifference = Math.abs(this.monitor.getNetworkHeight() - peer.state.height);
-
-        if (heightDifference >= 153) {
-            return this.determinePunishment(peer, this.offences.INVALID_HEIGHT);
         }
 
         return this.determinePunishment(peer, this.offences.UNKNOWN);


### PR DESCRIPTION
## Proposed changes

Remove the height ban now that the verifier takes care of issues like that.

## Types of changes

- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes