### PR TITLE
fix(core-p2p): disable rate limit for forger

### DIFF
--- a/__tests__/integration/core-p2p/mocks/core-container.ts
+++ b/__tests__/integration/core-p2p/mocks/core-container.ts
@@ -1,8 +1,8 @@
 import { Managers } from "@arkecosystem/crypto";
-import { defaults } from "../../../../packages/core-p2p/src/defaults";
 import { blocks2to100 } from "../../../utils/fixtures";
 import { delegates } from "../../../utils/fixtures/testnet/delegates";
 import { genesisBlock } from "../../../utils/fixtures/unitnet/block-model";
+import { defaults } from "./p2p-options";
 
 Managers.configManager.setFromPreset("unitnet");
 

--- a/__tests__/integration/core-p2p/mocks/p2p-options.ts
+++ b/__tests__/integration/core-p2p/mocks/p2p-options.ts
@@ -1,0 +1,1 @@
+export * from "../../../../packages/core-p2p/src/defaults";

--- a/__tests__/integration/core-p2p/socket-server/peer.test.ts
+++ b/__tests__/integration/core-p2p/socket-server/peer.test.ts
@@ -1,9 +1,11 @@
 import "jest-extended";
 
 import "../mocks/core-container";
+import { defaults } from "../mocks/p2p-options";
 
 import { Blocks, Managers } from "@arkecosystem/crypto/src";
 import delay from "delay";
+import SocketCluster from "socketcluster";
 import socketCluster from "socketcluster-client";
 import { startSocketServer } from "../../../../packages/core-p2p/src/socket-server";
 import { createPeerService } from "../../../helpers/peers";
@@ -13,6 +15,7 @@ import { wallets } from "../../../utils/fixtures/unitnet/wallets";
 
 Managers.configManager.setFromPreset("unitnet");
 
+let server: SocketCluster;
 let socket;
 let emit;
 
@@ -26,11 +29,12 @@ const headers = {
 
 beforeAll(async () => {
     process.env.CORE_ENV = "test";
+    defaults.remoteAccess = []; // empty for rate limit tests
 
     const { service, processor } = createPeerService();
 
-    await startSocketServer(service, { server: { port: 4007 } });
-    await delay(3000);
+    server = await startSocketServer(service, { server: { port: 4007 } });
+    await delay(1000);
 
     socket = socketCluster.create({
         port: 4007,
@@ -170,6 +174,26 @@ describe("Peer socket endpoint", () => {
 
             expect(onSocketError).toHaveBeenCalled();
             expect(socket.getState()).toBe("closed");
+        });
+
+        it("should not be disconnected and banned if is configured in remoteAccess", async () => {
+            // need to restart the server for config changes to be updated
+            defaults.remoteAccess = ["127.0.0.1", "::ffff:127.0.0.1"];
+            server.destroy();
+            await delay(2000);
+            const { service } = createPeerService();
+            server = await startSocketServer(service, { server: { port: 4007 } });
+
+            await delay(1000);
+
+            for (let i = 0; i < 30; i++) {
+                const { data } = await emit("p2p.peer.getStatus", {
+                    headers,
+                });
+                expect(data.height).toBeNumber();
+            }
+
+            expect(socket.getState()).toBe("open");
         });
     });
 });

--- a/packages/core-p2p/src/socket-server/worker.ts
+++ b/packages/core-p2p/src/socket-server/worker.ts
@@ -170,7 +170,7 @@ export class Worker extends SCWorker {
     }
 
     private hasExceededRateLimit(remoteAddress: string): boolean {
-        if ((this.config.whitelist || []).includes(remoteAddress)) {
+        if ([...this.config.whitelist, ...this.config.remoteAccess].includes(remoteAddress)) {
             return false;
         }
 


### PR DESCRIPTION
## Proposed changes

Fixed rate limit which was incorrectly applied to forger. (authorized with remoteAccess config parameter)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works