### PR TITLE
fix(core-tester-cli): init config manager from network preset

### DIFF
--- a/__tests__/integration/core-tester-cli/commands/send/delegate-registration.test.ts
+++ b/__tests__/integration/core-tester-cli/commands/send/delegate-registration.test.ts
@@ -15,7 +15,7 @@ beforeEach(() => {
     nock("http://localhost:4000")
         .get("/config")
         .thrice()
-        .reply(200, { data: { network: {} } });
+        .reply(200, { data: { network: { name: "unitnet" } } });
 
     jest.spyOn(httpie, "get");
     jest.spyOn(httpie, "post");

--- a/__tests__/integration/core-tester-cli/commands/send/second-signature.test.ts
+++ b/__tests__/integration/core-tester-cli/commands/send/second-signature.test.ts
@@ -14,7 +14,7 @@ beforeEach(() => {
     nock("http://localhost:4000")
         .get("/config")
         .thrice()
-        .reply(200, { data: { network: {} } });
+        .reply(200, { data: { network: { name: "unitnet" } } });
 
     jest.spyOn(httpie, "get");
     jest.spyOn(httpie, "post");

--- a/__tests__/integration/core-tester-cli/commands/send/transfer.test.ts
+++ b/__tests__/integration/core-tester-cli/commands/send/transfer.test.ts
@@ -14,7 +14,7 @@ beforeEach(() => {
     nock("http://localhost:4000")
         .get("/config")
         .twice()
-        .reply(200, { data: { network: {} } });
+        .reply(200, { data: { network: { name: "unitnet" } } });
 
     jest.spyOn(httpie, "post");
 });

--- a/__tests__/integration/core-tester-cli/commands/send/vote.test.ts
+++ b/__tests__/integration/core-tester-cli/commands/send/vote.test.ts
@@ -14,7 +14,7 @@ beforeEach(() => {
     nock("http://localhost:4000")
         .get("/config")
         .thrice()
-        .reply(200, { data: { network: {} } });
+        .reply(200, { data: { network: { name: "unitnet" } } });
 
     jest.spyOn(httpie, "get");
     jest.spyOn(httpie, "post");

--- a/packages/core-tester-cli/src/commands/command.ts
+++ b/packages/core-tester-cli/src/commands/command.ts
@@ -81,6 +81,8 @@ export abstract class BaseCommand extends Command {
         await this.setupConstants();
         await this.setupNetwork();
 
+        configManager.setFromPreset(this.network.name);
+
         this.signer = new Signer(this.network);
 
         return { args, flags };


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

Configuration manager of `crypto` package is initialized from `devnet` preset by default (source [#1](https://github.com/ArkEcosystem/core/blob/accc4ff45c0431ffdec6f24397095c2d90ccf93d/packages/crypto/src/managers/config.ts#L28) 
 [#2](https://github.com/ArkEcosystem/core/blob/accc4ff45c0431ffdec6f24397095c2d90ccf93d/packages/crypto/src/managers/config.ts#L185)).

When starting a new chain (for example `testnet`) with an updated config (for example `network.epoch`), `tester-cli` broadcasted transactions are not forged (and it fails silently which could be another issue).

The main reason is that `tester-cli` load local config  from node api ([source](https://github.com/ArkEcosystem/core/blob/accc4ff45c0431ffdec6f24397095c2d90ccf93d/packages/core-tester-cli/src/commands/command.ts#L75-L87)), but does not reset `crypto config manager` ([like `makeOffline` does](https://github.com/ArkEcosystem/core/blob/accc4ff45c0431ffdec6f24397095c2d90ccf93d/packages/core-tester-cli/src/commands/command.ts#L92)). So, when building a transaction with `crypto` package, it initialize [timestamp](https://github.com/ArkEcosystem/core/blob/develop/packages/crypto/src/builder/transactions/transaction.ts#L16) with the wrong config (`devnet` even if I send transaction to a `testnet` node). 

## Steps to reproduce

1. update `testnet.milestones.epoch config to current date.
2. Start a fresh local node
3. use `core-tester-cli` to broadcast a `transfer` transaction. 
4. Your transaction won't be forged and cli will fail

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [ ] Docs (documentation only changes)
- [ ] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)


## Further comments

<!--If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->

Other things to fix: 

- add `debug` logs to detect that a transaction validation failed due to invalid timestamp. 
