### PR TITLE
fix(core-database): don't swallow errors in buildWallets

### DIFF
--- a/__tests__/unit/core-database/__fixtures__/database-connection-stub.ts
+++ b/__tests__/unit/core-database/__fixtures__/database-connection-stub.ts
@@ -10,8 +10,8 @@ export class DatabaseConnectionStub implements Database.IConnection {
     public walletsRepository: Database.IWalletsRepository;
     public options: any;
 
-    public buildWallets(): Promise<boolean> {
-        return undefined;
+    public buildWallets(): Promise<void> {
+        return null;
     }
 
     public commitQueuedQueries(): any {}

--- a/packages/core-database-postgres/src/integrity-verifier.ts
+++ b/packages/core-database-postgres/src/integrity-verifier.ts
@@ -10,7 +10,7 @@ export class IntegrityVerifier {
 
     constructor(private readonly query: QueryExecutor, private readonly walletManager: Database.IWalletManager) {}
 
-    public async run(): Promise<boolean> {
+    public async run(): Promise<void> {
         this.logger.info("Integrity Verification - Step 1 of 8: Received Transactions");
         await this.buildReceivedTransactions();
 
@@ -40,7 +40,7 @@ export class IntegrityVerifier {
         );
         this.logger.info(`Number of registered delegates: ${Object.keys(this.walletManager.allByUsername()).length}`);
 
-        return this.verifyWalletsConsistency();
+        this.verifyWalletsConsistency();
     }
 
     private async buildReceivedTransactions(): Promise<void> {
@@ -169,28 +169,23 @@ export class IntegrityVerifier {
     }
 
     /**
-     * Verify the consistency of the wallets table by comparing all records against
-     * the in memory wallets.
+     * Verify the consistency of the wallets table by comparing all records against the in memory wallets.
+     *
      * NOTE: This is faster than rebuilding the entire table from scratch each time.
-     * @returns {Boolean}
      */
-    private async verifyWalletsConsistency(): Promise<boolean> {
-        let detectedInconsistency = false;
-
+    private verifyWalletsConsistency(): void {
         for (const wallet of this.walletManager.allByAddress()) {
             if (wallet.balance.isLessThan(0) && !this.isGenesis(wallet)) {
-                detectedInconsistency = true;
                 this.logger.warn(`Wallet '${wallet.address}' has a negative balance of '${wallet.balance}'`);
-                break;
+
+                // @TODO: throw here
             }
 
             if (wallet.voteBalance.isLessThan(0)) {
-                detectedInconsistency = true;
                 this.logger.warn(`Wallet ${wallet.address} has a negative vote balance of '${wallet.voteBalance}'`);
-                break;
+
+                // @TODO: throw here
             }
         }
-
-        return !detectedInconsistency;
     }
 }

--- a/packages/core-database-postgres/src/postgres-connection.ts
+++ b/packages/core-database-postgres/src/postgres-connection.ts
@@ -110,16 +110,8 @@ export class PostgresConnection implements Database.IConnection {
         this.logger.debug("Disconnected from database");
     }
 
-    public async buildWallets(): Promise<boolean> {
-        try {
-            return await new IntegrityVerifier(this.query, this.walletManager).run();
-        } catch (error) {
-            this.logger.error(error.stack);
-
-            app.forceExit("Failed to build wallets. This indicates a problem with the database.");
-
-            return false;
-        }
+    public async buildWallets(): Promise<void> {
+        await new IntegrityVerifier(this.query, this.walletManager).run();
     }
 
     public async commitQueuedQueries(): Promise<void> {

--- a/packages/core-database/src/database-service.ts
+++ b/packages/core-database/src/database-service.ts
@@ -122,15 +122,10 @@ export class DatabaseService implements Database.IDatabaseService {
         }
     }
 
-    // @TODO: make this throw an error
     public async buildWallets(): Promise<void> {
         this.walletManager.reset();
 
-        try {
-            await this.connection.buildWallets();
-        } catch (err) {
-            this.logger.error(err.stack);
-        }
+        await this.connection.buildWallets();
     }
 
     public async commitQueuedQueries(): Promise<void> {

--- a/packages/core-interfaces/src/core-database/database-connection.ts
+++ b/packages/core-interfaces/src/core-database/database-connection.ts
@@ -18,7 +18,7 @@ export interface IConnection {
 
     disconnect(): Promise<void>;
 
-    buildWallets(): Promise<boolean>;
+    buildWallets(): Promise<void>;
 
     saveBlock(block: Interfaces.IBlock): Promise<void>;
 


### PR DESCRIPTION
## Proposed changes

Errors in `buildWallets` were swallowed which meant the state machine would never be able to catch any issues with it.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist


- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes