### PR TITLE
refactor(core-p2p): make SocketCluster configurable

### DIFF
--- a/__tests__/integration/core-p2p/socket-server/peer.test.ts
+++ b/__tests__/integration/core-p2p/socket-server/peer.test.ts
@@ -27,7 +27,7 @@ beforeAll(async () => {
 
     const { service, processor } = createPeerService();
 
-    await startSocketServer(service, { port: 4007, rateLimit });
+    await startSocketServer(service, { server: { port: 4007 }, rateLimit });
     await delay(3000);
 
     socket = socketCluster.create({

--- a/__tests__/utils/config/testnet/plugins.js
+++ b/__tests__/utils/config/testnet/plugins.js
@@ -23,7 +23,7 @@ module.exports = {
         },
     },
     "@arkecosystem/core-p2p": {
-        socketCluster: {
+        server: {
             port: process.env.CORE_P2P_PORT || 4000
         },
         minimumVersions: [">=2.0.0"],

--- a/__tests__/utils/config/testnet/plugins.js
+++ b/__tests__/utils/config/testnet/plugins.js
@@ -23,8 +23,9 @@ module.exports = {
         },
     },
     "@arkecosystem/core-p2p": {
-        host: process.env.CORE_P2P_HOST || "0.0.0.0",
-        port: process.env.CORE_P2P_PORT || 4000,
+        socketCluster: {
+            port: process.env.CORE_P2P_PORT || 4000
+        },
         minimumVersions: [">=2.0.0"],
         minimumNetworkReach: 5,
         coldStart: 5,
@@ -45,12 +46,10 @@ module.exports = {
         },
     },
     "@arkecosystem/core-forger": {
-        hosts: [
-            {
-                ip: "127.0.0.1",
-                port: process.env.CORE_P2P_PORT || 4000,
-            },
-        ],
+        hosts: [{
+            ip: "127.0.0.1",
+            port: process.env.CORE_P2P_PORT || 4000,
+        }, ],
     },
     "@arkecosystem/core-json-rpc": {
         enabled: process.env.CORE_JSON_RPC_ENABLED,

--- a/__tests__/utils/config/unitnet/plugins.js
+++ b/__tests__/utils/config/unitnet/plugins.js
@@ -23,7 +23,7 @@ module.exports = {
         },
     },
     "@arkecosystem/core-p2p": {
-        socketCluster: {
+        server: {
             port: process.env.CORE_P2P_PORT || 4000
         },
         minimumVersions: [">=2.0.0"],

--- a/__tests__/utils/config/unitnet/plugins.js
+++ b/__tests__/utils/config/unitnet/plugins.js
@@ -23,8 +23,9 @@ module.exports = {
         },
     },
     "@arkecosystem/core-p2p": {
-        host: process.env.CORE_P2P_HOST || "0.0.0.0",
-        port: process.env.CORE_P2P_PORT || 4000,
+        socketCluster: {
+            port: process.env.CORE_P2P_PORT || 4000
+        },
         minimumVersions: [">=2.0.0"],
         minimumNetworkReach: 5,
         coldStart: 5,
@@ -45,12 +46,10 @@ module.exports = {
         },
     },
     "@arkecosystem/core-forger": {
-        hosts: [
-            {
-                ip: "127.0.0.1",
-                port: process.env.CORE_P2P_PORT || 4000,
-            },
-        ],
+        hosts: [{
+            ip: "127.0.0.1",
+            port: process.env.CORE_P2P_PORT || 4000,
+        }, ],
     },
     "@arkecosystem/core-json-rpc": {
         enabled: process.env.CORE_JSON_RPC_ENABLED,

--- a/packages/core-p2p/src/defaults.ts
+++ b/packages/core-p2p/src/defaults.ts
@@ -1,6 +1,6 @@
 export const defaults = {
     // https://socketcluster.io/#!/docs/api-socketcluster
-    socketCluster: {
+    server: {
         port: process.env.CORE_P2P_PORT || 4002,
         logLevel: process.env.CORE_NETWORK_NAME === "testnet" ? 1 : 0,
     },

--- a/packages/core-p2p/src/defaults.ts
+++ b/packages/core-p2p/src/defaults.ts
@@ -1,7 +1,9 @@
 export const defaults = {
-    host: process.env.CORE_P2P_HOST || "0.0.0.0",
-    port: process.env.CORE_P2P_PORT || 4002,
-    workers: 2,
+    // https://socketcluster.io/#!/docs/api-socketcluster
+    socketCluster: {
+        port: process.env.CORE_P2P_PORT || 4002,
+        logLevel: process.env.CORE_NETWORK_NAME === "testnet" ? 1 : 0,
+    },
     /**
      * The minimum peer version we expect
      */

--- a/packages/core-p2p/src/socket-server/index.ts
+++ b/packages/core-p2p/src/socket-server/index.ts
@@ -21,7 +21,7 @@ export const startSocketServer = async (service: P2P.IPeerService, config: Recor
             workers: 2,
             wsEngine: "ws",
         },
-        ...config.socketCluster,
+        ...config.server,
     });
 
     server.on("fail", data => app.resolvePlugin<Logger.ILogger>("logger").error(data.message));

--- a/packages/core/bin/config/devnet/plugins.js
+++ b/packages/core/bin/config/devnet/plugins.js
@@ -32,7 +32,7 @@ module.exports = {
         },
     },
     "@arkecosystem/core-p2p": {
-        socketCluster: {
+        server: {
             port: process.env.CORE_P2P_PORT || 4002
         },
         minimumNetworkReach: 5,

--- a/packages/core/bin/config/devnet/plugins.js
+++ b/packages/core/bin/config/devnet/plugins.js
@@ -32,8 +32,9 @@ module.exports = {
         },
     },
     "@arkecosystem/core-p2p": {
-        host: process.env.CORE_P2P_HOST || "0.0.0.0",
-        port: process.env.CORE_P2P_PORT || 4002,
+        socketCluster: {
+            port: process.env.CORE_P2P_PORT || 4002
+        },
         minimumNetworkReach: 5,
         coldStart: 5,
     },

--- a/packages/core/bin/config/mainnet/plugins.js
+++ b/packages/core/bin/config/mainnet/plugins.js
@@ -32,8 +32,9 @@ module.exports = {
         },
     },
     "@arkecosystem/core-p2p": {
-        host: process.env.CORE_P2P_HOST || "0.0.0.0",
-        port: process.env.CORE_P2P_PORT || 4001,
+        socketCluster: {
+            port: process.env.CORE_P2P_PORT || 4001
+        },
     },
     "@arkecosystem/core-blockchain": {},
     "@arkecosystem/core-api": {

--- a/packages/core/bin/config/mainnet/plugins.js
+++ b/packages/core/bin/config/mainnet/plugins.js
@@ -32,7 +32,7 @@ module.exports = {
         },
     },
     "@arkecosystem/core-p2p": {
-        socketCluster: {
+        server: {
             port: process.env.CORE_P2P_PORT || 4001
         },
     },

--- a/packages/core/bin/config/testnet/plugins.js
+++ b/packages/core/bin/config/testnet/plugins.js
@@ -32,7 +32,7 @@ module.exports = {
         },
     },
     "@arkecosystem/core-p2p": {
-        socketCluster: {
+        server: {
             port: process.env.CORE_P2P_PORT || 4000
         },
         minimumNetworkReach: 5,

--- a/packages/core/bin/config/testnet/plugins.js
+++ b/packages/core/bin/config/testnet/plugins.js
@@ -32,8 +32,9 @@ module.exports = {
         },
     },
     "@arkecosystem/core-p2p": {
-        host: process.env.CORE_P2P_HOST || "0.0.0.0",
-        port: process.env.CORE_P2P_PORT || 4000,
+        socketCluster: {
+            port: process.env.CORE_P2P_PORT || 4000
+        },
         minimumNetworkReach: 5,
         coldStart: 5,
     },


### PR DESCRIPTION
## Proposed changes

Allow passing in SC specific configuration and specifically log `fail` events as errors.

## Types of changes

- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes