### PR TITLE
feat(core-json-rpc): allow setting a vendor field for transactions

### DIFF
--- a/__tests__/integration/core-json-rpc/transactions.test.ts
+++ b/__tests__/integration/core-json-rpc/transactions.test.ts
@@ -3,6 +3,7 @@ import "jest-extended";
 import { app } from "@arkecosystem/core-container";
 import { Peer } from "@arkecosystem/core-p2p";
 import { Crypto } from "@arkecosystem/crypto";
+import { randomBytes } from "crypto";
 import nock from "nock";
 import { sendRequest } from "./__support__/request";
 import { setUp, tearDown } from "./__support__/setup";
@@ -75,6 +76,19 @@ describe("Transactions", () => {
             expect(response.body.result.recipientId).toBe("APnhwwyTbMiykJwYbGhYjNgtHiVJDSEhSn");
             expect(crypto.verify(response.body.result)).toBeTrue();
         });
+
+        it("should create a new transaction with a vendor field and verify", async () => {
+            const response = await sendRequest("transactions.create", {
+                amount: 100000000,
+                passphrase: "this is a top secret passphrase",
+                recipientId: "APnhwwyTbMiykJwYbGhYjNgtHiVJDSEhSn",
+                vendorField: "Hello World",
+            });
+
+            expect(response.body.result.recipientId).toBe("APnhwwyTbMiykJwYbGhYjNgtHiVJDSEhSn");
+            expect(response.body.result.vendorField).toBe("Hello World");
+            expect(crypto.verify(response.body.result)).toBeTrue();
+        });
     });
 
     describe("POST transactions.broadcast", () => {
@@ -107,11 +121,9 @@ describe("Transactions", () => {
     });
 
     describe("POST transactions.bip38.create", () => {
-        it("should create a new transaction", async () => {
-            const userId: string = require("crypto")
-                .randomBytes(32)
-                .toString("hex");
+        const userId: string = randomBytes(32).toString("hex");
 
+        it("should create a new transaction", async () => {
             await sendRequest("wallets.bip38.create", {
                 bip38: "this is a top secret passphrase",
                 userId,
@@ -125,6 +137,20 @@ describe("Transactions", () => {
             });
 
             expect(response.body.result.recipientId).toBe("AUDud8tvyVZa67p3QY7XPRUTjRGnWQQ9Xv");
+            expect(crypto.verify(response.body.result)).toBeTrue();
+        });
+
+        it("should create a new transaction with a vendor field", async () => {
+            const response = await sendRequest("transactions.bip38.create", {
+                bip38: "this is a top secret passphrase",
+                userId,
+                amount: 1000000000,
+                recipientId: "AUDud8tvyVZa67p3QY7XPRUTjRGnWQQ9Xv",
+                vendorField: "Hello World",
+            });
+
+            expect(response.body.result.recipientId).toBe("AUDud8tvyVZa67p3QY7XPRUTjRGnWQQ9Xv");
+            expect(response.body.result.vendorField).toBe("Hello World");
             expect(crypto.verify(response.body.result)).toBeTrue();
         });
 

--- a/packages/core-json-rpc/src/server/modules.ts
+++ b/packages/core-json-rpc/src/server/modules.ts
@@ -93,11 +93,15 @@ export const transactions = [
     {
         name: "transactions.create",
         async method(params) {
-            const transaction: Interfaces.ITransactionData = Transactions.BuilderFactory.transfer()
+            const transactionBuilder = Transactions.BuilderFactory.transfer()
                 .recipientId(params.recipientId)
-                .amount(params.amount)
-                .sign(params.passphrase)
-                .getStruct();
+                .amount(params.amount);
+
+            if (params.vendorField) {
+                transactionBuilder.vendorField(params.vendorField);
+            }
+
+            const transaction: Interfaces.ITransactionData = transactionBuilder.sign(params.passphrase).getStruct();
 
             await database.set(transaction.id, transaction);
 
@@ -107,6 +111,7 @@ export const transactions = [
             amount: Joi.number().required(),
             recipientId: Joi.string().required(),
             passphrase: Joi.string().required(),
+            vendorField: Joi.string(),
         },
     },
     {
@@ -135,11 +140,15 @@ export const transactions = [
                 return Boom.notFound(`User ${params.userId} could not be found.`);
             }
 
-            const transaction: Interfaces.ITransactionData = Transactions.BuilderFactory.transfer()
+            const transactionBuilder = Transactions.BuilderFactory.transfer()
                 .recipientId(params.recipientId)
-                .amount(params.amount)
-                .signWithWif(wallet.wif)
-                .getStruct();
+                .amount(params.amount);
+
+            if (params.vendorField) {
+                transactionBuilder.vendorField(params.vendorField);
+            }
+
+            const transaction: Interfaces.ITransactionData = transactionBuilder.signWithWif(wallet.wif).getStruct();
 
             await database.set(transaction.id, transaction);
 
@@ -150,6 +159,7 @@ export const transactions = [
             recipientId: Joi.string()
                 .length(34)
                 .required(),
+            vendorField: Joi.string(),
             bip38: Joi.string().required(),
             userId: Joi.string()
                 .hex()

--- a/packages/core-json-rpc/src/server/modules.ts
+++ b/packages/core-json-rpc/src/server/modules.ts
@@ -103,6 +103,10 @@ export const transactions = [
 
             const transaction: Interfaces.ITransactionData = transactionBuilder.sign(params.passphrase).getStruct();
 
+            if (!transactionBuilder.verify()) {
+                return Boom.badRequest("Failed to verify the transaction.");
+            }
+
             await database.set(transaction.id, transaction);
 
             return transaction;
@@ -149,6 +153,10 @@ export const transactions = [
             }
 
             const transaction: Interfaces.ITransactionData = transactionBuilder.signWithWif(wallet.wif).getStruct();
+
+            if (!transactionBuilder.verify()) {
+                return Boom.badRequest("Failed to verify the transaction.");
+            }
 
             await database.set(transaction.id, transaction);
 


### PR DESCRIPTION
## Proposed changes

Allow setting a vendor field for transactions created via the RPC and respond with an error if the transaction doesn't verify.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes