### PR TITLE
refactor(core-p2p): store connection errors in connector

### DIFF
--- a/__tests__/unit/core-p2p/peer-guard.test.ts
+++ b/__tests__/unit/core-p2p/peer-guard.test.ts
@@ -1,4 +1,5 @@
 import "jest-extended";
+
 import "./mocks/core-container";
 
 import { P2P } from "@arkecosystem/core-interfaces";
@@ -10,9 +11,11 @@ import { createStubPeer } from "../../helpers/peers";
 
 let peerMock: P2P.IPeer;
 let guard: P2P.IPeerGuard;
+let connector: P2P.IPeerConnector;
 
 beforeAll(async () => {
-    guard = new PeerGuard(new PeerConnector());
+    connector = new PeerConnector();
+    guard = new PeerGuard(connector);
 });
 
 beforeEach(async () => {
@@ -108,10 +111,9 @@ describe("PeerGuard", () => {
         });
 
         it('should return a 30 seconds suspension for "Application not ready"', () => {
-            const { until, reason } = guard.analyze({
-                ...dummy,
-                socketError: SocketErrors.AppNotReady,
-            });
+            connector.getError = jest.fn(() => SocketErrors.AppNotReady);
+
+            const { until, reason } = guard.analyze(dummy);
 
             expect(reason).toBe("Application is not ready");
             expect(convertToMinutes(until)).toBe(0.5);

--- a/packages/core-interfaces/src/core-p2p/peer-connector.ts
+++ b/packages/core-interfaces/src/core-p2p/peer-connector.ts
@@ -9,8 +9,9 @@ export interface IPeerConnector {
     disconnect(peer: IPeer): void;
 
     emit(peer: IPeer, event: string, data: any): void;
+
     getError(peer: IPeer): string;
-    setError(peer: IPeer, error: Error): void;
+    setError(peer: IPeer, error: string): void;
     hasError(peer: IPeer, error: string): boolean;
     forgetError(peer: IPeer): void;
 }

--- a/packages/core-interfaces/src/core-p2p/peer-connector.ts
+++ b/packages/core-interfaces/src/core-p2p/peer-connector.ts
@@ -4,7 +4,13 @@ import { IPeer } from "./peer";
 export interface IPeerConnector {
     all(): SCClientSocket[];
     connection(peer: IPeer): SCClientSocket;
+
     connect(peer: IPeer): SCClientSocket;
     disconnect(peer: IPeer): void;
+
     emit(peer: IPeer, event: string, data: any): void;
+    getError(peer: IPeer): string;
+    setError(peer: IPeer, error: Error): void;
+    hasError(peer: IPeer, error: string): boolean;
+    forgetError(peer: IPeer): void;
 }

--- a/packages/core-interfaces/src/core-p2p/peer.ts
+++ b/packages/core-interfaces/src/core-p2p/peer.ts
@@ -21,7 +21,6 @@ export interface IPeer {
     // @TODO: review and remove them where appropriate
     status: any;
     commonBlocks: any;
-    socketError: any; // @TODO: store errors in the PeerConnector
 
     setHeaders(headers: Record<string, string>): void;
 

--- a/packages/core-p2p/src/peer-communicator.ts
+++ b/packages/core-p2p/src/peer-communicator.ts
@@ -142,7 +142,8 @@ export class PeerCommunicator implements P2P.IPeerCommunicator {
     private async emit(peer: P2P.IPeer, event: string, data?: any, timeout?: number) {
         let response;
         try {
-            peer.socketError = null; // reset socket error between each call
+            this.connector.forgetError(peer);
+
             const timeBeforeSocketCall = new Date().getTime();
 
             this.updateHeaders(peer);
@@ -181,8 +182,7 @@ export class PeerCommunicator implements P2P.IPeerCommunicator {
             return;
         }
 
-        // guard will then be able to determine offence / punishment based on socketError
-        peer.socketError = error.name;
+        this.connector.setError(peer, error);
 
         switch (error.name) {
             case SocketErrors.Validation:

--- a/packages/core-p2p/src/peer-communicator.ts
+++ b/packages/core-p2p/src/peer-communicator.ts
@@ -182,7 +182,7 @@ export class PeerCommunicator implements P2P.IPeerCommunicator {
             return;
         }
 
-        this.connector.setError(peer, error);
+        this.connector.setError(peer, error.name);
 
         switch (error.name) {
             case SocketErrors.Validation:

--- a/packages/core-p2p/src/peer-connector.ts
+++ b/packages/core-p2p/src/peer-connector.ts
@@ -60,8 +60,8 @@ export class PeerConnector implements P2P.IPeerConnector {
         return this.errors.get(peer.ip);
     }
 
-    public setError(peer: P2P.IPeer, error: Error): void {
-        this.errors.set(peer.ip, error.name);
+    public setError(peer: P2P.IPeer, error: string): void {
+        this.errors.set(peer.ip, error);
     }
 
     public hasError(peer: P2P.IPeer, error: string): boolean {

--- a/packages/core-p2p/src/peer-connector.ts
+++ b/packages/core-p2p/src/peer-connector.ts
@@ -7,6 +7,7 @@ export class PeerConnector implements P2P.IPeerConnector {
     private readonly logger: Logger.ILogger = app.resolvePlugin<Logger.ILogger>("logger");
     private readonly emitter: EventEmitter.EventEmitter = app.resolvePlugin<EventEmitter.EventEmitter>("event-emitter");
     private readonly connections: PeerRepository<SCClientSocket> = new PeerRepository<SCClientSocket>();
+    private readonly errors: Map<string, string> = new Map<string, string>();
 
     public all(): SCClientSocket[] {
         return this.connections.values();
@@ -53,5 +54,21 @@ export class PeerConnector implements P2P.IPeerConnector {
 
     public emit(peer: P2P.IPeer, event: string, data: any): void {
         return this.connection(peer).emit(event, data);
+    }
+
+    public getError(peer: P2P.IPeer): string {
+        return this.errors.get(peer.ip);
+    }
+
+    public setError(peer: P2P.IPeer, error: Error): void {
+        this.errors.set(peer.ip, error.name);
+    }
+
+    public hasError(peer: P2P.IPeer, error: string): boolean {
+        return this.getError(peer) === error;
+    }
+
+    public forgetError(peer: P2P.IPeer): void {
+        this.errors.delete(peer.ip);
     }
 }

--- a/packages/core-p2p/src/peer-guard.ts
+++ b/packages/core-p2p/src/peer-guard.ts
@@ -86,7 +86,7 @@ export class PeerGuard implements P2P.IPeerGuard {
             return this.createPunishment(this.offences.socketNotOpen);
         }
 
-        if (peer.socketError === SocketErrors.AppNotReady) {
+        if (this.connector.hasError(peer, SocketErrors.AppNotReady)) {
             return this.createPunishment(this.offences.applicationNotReady);
         }
 

--- a/packages/core-p2p/src/peer.ts
+++ b/packages/core-p2p/src/peer.ts
@@ -17,7 +17,6 @@ export class Peer implements P2P.IPeer {
     // @TODO: review and remove them where appropriate
     public status: any;
     public commonBlocks: any;
-    public socketError: any;
 
     constructor(readonly ip: string, readonly port: number) {
         this.headers = {

--- a/packages/core-p2p/src/socket-server/versions/peer.ts
+++ b/packages/core-p2p/src/socket-server/versions/peer.ts
@@ -70,15 +70,15 @@ export async function postBlock({ req }): Promise<void> {
     const block: Interfaces.IBlockData = req.data.block;
 
     if (!isWhitelisted(app.resolveOptions("p2p").remoteAccess, req.headers.remoteAddress)) {
-        if (blockchain.pingBlock(block)) {
-            return;
-        }
-
-        const lastDownloadedBlock = blockchain.getLastDownloadedBlock();
+        const lastDownloadedBlock: Interfaces.IBlock = blockchain.getLastDownloadedBlock();
 
         if (!isBlockChained(lastDownloadedBlock, { data: block })) {
             throw new UnchainedBlockError(lastDownloadedBlock.data.height, block.height);
         }
+    }
+
+    if (blockchain.pingBlock(block)) {
+        return;
     }
 
     blockchain.handleIncomingBlock(block, req.headers.remoteAddress);

--- a/packages/core-p2p/src/socket-server/versions/peer.ts
+++ b/packages/core-p2p/src/socket-server/versions/peer.ts
@@ -70,15 +70,15 @@ export async function postBlock({ req }): Promise<void> {
     const block: Interfaces.IBlockData = req.data.block;
 
     if (!isWhitelisted(app.resolveOptions("p2p").remoteAccess, req.headers.remoteAddress)) {
+        if (blockchain.pingBlock(block)) {
+            return;
+        }
+
         const lastDownloadedBlock: Interfaces.IBlock = blockchain.getLastDownloadedBlock();
 
         if (!isBlockChained(lastDownloadedBlock, { data: block })) {
             throw new UnchainedBlockError(lastDownloadedBlock.data.height, block.height);
         }
-    }
-
-    if (blockchain.pingBlock(block)) {
-        return;
     }
 
     blockchain.handleIncomingBlock(block, req.headers.remoteAddress);


### PR DESCRIPTION
## Proposed changes

Resolves `@TODO: store errors in the PeerConnector`.

## Types of changes

- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes