### PR TITLE
refactor(core-p2p): add peer state interface

### DIFF
--- a/packages/core-interfaces/src/core-p2p/peer.ts
+++ b/packages/core-interfaces/src/core-p2p/peer.ts
@@ -12,9 +12,8 @@ export interface IPeer {
     os: string;
 
     latency: number;
-    downloadSize: number;
     headers: Record<string, string | number>;
-    state: any; // @TODO: add an interface/type
+    state: IPeerState;
     lastPinged: Dato | null;
     verificationResult: IPeerVerificationResult | null;
 
@@ -40,4 +39,11 @@ export interface IPeerBroadcast {
     os: string;
     height: number;
     latency: number;
+}
+
+export interface IPeerState {
+    height: number;
+    forgingAllowed: boolean;
+    currentSlot: number;
+    header: Record<string, any>;
 }

--- a/packages/core-p2p/src/peer.ts
+++ b/packages/core-p2p/src/peer.ts
@@ -8,9 +8,8 @@ export class Peer implements P2P.IPeer {
     public version: string;
     public os: string;
     public latency: number;
-    public downloadSize: number;
     public headers: Record<string, string | number>;
-    public state: any = {}; // @TODO: add an interface/type
+    public state: P2P.IPeerState;
     public lastPinged: Dato | null;
     public verificationResult: PeerVerificationResult | null;
 

--- a/packages/core-p2p/src/peer.ts
+++ b/packages/core-p2p/src/peer.ts
@@ -9,9 +9,14 @@ export class Peer implements P2P.IPeer {
     public os: string;
     public latency: number;
     public headers: Record<string, string | number>;
-    public state: P2P.IPeerState;
     public lastPinged: Dato | null;
     public verificationResult: PeerVerificationResult | null;
+    public state: P2P.IPeerState = {
+        height: null,
+        forgingAllowed: null,
+        currentSlot: null,
+        header: {},
+    };
 
     constructor(readonly ip: string, readonly port: number) {
         this.headers = {

--- a/packages/core-p2p/src/socket-server/versions/peer.ts
+++ b/packages/core-p2p/src/socket-server/versions/peer.ts
@@ -48,12 +48,7 @@ export async function getCommonBlocks({
     };
 }
 
-export async function getStatus(): Promise<{
-    height: number;
-    forgingAllowed: boolean;
-    currentSlot: number;
-    header: Record<string, any>;
-}> {
+export async function getStatus(): Promise<P2P.IPeerState> {
     const lastBlock = app.resolvePlugin<Blockchain.IBlockchain>("blockchain").getLastBlock();
 
     return {


### PR DESCRIPTION
## Proposed changes

Add an interface for the `peer.state` property.

## Types of changes

- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes