### PR TITLE
fix(core-p2p): set headers on peer instance

### DIFF
--- a/packages/core-p2p/src/peer-communicator.ts
+++ b/packages/core-p2p/src/peer-communicator.ts
@@ -142,7 +142,7 @@ export class PeerCommunicator implements P2P.IPeerCommunicator {
     // @TODO: add typehint for response
     private parseHeaders(peer: P2P.IPeer, response): any {
         ["nethash", "os", "version"].forEach(key => {
-            this[key] = response.headers[key] || this[key];
+            peer[key] = response.headers[key] || peer[key];
         });
 
         if (response.headers.height) {


### PR DESCRIPTION
## Proposed changes

Replace incorrectly used `this` by correct parameter `peer`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes