### PR TITLE
fix(core-p2p): frequent peer timeout errors

### DIFF
--- a/packages/core-p2p/src/monitor.ts
+++ b/packages/core-p2p/src/monitor.ts
@@ -685,17 +685,22 @@ export class Monitor implements P2P.IMonitor {
             app.forceExit("No seed peers defined in peers.json");
         }
 
-        let peers = peerList.map(peer => {
+        const peers = peerList.map(peer => {
             peer.version = app.getVersion();
             return peer;
         });
 
-        if (localConfig.get("peers")) {
-            peers = { ...peers, ...localConfig.get("peers") };
+        const localConfigPeers = localConfig.get("peers");
+        if (localConfigPeers) {
+            localConfigPeers.forEach(peerA => {
+                if (!peers.some(peerB => peerA.ip === peerB.ip && peerA.port === peerB.port)) {
+                    peers.push(peerA);
+                }
+            });
         }
 
         return Promise.all(
-            Object.values(peers).map((peer: any) => {
+            peers.map((peer: any) => {
                 this.guard.delete(peer.ip);
                 return this.acceptNewPeer(peer, { seed: true, lessVerbose: true });
             }),

--- a/packages/core-p2p/src/server/plugins/accept-request.ts
+++ b/packages/core-p2p/src/server/plugins/accept-request.ts
@@ -42,9 +42,13 @@ const register = async (server, options) => {
 
                 try {
                     if (!isLocalHost(peer.ip)) {
-                        const accepted = await monitor.acceptNewPeer(peer);
-                        if (!accepted && request.method === "post") {
-                            return Boom.forbidden();
+                        if (request.method === "post") {
+                            const accepted = await monitor.acceptNewPeer(peer);
+                            if (!accepted) {
+                                return Boom.forbidden();
+                            }
+                        } else {
+                            monitor.acceptNewPeer(peer);
                         }
                     }
                 } catch (error) {


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

Each request goes through the `accept-request` handler which waits for `acceptNewPeer` to complete before returning a response. If `peer A` makes a request to `peer B` and `peer B` does not know `peer A`, it will try to ping `peer A` in `acceptNewPeer`. Now depending on different factors `peer A` might not respond so the ping runs into a timeout. When this happens the request of `peer A` runs into a timeout as well, since `peer B` did not respond fast enough, because `peer A` didn't reply to the ping. Afterwards `peer B` will suspend `peer A` since `acceptNewPeer` failed. The next time `peer A` makes a request `peer B` will not try to ping it again, thus the request completes without running into a timeout.

This can be easily observed when running a relay behind a firewall.

For example:
```
2019-03-27 00:02:34][DEBUG]: Could not accept new peer 5.196.105.32:4001: Error: Peer 5.196.105.32: could not get status response
[2019-03-27 00:02:34][DEBUG]: Suspended 5.196.105.32 for 2 minutes because of "Timeout"
[2019-03-27 00:02:34][DEBUG]: Request to http://5.196.105.38:4001/peer/status failed: timeout of 3000ms exceeded
[2019-03-27 00:02:34][DEBUG]: Request to http://178.32.65.139:4001/peer/status failed: timeout of 3000ms exceeded
[2019-03-27 00:02:34][DEBUG]: Request to http://5.196.105.39:4001/peer/status failed: timeout of 3000ms exceeded
[2019-03-27 00:02:34][DEBUG]: Request to http://5.196.105.37:4001/peer/status failed: timeout of 3000ms exceeded
[2019-03-27 00:02:34][DEBUG]: Request to http://178.32.65.143:4001/peer/status failed: timeout of 3000ms exceeded
[2019-03-27 00:02:34][DEBUG]: Request to http://178.32.65.137:4001/peer/status failed: timeout of 3000ms exceeded
[2019-03-27 00:02:34][DEBUG]: Request to http://178.32.65.141:4001/peer/status failed: timeout of 3000ms exceeded
[2019-03-27 00:02:34][DEBUG]: Request to http://178.32.65.136:4001/peer/status failed: timeout of 3000ms exceeded
[2019-03-27 00:02:34][DEBUG]: Request to http://178.32.65.140:4001/peer/status failed: timeout of 3000ms exceeded
[2019-03-27 00:02:34][DEBUG]: Request to http://178.32.65.142:4001/peer/status failed: timeout of 3000ms exceeded
[2019-03-27 00:02:34][DEBUG]: Request to http://178.32.65.138:4001/peer/status failed: timeout of 3000ms exceeded
[2019-03-27 00:02:34][DEBUG]: Request to http://54.36.121.115:4001/peer/status failed: timeout of 3000ms exceeded
[2019-03-27 00:02:34][DEBUG]: Request to http://46.105.160.106:4001/peer/status failed: timeout of 3000ms exceeded
[2019-03-27 00:02:34][DEBUG]: Request to http://54.38.120.34:4001/peer/status failed: timeout of 3000ms exceeded
[2019-03-27 00:02:34][DEBUG]: Request to http://151.80.125.38:4001/peer/status failed: timeout of 3000ms exceeded
[2019-03-27 00:02:34][DEBUG]: Request to http://45.32.238.137:4001/peer/status failed: timeout of 3000ms exceeded
[2019-03-27 00:02:34][DEBUG]: Request to http://51.255.105.53:4001/peer/status failed: timeout of 3000ms exceeded
[2019-03-27 00:02:34][DEBUG]: Request to http://54.38.120.36:4001/peer/status failed: timeout of 3000ms exceeded
[2019-03-27 00:02:34][DEBUG]: Request to http://46.105.160.104:4001/peer/status failed: timeout of 3000ms exceeded
```
The fix is to call `acceptNewPeer` non-blocking for `GET` requests which is fine, since the result is only used for `POST` requests.

While testing I also noticed that `buildPeers` is broken, which silently failed because it was swallowing thrown errors.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [ ] Docs (documentation only changes)
- [ ] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [ ] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
