### PR TITLE
fix: insert the genesis block as soon as the database is ready

### DIFF
--- a/__tests__/unit/core-blockchain/state-machine.test.ts
+++ b/__tests__/unit/core-blockchain/state-machine.test.ts
@@ -15,7 +15,7 @@ import { logger } from "./mocks/logger";
 let stateMachine;
 
 beforeAll(async () => {
-    stateMachine = require("../../../packages/core-blockchain/src/state-machine").stateMachine;
+    ({ stateMachine } = require("../../../packages/core-blockchain/src/state-machine"));
 
     process.env.CORE_ENV = "";
 });
@@ -168,13 +168,9 @@ describe("State Machine", () => {
                 loggerWarn = jest.spyOn(logger, "warn");
 
                 databaseMocks = {
-                    getLastBlock: jest.spyOn(blockchain.database, "getLastBlock").mockReturnValue({
-                        // @ts-ignore
-                        data: {
-                            height: 1,
-                            timestamp: slots.getTime(),
-                        },
-                    }),
+                    getLastBlock: jest
+                        .spyOn(blockchain.database, "getLastBlock")
+                        .mockReturnValue(new Block(genesisBlockJSON)),
                     // @ts-ignore
                     saveBlock: jest.spyOn(blockchain.database, "saveBlock").mockReturnValue(true),
                     verifyBlockchain: jest.spyOn(blockchain.database, "verifyBlockchain").mockReturnValue({
@@ -197,13 +193,6 @@ describe("State Machine", () => {
                 jest.restoreAllMocks();
 
                 process.env.NODE_ENV = "TEST";
-            });
-
-            it("should get genesis block from config if there is no last block in database", async () => {
-                jest.spyOn(blockchain.database, "getLastBlock").mockReturnValue(null);
-
-                await expect(() => actionMap.init()).toDispatch(blockchain, "STARTED");
-                expect(databaseMocks.saveBlock).toHaveBeenCalled();
             });
 
             it("should dispatch FAILURE if there is no last block in database and genesis block payload hash != configured nethash", async () => {

--- a/packages/core-api/src/services/transformer.ts
+++ b/packages/core-api/src/services/transformer.ts
@@ -10,9 +10,9 @@ import { transformTransactionLegacy } from "../versions/1/transactions/transform
 import { transformBlock } from "../versions/2/blocks/transformer";
 import { transformDelegate } from "../versions/2/delegates/transformer";
 import { transformPeer } from "../versions/2/peers/transformer";
+import { transformRoundDelegate } from "../versions/2/rounds/transformer";
 import { transformFeeStatistics } from "../versions/2/shared/transformers/fee-statistics";
 import { transformPorts } from "../versions/2/shared/transformers/ports";
-import { transformRoundDelegate } from "../versions/2/rounds/transformer";
 import { transformTransaction } from "../versions/2/transactions/transformer";
 import { transformWallet } from "../versions/2/wallets/transformer";
 

--- a/packages/core-blockchain/src/state-machine.ts
+++ b/packages/core-blockchain/src/state-machine.ts
@@ -127,12 +127,6 @@ blockchainMachine.actionMap = (blockchain: Blockchain) => ({
         try {
             const block: models.Block = await blockchain.database.getLastBlock();
 
-            if (block.data.payloadHash !== config.get("network.nethash")) {
-                logger.error("FATAL: The genesis block payload hash is different from configured the nethash");
-
-                return blockchain.dispatch("FAILURE");
-            }
-
             if (!blockchain.database.restoredDatabaseIntegrity) {
                 logger.info("Verifying database integrity");
 
@@ -151,6 +145,12 @@ blockchainMachine.actionMap = (blockchain: Blockchain) => ({
 
             // only genesis block? special case of first round needs to be dealt with
             if (block.data.height === 1) {
+                if (block.data.payloadHash !== config.get("network.nethash")) {
+                    logger.error("FATAL: The genesis block payload hash is different from configured the nethash");
+
+                    return blockchain.dispatch("FAILURE");
+                }
+
                 await blockchain.database.deleteRound(1);
             }
 

--- a/packages/core-blockchain/src/state-machine.ts
+++ b/packages/core-blockchain/src/state-machine.ts
@@ -125,20 +125,12 @@ blockchainMachine.actionMap = (blockchain: Blockchain) => ({
 
     async init() {
         try {
-            let block = await blockchain.database.getLastBlock();
+            const block: models.Block = await blockchain.database.getLastBlock();
 
-            if (!block) {
-                logger.warn("No block found in database");
+            if (block.data.payloadHash !== config.get("network.nethash")) {
+                logger.error("FATAL: The genesis block payload hash is different from configured the nethash");
 
-                block = new Block(config.get("genesisBlock"));
-
-                if (block.data.payloadHash !== config.get("network.nethash")) {
-                    logger.error("FATAL: The genesis block payload hash is different from configured the nethash");
-
-                    return blockchain.dispatch("FAILURE");
-                }
-
-                await blockchain.database.saveBlock(block);
+                return blockchain.dispatch("FAILURE");
             }
 
             if (!blockchain.database.restoredDatabaseIntegrity) {

--- a/packages/core-database/src/database-service.ts
+++ b/packages/core-database/src/database-service.ts
@@ -47,6 +47,7 @@ export class DatabaseService implements Database.IDatabaseService {
 
     public async init(): Promise<void> {
         await this.loadBlocksFromCurrentRound();
+        await this.createGenesisBlock();
     }
 
     public async restoreCurrentRound(height: number): Promise<void> {
@@ -519,6 +520,14 @@ export class DatabaseService implements Database.IDatabaseService {
             return transactionHandler.canBeApplied(transaction, sender) && !dbTransaction;
         } catch {
             return false;
+        }
+    }
+
+    protected async createGenesisBlock(): Promise<void> {
+        if (!(await this.getLastBlock())) {
+            this.logger.warn("No block found in database");
+
+            await this.saveBlock(new Block(this.config.get("genesisBlock")));
         }
     }
 

--- a/packages/core-database/src/database-service.ts
+++ b/packages/core-database/src/database-service.ts
@@ -523,7 +523,7 @@ export class DatabaseService implements Database.IDatabaseService {
         }
     }
 
-    protected async createGenesisBlock(): Promise<void> {
+    private async createGenesisBlock(): Promise<void> {
         if (!(await this.getLastBlock())) {
             this.logger.warn("No block found in database");
 

--- a/packages/core-interfaces/src/core-database/database-service.ts
+++ b/packages/core-interfaces/src/core-database/database-service.ts
@@ -115,6 +115,4 @@ export interface IDatabaseService {
     getBlocksForRound(round?: number): Promise<models.Block[]>;
 
     getCommonBlocks(ids: string[]): Promise<models.IBlockData[]>;
-
-    createGenesisBlock(): Promise<void>;
 }

--- a/packages/core-interfaces/src/core-database/database-service.ts
+++ b/packages/core-interfaces/src/core-database/database-service.ts
@@ -115,4 +115,6 @@ export interface IDatabaseService {
     getBlocksForRound(round?: number): Promise<models.Block[]>;
 
     getCommonBlocks(ids: string[]): Promise<models.IBlockData[]>;
+
+    createGenesisBlock(): Promise<void>;
 }


### PR DESCRIPTION
## Proposed changes

When a node starts with a fresh database it won't have a genesis block until `core-blockchain` is mounted and the state machine entered the `init` state which will insert it.

This logic is flawed and causes issues with the peer verifier. The first problem is that during the start of a node https://github.com/ArkEcosystem/core/blob/2.4/packages/core-p2p/src/peer-verifier.ts#L122 will always be false as `core-p2p` is mounted before `core-blockchain` so it only becomes true once `core-blockchain` has created that registration in the container. As this will always be false we switch to hitting the database in https://github.com/ArkEcosystem/core/blob/2.4/packages/core-p2p/src/peer-verifier.ts#L125 which will also fail for the same reason as the first condition.

The result of that is that if you run a with a fresh database and peers ping you back they all will get banned/rejected because you have no block in your database that can be compared to their last block based on height. As soon as `core-blockchain` is mounted and the peers ping you everything will be fine which is why this bug only shows when you run a node from 0 with a fresh database.

**Now the genesis block is inserted into the database as soon as it is ready which means there will always be a genesis block available.**

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes