### PR TITLE
fix(core-p2p): avoid duplicate connections with the same peer

### DIFF
--- a/__tests__/integration/core-p2p/network-monitor.test.ts
+++ b/__tests__/integration/core-p2p/network-monitor.test.ts
@@ -47,7 +47,7 @@ beforeEach(async () => {
 
     storage.setPeer(peer);
 
-    connector.ensureConnection(peer);
+    connector.connect(peer);
 });
 
 describe("NetworkMonitor", () => {

--- a/packages/core-api/src/versions/1/peers/transformer.ts
+++ b/packages/core-api/src/versions/1/peers/transformer.ts
@@ -8,7 +8,6 @@ export function transformPeerLegacy(model) {
         port: model.port,
         version: model.version,
         height: model.height,
-        status: [200, "OK"].includes(model.status) ? "OK" : "ERROR",
         os: model.os,
         delay: model.latency,
     };

--- a/packages/core-api/src/versions/2/peers/transformer.ts
+++ b/packages/core-api/src/versions/2/peers/transformer.ts
@@ -8,7 +8,6 @@ export function transformPeer(model) {
         port: +model.port,
         version: model.version,
         height: model.state ? model.state.height : model.height,
-        status: [200, "OK"].includes(model.status) ? 200 : 400,
         os: model.os,
         latency: model.latency,
     };

--- a/packages/core-interfaces/src/core-p2p/peer-connector.ts
+++ b/packages/core-interfaces/src/core-p2p/peer-connector.ts
@@ -4,7 +4,6 @@ import { IPeer } from "./peer";
 export interface IPeerConnector {
     all(): SCClientSocket[];
     connection(peer: IPeer): SCClientSocket;
-    ensureConnection(peer: IPeer): SCClientSocket;
     connect(peer: IPeer): SCClientSocket;
     disconnect(peer: IPeer): void;
     emit(peer: IPeer, event: string, data: any): void;

--- a/packages/core-p2p/src/peer-communicator.ts
+++ b/packages/core-p2p/src/peer-communicator.ts
@@ -178,7 +178,7 @@ export class PeerCommunicator implements P2P.IPeerCommunicator {
 
             this.updateHeaders(peer);
 
-            response = await socketEmit(this.connector.ensureConnection(peer), event, data, peer.headers, timeout);
+            response = await socketEmit(this.connector.connect(peer), event, data, peer.headers, timeout);
 
             peer.latency = new Date().getTime() - timeBeforeSocketCall;
             this.parseHeaders(peer, response);

--- a/packages/core-p2p/src/peer-processors.ts
+++ b/packages/core-p2p/src/peer-processors.ts
@@ -97,14 +97,14 @@ export class PeerProcessor implements P2P.IPeerProcessor {
 
         punishment = punishment || this.guard.analyze(peer);
 
+        this.connector.disconnect(peer);
+
         if (!punishment) {
             return;
         }
 
         this.storage.setSuspendedPeer(new PeerSuspension(peer, punishment));
         this.storage.forgetPeer(peer);
-
-        this.connector.disconnect(peer);
 
         this.logger.debug(
             `Suspended ${peer.ip} for ${prettyMs(punishment.until.diff(dato()), {
@@ -158,12 +158,8 @@ export class PeerProcessor implements P2P.IPeerProcessor {
 
             this.emitter.emit("peer.added", newPeer);
         } catch (error) {
-            if (error instanceof PeerStatusResponseError) {
-                this.logger.debug(error.message);
-            } else {
-                this.logger.debug(`Could not accept new peer ${newPeer.ip}:${newPeer.port}: ${error}`);
-                this.suspend(newPeer);
-            }
+            this.logger.debug(`Could not accept new peer ${newPeer.ip}:${newPeer.port}: ${error}`);
+            this.suspend(newPeer);
         } finally {
             this.storage.forgetPendingPeer(peer);
         }

--- a/packages/core-p2p/src/peer-processors.ts
+++ b/packages/core-p2p/src/peer-processors.ts
@@ -148,8 +148,6 @@ export class PeerProcessor implements P2P.IPeerProcessor {
         try {
             this.storage.setPendingPeer(peer);
 
-            this.connector.connect(newPeer);
-
             await this.communicator.ping(newPeer, 3000);
 
             this.storage.setPeer(newPeer);

--- a/packages/core-p2p/src/peer-processors.ts
+++ b/packages/core-p2p/src/peer-processors.ts
@@ -148,6 +148,8 @@ export class PeerProcessor implements P2P.IPeerProcessor {
         try {
             this.storage.setPendingPeer(peer);
 
+            this.connector.connect(newPeer);
+
             await this.communicator.ping(newPeer, 3000);
 
             this.storage.setPeer(newPeer);
@@ -155,8 +157,6 @@ export class PeerProcessor implements P2P.IPeerProcessor {
             if (!options.lessVerbose) {
                 this.logger.debug(`Accepted new peer ${newPeer.ip}:${newPeer.port}`);
             }
-
-            this.connector.connect(newPeer);
 
             this.emitter.emit("peer.added", newPeer);
         } catch (error) {

--- a/packages/core-p2p/src/utils/socket.ts
+++ b/packages/core-p2p/src/utils/socket.ts
@@ -14,8 +14,8 @@ export const socketEmit = async (
         headers,
     };
 
-    // if socket is not connected, we give it 1 second
-    for (let i = 0; i < 10 && socket.getState() !== socket.OPEN; i++) {
+    // if socket is not connected, we give it 2 seconds
+    for (let i = 0; i < 20 && socket.getState() !== socket.OPEN; i++) {
         await delay(100);
     }
 


### PR DESCRIPTION
## Proposed changes

When accepting new peer, connect to peer before pinging.
Before we were doing :
- ping (without connecting before) : peer connection is made "on-the-fly" (ensureConnection method)
- connect to peer : creates a new connection to same peer resulting in socket error as there is already the connection from ping

Also some minor refactor on peer api (removing obsolete status), and giving more time to wait for peer socket to be open.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes