### PR TITLE
refactor(core-p2p): suspend peers if they exceed the rate limit

### DIFF
--- a/__tests__/integration/core-forger/client.test.ts
+++ b/__tests__/integration/core-forger/client.test.ts
@@ -77,7 +77,7 @@ describe("Client", () => {
                 const expectedResponse = { foo: "bar" };
 
                 await socketManager.addMock("p2p.peer.getStatus", mockPeerStatus);
-                await socketManager.addMock("p2p.internal.getCurrentRound", { data: expectedResponse });
+                await socketManager.addMock("p2p.internal.getCurrentRound", expectedResponse);
 
                 const response = await client.getRound();
 
@@ -90,7 +90,7 @@ describe("Client", () => {
         describe("when the host is available", () => {
             it("should be ok", async () => {
                 const expectedResponse = { transactions: [] };
-                await socketManager.addMock("p2p.internal.getUnconfirmedTransactions", { data: expectedResponse });
+                await socketManager.addMock("p2p.internal.getUnconfirmedTransactions", expectedResponse);
 
                 const response = await client.getTransactions();
 
@@ -103,7 +103,7 @@ describe("Client", () => {
         describe("when the host is available", () => {
             it("should be ok", async () => {
                 const expectedResponse = new NetworkState(NetworkStateStatus.Test);
-                await socketManager.addMock("p2p.internal.getNetworkState", { data: expectedResponse });
+                await socketManager.addMock("p2p.internal.getNetworkState", expectedResponse);
 
                 const response = await client.getNetworkState();
 

--- a/__tests__/integration/core-p2p/socket-server/peer.test.ts
+++ b/__tests__/integration/core-p2p/socket-server/peer.test.ts
@@ -28,7 +28,7 @@ beforeAll(async () => {
 
     const { service, processor } = createPeerService();
 
-    await startSocketServer(service, { server: { port: 4007 }, rateLimit: 32 });
+    await startSocketServer(service, { server: { port: 4007 } });
     await delay(3000);
 
     socket = socketCluster.create({
@@ -136,7 +136,7 @@ describe("Peer socket endpoint", () => {
         it("should not be disconnected / banned when below rate limit", async () => {
             await delay(1100);
 
-            for (let i = 0; i < 30; i++) {
+            for (let i = 0; i < 20; i++) {
                 const { success } = await emit("p2p.peer.getStatus", {
                     headers,
                 });
@@ -159,14 +159,14 @@ describe("Peer socket endpoint", () => {
 
             await delay(1100);
 
-            for (let i = 0; i < 31; i++) {
+            for (let i = 0; i < 20; i++) {
                 const { success } = await emit("p2p.peer.getStatus", {
                     headers,
                 });
                 expect(success).toBeTrue();
             }
 
-            // 32nd call, should throw CoreRateLimitExceededError
+            // 21st call, should throw CoreRateLimitExceededError
             await expect(
                 emit("p2p.peer.postBlock", {
                     data: { block: Blocks.Block.fromData(genesisBlock).toJson() },

--- a/__tests__/unit/core-p2p/mocks/scworker.ts
+++ b/__tests__/unit/core-p2p/mocks/scworker.ts
@@ -6,7 +6,7 @@ class SCWorker {
         MIDDLEWARE_EMIT: null,
     };
 
-    public sendToMaster = jest.fn();
+    public sendToMaster = jest.fn().mockImplementation((data, cb) => cb(null, {}));
 }
 
 jest.mock("socketcluster/scworker", () => SCWorker);

--- a/__tests__/unit/core-p2p/socket-server/versions/internal/handlers/rounds.test.ts
+++ b/__tests__/unit/core-p2p/socket-server/versions/internal/handlers/rounds.test.ts
@@ -17,16 +17,14 @@ describe("Internal handlers - rounds", () => {
             const nextForger = (parseInt((timestampSlots / 8) as any) + 1) % 51;
 
             expect(round).toEqual({
-                data: {
-                    current: 2 / 51,
-                    reward: 0,
-                    timestamp: timestampSlots,
-                    delegates,
-                    currentForger: delegates[currentForger],
-                    nextForger: delegates[nextForger],
-                    lastBlock: { height: 1, timestamp: 222 },
-                    canForge: parseInt((1 + 222 / 8) as any) * 8 < timestampSlots - 1,
-                },
+                current: 2 / 51,
+                reward: 0,
+                timestamp: timestampSlots,
+                delegates,
+                currentForger: delegates[currentForger],
+                nextForger: delegates[nextForger],
+                lastBlock: { height: 1, timestamp: 222 },
+                canForge: parseInt((1 + 222 / 8) as any) * 8 < timestampSlots - 1,
             });
         });
     });

--- a/__tests__/unit/core-p2p/socket-server/versions/internal/handlers/transactions.test.ts
+++ b/__tests__/unit/core-p2p/socket-server/versions/internal/handlers/transactions.test.ts
@@ -1,56 +1,17 @@
-import { blockchain } from "../../../../mocks/blockchain";
 import "../../../../mocks/core-container";
-import { database } from "../../../../mocks/database";
 
-import { Transactions } from "@arkecosystem/crypto";
-import {
-    getUnconfirmedTransactions,
-    verifyTransaction,
-} from "../../../../../../../packages/core-p2p/src/socket-server/versions/internal";
-import { genesisBlock } from "../../../../../../utils/config/unitnet/genesisBlock";
+import { blockchain } from "../../../../mocks/blockchain";
+
+import { getUnconfirmedTransactions } from "../../../../../../../packages/core-p2p/src/socket-server/versions/internal";
 
 jest.mock("../../../../../../../packages/core-p2p/src/socket-server/utils/validate");
 
 describe("Internal handlers - transactions", () => {
-    describe("verifyTransaction", () => {
-        it("should return 'valid' object when transaction is valid", async () => {
-            database.verifyTransaction = jest.fn().mockReturnValue(true);
-            const req = {
-                data: {
-                    transaction: Transactions.Transaction.toBytes(genesisBlock.transactions[0]),
-                },
-            };
-            const result = await verifyTransaction({ req });
-            expect(result).toEqual({
-                data: {
-                    valid: true,
-                },
-            });
-        });
-
-        it("should return 'invalid' object when transaction is invalid", async () => {
-            database.verifyTransaction = jest.fn().mockReturnValue(false);
-            const req = {
-                data: {
-                    transaction: Transactions.Transaction.toBytes(genesisBlock.transactions[0]),
-                },
-            };
-            const result = await verifyTransaction({ req });
-            expect(result).toEqual({
-                data: {
-                    valid: false,
-                },
-            });
-        });
-    });
-
     describe("getUnconfirmedTransactions", () => {
         it("should return unconfirmed transactions", () => {
             blockchain.getUnconfirmedTransactions = jest.fn().mockReturnValue(["111"]);
             const result = getUnconfirmedTransactions();
-            expect(result).toEqual({
-                data: ["111"],
-            });
+            expect(result).toEqual(["111"]);
         });
     });
 });

--- a/__tests__/unit/core-p2p/socket-server/worker.test.ts
+++ b/__tests__/unit/core-p2p/socket-server/worker.test.ts
@@ -12,13 +12,14 @@ beforeAll(() => {
 describe("Worker", () => {
     describe("run", () => {
         it("should init the worker", async () => {
-            worker.run();
+            await worker.run();
+
             await delay(500);
 
             // initRateLimit calls sendToMaster
             expect(worker.sendToMaster).toHaveBeenCalledWith(
                 {
-                    endpoint: "p2p.init.getConfig",
+                    endpoint: "p2p.utils.getConfig",
                 },
                 expect.any(Function),
             );

--- a/__tests__/unit/core-p2p/socket-server/worker.test.ts
+++ b/__tests__/unit/core-p2p/socket-server/worker.test.ts
@@ -3,11 +3,7 @@ import "../mocks/scworker";
 import delay from "delay";
 import { Worker } from "../../../../packages/core-p2p/src/socket-server/worker";
 
-let worker;
-
-beforeAll(() => {
-    worker = new Worker();
-});
+const worker = new Worker();
 
 describe("Worker", () => {
     describe("run", () => {

--- a/packages/core-forger/src/client.ts
+++ b/packages/core-forger/src/client.ts
@@ -12,11 +12,13 @@ export class Client {
         ip: string;
         socket: socketCluster.SCClientSocket;
     }>;
+
     private host: {
         port: number;
         ip: string;
         socket: socketCluster.SCClientSocket;
     };
+
     private headers: {
         version: string;
         port: number;
@@ -24,7 +26,7 @@ export class Client {
         "Content-Type": "application/json";
     };
 
-    private logger: Logger.ILogger;
+    private logger: Logger.ILogger = app.resolvePlugin<Logger.ILogger>("logger");
 
     /**
      * Create a new client instance.
@@ -32,7 +34,6 @@ export class Client {
      */
     constructor(hosts) {
         this.hosts = Array.isArray(hosts) ? hosts : [hosts];
-        this.logger = app.resolvePlugin<Logger.ILogger>("logger");
 
         const { port, ip } = this.hosts[0];
 
@@ -186,10 +187,10 @@ export class Client {
         throw new HostNoResponseError(this.hosts.map(h => h.ip).join());
     }
 
-    private async emit<T>(event: string, data: any, timeout: number = 2000) {
+    private async emit<T>(event: string, data: any, timeout: number = 2000): Promise<any> {
         try {
-            const response: any = await socketEmit(this.host.ip, this.host.socket, event, data, this.headers, timeout);
-            return response.data;
+            const response = await socketEmit(this.host.ip, this.host.socket, event, data, this.headers, timeout);
+            return response;
         } catch (error) {
             throw new RelayCommunicationError(`${this.host.ip}:${this.host.port}<${event}>`, error.message);
         }

--- a/packages/core-forger/src/client.ts
+++ b/packages/core-forger/src/client.ts
@@ -105,7 +105,7 @@ export class Client {
 
         const response = await this.emit<P2P.IResponse<P2P.ICurrentRound>>("p2p.internal.getCurrentRound", {});
 
-        return response.data;
+        return response;
     }
 
     /**
@@ -119,7 +119,7 @@ export class Client {
                 4000,
             );
 
-            return NetworkState.parse(response.data);
+            return NetworkState.parse(response);
         } catch (e) {
             this.logger.error(
                 `Could not retrieve network state: ${this.host.ip} p2p.internal.getNetworkState : ${e.message}`,
@@ -137,7 +137,7 @@ export class Client {
             {},
         );
 
-        return response.data;
+        return response;
     }
 
     /**
@@ -189,8 +189,8 @@ export class Client {
 
     private async emit<T>(event: string, data: any, timeout: number = 2000): Promise<any> {
         try {
-            const response = await socketEmit(this.host.ip, this.host.socket, event, data, this.headers, timeout);
-            return response;
+            const response: any = await socketEmit(this.host.ip, this.host.socket, event, data, this.headers, timeout);
+            return response.data;
         } catch (error) {
             throw new RelayCommunicationError(`${this.host.ip}:${this.host.port}<${event}>`, error.message);
         }

--- a/packages/core-p2p/src/defaults.ts
+++ b/packages/core-p2p/src/defaults.ts
@@ -1,6 +1,7 @@
 export const defaults = {
     // https://socketcluster.io/#!/docs/api-socketcluster
     server: {
+        hostname: process.env.CORE_P2P_HOST || "0.0.0.0",
         port: process.env.CORE_P2P_PORT || 4002,
         logLevel: process.env.CORE_NETWORK_NAME === "testnet" ? 1 : 0,
     },
@@ -61,10 +62,5 @@ export const defaults = {
     /**
      * Rate limit config, used in socket-server worker / master
      */
-    rateLimit: {
-        enabled: true,
-        socketLimit: 20, // max number of messages per second per socket connection
-        ipWhitelist: ["127.0.0.1", "::ffff:127.0.0.1"],
-        banDurationMs: 10 * 60 * 1000, // 10 minute ban for peer exceeding rate limit
-    },
+    rateLimit: 20, // max number of messages per second per socket connection
 };

--- a/packages/core-p2p/src/socket-server/index.ts
+++ b/packages/core-p2p/src/socket-server/index.ts
@@ -26,25 +26,20 @@ export const startSocketServer = async (service: P2P.IPeerService, config: Recor
 
     // socketcluster types do not allow on("workerMessage") so casting as any
     (server as any).on("workerMessage", async (workerId, req, res) => {
-        // special endpoint for worker init, when need to get plugin config
-        if (req.endpoint === "p2p.init.getConfig") {
-            return res(null, config);
-        }
-
         const [prefix, version, method] = req.endpoint.split(".");
 
         try {
             return res(null, {
-                data: (await handlers[version][method]({ service, req })) || {},
+                data: await handlers[version][method]({ service, req }),
                 headers: getHeaders(),
             });
         } catch (e) {
             app.resolvePlugin<Logger.ILogger>("logger").error(e);
 
-            // return explicit error when data validation error
             if (e.name === SocketErrors.Validation) {
                 return res(e);
             }
+
             return res(new Error(`Socket call to ${req.endpoint} failed.`));
         }
     });

--- a/packages/core-p2p/src/socket-server/versions/internal.ts
+++ b/packages/core-p2p/src/socket-server/versions/internal.ts
@@ -1,7 +1,7 @@
 import { app } from "@arkecosystem/core-container";
 import { Blockchain, Database, EventEmitter, Logger, P2P } from "@arkecosystem/core-interfaces";
 import { roundCalculator } from "@arkecosystem/core-utils";
-import { Crypto, Interfaces, Transactions } from "@arkecosystem/crypto";
+import { Crypto, Interfaces } from "@arkecosystem/crypto";
 import { validate } from "../utils/validate";
 import { schema } from "./peer/schema";
 
@@ -20,24 +20,6 @@ export function emitEvent({ req }): void {
     );
 
     app.resolvePlugin<EventEmitter.EventEmitter>("event-emitter").emit(req.data.event, req.data.body);
-}
-
-export async function verifyTransaction({ req }): Promise<boolean> {
-    validate(
-        {
-            type: "object",
-            required: ["transaction"],
-            additionalProperties: false,
-            properties: {
-                transaction: { $ref: "transaction" },
-            },
-        },
-        req.data,
-    );
-
-    return app
-        .resolvePlugin<Database.IDatabaseService>("database")
-        .verifyTransaction(Transactions.Transaction.fromBytes(req.data.transaction));
 }
 
 export function getUnconfirmedTransactions(): {

--- a/packages/core-p2p/src/socket-server/versions/utils.ts
+++ b/packages/core-p2p/src/socket-server/versions/utils.ts
@@ -1,27 +1,63 @@
 import { app } from "@arkecosystem/core-container";
+import { EventEmitter, P2P } from "@arkecosystem/core-interfaces";
 import { isWhitelisted } from "../../utils/is-whitelisted";
 import * as internalHandlers from "./internal";
 import * as peerHandlers from "./peer";
 
-export function getHandlers() {
+export function getHandlers(): { data: { [key: string]: string[] } } {
     return {
-        peer: Object.keys(peerHandlers),
-        internal: Object.keys(internalHandlers),
+        data: {
+            peer: Object.keys(peerHandlers),
+            internal: Object.keys(internalHandlers),
+        },
     };
 }
 
-export function log({ req }) {
+export function log({ req }): void {
     app.resolvePlugin("logger")[req.data.level](req.data.message);
 }
 
-export function isForgerAuthorized({ req }) {
-    return isWhitelisted(app.resolveOptions("p2p").remoteAccess, req.data.ip);
+export function isForgerAuthorized({ req }): { data: { authorized: boolean } } {
+    return {
+        data: { authorized: isWhitelisted(app.resolveOptions("p2p").remoteAccess, req.data.ip) },
+    };
 }
 
-export function isAppReady() {
-    return {
-        transactionPool: !!app.resolvePlugin("transaction-pool"),
-        blockchain: !!app.resolvePlugin("blockchain"),
-        p2p: !!app.resolvePlugin("p2p"),
+export function isAppReady(): {
+    data: {
+        transactionPool: boolean;
+        blockchain: boolean;
+        p2p: boolean;
     };
+} {
+    return {
+        data: {
+            transactionPool: !!app.resolvePlugin("transaction-pool"),
+            blockchain: !!app.resolvePlugin("blockchain"),
+            p2p: !!app.resolvePlugin("p2p"),
+        },
+    };
+}
+
+export function suspendPeer({ req }: { req }): void {
+    app.resolvePlugin<EventEmitter.EventEmitter>("event-emitter").emit("internal.p2p.suspendPeer", {
+        peer: req.data.remoteAddress,
+        punishment: req.data.punishment,
+    });
+}
+
+export function isSuspended({ service, req }: { service: P2P.IPeerService; req }): { data: { suspended: boolean } } {
+    return {
+        data: { suspended: service.getStorage().hasSuspendedPeer(req.data.remoteAccess) },
+    };
+}
+
+export function getSuspendedPeers({ service }: { service: P2P.IPeerService }): { data: P2P.IPeerSuspension[] } {
+    return {
+        data: service.getStorage().getSuspendedPeers(),
+    };
+}
+
+export function getConfig(): { data: Record<string, any> } {
+    return { data: app.resolveOptions("p2p") };
 }

--- a/packages/core-p2p/src/socket-server/versions/utils.ts
+++ b/packages/core-p2p/src/socket-server/versions/utils.ts
@@ -4,12 +4,22 @@ import { isWhitelisted } from "../../utils/is-whitelisted";
 import * as internalHandlers from "./internal";
 import * as peerHandlers from "./peer";
 
-export function getHandlers(): { data: { [key: string]: string[] } } {
+export function isAppReady(): {
+    transactionPool: boolean;
+    blockchain: boolean;
+    p2p: boolean;
+} {
     return {
-        data: {
-            peer: Object.keys(peerHandlers),
-            internal: Object.keys(internalHandlers),
-        },
+        transactionPool: !!app.resolvePlugin("transaction-pool"),
+        blockchain: !!app.resolvePlugin("blockchain"),
+        p2p: !!app.resolvePlugin("p2p"),
+    };
+}
+
+export function getHandlers(): { [key: string]: string[] } {
+    return {
+        peer: Object.keys(peerHandlers),
+        internal: Object.keys(internalHandlers),
     };
 }
 
@@ -17,26 +27,8 @@ export function log({ req }): void {
     app.resolvePlugin("logger")[req.data.level](req.data.message);
 }
 
-export function isForgerAuthorized({ req }): { data: { authorized: boolean } } {
-    return {
-        data: { authorized: isWhitelisted(app.resolveOptions("p2p").remoteAccess, req.data.ip) },
-    };
-}
-
-export function isAppReady(): {
-    data: {
-        transactionPool: boolean;
-        blockchain: boolean;
-        p2p: boolean;
-    };
-} {
-    return {
-        data: {
-            transactionPool: !!app.resolvePlugin("transaction-pool"),
-            blockchain: !!app.resolvePlugin("blockchain"),
-            p2p: !!app.resolvePlugin("p2p"),
-        },
-    };
+export function isForgerAuthorized({ req }): { authorized: boolean } {
+    return { authorized: isWhitelisted(app.resolveOptions("p2p").remoteAccess, req.data.ip) };
 }
 
 export function suspendPeer({ req }: { req }): void {
@@ -46,18 +38,10 @@ export function suspendPeer({ req }: { req }): void {
     });
 }
 
-export function isSuspended({ service, req }: { service: P2P.IPeerService; req }): { data: { suspended: boolean } } {
-    return {
-        data: { suspended: service.getStorage().hasSuspendedPeer(req.data.remoteAccess) },
-    };
+export function isSuspended({ service, req }: { service: P2P.IPeerService; req }): { suspended: boolean } {
+    return { suspended: service.getStorage().hasSuspendedPeer(req.data.remoteAccess) };
 }
 
-export function getSuspendedPeers({ service }: { service: P2P.IPeerService }): { data: P2P.IPeerSuspension[] } {
-    return {
-        data: service.getStorage().getSuspendedPeers(),
-    };
-}
-
-export function getConfig(): { data: Record<string, any> } {
-    return { data: app.resolveOptions("p2p") };
+export function getConfig(): Record<string, any> {
+    return app.resolveOptions("p2p");
 }

--- a/packages/core-p2p/src/socket-server/worker.ts
+++ b/packages/core-p2p/src/socket-server/worker.ts
@@ -164,7 +164,7 @@ export class Worker extends SCWorker {
                     ...{ endpoint },
                     ...data,
                 },
-                (err, res) => (err ? reject(err) : resolve(res.data)),
+                (err, res) => (err ? reject(err) : resolve(res)),
             );
         });
     }

--- a/packages/core-p2p/src/socket-server/worker.ts
+++ b/packages/core-p2p/src/socket-server/worker.ts
@@ -3,145 +3,116 @@ import { SocketErrors } from "../enums";
 import { validateHeaders } from "./utils/validate-headers";
 
 export class Worker extends SCWorker {
-    private bannedPeers = {};
-    private peersMsgTimestamps = {};
-    private rateLimit = null; // will be then initialized from config
-    private banDurationMs = null; // will be then initialized from config
-    private ipWhitelist = []; // will be then initialized from config
+    private peersMsgTimestamps: Record<string, number[]> = {};
     private config: Record<string, any>;
 
-    public run() {
+    public async run() {
         this.log(`Socket worker started, PID: ${process.pid}`);
 
-        const scServer = this.scServer;
+        await this.loadConfiguration();
 
-        this.initRateLimit();
-
-        scServer.on("connection", socket => this.registerEndpoints(socket));
-        scServer.addMiddleware(scServer.MIDDLEWARE_HANDSHAKE_WS, (req, next) => this.middlewareHandshake(req, next));
-        scServer.addMiddleware(scServer.MIDDLEWARE_EMIT, (req, next) => this.middlewareEmit(req, next));
+        this.scServer.on("connection", socket => this.handleConnection(socket));
+        this.scServer.addMiddleware(this.scServer.MIDDLEWARE_HANDSHAKE_WS, (req, next) =>
+            this.handleHandshake(req, next),
+        );
+        this.scServer.addMiddleware(this.scServer.MIDDLEWARE_EMIT, (req, next) => this.handleEmit(req, next));
     }
 
-    public async initRateLimit() {
-        const config: any = await this.sendToMasterAsync({
-            endpoint: "p2p.init.getConfig",
-        });
+    private async loadConfiguration(): Promise<void> {
+        const { data } = await this.sendToMasterAsync("p2p.utils.getConfig");
 
-        this.config = config;
+        this.config = data;
+    }
 
-        if (config.rateLimit && config.rateLimit.enabled) {
-            this.rateLimit = config.rateLimit.socketLimit;
-            this.banDurationMs = config.rateLimit.banDurationMs;
-            this.ipWhitelist = config.rateLimit.ipWhitelist;
+    private async handleConnection(socket): Promise<void> {
+        const { data } = await this.sendToMasterAsync("p2p.utils.getHandlers");
+
+        for (const [version, handlers] of Object.entries(data)) {
+            for (const handler of Object.values(handlers)) {
+                // @ts-ignore
+                socket.on(`p2p.${version}.${handler}`, async (data, res) => {
+                    try {
+                        return res(null, await this.sendToMasterAsync(`p2p.${version}.${handler}`, data));
+                    } catch (e) {
+                        return res(e);
+                    }
+                });
+            }
         }
     }
 
-    public async registerEndpoints(socket) {
-        const handlers: any = await this.sendToMasterAsync({
-            endpoint: "p2p.utils.getHandlers",
-        });
-
-        for (const name of handlers.data.peer) {
-            socket.on(`p2p.peer.${name}`, async (data, res) =>
-                this.forwardToMaster(Object.assign(data, { endpoint: `p2p.peer.${name}` }), res),
-            );
-        }
-
-        for (const name of handlers.data.internal) {
-            socket.on(`p2p.internal.${name}`, async (data, res) =>
-                this.forwardToMaster(Object.assign(data, { endpoint: `p2p.internal.${name}` }), res),
-            );
-        }
-    }
-
-    public async middlewareHandshake(req, next): Promise<void> {
-        const blacklist = this.config.blacklist || [];
-        if (blacklist.includes(req.ip)) {
+    private async handleHandshake(req, next): Promise<void> {
+        if ((this.config.blacklist || []).includes(req.socket.remoteAddress)) {
+            // @ts-ignore
             req.socket.disconnect(4403, "Forbidden");
             return;
         }
 
-        if (this.isBanned(req.ip)) {
+        if (await this.isSuspended(req.socket.remoteAddress)) {
             return next(new Error("Banned because exceeded rate limit"));
         }
 
         next();
     }
 
-    public async middlewareEmit(req, next): Promise<void> {
-        const createError = (name, message) => {
-            const err = new Error(message);
-            err.name = name;
-            return err;
-        };
+    private async handleEmit(req, next): Promise<void> {
+        if (this.hasExceededRateLimit(req.socket.remoteAddress)) {
+            this.suspendPeer(req.socket.remoteAddress, "tooManyRequests");
 
-        if (!this.isRateLimitOk(req.socket.remoteAddress)) {
-            this.banPeer(req.socket.remoteAddress);
-
-            next(createError(SocketErrors.RateLimitExceeded, "Rate limit exceeded"));
-
-            this.log(
-                `Rate limit exceeded from ${req.socket.remoteAddress} : banning and disconnecting socket.`,
-                "error",
-            );
+            next(this.createError(SocketErrors.RateLimitExceeded, "Rate limit exceeded"));
 
             req.socket.disconnect(4429, "Rate limit exceeded");
 
             return;
         }
 
-        // only allow requests with data and headers specified
         if (!req.data || !req.data.headers) {
-            return next(createError(SocketErrors.HeadersRequired, "Request data and data.headers is mandatory"));
+            return next(this.createError(SocketErrors.HeadersRequired, "Request data and data.headers is mandatory"));
         }
 
         try {
-            const [prefix, version, method] = req.event.split(".");
+            const [prefix, version] = req.event.split(".");
+
             if (prefix !== "p2p") {
-                return next(createError(SocketErrors.WrongEndpoint, `Wrong endpoint : ${req.event}`));
+                return next(this.createError(SocketErrors.WrongEndpoint, `Wrong endpoint: ${req.event}`));
             }
 
-            // Validate headers
             const headersValidation = validateHeaders(req.data.headers);
             if (!headersValidation.valid) {
                 return next(
-                    createError(
+                    this.createError(
                         SocketErrors.HeadersValidationFailed,
                         `Headers validation failed: ${headersValidation.errors.map(e => e.message).join()}`,
                     ),
                 );
             }
 
-            // Check that blockchain, tx-pool and monitor gard are ready
-            const isAppReady: any = await this.sendToMasterAsync({
-                endpoint: "p2p.utils.isAppReady",
-            });
+            // Check that blockchain, tx-pool and p2p are ready
+            const isAppReady: any = await this.sendToMasterAsync("p2p.utils.isAppReady");
+
             for (const [plugin, ready] of Object.entries(isAppReady.data)) {
                 if (!ready) {
                     return next(
-                        createError(SocketErrors.AppNotReady, `Application is not ready : ${plugin} is not ready`),
+                        this.createError(SocketErrors.AppNotReady, `Application is not ready : ${plugin} is not ready`),
                     );
                 }
             }
 
             if (version === "internal") {
-                // Only allow internal to whitelisted (remoteAccess) peer / forger
-                const isForgerAuthorized: any = await this.sendToMasterAsync({
-                    endpoint: "p2p.utils.isForgerAuthorized",
+                const { data } = await this.sendToMasterAsync("p2p.utils.isForgerAuthorized", {
                     data: { ip: req.socket.remoteAddress },
                 });
-                if (!isForgerAuthorized.data) {
+
+                if (!data.authorized) {
                     return next(
-                        createError(
+                        this.createError(
                             SocketErrors.ForgerNotAuthorized,
                             "Not authorized: internal endpoint is only available for whitelisted forger",
                         ),
                     );
                 }
             } else if (version === "peer") {
-                // here is where we can acceptNewPeer()
-                await this.sendToMasterAsync({
-                    endpoint: "p2p.peer.acceptNewPeer",
+                await this.sendToMasterAsync("p2p.peer.acceptNewPeer", {
                     data: { ip: req.socket.remoteAddress },
                     headers: req.data.headers,
                 });
@@ -158,71 +129,78 @@ export class Worker extends SCWorker {
                 return next(e);
             }
 
-            return next(createError(SocketErrors.Unknown, "Unknown error"));
+            return next(this.createError(SocketErrors.Unknown, "Unknown error"));
         }
+
         next();
     }
 
-    public async sendToMasterAsync(data) {
-        return new Promise((resolve, reject) => {
-            this.sendToMaster(data, (err, val) => (err ? reject(err) : resolve(val)));
+    private async suspendPeer(remoteAddress: string, punishment: string): Promise<void> {
+        await this.sendToMasterAsync("p2p.utils.suspendPeer", {
+            data: { remoteAddress, punishment },
         });
     }
 
-    public async forwardToMaster(data, res) {
-        try {
-            const masterResponse = await this.sendToMasterAsync(data);
+    private async isSuspended(remoteAddress: string): Promise<boolean> {
+        const { data } = await this.sendToMasterAsync("p2p.utils.isSuspended", {
+            data: { remoteAddress },
+        });
 
-            return res(null, masterResponse);
-        } catch (e) {
-            return res(e);
-        }
-    }
-
-    private isRateLimitOk(peerIp): boolean {
-        if (!this.rateLimit || !this.banDurationMs || this.ipWhitelist.includes(peerIp)) {
-            return true;
-        }
-
-        this.peersMsgTimestamps[peerIp] = this.peersMsgTimestamps[peerIp] || [];
-        this.peersMsgTimestamps[peerIp].push(new Date().getTime());
-
-        const tsLength = this.peersMsgTimestamps[peerIp].length;
-
-        if (tsLength < this.rateLimit) {
-            return true;
-        }
-
-        this.peersMsgTimestamps[peerIp] = this.peersMsgTimestamps[peerIp].slice(tsLength - this.rateLimit);
-
-        return this.peersMsgTimestamps[peerIp][this.rateLimit - 1] - this.peersMsgTimestamps[peerIp][0] > 1000;
-    }
-
-    private banPeer(peerIp): void {
-        this.bannedPeers[peerIp] = new Date().getTime();
-    }
-
-    private isBanned(peerIp): boolean {
-        if (!this.rateLimit || !this.banDurationMs) {
-            return false;
-        }
-
-        if (this.bannedPeers[peerIp] && new Date().getTime() - this.bannedPeers[peerIp] > this.banDurationMs) {
-            delete this.bannedPeers[peerIp];
-        }
-
-        return !!this.bannedPeers[peerIp];
+        return data.suspended;
     }
 
     private async log(message: string, level: string = "info"): Promise<void> {
         try {
-            await this.sendToMasterAsync({
-                endpoint: "p2p.utils.log",
+            await this.sendToMasterAsync("p2p.utils.log", {
                 data: { level, message },
             });
         } catch (e) {
             console.error(`Error while trying to log the following message: ${message}`);
         }
+    }
+
+    private async sendToMasterAsync(endpoint: string, data?: Record<string, any>): Promise<any> {
+        return new Promise((resolve, reject) => {
+            this.sendToMaster(
+                {
+                    ...{ endpoint },
+                    ...data,
+                },
+                (err, res) => (err ? reject(err) : resolve(res.data)),
+            );
+        });
+    }
+
+    private hasExceededRateLimit(remoteAddress: string): boolean {
+        if ((this.config.whitelist || []).includes(remoteAddress)) {
+            return false;
+        }
+
+        this.peersMsgTimestamps[remoteAddress] = this.peersMsgTimestamps[remoteAddress] || [];
+        this.peersMsgTimestamps[remoteAddress].push(new Date().getTime());
+
+        const requestCount = this.peersMsgTimestamps[remoteAddress].length;
+
+        if (requestCount > this.config.rateLimit) {
+            return true;
+        }
+
+        this.peersMsgTimestamps[remoteAddress] = this.peersMsgTimestamps[remoteAddress].slice(
+            requestCount - this.config.rateLimit,
+        );
+
+        return (
+            this.peersMsgTimestamps[remoteAddress][this.config.rateLimit - 1] -
+                this.peersMsgTimestamps[remoteAddress][0] <
+            1000
+        );
+    }
+
+    private createError(name, message): Error {
+        const error: Error = new Error(message);
+        error.name = name;
+
+        return error;
     }
 }
 

--- a/packages/core-p2p/src/socket-server/worker.ts
+++ b/packages/core-p2p/src/socket-server/worker.ts
@@ -179,7 +179,7 @@ export class Worker extends SCWorker {
 
         const requestCount = this.peersMsgTimestamps[remoteAddress].length;
 
-        if (requestCount <= this.config.rateLimit) {
+        if (requestCount < this.config.rateLimit) {
             return false;
         }
 


### PR DESCRIPTION
## Proposed changes

Instead of keeping a separate banning list we suspend peers with `tooManyRequests`.

## Types of changes

- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes