### PR TITLE
refactor(core-p2p): suspend a peer directly with the noCommonBlocks punishment

### DIFF
--- a/__tests__/unit/core-p2p/peer-guard.test.ts
+++ b/__tests__/unit/core-p2p/peer-guard.test.ts
@@ -66,12 +66,7 @@ describe("PeerGuard", () => {
         });
 
         it('should return a 5 minutes suspension for "No Common Blocks"', () => {
-            const { until, reason } = guard.analyze({
-                ...dummy,
-                ...{
-                    commonBlocks: false,
-                },
-            });
+            const { until, reason } = guard.punishment("noCommonBlocks");
 
             expect(reason).toBe("No Common Blocks");
             expect(convertToMinutes(until)).toBe(5);

--- a/packages/core-interfaces/src/core-p2p/peer.ts
+++ b/packages/core-interfaces/src/core-p2p/peer.ts
@@ -20,7 +20,6 @@ export interface IPeer {
 
     // @TODO: review and remove them where appropriate
     status: any;
-    commonBlocks: any;
     socketError: any; // @TODO: store errors in the PeerConnector
 
     setHeaders(headers: Record<string, string>): void;

--- a/packages/core-p2p/src/peer-communicator.ts
+++ b/packages/core-p2p/src/peer-communicator.ts
@@ -92,9 +92,7 @@ export class PeerCommunicator implements P2P.IPeerCommunicator {
 
             this.logger.error(`Could not determine common blocks with ${peer.ip}${sfx}: ${error.message}`);
 
-            peer.commonBlocks = false;
-
-            this.emitter.emit("internal.p2p.suspendPeer", { peer });
+            this.emitter.emit("internal.p2p.suspendPeer", { peer, punishment: "noCommonBlocks" });
         }
 
         return false;

--- a/packages/core-p2p/src/peer-guard.ts
+++ b/packages/core-p2p/src/peer-guard.ts
@@ -74,12 +74,6 @@ export class PeerGuard implements P2P.IPeerGuard {
             }
         }
 
-        if (peer.commonBlocks === false) {
-            delete peer.commonBlocks;
-
-            return this.createPunishment(this.offences.noCommonBlocks);
-        }
-
         const connection: SCClientSocket = this.connector.connection(peer);
 
         if (connection && connection.getState() !== connection.OPEN) {

--- a/packages/core-p2p/src/peer.ts
+++ b/packages/core-p2p/src/peer.ts
@@ -16,7 +16,6 @@ export class Peer implements P2P.IPeer {
 
     // @TODO: review and remove them where appropriate
     public status: any;
-    public commonBlocks: any;
     public socketError: any;
 
     constructor(readonly ip: string, readonly port: number) {


### PR DESCRIPTION
## Proposed changes

Removes the `peer.commonBlocks` property which was only used to suspend a peer and instead directly emits a suspension with the `noCommonBlocks` punishment.

## Types of changes

- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes