### PR TITLE
fix: forget peer connection on disconnect

### DIFF
--- a/packages/core-p2p/src/peer-connector.ts
+++ b/packages/core-p2p/src/peer-connector.ts
@@ -44,6 +44,7 @@ export class PeerConnector implements P2P.IPeerConnector {
 
         if (connection) {
             connection.destroy();
+            this.connections.forget(peer.ip);
         }
     }
 


### PR DESCRIPTION
## Proposed changes

Not only destroy socket on peer disconnect, but also forget the peer connection from our connections list.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes