### PR TITLE
refactor(p2p): remove the status property from peers

### DIFF
--- a/packages/core-api/src/versions/1/peers/controller.ts
+++ b/packages/core-api/src/versions/1/peers/controller.ts
@@ -15,22 +15,11 @@ export class PeersController extends Controller {
                 return super.respondWith("No peers found", true);
             }
 
-            let peers = allPeers
-                .map(peer => {
-                    // just use 'OK' status for API instead of p2p http status codes
-                    peer.status = peer.status === 200 ? "OK" : peer.status;
-                    return peer;
-                })
-                .sort((a, b) => a.latency - b.latency);
+            let peers = allPeers.sort((a, b) => a.latency - b.latency);
             // @ts-ignore
             peers = request.query.os
                 ? // @ts-ignore
                   allPeers.filter(peer => peer.os === (request.query as any).os)
-                : peers;
-            // @ts-ignore
-            peers = request.query.status
-                ? // @ts-ignore
-                  allPeers.filter(peer => peer.status === (request.query as any).status)
                 : peers;
             // @ts-ignore
             peers = request.query.port

--- a/packages/core-api/src/versions/2/peers/controller.ts
+++ b/packages/core-api/src/versions/2/peers/controller.ts
@@ -15,11 +15,6 @@ export class PeersController extends Controller {
                   result.filter(peer => peer.os === (request.query as any).os)
                 : result;
             // @ts-ignore
-            result = request.query.status
-                ? // @ts-ignore
-                  result.filter(peer => peer.status === (request.query as any).status)
-                : result;
-            // @ts-ignore
             result = request.query.port
                 ? // @ts-ignore
                   result.filter(peer => peer.port === (request.query as any).port)

--- a/packages/core-interfaces/src/core-p2p/peer.ts
+++ b/packages/core-interfaces/src/core-p2p/peer.ts
@@ -18,8 +18,6 @@ export interface IPeer {
     lastPinged: Dato | null;
     verificationResult: IPeerVerificationResult | null;
 
-    // @TODO: review and remove them where appropriate
-    status: any;
     commonBlocks: any;
     socketError: any; // @TODO: store errors in the PeerConnector
 

--- a/packages/core-p2p/src/peer.ts
+++ b/packages/core-p2p/src/peer.ts
@@ -14,8 +14,6 @@ export class Peer implements P2P.IPeer {
     public lastPinged: Dato | null;
     public verificationResult: PeerVerificationResult | null;
 
-    // @TODO: review and remove them where appropriate
-    public status: any;
     public commonBlocks: any;
     public socketError: any;
 


### PR DESCRIPTION
## Proposed changes

Removes the unused `peer.status` property.

## Types of changes

- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes