### PR TITLE
fix(core-p2p): still download blocks when network height <= our height

### DIFF
--- a/__tests__/unit/core-p2p/network-monitor.test.ts
+++ b/__tests__/unit/core-p2p/network-monitor.test.ts
@@ -275,6 +275,27 @@ describe("NetworkMonitor", () => {
             }
             expect(await monitor.syncWithNetwork(1)).toEqual(expectedBlocks);
         });
+
+        it("should still download blocks from 1 peer if network height === our height", async () => {
+            const mockBlock = { id: "123456" };
+
+            communicator.getPeerBlocks = jest.fn().mockReturnValue([mockBlock]);
+
+            storage.setPeer(
+                createStubPeer({
+                    ip: "1.1.1.1",
+                    port: 4000,
+                    state: {
+                        height: 20,
+                        currentSlot: 2,
+                        forgingAllowed: true,
+                    },
+                    verificationResult: { forked: false },
+                }),
+            );
+
+            expect(await monitor.syncWithNetwork(20)).toEqual([mockBlock]);
+        });
     });
 
     describe("broadcastBlock", () => {

--- a/packages/core-p2p/src/network-monitor.ts
+++ b/packages/core-p2p/src/network-monitor.ts
@@ -290,7 +290,8 @@ export class NetworkMonitor implements P2P.INetworkMonitor {
 
             const networkHeight: number = this.getNetworkHeight();
 
-            if (!networkHeight) {
+            if (!networkHeight || networkHeight <= fromBlockHeight) {
+                // networkHeight is what we believe network height is, so even if it is <= our height, we download blocks
                 return this.communicator.downloadBlocks(sample(peersFiltered), fromBlockHeight);
             }
 


### PR DESCRIPTION
## Proposed changes

In block download logic, networkHeight is what we believe network height is, so even if we have a value for it less than or equal to our height, we should still download blocks.
(we might not have up-to-date peers heights)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works