### PR TITLE
refactor: always use crypto identities to work with keys and addresses

### DIFF
--- a/__tests__/integration/core-blockchain/blockchain.test.ts
+++ b/__tests__/integration/core-blockchain/blockchain.test.ts
@@ -3,7 +3,7 @@ import "../../utils";
 /* tslint:disable:max-line-length */
 import { Wallet } from "@arkecosystem/core-database";
 import { roundCalculator } from "@arkecosystem/core-utils";
-import { Blocks, Crypto, Interfaces, Transactions, Utils } from "@arkecosystem/crypto";
+import { Blocks, Crypto, Identities, Interfaces, Transactions, Utils } from "@arkecosystem/crypto";
 import delay from "delay";
 import { Blockchain } from "../../../packages/core-blockchain/src/blockchain";
 import { genesisBlock as GB } from "../../utils/config/testnet/genesisBlock";
@@ -170,14 +170,14 @@ describe("Blockchain", () => {
                 transactions: sortedTransactions,
             };
 
-            return Blocks.BlockFactory.make(data, Crypto.crypto.getKeys(generatorKeys.secret));
+            return Blocks.BlockFactory.make(data, Identities.Keys.fromPassphrase(generatorKeys.secret));
         };
 
         it("should restore vote balances after a rollback", async () => {
             const mockCallback = jest.fn(() => true);
 
             // Create key pair for new voter
-            const keyPair = Crypto.crypto.getKeys("secret");
+            const keyPair = Identities.Keys.fromPassphrase("secret");
             const recipient = Crypto.crypto.getAddress(keyPair.publicKey);
 
             let nextForger = await getNextForger();

--- a/__tests__/integration/core-transaction-pool/guard.test.ts
+++ b/__tests__/integration/core-transaction-pool/guard.test.ts
@@ -2,7 +2,7 @@ import "jest-extended";
 
 import { Container } from "@arkecosystem/core-interfaces";
 import { TransactionHandlerRegistry } from "@arkecosystem/core-transactions";
-import { Blocks, Crypto, Interfaces, Utils } from "@arkecosystem/crypto";
+import { Blocks, Crypto, Identities, Interfaces, Utils } from "@arkecosystem/crypto";
 import { generateMnemonic } from "bip39";
 import { TransactionFactory } from "../../helpers/transaction-factory";
 import { delegates, genesisBlock, wallets, wallets2ndSig } from "../../utils/fixtures/unitnet";
@@ -108,7 +108,7 @@ describe("Transaction Guard", () => {
 
         it("should not apply the tx to the balance of the sender & recipient with dyn fee < min fee", async () => {
             const delegate0 = delegates[14];
-            const { publicKey } = crypto.getKeys(generateMnemonic());
+            const { publicKey } = Identities.Keys.fromPassphrase(generateMnemonic());
             const newAddress = crypto.getAddress(publicKey);
 
             const delegateWallet = transactionPool.walletManager.findByPublicKey(delegate0.publicKey);
@@ -133,7 +133,7 @@ describe("Transaction Guard", () => {
 
         it("should update the balance of the sender & recipient with dyn fee > min fee", async () => {
             const delegate1 = delegates[1];
-            const { publicKey } = crypto.getKeys(generateMnemonic());
+            const { publicKey } = Identities.Keys.fromPassphrase(generateMnemonic());
             const newAddress = crypto.getAddress(publicKey);
 
             const delegateWallet = transactionPool.walletManager.findByPublicKey(delegate1.publicKey);
@@ -163,7 +163,7 @@ describe("Transaction Guard", () => {
         it("should update the balance of the sender & recipient with multiple transactions type", async () => {
             const delegate2 = delegates[2];
             const newWalletPassphrase = generateMnemonic();
-            const { publicKey } = crypto.getKeys(newWalletPassphrase);
+            const { publicKey } = Identities.Keys.fromPassphrase(newWalletPassphrase);
             const newAddress = crypto.getAddress(publicKey);
 
             const delegateWallet = transactionPool.walletManager.findByPublicKey(delegate2.publicKey);
@@ -226,7 +226,7 @@ describe("Transaction Guard", () => {
         it("should not accept transaction in excess", async () => {
             const delegate3 = delegates[3];
             const newWalletPassphrase = generateMnemonic();
-            const { publicKey } = crypto.getKeys(newWalletPassphrase);
+            const { publicKey } = Identities.Keys.fromPassphrase(newWalletPassphrase);
             const newAddress = crypto.getAddress(publicKey);
 
             const delegateWallet = transactionPool.walletManager.findByPublicKey(delegate3.publicKey);

--- a/__tests__/integration/core-transaction-pool/pool-wallet-manager.test.ts
+++ b/__tests__/integration/core-transaction-pool/pool-wallet-manager.test.ts
@@ -1,6 +1,6 @@
 import { Blockchain, Container, Database } from "@arkecosystem/core-interfaces";
 import { TransactionHandlerRegistry } from "@arkecosystem/core-transactions";
-import { Blocks, Crypto, Utils } from "@arkecosystem/crypto";
+import { Blocks, Crypto, Identities, Utils } from "@arkecosystem/crypto";
 import { generateMnemonic } from "bip39";
 import { TransactionFactory } from "../../helpers/transaction-factory";
 import { delegates, genesisBlock, wallets } from "../../utils/fixtures/unitnet";
@@ -60,7 +60,7 @@ describe("applyPoolTransactionToSender", () => {
     describe("update the balance", () => {
         it("should only update the balance of the sender", async () => {
             const delegate0 = delegates[0];
-            const { publicKey } = crypto.getKeys(generateMnemonic());
+            const { publicKey } = Identities.Keys.fromPassphrase(generateMnemonic());
             const newAddress = crypto.getAddress(publicKey);
 
             const delegateWallet = poolWalletManager.findByAddress(delegate0.address);
@@ -84,7 +84,7 @@ describe("applyPoolTransactionToSender", () => {
 
         it("should only update the balance of the sender with dyn fees", async () => {
             const delegate0 = delegates[1];
-            const { publicKey } = crypto.getKeys(generateMnemonic());
+            const { publicKey } = Identities.Keys.fromPassphrase(generateMnemonic());
             const newAddress = crypto.getAddress(publicKey);
 
             const delegateWallet = poolWalletManager.findByAddress(delegate0.address);

--- a/__tests__/unit/core-database/wallet-manager.test.ts
+++ b/__tests__/unit/core-database/wallet-manager.test.ts
@@ -3,7 +3,7 @@ import "./mocks/core-container";
 
 import { Database } from "@arkecosystem/core-interfaces";
 import { InsufficientBalanceError } from "@arkecosystem/core-transactions/src/errors";
-import { Blocks, Constants, Crypto, Enums, Interfaces, Transactions, Utils } from "@arkecosystem/crypto";
+import { Blocks, Constants, Crypto, Enums, Identities, Interfaces, Transactions, Utils } from "@arkecosystem/crypto";
 import { Wallet } from "../../../packages/core-database/src";
 import { TransactionFactory } from "../../helpers/transaction-factory";
 import { fixtures } from "../../utils";
@@ -264,8 +264,8 @@ describe("Wallet Manager", () => {
         });
 
         it("should revert vote transaction and correctly update vote balances", async () => {
-            const delegateKeys = crypto.getKeys("delegate");
-            const voterKeys = crypto.getKeys("secret");
+            const delegateKeys = Identities.Keys.fromPassphrase("delegate");
+            const voterKeys = Identities.Keys.fromPassphrase("secret");
 
             const delegate = walletManager.findByPublicKey(delegateKeys.publicKey);
             delegate.username = "unittest";
@@ -299,8 +299,8 @@ describe("Wallet Manager", () => {
         });
 
         it("should revert unvote transaction and correctly update vote balances", async () => {
-            const delegateKeys = crypto.getKeys("delegate");
-            const voterKeys = crypto.getKeys("secret");
+            const delegateKeys = Identities.Keys.fromPassphrase("delegate");
+            const voterKeys = Identities.Keys.fromPassphrase("secret");
 
             const delegate = walletManager.findByPublicKey(delegateKeys.publicKey);
             delegate.username = "unittest";

--- a/__tests__/unit/core-transactions/handler-registry.test.ts
+++ b/__tests__/unit/core-transactions/handler-registry.test.ts
@@ -1,7 +1,7 @@
 import "jest-extended";
 
 import { Database, TransactionPool } from "@arkecosystem/core-interfaces";
-import { Crypto, Enums, Interfaces, Managers, Transactions, Utils } from "@arkecosystem/crypto";
+import { Crypto, Enums, Identities, Interfaces, Managers, Transactions, Utils } from "@arkecosystem/crypto";
 import bs58check from "bs58check";
 import ByteBuffer from "bytebuffer";
 import { errors, TransactionHandler, TransactionHandlerRegistry } from "../../../packages/core-transactions/src";
@@ -110,7 +110,7 @@ describe("TransactionHandlerRegistry", () => {
     it("should be able to instantiate a custom transaction", () => {
         TransactionHandlerRegistry.registerCustomTransactionHandler(TestTransactionHandler);
 
-        const keys = crypto.getKeys("secret");
+        const keys = Identities.Keys.fromPassphrase("secret");
         const data: Interfaces.ITransactionData = {
             type: TEST_TRANSACTION_TYPE,
             timestamp: slots.getTime(),

--- a/__tests__/unit/crypto/crypto/message.test.ts
+++ b/__tests__/unit/crypto/crypto/message.test.ts
@@ -1,16 +1,13 @@
 import "jest-extended";
 
-import { crypto } from "../../../../packages/crypto/src/crypto";
 import { Message } from "../../../../packages/crypto/src/crypto/message";
-import { devnet } from "../../../../packages/crypto/src/networks";
+import { identity } from "../../../utils/identities";
 
-const passphrase = "sample passphrase";
-const wif = crypto.keysToWIF(crypto.getKeys(passphrase), devnet.network);
 const signedMessageEntries: any = [
-    ["publicKey", "03bb51bbf5bf84759452e33dd97cf72cc8904be07df07a946a0d84939400f17e87"],
+    ["publicKey", identity.publicKey],
     [
         "signature",
-        "304402204550cd28d369a7f6eccd399b315e42e054a2f21f6771983af4ed3c5f7c7fa83102200699fef72cc64e79ccba85a31666e9508c052038c71c04260264e3d2d11c7e08",
+        "3045022100b5ad008d8a2935cd2261c56ef1605b2e35810f47940277d1d8a6a202a08c6de0022021fcbf9ec9db67f8c7019ff2ce07376f8a203ea77f26f2f7d564d5b8f4bde1a7",
     ],
     ["message", "test"],
 ];
@@ -18,30 +15,30 @@ const signedMessageEntries: any = [
 describe("Message", () => {
     describe("sign", () => {
         it("should sign a message", () => {
-            expect(Message.sign("test", passphrase)).toContainAllEntries(signedMessageEntries);
+            expect(Message.sign("test", identity.bip39)).toContainAllEntries(signedMessageEntries);
         });
     });
 
     describe("signWithWif", () => {
         it("should sign a message", () => {
-            expect(Message.signWithWif("test", wif)).toContainAllEntries(signedMessageEntries);
+            expect(Message.signWithWif("test", identity.wif)).toContainAllEntries(signedMessageEntries);
         });
 
         it("should sign a message and match passphrase", () => {
-            const signedMessage = Message.sign("test", passphrase);
-            const signedWifMessage = Message.signWithWif("test", wif);
+            const signedMessage = Message.sign("test", identity.bip39);
+            const signedWifMessage = Message.signWithWif("test", identity.wif);
             expect(signedMessage).toEqual(signedWifMessage);
         });
     });
 
     describe("verify", () => {
         it("should verify a signed message", () => {
-            const signedMessage = Message.sign("test", passphrase);
+            const signedMessage = Message.sign("test", identity.bip39);
             expect(Message.verify(signedMessage)).toBe(true);
         });
 
         it("should verify a signed wif message", () => {
-            const signedMessage = Message.signWithWif("test", wif);
+            const signedMessage = Message.signWithWif("test", identity.wif);
             expect(Message.verify(signedMessage)).toBe(true);
         });
     });

--- a/__tests__/unit/crypto/transactions/builders/transactions/__shared__/transaction-builder.ts
+++ b/__tests__/unit/crypto/transactions/builders/transactions/__shared__/transaction-builder.ts
@@ -1,6 +1,8 @@
 import { crypto, slots } from "../../../../../../../packages/crypto/src/crypto";
+import { Keys } from "../../../../../../../packages/crypto/src/identities";
 import { TransactionBuilder } from "../../../../../../../packages/crypto/src/transactions/builders/transactions/transaction";
 import * as Utils from "../../../../../../../packages/crypto/src/utils";
+import { identity, identitySecond } from "../../../../../../utils/identities";
 
 export const transactionBuilder = <T extends TransactionBuilder<T>>(provider: () => TransactionBuilder<T>) => {
     describe("TransactionBuilder", () => {
@@ -114,94 +116,72 @@ export const transactionBuilder = <T extends TransactionBuilder<T>>(provider: ()
         describe("sign", () => {
             it("signs this transaction with the keys of the passphrase", () => {
                 const builder = provider();
-                const keys = {
-                    publicKey: "02d0d835266297f15c192be2636eb3fbc30b39b87fc583ff112062ef8ae1a1f2af",
-                };
-                // @ts-ignore
-                crypto.getKeys = jest.fn(() => keys);
-                crypto.sign = jest.fn();
 
-                builder.sign("dummy pass");
+                const spyKeys = jest.spyOn(Keys, "fromPassphrase").mockReturnValueOnce(identity.keys);
+                const spySign = jest.spyOn(crypto, "sign").mockImplementationOnce(jest.fn());
 
-                expect(crypto.getKeys).toHaveBeenCalledWith("dummy pass");
-                expect(crypto.sign).toHaveBeenCalledWith((builder as any).getSigningObject(), keys);
+                builder.sign(identity.bip39);
+
+                expect(spyKeys).toHaveBeenCalledWith(identity.bip39);
+                expect(spySign).toHaveBeenCalledWith((builder as any).getSigningObject(), identity.keys);
             });
 
             it("establishes the public key of the sender", () => {
                 const builder = provider();
-                const keys = {
-                    publicKey: "02d0d835266297f15c192be2636eb3fbc30b39b87fc583ff112062ef8ae1a1f2af",
-                };
-                // @ts-ignore
-                crypto.getKeys = jest.fn(() => keys);
-                crypto.sign = jest.fn();
-                builder.sign("my real pass");
-                expect(builder.data.senderPublicKey).toBe(keys.publicKey);
+                builder.sign(identity.bip39);
+
+                expect(builder.data.senderPublicKey).toBe(identity.keys.publicKey);
             });
         });
 
         describe("signWithWif", () => {
             it("signs this transaction with keys from a wif", () => {
+                const spyKeys = jest.spyOn(Keys, "fromWIF").mockReturnValueOnce(identity.keys);
+                const spySign = jest.spyOn(crypto, "sign").mockImplementationOnce(jest.fn());
+
                 const builder = provider();
-                const keys = {
-                    publicKey: "02d0d835266297f15c192be2636eb3fbc30b39b87fc583ff112062ef8ae1a1f2af",
-                };
-                // @ts-ignore
-                crypto.getKeysFromWIF = jest.fn(() => keys);
-                crypto.sign = jest.fn();
+                builder.network(23).signWithWif(identity.bip39);
 
-                builder.network(23).signWithWif("dummy pass");
-
-                expect(crypto.getKeysFromWIF).toHaveBeenCalledWith("dummy pass", {
+                expect(spyKeys).toHaveBeenCalledWith(identity.bip39, {
                     wif: 170,
                 });
-                expect(crypto.sign).toHaveBeenCalledWith((builder as any).getSigningObject(), keys);
+                expect(spySign).toHaveBeenCalledWith((builder as any).getSigningObject(), identity.keys);
             });
 
             it("establishes the public key of the sender", () => {
                 const builder = provider();
-                const keys = {
-                    publicKey: "02d0d835266297f15c192be2636eb3fbc30b39b87fc583ff112062ef8ae1a1f2af",
-                };
-                // @ts-ignore
-                crypto.getKeysFromWIF = jest.fn(() => keys);
-                crypto.sign = jest.fn();
-                builder.signWithWif("my real pass");
-                expect(builder.data.senderPublicKey).toBe(keys.publicKey);
+                builder.signWithWif(identity.wif);
+
+                expect(builder.data.senderPublicKey).toBe(identity.publicKey);
             });
         });
 
         describe("secondSign", () => {
             it("signs this transaction with the keys of the second passphrase", () => {
                 const builder = provider();
-                let keys;
-                crypto.getKeys = jest.fn(pass => {
-                    keys = { publicKey: `${pass} public key` };
-                    return keys;
-                });
-                crypto.secondSign = jest.fn();
 
-                builder.secondSign("my very real second pass");
+                const spyKeys = jest.spyOn(Keys, "fromPassphrase").mockReturnValueOnce(identitySecond.keys);
+                const spySecondSign = jest.spyOn(crypto, "secondSign").mockImplementationOnce(jest.fn());
 
-                expect(crypto.getKeys).toHaveBeenCalledWith("my very real second pass");
-                expect(crypto.secondSign).toHaveBeenCalledWith((builder as any).getSigningObject(), keys);
+                builder.secondSign(identitySecond.bip39);
+
+                expect(spyKeys).toHaveBeenCalledWith(identitySecond.bip39);
+                expect(spySecondSign).toHaveBeenCalledWith((builder as any).getSigningObject(), identitySecond.keys);
             });
         });
 
         describe("secondSignWithWif", () => {
             it("signs this transaction with the keys of a second wif", () => {
+                const spyKeys = jest.spyOn(Keys, "fromWIF").mockReturnValueOnce(identitySecond.keys);
+                const spySecondSign = jest.spyOn(crypto, "secondSign").mockImplementationOnce(jest.fn());
+
                 const builder = provider();
-                let keys;
-                crypto.getKeysFromWIF = jest.fn(pass => {
-                    keys = { publicKey: `${pass} public key` };
-                    return keys;
+                builder.network(23).secondSignWithWif(identitySecond.bip39, null);
+
+                expect(spyKeys).toHaveBeenCalledWith(identitySecond.bip39, {
+                    wif: 170,
                 });
-                crypto.secondSign = jest.fn();
-
-                builder.network(23).secondSignWithWif("my very real second pass", null);
-
-                expect(crypto.getKeysFromWIF).toHaveBeenCalledWith("my very real second pass", { wif: 170 });
-                expect(crypto.secondSign).toHaveBeenCalledWith((builder as any).getSigningObject(), keys);
+                expect(spySecondSign).toHaveBeenCalledWith((builder as any).getSigningObject(), identitySecond.keys);
             });
         });
     });

--- a/__tests__/unit/crypto/transactions/builders/transactions/__shared__/transaction-builder.ts
+++ b/__tests__/unit/crypto/transactions/builders/transactions/__shared__/transaction-builder.ts
@@ -127,10 +127,13 @@ export const transactionBuilder = <T extends TransactionBuilder<T>>(provider: ()
             });
 
             it("establishes the public key of the sender", () => {
+                const spySign = jest.spyOn(crypto, "sign").mockImplementationOnce(jest.fn());
+
                 const builder = provider();
                 builder.sign(identity.bip39);
 
                 expect(builder.data.senderPublicKey).toBe(identity.keys.publicKey);
+                expect(spySign).toHaveBeenCalledWith((builder as any).getSigningObject(), identity.keys);
             });
         });
 
@@ -149,10 +152,13 @@ export const transactionBuilder = <T extends TransactionBuilder<T>>(provider: ()
             });
 
             it("establishes the public key of the sender", () => {
+                const spySign = jest.spyOn(crypto, "sign").mockImplementationOnce(jest.fn());
+
                 const builder = provider();
                 builder.signWithWif(identity.wif);
 
                 expect(builder.data.senderPublicKey).toBe(identity.publicKey);
+                expect(spySign).toHaveBeenCalledWith((builder as any).getSigningObject(), identity.keys);
             });
         });
 

--- a/__tests__/unit/crypto/transactions/builders/transactions/second-signature.test.ts
+++ b/__tests__/unit/crypto/transactions/builders/transactions/second-signature.test.ts
@@ -1,11 +1,12 @@
 import "jest-extended";
 
 import { Utils } from "@arkecosystem/crypto";
-import { crypto } from "../../../../../../packages/crypto/src/crypto";
 import { TransactionTypes } from "../../../../../../packages/crypto/src/enums";
+import { Keys } from "../../../../../../packages/crypto/src/identities";
 import { feeManager } from "../../../../../../packages/crypto/src/managers/fee";
 import { BuilderFactory } from "../../../../../../packages/crypto/src/transactions";
 import { SecondSignatureBuilder } from "../../../../../../packages/crypto/src/transactions/builders/transactions/second-signature";
+import { identity } from "../../../../../utils/identities";
 import { transactionBuilder } from "./__shared__/transaction-builder";
 
 let builder: SecondSignatureBuilder;
@@ -38,13 +39,11 @@ describe("Second Signature Transaction", () => {
 
     describe("signatureAsset", () => {
         it("establishes the signature on the asset", () => {
-            // @ts-ignore
-            crypto.getKeys = jest.fn(pass => ({ publicKey: `${pass} public key` }));
-            crypto.sign = jest.fn();
+            jest.spyOn(Keys, "fromWIF").mockReturnValueOnce(identity.keys);
 
-            builder.signatureAsset("bad pass");
+            builder.signatureAsset(identity.bip39);
 
-            expect(builder.data.asset.signature.publicKey).toBe("bad pass public key");
+            expect(builder.data.asset.signature.publicKey).toBe(identity.publicKey);
         });
     });
 });

--- a/__tests__/unit/crypto/transactions/builders/transactions/transfer.test.ts
+++ b/__tests__/unit/crypto/transactions/builders/transactions/transfer.test.ts
@@ -1,8 +1,8 @@
 import "jest-extended";
 
 import { Utils } from "@arkecosystem/crypto";
-import { crypto } from "../../../../../../packages/crypto/src/crypto";
 import { TransactionTypes } from "../../../../../../packages/crypto/src/enums";
+import { Keys, WIF } from "../../../../../../packages/crypto/src/identities";
 import { feeManager } from "../../../../../../packages/crypto/src/managers/fee";
 import { devnet } from "../../../../../../packages/crypto/src/networks";
 import { BuilderFactory } from "../../../../../../packages/crypto/src/transactions";
@@ -45,8 +45,8 @@ describe("Transfer Transaction", () => {
         it("should sign a transaction and match signed with a passphrase", () => {
             const passphrase = "sample passphrase";
             const network = 23;
-            const keys = crypto.getKeys(passphrase);
-            const wif = crypto.keysToWIF(keys, devnet.network);
+            const keys = Keys.fromPassphrase(passphrase);
+            const wif = WIF.fromKeys(keys, devnet.network);
 
             const wifTransaction = builder
                 .amount("10")
@@ -68,8 +68,8 @@ describe("Transfer Transaction", () => {
             const passphrase = "first passphrase";
             const secondPassphrase = "second passphrase";
             const network = 23;
-            const keys = crypto.getKeys(secondPassphrase);
-            const wif = crypto.keysToWIF(keys, devnet.network);
+            const keys = Keys.fromPassphrase(secondPassphrase);
+            const wif = WIF.fromKeys(keys, devnet.network);
 
             const wifTransaction = builder
                 .amount("10")

--- a/__tests__/unit/crypto/transactions/builders/transactions/vote.test.ts
+++ b/__tests__/unit/crypto/transactions/builders/transactions/vote.test.ts
@@ -1,11 +1,12 @@
 import "jest-extended";
 
-import { crypto } from "../../../../../../packages/crypto/src/crypto";
 import { TransactionTypes } from "../../../../../../packages/crypto/src/enums";
+import { Keys } from "../../../../../../packages/crypto/src/identities";
 import { feeManager } from "../../../../../../packages/crypto/src/managers/fee";
 import { BuilderFactory } from "../../../../../../packages/crypto/src/transactions";
 import { VoteBuilder } from "../../../../../../packages/crypto/src/transactions/builders/transactions/vote";
 import * as Utils from "../../../../../../packages/crypto/src/utils";
+import { identity } from "../../../../../utils/identities";
 import { transactionBuilder } from "./__shared__/transaction-builder";
 
 let builder: VoteBuilder;
@@ -58,31 +59,19 @@ describe("Vote Transaction", () => {
 
     describe("sign", () => {
         it("establishes the recipient id", () => {
-            const pass = "dummy pass";
+            jest.spyOn(Keys, "fromWIF").mockReturnValueOnce(identity.keys);
 
-            // @ts-ignore
-            crypto.getKeys = jest.fn(() => ({
-                publicKey: "02d0d835266297f15c192be2636eb3fbc30b39b87fc583ff112062ef8ae1a1f2af",
-            }));
-            crypto.sign = jest.fn();
-
-            builder.sign(pass);
-            expect(builder.data.recipientId).toBe("D5q7YfEFDky1JJVQQEy4MGyiUhr5cGg47F");
+            builder.sign("this is a top secret passphrase");
+            expect(builder.data.recipientId).toBe("D61mfSggzbvQgTUe6JhYKH2doHaqJ3Dyib");
         });
     });
 
     describe("signWithWif", () => {
         it("establishes the recipient id", () => {
-            const pass = "dummy pass";
+            jest.spyOn(Keys, "fromWIF").mockReturnValueOnce(identity.keys);
 
-            // @ts-ignore
-            crypto.getKeysFromWIF = jest.fn(() => ({
-                publicKey: "02d0d835266297f15c192be2636eb3fbc30b39b87fc583ff112062ef8ae1a1f2af",
-            }));
-            // builder.signWithWif = jest.fn();
-
-            builder.signWithWif(pass);
-            expect(builder.data.recipientId).toBe("D5q7YfEFDky1JJVQQEy4MGyiUhr5cGg47F");
+            builder.signWithWif(identity.wif);
+            expect(builder.data.recipientId).toBe(identity.address);
         });
     });
 });

--- a/__tests__/unit/crypto/transactions/schemas.test.ts
+++ b/__tests__/unit/crypto/transactions/schemas.test.ts
@@ -1,7 +1,7 @@
 import { Utils } from "@arkecosystem/crypto";
 import { ARKTOSHI } from "../../../../packages/crypto/src/constants";
-import { crypto } from "../../../../packages/crypto/src/crypto";
 import { TransactionTypes } from "../../../../packages/crypto/src/enums";
+import { PublicKey } from "../../../../packages/crypto/src/identities";
 import { configManager } from "../../../../packages/crypto/src/managers";
 import { BuilderFactory } from "../../../../packages/crypto/src/transactions";
 import { TransactionRegistry } from "../../../../packages/crypto/src/transactions";
@@ -620,7 +620,7 @@ describe.skip("Multi Signature Transaction", () => {
         for (let i = 0; i < 20; i++) {
             const value = `passphrase ${i}`;
             values.push(value);
-            multiSignatureAsset.keysgroup.push(crypto.getKeys(value).publicKey);
+            multiSignatureAsset.keysgroup.push(PublicKey.fromPassphrase(value));
         }
         transaction.multiSignatureAsset(multiSignatureAsset).sign("passphrase");
         signTransaction(transaction, values);

--- a/__tests__/unit/crypto/transactions/transaction.test.ts
+++ b/__tests__/unit/crypto/transactions/transaction.test.ts
@@ -9,6 +9,7 @@ import {
     TransactionVersionError,
     UnkownTransactionError,
 } from "../../../../packages/crypto/src/errors";
+import { PublicKey } from "../../../../packages/crypto/src/identities";
 import { ITransactionData } from "../../../../packages/crypto/src/interfaces";
 import { configManager } from "../../../../packages/crypto/src/managers";
 import { BuilderFactory, Transaction, TransactionFactory } from "../../../../packages/crypto/src/transactions";
@@ -63,7 +64,7 @@ const createRandomTx = type => {
         case 4: {
             // multisignature registration
             const passphrases = [1, 2, 3].map(() => Math.random().toString(36));
-            const publicKeys = passphrases.map(passphrase => `+${crypto.getKeys(passphrase).publicKey}`);
+            const publicKeys = passphrases.map(passphrase => `+${PublicKey.fromPassphrase(passphrase)}`);
             const min = Math.min(1, publicKeys.length);
             const max = Math.max(1, publicKeys.length);
             const minSignatures = Math.floor(Math.random() * (max - min)) + min;

--- a/__tests__/utils/fixtures/testnet/delegates.ts
+++ b/__tests__/utils/fixtures/testnet/delegates.ts
@@ -1,4 +1,4 @@
-import { Crypto, Managers } from "@arkecosystem/crypto";
+import { Identities, Managers } from "@arkecosystem/crypto";
 
 /**
  * Get the testnet genesis delegates information
@@ -11,8 +11,8 @@ import { secrets } from "../../config/testnet/delegates.json";
 import { genesisBlock } from "../../config/testnet/genesisBlock";
 
 export const delegates: any = secrets.map(secret => {
-    const publicKey = Crypto.crypto.getKeys(secret).publicKey;
-    const address = Crypto.crypto.getAddress(publicKey);
+    const publicKey: string = Identities.PublicKey.fromPassphrase(secret);
+    const address: string = Identities.Address.fromPassphrase(secret);
     const balance = genesisBlock.transactions.find(
         transaction => transaction.recipientId === address && transaction.type === 0,
     ).amount;

--- a/__tests__/utils/fixtures/unitnet/delegates.ts
+++ b/__tests__/utils/fixtures/unitnet/delegates.ts
@@ -1,4 +1,4 @@
-import { Crypto, Managers } from "@arkecosystem/crypto";
+import { Identities, Managers } from "@arkecosystem/crypto";
 
 /**
  * Get the unitnet genesis delegates information
@@ -11,8 +11,8 @@ import { secrets } from "../../config/unitnet/delegates.json";
 import { genesisBlock } from "../../config/unitnet/genesisBlock";
 
 export const delegates: any = secrets.map(secret => {
-    const publicKey = Crypto.crypto.getKeys(secret).publicKey;
-    const address = Crypto.crypto.getAddress(publicKey);
+    const publicKey: string = Identities.PublicKey.fromPassphrase(secret);
+    const address: string = Identities.Address.fromPassphrase(secret);
     const balance = genesisBlock.transactions.find(
         transaction => transaction.recipientId === address && transaction.type === 0,
     ).amount;

--- a/__tests__/utils/generators/wallets.ts
+++ b/__tests__/utils/generators/wallets.ts
@@ -1,4 +1,5 @@
 import { Crypto, Managers } from "@arkecosystem/crypto";
+import { Identities } from "@arkecosystem/crypto/src";
 import { generateMnemonic } from "bip39";
 
 export const generateWallets = (network, quantity = 10) => {
@@ -11,9 +12,9 @@ export const generateWallets = (network, quantity = 10) => {
 
     const wallets = [];
     for (let i = 0; i < quantity; i++) {
-        const passphrase = generateMnemonic();
-        const publicKey = Crypto.crypto.getKeys(passphrase).publicKey;
-        const address = Crypto.crypto.getAddress(publicKey);
+        const passphrase: string = generateMnemonic();
+        const publicKey: string = Identities.PublicKey.fromPassphrase(passphrase);
+        const address: string = Identities.Address.fromPassphrase(passphrase);
 
         wallets.push({ address, passphrase, publicKey });
     }

--- a/__tests__/utils/generators/wallets.ts
+++ b/__tests__/utils/generators/wallets.ts
@@ -1,5 +1,4 @@
-import { Crypto, Managers } from "@arkecosystem/crypto";
-import { Identities } from "@arkecosystem/crypto/src";
+import { Identities, Managers } from "@arkecosystem/crypto";
 import { generateMnemonic } from "bip39";
 
 export const generateWallets = (network, quantity = 10) => {

--- a/__tests__/utils/identities.ts
+++ b/__tests__/utils/identities.ts
@@ -1,0 +1,32 @@
+import { Address, Keys, PrivateKey, PublicKey, WIF } from "../../packages/crypto/src/identities";
+import { IKeyPair } from "../../packages/crypto/src/interfaces";
+
+interface IIdentity {
+    bip39: string;
+    address: string;
+    publicKey: string;
+    privateKey: string;
+    keys: IKeyPair;
+    wif: string;
+}
+
+const bip39: string = "this is a top secret passphrase";
+const bip39Second: string = "this is a top secret second passphrase";
+
+export const identity: IIdentity = {
+    bip39,
+    address: Address.fromPassphrase(bip39),
+    publicKey: PublicKey.fromPassphrase(bip39),
+    privateKey: PrivateKey.fromPassphrase(bip39),
+    keys: Keys.fromPassphrase(bip39),
+    wif: WIF.fromPassphrase(bip39),
+};
+
+export const identitySecond: IIdentity = {
+    bip39: bip39Second,
+    address: Address.fromPassphrase(bip39Second),
+    publicKey: PublicKey.fromPassphrase(bip39Second),
+    privateKey: PrivateKey.fromPassphrase(bip39Second),
+    keys: Keys.fromPassphrase(bip39Second),
+    wif: WIF.fromPassphrase(bip39Second),
+};

--- a/packages/core-database/src/database-service.ts
+++ b/packages/core-database/src/database-service.ts
@@ -3,10 +3,8 @@ import { ApplicationEvents } from "@arkecosystem/core-event-emitter";
 import { Blockchain, Database, EventEmitter, Logger, Shared } from "@arkecosystem/core-interfaces";
 import { TransactionHandler, TransactionHandlerRegistry } from "@arkecosystem/core-transactions";
 import { roundCalculator } from "@arkecosystem/core-utils";
-import { Blocks, Crypto, Interfaces, Managers, Transactions, Utils } from "@arkecosystem/crypto";
+import { Blocks, Crypto, Identities, Interfaces, Managers, Transactions, Utils } from "@arkecosystem/crypto";
 import assert from "assert";
-
-const { crypto, HashAlgorithms } = Crypto;
 
 export class DatabaseService implements Database.IDatabaseService {
     public connection: Database.IConnection;
@@ -164,7 +162,7 @@ export class DatabaseService implements Database.IDatabaseService {
         }
 
         const seedSource: string = round.toString();
-        let currentSeed: Buffer = HashAlgorithms.sha256(seedSource);
+        let currentSeed: Buffer = Crypto.HashAlgorithms.sha256(seedSource);
 
         for (let i = 0, delCount = delegates.length; i < delCount; i++) {
             for (let x = 0; x < 4 && i < delCount; i++, x++) {
@@ -173,7 +171,7 @@ export class DatabaseService implements Database.IDatabaseService {
                 delegates[newIndex] = delegates[i];
                 delegates[i] = b;
             }
-            currentSeed = HashAlgorithms.sha256(currentSeed);
+            currentSeed = Crypto.HashAlgorithms.sha256(currentSeed);
         }
 
         const forgingDelegates: Database.IDelegateWallet[] = delegates.map(delegate => {
@@ -533,10 +531,7 @@ export class DatabaseService implements Database.IDatabaseService {
     }
 
     public async verifyTransaction(transaction: Interfaces.ITransaction): Promise<boolean> {
-        const senderId: string = crypto.getAddress(
-            transaction.data.senderPublicKey,
-            this.config.get("network.pubKeyHash"),
-        );
+        const senderId: string = Identities.Address.fromPublicKey(transaction.data.senderPublicKey);
 
         const sender: Database.IWallet = this.walletManager.findByAddress(senderId); // should exist
         const transactionHandler: TransactionHandler = TransactionHandlerRegistry.get(transaction.type);

--- a/packages/core-database/src/wallet-manager.ts
+++ b/packages/core-database/src/wallet-manager.ts
@@ -1,13 +1,10 @@
 import { app } from "@arkecosystem/core-container";
 import { Database, Logger, Shared } from "@arkecosystem/core-interfaces";
 import { TransactionHandler, TransactionHandlerRegistry } from "@arkecosystem/core-transactions";
-import { Crypto, Enums, Interfaces, Utils } from "@arkecosystem/crypto";
+import { Enums, Identities, Interfaces, Utils } from "@arkecosystem/crypto";
 import cloneDeep from "lodash.clonedeep";
 import pluralize from "pluralize";
 import { Wallet } from "./wallet";
-
-const { TransactionTypes } = Enums;
-const { crypto } = Crypto;
 
 export class WalletManager implements Database.IWalletManager {
     public logger = app.resolvePlugin<Logger.ILogger>("logger");
@@ -54,7 +51,7 @@ export class WalletManager implements Database.IWalletManager {
 
     public findByPublicKey(publicKey: string): Database.IWallet {
         if (publicKey && !this.byPublicKey[publicKey]) {
-            const address = crypto.getAddress(publicKey);
+            const address = Identities.Address.fromPublicKey(publicKey);
 
             const wallet = this.findByAddress(address);
             wallet.publicKey = publicKey;
@@ -243,7 +240,7 @@ export class WalletManager implements Database.IWalletManager {
         let delegate: Database.IWallet = this.byPublicKey[block.data.generatorPublicKey];
 
         if (!delegate) {
-            const generator: string = crypto.getAddress(generatorPublicKey);
+            const generator: string = Identities.Address.fromPublicKey(generatorPublicKey);
 
             if (block.data.height === 1) {
                 delegate = new Wallet(generator);
@@ -352,7 +349,7 @@ export class WalletManager implements Database.IWalletManager {
         const recipient: Database.IWallet = this.findByAddress(recipientId);
 
         // TODO: can/should be removed?
-        if (type === TransactionTypes.SecondSignature) {
+        if (type === Enums.TransactionTypes.SecondSignature) {
             data.recipientId = "";
         }
 
@@ -373,12 +370,12 @@ export class WalletManager implements Database.IWalletManager {
 
         transactionHandler.applyToSender(transaction, sender);
 
-        if (type === TransactionTypes.DelegateRegistration) {
+        if (type === Enums.TransactionTypes.DelegateRegistration) {
             this.reindex(sender);
         }
 
         // TODO: make more generic
-        if (recipient && type === TransactionTypes.Transfer) {
+        if (recipient && type === Enums.TransactionTypes.Transfer) {
             transactionHandler.applyToRecipient(transaction, recipient);
         }
 
@@ -398,11 +395,11 @@ export class WalletManager implements Database.IWalletManager {
         transactionHandler.revertForSender(transaction, sender);
 
         // removing the wallet from the delegates index
-        if (type === TransactionTypes.DelegateRegistration) {
+        if (type === Enums.TransactionTypes.DelegateRegistration) {
             delete this.byUsername[data.asset.delegate.username];
         }
 
-        if (recipient && type === TransactionTypes.Transfer) {
+        if (recipient && type === Enums.TransactionTypes.Transfer) {
             transactionHandler.revertForRecipient(transaction, recipient);
         }
 
@@ -457,7 +454,7 @@ export class WalletManager implements Database.IWalletManager {
         revert: boolean = false,
     ): void {
         // TODO: multipayment?
-        if (transaction.type !== TransactionTypes.Vote) {
+        if (transaction.type !== Enums.TransactionTypes.Vote) {
             // Update vote balance of the sender's delegate
             if (sender.vote) {
                 const delegate: Database.IWallet = this.findByPublicKey(sender.vote);

--- a/packages/core-database/src/wallet.ts
+++ b/packages/core-database/src/wallet.ts
@@ -1,8 +1,5 @@
 import { Database } from "@arkecosystem/core-interfaces";
-import { Crypto, Enums, Interfaces, Utils } from "@arkecosystem/crypto";
-
-const { TransactionTypes } = Enums;
-const { crypto } = Crypto;
+import { Crypto, Enums, Identities, Interfaces, Utils } from "@arkecosystem/crypto";
 
 export class Wallet implements Database.IWallet {
     public address: string;
@@ -43,7 +40,7 @@ export class Wallet implements Database.IWallet {
     public applyBlock(block: Interfaces.IBlockData): boolean {
         if (
             block.generatorPublicKey === this.publicKey ||
-            crypto.getAddress(block.generatorPublicKey) === this.address
+            Identities.Address.fromPublicKey(block.generatorPublicKey) === this.address
         ) {
             this.balance = this.balance.plus(block.reward).plus(block.totalFee);
 
@@ -64,7 +61,7 @@ export class Wallet implements Database.IWallet {
     public revertBlock(block: Interfaces.IBlockData): boolean {
         if (
             block.generatorPublicKey === this.publicKey ||
-            crypto.getAddress(block.generatorPublicKey) === this.address
+            Identities.Address.fromPublicKey(block.generatorPublicKey) === this.address
         ) {
             this.balance = this.balance.minus(block.reward).minus(block.totalFee);
 
@@ -128,35 +125,38 @@ export class Wallet implements Database.IWallet {
                     .minus(transaction.fee)
                     .toFixed(),
             });
-            audit.push({ "Signature validation": crypto.verify(transaction) });
+            audit.push({ "Signature validation": Crypto.crypto.verify(transaction) });
             // TODO: this can blow up if 2nd phrase and other transactions are in the wrong order
             if (this.secondPublicKey) {
                 audit.push({
-                    "Second Signature Verification": crypto.verifySecondSignature(transaction, this.secondPublicKey),
+                    "Second Signature Verification": Crypto.crypto.verifySecondSignature(
+                        transaction,
+                        this.secondPublicKey,
+                    ),
                 });
             }
         }
 
-        if (transaction.type === TransactionTypes.Transfer) {
+        if (transaction.type === Enums.TransactionTypes.Transfer) {
             audit.push({ Transfer: true });
         }
 
-        if (transaction.type === TransactionTypes.SecondSignature) {
+        if (transaction.type === Enums.TransactionTypes.SecondSignature) {
             audit.push({ "Second public key": this.secondPublicKey });
         }
 
-        if (transaction.type === TransactionTypes.DelegateRegistration) {
+        if (transaction.type === Enums.TransactionTypes.DelegateRegistration) {
             const username = transaction.asset.delegate.username;
             audit.push({ "Current username": this.username });
             audit.push({ "New username": username });
         }
 
-        if (transaction.type === TransactionTypes.Vote) {
+        if (transaction.type === Enums.TransactionTypes.Vote) {
             audit.push({ "Current vote": this.vote });
             audit.push({ "New vote": transaction.asset.votes[0] });
         }
 
-        if (transaction.type === TransactionTypes.MultiSignature) {
+        if (transaction.type === Enums.TransactionTypes.MultiSignature) {
             const keysgroup = transaction.asset.multisignature.keysgroup;
             audit.push({ "Multisignature not yet registered": !this.multisignature });
             audit.push({
@@ -170,24 +170,24 @@ export class Wallet implements Database.IWallet {
             });
         }
 
-        if (transaction.type === TransactionTypes.Ipfs) {
+        if (transaction.type === Enums.TransactionTypes.Ipfs) {
             audit.push({ IPFS: true });
         }
 
-        if (transaction.type === TransactionTypes.TimelockTransfer) {
+        if (transaction.type === Enums.TransactionTypes.TimelockTransfer) {
             audit.push({ Timelock: true });
         }
 
-        if (transaction.type === TransactionTypes.MultiPayment) {
+        if (transaction.type === Enums.TransactionTypes.MultiPayment) {
             const amount = transaction.asset.payments.reduce((a, p) => a.plus(p.amount), Utils.BigNumber.ZERO);
             audit.push({ "Multipayment remaining amount": amount });
         }
 
-        if (transaction.type === TransactionTypes.DelegateResignation) {
+        if (transaction.type === Enums.TransactionTypes.DelegateResignation) {
             audit.push({ "Resignate Delegate": this.username });
         }
 
-        if (!Object.values(TransactionTypes).includes(transaction.type)) {
+        if (!Object.values(Enums.TransactionTypes).includes(transaction.type)) {
             audit.push({ "Unknown Type": true });
         }
 
@@ -222,7 +222,7 @@ export class Wallet implements Database.IWallet {
      * Verify the wallet.
      */
     private verify(transaction: Interfaces.ITransactionData, signature: string, publicKey: string): boolean {
-        const hash = crypto.getHash(transaction, { excludeSignature: true, excludeSecondSignature: true });
-        return crypto.verifyHash(hash, signature, publicKey);
+        const hash = Crypto.crypto.getHash(transaction, { excludeSignature: true, excludeSecondSignature: true });
+        return Crypto.crypto.verifyHash(hash, signature, publicKey);
     }
 }

--- a/packages/core-forger/src/delegate.ts
+++ b/packages/core-forger/src/delegate.ts
@@ -1,11 +1,11 @@
-import { Blocks, Crypto, Interfaces, Types, Utils } from "@arkecosystem/crypto";
+import { Blocks, Crypto, Identities, Interfaces, Types, Utils } from "@arkecosystem/crypto";
 import forge from "node-forge";
 import { authenticator } from "otplib";
 import wif from "wif";
 
 export class Delegate {
     public static encryptPassphrase(passphrase: string, network: Types.NetworkType, password: string): string {
-        const keys = Crypto.crypto.getKeys(passphrase);
+        const keys = Identities.Keys.fromPassphrase(passphrase);
         const decoded = wif.decode(Crypto.crypto.keysToWIF(keys, network), network.wif);
 
         return Crypto.bip38.encrypt(decoded.privateKey, decoded.compressed, password);
@@ -19,7 +19,7 @@ export class Delegate {
         const decryptedWif: Interfaces.IDecryptResult = Crypto.bip38.decrypt(passphrase, password);
         const wifKey: string = wif.encode(network.wif, decryptedWif.privateKey, decryptedWif.compressed);
 
-        return Crypto.crypto.getKeysFromWIF(wifKey, network);
+        return Identities.Keys.fromWIF(wifKey, network);
     }
 
     public network: Types.NetworkType;
@@ -42,7 +42,7 @@ export class Delegate {
             try {
                 this.keys = Delegate.decryptPassphrase(passphrase, network, password);
                 this.publicKey = this.keys.publicKey;
-                this.address = Crypto.crypto.getAddress(this.keys.publicKey, network.pubKeyHash);
+                this.address = Identities.Address.fromPublicKey(this.keys.publicKey, network.pubKeyHash);
                 this.otpSecret = authenticator.generateSecret();
                 this.bip38 = true;
 
@@ -53,9 +53,9 @@ export class Delegate {
                 this.address = null;
             }
         } else {
-            this.keys = Crypto.crypto.getKeys(passphrase);
+            this.keys = Identities.Keys.fromPassphrase(passphrase);
             this.publicKey = this.keys.publicKey;
-            this.address = Crypto.crypto.getAddress(this.publicKey, network.pubKeyHash);
+            this.address = Identities.Address.fromPublicKey(this.publicKey, network.pubKeyHash);
         }
     }
 
@@ -71,7 +71,7 @@ export class Delegate {
     public decryptKeysWithOtp(): void {
         const wifKey: string = this.decryptDataWithOtp(this.encryptedKeys, this.otp);
 
-        this.keys = Crypto.crypto.getKeysFromWIF(wifKey, this.network);
+        this.keys = Identities.Keys.fromWIF(wifKey, this.network);
         this.otp = null;
         this.encryptedKeys = null;
     }

--- a/packages/core-json-rpc/src/server/modules.ts
+++ b/packages/core-json-rpc/src/server/modules.ts
@@ -1,4 +1,4 @@
-import { Crypto, Interfaces, Transactions } from "@arkecosystem/crypto";
+import { Crypto, Identities, Interfaces, Transactions } from "@arkecosystem/crypto";
 import { generateMnemonic } from "bip39";
 import Boom from "boom";
 import { IWallet } from "../interfaces";
@@ -235,11 +235,11 @@ export const wallets = [
     {
         name: "wallets.create",
         async method(params: { passphrase: string }) {
-            const { publicKey }: Interfaces.IKeyPair = Crypto.crypto.getKeys(params.passphrase);
+            const { publicKey }: Interfaces.IKeyPair = Identities.Keys.fromPassphrase(params.passphrase);
 
             return {
                 publicKey,
-                address: Crypto.crypto.getAddress(publicKey),
+                address: Identities.Address.fromPublicKey(publicKey),
             };
         },
         schema: {
@@ -317,11 +317,13 @@ export const wallets = [
 
                 return {
                     publicKey: keys.publicKey,
-                    address: Crypto.crypto.getAddress(keys.publicKey),
+                    address: Identities.Address.fromPublicKey(keys.publicKey),
                     wif,
                 };
             } catch (error) {
-                const { publicKey, privateKey }: Interfaces.IKeyPair = Crypto.crypto.getKeys(generateMnemonic());
+                const { publicKey, privateKey }: Interfaces.IKeyPair = Identities.Keys.fromPassphrase(
+                    generateMnemonic(),
+                );
 
                 const encryptedWIF: string = Crypto.bip38.encrypt(
                     Buffer.from(privateKey, "hex"),
@@ -336,7 +338,7 @@ export const wallets = [
 
                 return {
                     publicKey,
-                    address: Crypto.crypto.getAddress(publicKey),
+                    address: Identities.Address.fromPublicKey(publicKey),
                     wif: decryptWIF(encryptedWIF, params.userId, params.bip38).wif,
                 };
             }
@@ -370,7 +372,7 @@ export const wallets = [
 
             return {
                 publicKey: keys.publicKey,
-                address: Crypto.crypto.getAddress(keys.publicKey),
+                address: Identities.Address.fromPublicKey(keys.publicKey),
                 wif,
             };
         },

--- a/packages/core-json-rpc/src/server/utils.ts
+++ b/packages/core-json-rpc/src/server/utils.ts
@@ -1,4 +1,4 @@
-import { Crypto, Interfaces, Managers } from "@arkecosystem/crypto";
+import { Crypto, Identities, Interfaces, Managers } from "@arkecosystem/crypto";
 import wif from "wif";
 import { IWallet } from "../interfaces";
 import { database } from "./services/database";
@@ -21,5 +21,5 @@ export function decryptWIF(encryptedWif, userId, bip38password): IWallet {
         decrypted.compressed,
     );
 
-    return { keys: Crypto.crypto.getKeysFromWIF(encodedWIF), wif: encodedWIF };
+    return { keys: Identities.Keys.fromWIF(encodedWIF), wif: encodedWIF };
 }

--- a/packages/core-tester-cli/src/commands/debug/identity.ts
+++ b/packages/core-tester-cli/src/commands/debug/identity.ts
@@ -1,4 +1,4 @@
-import { Crypto, Managers, Types } from "@arkecosystem/crypto";
+import { Identities, Interfaces, Managers, Types } from "@arkecosystem/crypto";
 import { flags } from "@oclif/command";
 import { handleOutput } from "../../utils";
 import { BaseCommand } from "../command";
@@ -26,24 +26,24 @@ export class IdentityCommand extends BaseCommand {
         let output;
 
         if (flags.type === "passphrase") {
-            const keys = Crypto.crypto.getKeys(flags.data);
+            const keys: Interfaces.IKeyPair = Identities.Keys.fromPassphrase(flags.data);
             output = {
                 passphrase: flags.data,
                 publicKey: keys.publicKey,
                 privateKey: keys.privateKey,
-                address: Crypto.crypto.getAddress(keys.publicKey),
+                address: Identities.Address.fromPublicKey(keys.publicKey),
             };
         } else if (flags.type === "privateKey") {
-            const keys = Crypto.crypto.getKeysByPrivateKey(flags.data);
+            const keys: Interfaces.IKeyPair = Identities.Keys.fromPrivateKey(flags.data);
             output = {
                 publicKey: keys.publicKey,
                 privateKey: keys.privateKey,
-                address: Crypto.crypto.getAddress(keys.publicKey),
+                address: Identities.Address.fromPublicKey(keys.publicKey),
             };
         } else if (flags.type === "publicKey") {
             output = {
                 publicKey: flags.data,
-                address: Crypto.crypto.getAddress(flags.data),
+                address: Identities.Address.fromPublicKey(flags.data),
             };
         }
 

--- a/packages/core-tester-cli/src/commands/make/wallets.ts
+++ b/packages/core-tester-cli/src/commands/make/wallets.ts
@@ -1,4 +1,4 @@
-import { Crypto } from "@arkecosystem/crypto";
+import { Identities, Interfaces } from "@arkecosystem/crypto";
 import { flags } from "@oclif/command";
 import { generateMnemonic } from "bip39";
 import { writeFileSync } from "fs";
@@ -26,9 +26,9 @@ export class WalletCommand extends BaseCommand {
 
         const wallets = {};
         for (let i = 0; i < flags.quantity; i++) {
-            const passphrase = generateMnemonic();
-            const keys = Crypto.crypto.getKeys(passphrase);
-            const address = Crypto.crypto.getAddress(keys.publicKey, this.network.version);
+            const passphrase: string = generateMnemonic();
+            const keys: Interfaces.IKeyPair = Identities.Keys.fromPassphrase(passphrase);
+            const address: string = Identities.Address.fromPublicKey(keys.publicKey);
 
             wallets[address] = { address, keys, passphrase };
         }

--- a/packages/core-transaction-pool/src/pool-wallet-manager.ts
+++ b/packages/core-transaction-pool/src/pool-wallet-manager.ts
@@ -2,9 +2,7 @@ import { app } from "@arkecosystem/core-container";
 import { Wallet, WalletManager } from "@arkecosystem/core-database";
 import { Database } from "@arkecosystem/core-interfaces";
 import { TransactionHandlerRegistry } from "@arkecosystem/core-transactions";
-import { Crypto, Interfaces, Utils } from "@arkecosystem/crypto";
-
-const { crypto } = Crypto;
+import { Identities, Interfaces, Utils } from "@arkecosystem/crypto";
 
 export class PoolWalletManager extends WalletManager {
     public readonly databaseService = app.resolvePlugin<Database.IDatabaseService>("database");
@@ -30,7 +28,7 @@ export class PoolWalletManager extends WalletManager {
 
     public deleteWallet(publicKey) {
         this.forgetByPublicKey(publicKey);
-        this.forgetByAddress(crypto.getAddress(publicKey));
+        this.forgetByAddress(Identities.Address.fromPublicKey(publicKey));
     }
 
     /**
@@ -40,7 +38,7 @@ export class PoolWalletManager extends WalletManager {
         // Edge case if sender is unknown and has no balance.
         // NOTE: Check is performed against the database wallet manager.
         if (!this.databaseService.walletManager.exists(transaction.data.senderPublicKey)) {
-            const senderAddress = crypto.getAddress(transaction.data.senderPublicKey);
+            const senderAddress = Identities.Address.fromPublicKey(transaction.data.senderPublicKey);
 
             if (this.databaseService.walletManager.findByAddress(senderAddress).balance.isZero()) {
                 errors.push("Cold wallet is not allowed to send until receiving transaction is confirmed.");

--- a/packages/core-transactions/src/handlers/transaction.ts
+++ b/packages/core-transactions/src/handlers/transaction.ts
@@ -1,7 +1,7 @@
 // tslint:disable:max-classes-per-file
 
 import { Database, EventEmitter, TransactionPool } from "@arkecosystem/core-interfaces";
-import { Crypto, Enums, Interfaces, Managers, Transactions } from "@arkecosystem/crypto";
+import { Crypto, Enums, Identities, Interfaces, Managers, Transactions } from "@arkecosystem/crypto";
 
 import {
     InsufficientBalanceError,
@@ -11,8 +11,6 @@ import {
     UnexpectedSecondSignatureError,
 } from "../errors";
 import { ITransactionHandler } from "../interfaces";
-
-const { TransactionTypes } = Enums;
 
 export abstract class TransactionHandler implements ITransactionHandler {
     public abstract getConstructor(): Transactions.TransactionConstructor;
@@ -67,7 +65,7 @@ export abstract class TransactionHandler implements ITransactionHandler {
         const { data } = transaction;
         if (
             data.senderPublicKey === wallet.publicKey ||
-            Crypto.crypto.getAddress(data.senderPublicKey) === wallet.address
+            Identities.Address.fromPublicKey(data.senderPublicKey) === wallet.address
         ) {
             wallet.balance = wallet.balance.minus(data.amount).minus(data.fee);
 
@@ -86,7 +84,7 @@ export abstract class TransactionHandler implements ITransactionHandler {
         const { data } = transaction;
         if (
             data.senderPublicKey === wallet.publicKey ||
-            Crypto.crypto.getAddress(data.senderPublicKey) === wallet.address
+            Identities.Address.fromPublicKey(data.senderPublicKey) === wallet.address
         ) {
             wallet.balance = wallet.balance.plus(data.amount).plus(data.fee);
 
@@ -117,7 +115,7 @@ export abstract class TransactionHandler implements ITransactionHandler {
         guard.pushError(
             data,
             "ERR_UNSUPPORTED",
-            `Invalidating transaction of unsupported type '${TransactionTypes[data.type]}'`,
+            `Invalidating transaction of unsupported type '${Enums.TransactionTypes[data.type]}'`,
         );
         return false;
     }
@@ -128,7 +126,9 @@ export abstract class TransactionHandler implements ITransactionHandler {
             guard.pushError(
                 data,
                 "ERR_PENDING",
-                `Sender ${senderPublicKey} already has a transaction of type '${TransactionTypes[type]}' in the pool`,
+                `Sender ${senderPublicKey} already has a transaction of type '${
+                    Enums.TransactionTypes[type]
+                }' in the pool`,
             );
 
             return true;

--- a/packages/core/src/commands/config/forger/bip38.ts
+++ b/packages/core/src/commands/config/forger/bip38.ts
@@ -1,4 +1,4 @@
-import { Crypto, Managers } from "@arkecosystem/crypto";
+import { Crypto, Identities, Managers } from "@arkecosystem/crypto";
 import { flags } from "@oclif/command";
 import bip39 from "bip39";
 import fs from "fs-extra";
@@ -88,7 +88,7 @@ $ ark config:forger:bip38 --bip39="..." --password="..."
 
         this.addTask("Loading private key", async () => {
             // @ts-ignore
-            decodedWIF = wif.decode(crypto.keysToWIF(crypto.getKeys(flags.bip39)));
+            decodedWIF = wif.decode(crypto.keysToWIF(Identities.Keys.fromPassphrase(flags.bip39)));
         });
 
         this.addTask("Encrypt BIP38", async () => {

--- a/packages/crypto/src/crypto/bip38.ts
+++ b/packages/crypto/src/crypto/bip38.ts
@@ -10,7 +10,7 @@ import bs58check from "bs58check";
 import xor from "buffer-xor/inplace";
 import crypto from "crypto";
 import secp256k1 from "secp256k1";
-import { crypto as arkCrypto, HashAlgorithms } from "../crypto";
+import { HashAlgorithms } from "../crypto";
 import {
     Bip38CompressionError,
     Bip38LengthError,
@@ -18,6 +18,7 @@ import {
     Bip38TypeError,
     PrivateKeyLengthError,
 } from "../errors";
+import { Keys } from "../identities";
 import { IDecryptResult } from "../interfaces";
 
 const SCRYPT_PARAMS = {
@@ -231,5 +232,5 @@ function getAddressPrivate(privateKey: Buffer, compressed: boolean): string {
 }
 
 function getPublicKey(buffer: Buffer, compressed: boolean): Buffer {
-    return Buffer.from(arkCrypto.getKeysByPrivateKey(buffer, compressed).publicKey, "hex");
+    return Buffer.from(Keys.fromPrivateKey(buffer, compressed).publicKey, "hex");
 }

--- a/packages/crypto/src/crypto/message.ts
+++ b/packages/crypto/src/crypto/message.ts
@@ -1,3 +1,4 @@
+import { Keys } from "../identities";
 import { IKeyPair, IMessage } from "../interfaces";
 import { INetwork } from "../interfaces/networks";
 import { configManager } from "../managers";
@@ -6,7 +7,7 @@ import { HashAlgorithms } from "./hash-algorithms";
 
 export class Message {
     public static sign(message: string, passphrase: string): IMessage {
-        const keys: IKeyPair = crypto.getKeys(passphrase);
+        const keys: IKeyPair = Keys.fromPassphrase(passphrase);
 
         return {
             publicKey: keys.publicKey,
@@ -20,7 +21,7 @@ export class Message {
             network = configManager.get("network");
         }
 
-        const keys: IKeyPair = crypto.getKeysFromWIF(wif, network);
+        const keys: IKeyPair = Keys.fromWIF(wif, network);
 
         return {
             publicKey: keys.publicKey,

--- a/packages/crypto/src/transactions/builders/transactions/second-signature.ts
+++ b/packages/crypto/src/transactions/builders/transactions/second-signature.ts
@@ -1,5 +1,5 @@
-import { crypto } from "../../../crypto";
 import { TransactionTypes } from "../../../enums";
+import { Keys } from "../../../identities";
 import { ITransactionAsset, ITransactionData } from "../../../interfaces";
 import { feeManager } from "../../../managers";
 import { BigNumber } from "../../../utils";
@@ -18,7 +18,7 @@ export class SecondSignatureBuilder extends TransactionBuilder<SecondSignatureBu
     }
 
     public signatureAsset(secondPassphrase: string): SecondSignatureBuilder {
-        this.data.asset.signature.publicKey = crypto.getKeys(secondPassphrase).publicKey;
+        this.data.asset.signature.publicKey = Keys.fromPassphrase(secondPassphrase).publicKey;
         return this;
     }
 

--- a/packages/crypto/src/transactions/deserializer.ts
+++ b/packages/crypto/src/transactions/deserializer.ts
@@ -1,8 +1,8 @@
 import ByteBuffer from "bytebuffer";
 import { TransactionRegistry } from ".";
-import { crypto } from "../crypto";
 import { TransactionTypes } from "../enums";
 import { TransactionVersionError } from "../errors";
+import { Address } from "../identities";
 import { ITransaction, ITransactionData } from "../interfaces";
 import { BigNumber } from "../utils";
 
@@ -107,7 +107,7 @@ class Deserializer {
         transaction.secondSignature = transaction.secondSignature || transaction.signSignature;
 
         if (transaction.type === TransactionTypes.Vote) {
-            transaction.recipientId = crypto.getAddress(transaction.senderPublicKey, transaction.network);
+            transaction.recipientId = Address.fromPublicKey(transaction.senderPublicKey, transaction.network);
         } else if (transaction.type === TransactionTypes.MultiSignature) {
             transaction.asset.multisignature.keysgroup = transaction.asset.multisignature.keysgroup.map(k =>
                 k.startsWith("+") ? k : `+${k}`,


### PR DESCRIPTION
## Proposed changes

Always use identities instead of the underlying `crypto.get*` methods. Will make the `crypto.get*` methods private/protected in another bigger PR that is coming the next days.

## Types of changes

- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes