### PR TITLE
refactor: pass IBlockData instead of IBlock to isBlockChained

### DIFF
--- a/__tests__/unit/core-utils/is-blocked-chained.test.ts
+++ b/__tests__/unit/core-utils/is-blocked-chained.test.ts
@@ -6,110 +6,90 @@ import { isBlockChained } from "../../../packages/core-utils/src";
 describe("isChained", () => {
     it("should be ok", () => {
         const previousBlock = {
-            data: {
-                id: "1",
-                timestamp: Crypto.slots.getSlotTime(0),
-                height: 1,
-                previousBlock: null,
-            },
-        } as Interfaces.IBlock;
+            id: "1",
+            timestamp: Crypto.slots.getSlotTime(0),
+            height: 1,
+            previousBlock: null,
+        } as Interfaces.IBlockData;
 
         const nextBlock = {
-            data: {
-                id: "2",
-                timestamp: Crypto.slots.getSlotTime(1),
-                height: 2,
-                previousBlock: "1",
-            },
-        } as Interfaces.IBlock;
+            id: "2",
+            timestamp: Crypto.slots.getSlotTime(1),
+            height: 2,
+            previousBlock: "1",
+        } as Interfaces.IBlockData;
 
         expect(isBlockChained(previousBlock, nextBlock)).toBeTrue();
     });
 
     it("should not chain when previous block does not match", () => {
         const previousBlock = {
-            data: {
-                id: "2",
-                timestamp: Crypto.slots.getSlotTime(0),
-                height: 2,
-                previousBlock: null,
-            },
-        } as Interfaces.IBlock;
+            id: "2",
+            timestamp: Crypto.slots.getSlotTime(0),
+            height: 2,
+            previousBlock: null,
+        } as Interfaces.IBlockData;
 
         const nextBlock = {
-            data: {
-                id: "1",
-                timestamp: Crypto.slots.getSlotTime(1),
-                height: 3,
-                previousBlock: "1",
-            },
-        } as Interfaces.IBlock;
+            id: "1",
+            timestamp: Crypto.slots.getSlotTime(1),
+            height: 3,
+            previousBlock: "1",
+        } as Interfaces.IBlockData;
 
         expect(isBlockChained(previousBlock, nextBlock)).toBeFalse();
     });
 
     it("should not chain when next height is not plus 1", () => {
         const previousBlock = {
-            data: {
-                id: "1",
-                timestamp: Crypto.slots.getSlotTime(0),
-                height: 1,
-                previousBlock: null,
-            },
-        } as Interfaces.IBlock;
+            id: "1",
+            timestamp: Crypto.slots.getSlotTime(0),
+            height: 1,
+            previousBlock: null,
+        } as Interfaces.IBlockData;
 
         const nextBlock = {
-            data: {
-                id: "2",
-                timestamp: Crypto.slots.getSlotTime(1),
-                height: 3,
-                previousBlock: "1",
-            },
-        } as Interfaces.IBlock;
+            id: "2",
+            timestamp: Crypto.slots.getSlotTime(1),
+            height: 3,
+            previousBlock: "1",
+        } as Interfaces.IBlockData;
 
         expect(isBlockChained(previousBlock, nextBlock)).toBeFalse();
     });
 
     it("should not chain when same slot", () => {
         const previousBlock = {
-            data: {
-                id: "1",
-                timestamp: Crypto.slots.getSlotTime(0),
-                height: 1,
-                previousBlock: null,
-            },
-        } as Interfaces.IBlock;
+            id: "1",
+            timestamp: Crypto.slots.getSlotTime(0),
+            height: 1,
+            previousBlock: null,
+        } as Interfaces.IBlockData;
 
         const nextBlock = {
-            data: {
-                id: "2",
-                timestamp: Crypto.slots.getSlotTime(0),
-                height: 3,
-                previousBlock: "1",
-            },
-        } as Interfaces.IBlock;
+            id: "2",
+            timestamp: Crypto.slots.getSlotTime(0),
+            height: 3,
+            previousBlock: "1",
+        } as Interfaces.IBlockData;
 
         expect(isBlockChained(previousBlock, nextBlock)).toBeFalse();
     });
 
     it("should not chain when lower slot", () => {
         const previousBlock = {
-            data: {
-                id: "1",
-                timestamp: Crypto.slots.getSlotTime(1),
-                height: 1,
-                previousBlock: null,
-            },
-        } as Interfaces.IBlock;
+            id: "1",
+            timestamp: Crypto.slots.getSlotTime(1),
+            height: 1,
+            previousBlock: null,
+        } as Interfaces.IBlockData;
 
         const nextBlock = {
-            data: {
-                id: "2",
-                timestamp: Crypto.slots.getSlotTime(0),
-                height: 3,
-                previousBlock: "1",
-            },
-        } as Interfaces.IBlock;
+            id: "2",
+            timestamp: Crypto.slots.getSlotTime(0),
+            height: 3,
+            previousBlock: "1",
+        } as Interfaces.IBlockData;
 
         expect(isBlockChained(previousBlock, nextBlock)).toBeFalse();
     });

--- a/packages/core-blockchain/src/blockchain.ts
+++ b/packages/core-blockchain/src/blockchain.ts
@@ -458,7 +458,7 @@ export class Blockchain implements blockchain.IBlockchain {
     /**
      * Get the last downloaded block of the blockchain.
      */
-    public getLastDownloadedBlock(): { data: Interfaces.IBlockData } {
+    public getLastDownloadedBlock(): Interfaces.IBlock {
         return this.state.lastDownloadedBlock;
     }
 

--- a/packages/core-blockchain/src/processor/block-processor.ts
+++ b/packages/core-blockchain/src/processor/block-processor.ts
@@ -45,7 +45,7 @@ export class BlockProcessor {
         }
 
         const isValidGenerator = await validateGenerator(block);
-        const isChained = isBlockChained(this.blockchain.getLastBlock(), block);
+        const isChained = isBlockChained(this.blockchain.getLastBlock().data, block.data);
         if (!isChained) {
             return new UnchainedHandler(this.blockchain, block, isValidGenerator);
         }

--- a/packages/core-blockchain/src/state-machine.ts
+++ b/packages/core-blockchain/src/state-machine.ts
@@ -215,9 +215,7 @@ blockchainMachine.actionMap = (blockchain: Blockchain) => ({
         }
 
         const empty = !blocks || blocks.length === 0;
-        const chained =
-            // @ts-ignore - @TODO: second argument has to be an IBlock
-            !empty && (isBlockChained(lastDownloadedBlock, { data: blocks[0] }) || Utils.isException(blocks[0]));
+        const chained = !empty && (isBlockChained(lastDownloadedBlock.data, blocks[0]) || Utils.isException(blocks[0]));
 
         if (chained) {
             logger.info(

--- a/packages/core-interfaces/src/core-blockchain/blockchain.ts
+++ b/packages/core-interfaces/src/core-blockchain/blockchain.ts
@@ -145,7 +145,7 @@ export interface IBlockchain {
      * Get the last downloaded block of the blockchain.
      * @return {Object}
      */
-    getLastDownloadedBlock(): { data: Interfaces.IBlockData };
+    getLastDownloadedBlock(): Interfaces.IBlock;
 
     /**
      * Get the block ping.

--- a/packages/core-p2p/src/socket-server/versions/peer.ts
+++ b/packages/core-p2p/src/socket-server/versions/peer.ts
@@ -69,11 +69,9 @@ export async function postBlock({ req }): Promise<void> {
             return;
         }
 
-        // @ts-ignore - @TODO: has to be an IBlock
         const lastDownloadedBlock: Interfaces.IBlock = blockchain.getLastDownloadedBlock();
 
-        // @ts-ignore - @TODO: second argument has to be an IBlock
-        if (!isBlockChained(lastDownloadedBlock, { data: block })) {
+        if (!isBlockChained(lastDownloadedBlock.data, block)) {
             throw new UnchainedBlockError(lastDownloadedBlock.data.height, block.height);
         }
     }

--- a/packages/core-utils/src/is-block-chained.ts
+++ b/packages/core-utils/src/is-block-chained.ts
@@ -1,12 +1,12 @@
 import { Crypto, Interfaces } from "@arkecosystem/crypto";
 
-export const isBlockChained = (previousBlock: Interfaces.IBlock, nextBlock: Interfaces.IBlock): boolean => {
-    const followsPrevious = nextBlock.data.previousBlock === previousBlock.data.id;
-    const isPlusOne = nextBlock.data.height === previousBlock.data.height + 1;
+export function isBlockChained(previousBlock: Interfaces.IBlockData, nextBlock: Interfaces.IBlockData): boolean {
+    const followsPrevious = nextBlock.previousBlock === previousBlock.id;
+    const isPlusOne = nextBlock.height === previousBlock.height + 1;
 
-    const previousSlot = Crypto.slots.getSlotNumber(previousBlock.data.timestamp);
-    const nextSlot = Crypto.slots.getSlotNumber(nextBlock.data.timestamp);
+    const previousSlot = Crypto.slots.getSlotNumber(previousBlock.timestamp);
+    const nextSlot = Crypto.slots.getSlotNumber(nextBlock.timestamp);
     const isAfterPreviousSlot = previousSlot < nextSlot;
 
     return followsPrevious && isPlusOne && isAfterPreviousSlot;
-};
+}


### PR DESCRIPTION
## Proposed changes

Removes the need for hacks like casting with `as IBlockData` or using `@ts-ignore` as the function only works with `IBlockData` and never used any instance props or functions of `IBlock`.

## Types of changes

- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes