### PR TITLE
chore(deps): remove extraneous jest-mock-process dependency

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,269 +1,59 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.13.1
+version: v1.13.5
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
-  SNYK-JS-MERGE-72553:
-    - jest-mock-process > jest > jest-cli > jest-haste-map > sane > exec-sh > merge:
+  SNYK-JS-HANDLEBARS-174183:
+    - '@arkecosystem/core-vote-report > handlebars':
         reason: None given
-        expires: '2018-12-11T05:03:38.309Z'
-    - jest-mock-process > jest > jest-cli > jest-haste-map > sane > watch > exec-sh > merge:
+        expires: '2019-05-23T03:45:31.072Z'
+    - '@types/handlebars > handlebars':
         reason: None given
-        expires: '2018-12-11T05:03:38.309Z'
-    - jest-mock-process > jest > jest-cli > jest-runtime > jest-haste-map > sane > exec-sh > merge:
+        expires: '2019-05-23T03:45:31.072Z'
+    - '@types/vision > handlebars':
         reason: None given
-        expires: '2018-12-11T05:03:38.309Z'
-    - jest-mock-process > jest > jest-cli > jest-runner > jest-haste-map > sane > exec-sh > merge:
+        expires: '2019-05-23T03:45:31.072Z'
+  SNYK-JS-LODASH-73638:
+    - '@arkecosystem/core > @arkecosystem/core-database-postgres > sql > lodash':
         reason: None given
-        expires: '2018-12-11T05:03:38.309Z'
-    - jest-mock-process > jest > jest-cli > jest-runtime > jest-haste-map > sane > watch > exec-sh > merge:
+        expires: '2019-05-23T03:45:31.072Z'
+    - '@arkecosystem/core > @arkecosystem/core-snapshots > @arkecosystem/core-database-postgres > sql > lodash':
         reason: None given
-        expires: '2018-12-11T05:03:38.310Z'
-    - jest-mock-process > jest > jest-cli > jest-runner > jest-haste-map > sane > watch > exec-sh > merge:
+        expires: '2019-05-23T03:45:31.072Z'
+    - '@arkecosystem/core > @arkecosystem/core-json-rpc > @keyv/sqlite > @keyv/sql > sql > lodash':
         reason: None given
-        expires: '2018-12-11T05:03:38.310Z'
-    - jest-mock-process > jest > jest-cli > jest-runner > jest-runtime > jest-haste-map > sane > exec-sh > merge:
+        expires: '2019-05-23T03:45:31.072Z'
+  SNYK-JS-LODASH-73639:
+    - '@arkecosystem/core > @arkecosystem/core-database-postgres > sql > lodash':
         reason: None given
-        expires: '2018-12-11T05:03:38.310Z'
-    - jest-mock-process > jest > jest-cli > jest-runner > jest-runtime > jest-haste-map > sane > watch > exec-sh > merge:
+        expires: '2019-05-23T03:45:31.072Z'
+    - '@arkecosystem/core > @arkecosystem/core-snapshots > @arkecosystem/core-database-postgres > sql > lodash':
         reason: None given
-        expires: '2018-12-11T05:03:38.310Z'
-  'npm:braces:20180219':
-    - jest-mock-process > jest > jest-cli > micromatch > braces:
+        expires: '2019-05-23T03:45:31.072Z'
+    - '@arkecosystem/core > @arkecosystem/core-json-rpc > @keyv/sqlite > @keyv/sql > sql > lodash':
         reason: None given
-        expires: '2018-12-11T05:03:38.310Z'
-    - jest-mock-process > jest > jest-cli > jest-message-util > micromatch > braces:
-        reason: None given
-        expires: '2018-12-11T05:03:38.310Z'
-    - jest-mock-process > jest > jest-cli > jest-runtime > micromatch > braces:
-        reason: None given
-        expires: '2018-12-11T05:03:38.310Z'
-    - jest-mock-process > jest > jest-cli > jest-config > micromatch > braces:
-        reason: None given
-        expires: '2018-12-11T05:03:38.310Z'
-    - jest-mock-process > jest > jest-cli > jest-haste-map > micromatch > braces:
-        reason: None given
-        expires: '2018-12-11T05:03:38.310Z'
-    - jest-mock-process > jest > jest-cli > jest-runner > jest-haste-map > micromatch > braces:
-        reason: None given
-        expires: '2018-12-11T05:03:38.310Z'
-    - jest-mock-process > jest > jest-cli > jest-snapshot > jest-message-util > micromatch > braces:
-        reason: None given
-        expires: '2018-12-11T05:03:38.310Z'
-    - jest-mock-process > jest > jest-cli > jest-runtime > jest-haste-map > micromatch > braces:
-        reason: None given
-        expires: '2018-12-11T05:03:38.310Z'
-    - jest-mock-process > jest > jest-cli > jest-runtime > jest-message-util > micromatch > braces:
-        reason: None given
-        expires: '2018-12-11T05:03:38.310Z'
-    - jest-mock-process > jest > jest-cli > jest-runner > jest-runtime > micromatch > braces:
-        reason: None given
-        expires: '2018-12-11T05:03:38.310Z'
-    - jest-mock-process > jest > jest-cli > jest-runner > jest-config > micromatch > braces:
-        reason: None given
-        expires: '2018-12-11T05:03:38.311Z'
-    - jest-mock-process > jest > jest-cli > jest-runtime > jest-config > micromatch > braces:
-        reason: None given
-        expires: '2018-12-11T05:03:38.311Z'
-    - jest-mock-process > jest > jest-cli > jest-runner > jest-message-util > micromatch > braces:
-        reason: None given
-        expires: '2018-12-11T05:03:38.311Z'
-    - jest-mock-process > jest > jest-cli > jest-util > jest-message-util > micromatch > braces:
-        reason: None given
-        expires: '2018-12-11T05:03:38.311Z'
-    - jest-mock-process > jest > jest-cli > jest-runner > jest-runtime > jest-message-util > micromatch > braces:
-        reason: None given
-        expires: '2018-12-11T05:03:38.311Z'
-    - jest-mock-process > jest > jest-cli > jest-config > jest-util > jest-message-util > micromatch > braces:
-        reason: None given
-        expires: '2018-12-11T05:03:38.311Z'
-    - jest-mock-process > jest > jest-cli > jest-runner > jest-util > jest-message-util > micromatch > braces:
-        reason: None given
-        expires: '2018-12-11T05:03:38.311Z'
-    - jest-mock-process > jest > jest-cli > jest-runtime > babel-plugin-istanbul > test-exclude > micromatch > braces:
-        reason: None given
-        expires: '2018-12-11T05:03:38.311Z'
-    - jest-mock-process > jest > jest-cli > jest-runner > jest-runtime > jest-config > micromatch > braces:
-        reason: None given
-        expires: '2018-12-11T05:03:38.311Z'
-    - jest-mock-process > jest > jest-cli > jest-runner > jest-runtime > jest-haste-map > micromatch > braces:
-        reason: None given
-        expires: '2018-12-11T05:03:38.311Z'
-    - jest-mock-process > jest > jest-cli > jest-environment-jsdom > jest-util > jest-message-util > micromatch > braces:
-        reason: None given
-        expires: '2018-12-11T05:03:38.311Z'
-    - jest-mock-process > jest > jest-cli > jest-runner > jest-jasmine2 > jest-message-util > micromatch > braces:
-        reason: None given
-        expires: '2018-12-11T05:03:38.311Z'
-    - jest-mock-process > jest > jest-cli > jest-config > jest-jasmine2 > jest-message-util > micromatch > braces:
-        reason: None given
-        expires: '2018-12-11T05:03:38.311Z'
-    - jest-mock-process > jest > jest-cli > jest-resolve-dependencies > jest-snapshot > jest-message-util > micromatch > braces:
-        reason: None given
-        expires: '2018-12-11T05:03:38.311Z'
-    - jest-mock-process > jest > jest-cli > jest-runtime > jest-snapshot > jest-message-util > micromatch > braces:
-        reason: None given
-        expires: '2018-12-11T05:03:38.312Z'
-    - jest-mock-process > jest > jest-cli > jest-runtime > jest-util > jest-message-util > micromatch > braces:
-        reason: None given
-        expires: '2018-12-11T05:03:38.312Z'
-    - jest-mock-process > jest > jest-cli > jest-runner > jest-runtime > babel-plugin-istanbul > test-exclude > micromatch > braces:
-        reason: None given
-        expires: '2018-12-11T05:03:38.312Z'
-    - jest-mock-process > jest > jest-cli > jest-config > jest-jasmine2 > expect > jest-message-util > micromatch > braces:
-        reason: None given
-        expires: '2018-12-11T05:03:38.312Z'
-    - jest-mock-process > jest > jest-cli > jest-config > jest-jasmine2 > jest-util > jest-message-util > micromatch > braces:
-        reason: None given
-        expires: '2018-12-11T05:03:38.312Z'
-    - jest-mock-process > jest > jest-cli > jest-runner > jest-jasmine2 > jest-util > jest-message-util > micromatch > braces:
-        reason: None given
-        expires: '2018-12-11T05:03:38.312Z'
-    - jest-mock-process > jest > jest-cli > jest-config > jest-environment-jsdom > jest-util > jest-message-util > micromatch > braces:
-        reason: None given
-        expires: '2018-12-11T05:03:38.312Z'
-    - jest-mock-process > jest > jest-cli > jest-runtime > jest-config > jest-util > jest-message-util > micromatch > braces:
-        reason: None given
-        expires: '2018-12-11T05:03:38.312Z'
-    - jest-mock-process > jest > jest-cli > jest-runner > jest-jasmine2 > expect > jest-message-util > micromatch > braces:
-        reason: None given
-        expires: '2018-12-11T05:03:38.312Z'
-    - jest-mock-process > jest > jest-cli > jest-runner > jest-config > jest-util > jest-message-util > micromatch > braces:
-        reason: None given
-        expires: '2018-12-11T05:03:38.312Z'
-    - jest-mock-process > jest > jest-cli > jest-runner > jest-config > jest-jasmine2 > jest-message-util > micromatch > braces:
-        reason: None given
-        expires: '2018-12-11T05:03:38.312Z'
-    - jest-mock-process > jest > jest-cli > jest-runtime > jest-config > jest-jasmine2 > jest-message-util > micromatch > braces:
-        reason: None given
-        expires: '2018-12-11T05:03:38.312Z'
-    - jest-mock-process > jest > jest-cli > jest-config > jest-jasmine2 > jest-snapshot > jest-message-util > micromatch > braces:
-        reason: None given
-        expires: '2018-12-11T05:03:38.312Z'
-    - jest-mock-process > jest > jest-cli > jest-runner > jest-jasmine2 > jest-snapshot > jest-message-util > micromatch > braces:
-        reason: None given
-        expires: '2018-12-11T05:03:38.312Z'
-    - jest-mock-process > jest > jest-cli > jest-config > jest-environment-node > jest-util > jest-message-util > micromatch > braces:
-        reason: None given
-        expires: '2018-12-11T05:03:38.312Z'
-    - jest-mock-process > jest > jest-cli > jest-runner > jest-runtime > jest-snapshot > jest-message-util > micromatch > braces:
-        reason: None given
-        expires: '2018-12-11T05:03:38.312Z'
-    - jest-mock-process > jest > jest-cli > jest-runner > jest-runtime > jest-util > jest-message-util > micromatch > braces:
-        reason: None given
-        expires: '2018-12-11T05:03:38.312Z'
-    - jest-mock-process > jest > jest-cli > jest-config > babel-jest > babel-plugin-istanbul > test-exclude > micromatch > braces:
-        reason: None given
-        expires: '2018-12-11T05:03:38.312Z'
-    - jest-mock-process > jest > jest-cli > jest-runtime > jest-config > jest-jasmine2 > jest-util > jest-message-util > micromatch > braces:
-        reason: None given
-        expires: '2018-12-11T05:03:38.312Z'
-    - jest-mock-process > jest > jest-cli > jest-runner > jest-runtime > jest-config > jest-jasmine2 > jest-message-util > micromatch > braces:
-        reason: None given
-        expires: '2018-12-11T05:03:38.313Z'
-    - jest-mock-process > jest > jest-cli > jest-runtime > jest-config > jest-jasmine2 > jest-snapshot > jest-message-util > micromatch > braces:
-        reason: None given
-        expires: '2018-12-11T05:03:38.313Z'
-    - jest-mock-process > jest > jest-cli > jest-runner > jest-config > babel-jest > babel-plugin-istanbul > test-exclude > micromatch > braces:
-        reason: None given
-        expires: '2018-12-11T05:03:38.313Z'
-    - jest-mock-process > jest > jest-cli > jest-runtime > jest-config > babel-jest > babel-plugin-istanbul > test-exclude > micromatch > braces:
-        reason: None given
-        expires: '2018-12-11T05:03:38.313Z'
-    - jest-mock-process > jest > jest-cli > jest-runner > jest-config > jest-jasmine2 > expect > jest-message-util > micromatch > braces:
-        reason: None given
-        expires: '2018-12-11T05:03:38.313Z'
-    - jest-mock-process > jest > jest-cli > jest-runtime > jest-config > jest-jasmine2 > expect > jest-message-util > micromatch > braces:
-        reason: None given
-        expires: '2018-12-11T05:03:38.313Z'
-    - jest-mock-process > jest > jest-cli > jest-runtime > jest-config > jest-environment-jsdom > jest-util > jest-message-util > micromatch > braces:
-        reason: None given
-        expires: '2018-12-11T05:03:38.313Z'
-    - jest-mock-process > jest > jest-cli > jest-runner > jest-runtime > jest-config > jest-util > jest-message-util > micromatch > braces:
-        reason: None given
-        expires: '2018-12-11T05:03:38.313Z'
-    - jest-mock-process > jest > jest-cli > jest-runner > jest-config > jest-jasmine2 > jest-util > jest-message-util > micromatch > braces:
-        reason: None given
-        expires: '2018-12-11T05:03:38.313Z'
-    - jest-mock-process > jest > jest-cli > jest-runner > jest-config > jest-jasmine2 > jest-snapshot > jest-message-util > micromatch > braces:
-        reason: None given
-        expires: '2018-12-11T05:03:38.313Z'
-    - jest-mock-process > jest > jest-cli > jest-runner > jest-config > jest-environment-jsdom > jest-util > jest-message-util > micromatch > braces:
-        reason: None given
-        expires: '2018-12-11T05:03:38.313Z'
-    - jest-mock-process > jest > jest-cli > jest-runner > jest-config > jest-environment-node > jest-util > jest-message-util > micromatch > braces:
-        reason: None given
-        expires: '2018-12-11T05:03:38.313Z'
-    - jest-mock-process > jest > jest-cli > jest-runtime > jest-config > jest-environment-node > jest-util > jest-message-util > micromatch > braces:
-        reason: None given
-        expires: '2018-12-11T05:03:38.313Z'
-    - jest-mock-process > jest > jest-cli > jest-runner > jest-runtime > jest-config > jest-environment-node > jest-util > jest-message-util > micromatch > braces:
-        reason: None given
-        expires: '2018-12-11T05:03:38.313Z'
-    - jest-mock-process > jest > jest-cli > jest-runner > jest-runtime > jest-config > jest-jasmine2 > jest-util > jest-message-util > micromatch > braces:
-        reason: None given
-        expires: '2018-12-11T05:03:38.313Z'
-    - jest-mock-process > jest > jest-cli > jest-runner > jest-runtime > jest-config > jest-jasmine2 > expect > jest-message-util > micromatch > braces:
-        reason: None given
-        expires: '2018-12-11T05:03:38.313Z'
-    - jest-mock-process > jest > jest-cli > jest-runner > jest-runtime > jest-config > jest-environment-jsdom > jest-util > jest-message-util > micromatch > braces:
-        reason: None given
-        expires: '2018-12-11T05:03:38.313Z'
-    - jest-mock-process > jest > jest-cli > jest-runner > jest-runtime > jest-config > jest-jasmine2 > jest-snapshot > jest-message-util > micromatch > braces:
-        reason: None given
-        expires: '2018-12-11T05:03:38.313Z'
-    - jest-mock-process > jest > jest-cli > jest-runner > jest-runtime > jest-config > babel-jest > babel-plugin-istanbul > test-exclude > micromatch > braces:
-        reason: None given
-        expires: '2018-12-11T05:03:38.314Z'
-  'npm:chownr:20180731':
-    - '@arkecosystem/core > @arkecosystem/core-transaction-pool > better-sqlite3 > tar > chownr':
-        reason: None given
-        expires: '2018-12-11T05:03:38.314Z'
-    - '@arkecosystem/core > @arkecosystem/core-webhooks > sqlite3 > node-pre-gyp > tar > chownr':
-        reason: None given
-        expires: '2018-12-11T05:03:38.314Z'
-    - '@arkecosystem/core > @arkecosystem/core-json-rpc > @keyv/sqlite > sqlite3 > node-pre-gyp > tar > chownr':
-        reason: None given
-        expires: '2018-12-11T05:03:38.314Z'
-    - jest-mock-process > jest > jest-cli > jest-haste-map > sane > fsevents > node-pre-gyp > tar > chownr:
-        reason: None given
-        expires: '2018-12-11T05:03:38.314Z'
-    - jest-mock-process > jest > jest-cli > jest-runtime > jest-haste-map > sane > fsevents > node-pre-gyp > tar > chownr:
-        reason: None given
-        expires: '2018-12-11T05:03:38.314Z'
-    - jest-mock-process > jest > jest-cli > jest-runner > jest-haste-map > sane > fsevents > node-pre-gyp > tar > chownr:
-        reason: None given
-        expires: '2018-12-11T05:03:38.314Z'
-    - jest-mock-process > jest > jest-cli > jest-runner > jest-runtime > jest-haste-map > sane > fsevents > node-pre-gyp > tar > chownr:
-        reason: None given
-        expires: '2018-12-11T05:03:38.314Z'
+        expires: '2019-05-23T03:45:31.072Z'
   'npm:lodash:20180130':
     - '@arkecosystem/core > @arkecosystem/core-database-postgres > sql > lodash':
         reason: None given
-        expires: '2018-12-11T05:03:38.314Z'
-    - '@arkecosystem/core-snapshots > @arkecosystem/core-database-postgres > sql > lodash':
+        expires: '2019-05-23T03:45:31.072Z'
+    - '@arkecosystem/core > @arkecosystem/core-snapshots > @arkecosystem/core-database-postgres > sql > lodash':
         reason: None given
-        expires: '2018-12-11T05:03:38.314Z'
+        expires: '2019-05-23T03:45:31.072Z'
     - '@arkecosystem/core > @arkecosystem/core-json-rpc > @keyv/sqlite > @keyv/sql > sql > lodash':
         reason: None given
-        expires: '2018-12-11T05:03:38.314Z'
-  'npm:mem:20180117':
-    - jest-mock-process > jest > jest-cli > yargs > os-locale > mem:
+        expires: '2019-05-23T03:45:31.072Z'
+  'npm:braces:20180219':
+    - '@arkecosystem/core-jest-matchers > jest-extended > expect > jest-message-util > micromatch > braces':
         reason: None given
-        expires: '2018-12-11T05:03:38.315Z'
-    - jest-mock-process > jest > jest-cli > jest-runtime > yargs > os-locale > mem:
-        reason: None given
-        expires: '2018-12-11T05:03:38.315Z'
-    - jest-mock-process > jest > jest-cli > jest-runner > jest-runtime > yargs > os-locale > mem:
-        reason: None given
-        expires: '2018-12-11T05:03:38.315Z'
+        expires: '2019-05-23T03:45:31.072Z'
   'npm:sql:20180512':
     - '@arkecosystem/core > @arkecosystem/core-database-postgres > sql':
         reason: None given
-        expires: '2018-12-11T05:03:38.315Z'
-    - '@arkecosystem/core-snapshots > @arkecosystem/core-database-postgres > sql':
+        expires: '2019-05-23T03:45:31.072Z'
+    - '@arkecosystem/core > @arkecosystem/core-snapshots > @arkecosystem/core-database-postgres > sql':
         reason: None given
-        expires: '2018-12-11T05:03:38.315Z'
+        expires: '2019-05-23T03:45:31.072Z'
     - '@arkecosystem/core > @arkecosystem/core-json-rpc > @keyv/sqlite > @keyv/sql > sql':
         reason: None given
-        expires: '2018-12-11T05:03:38.315Z'
+        expires: '2019-05-23T03:45:31.072Z'
 patch: {}

--- a/packages/core-container/package.json
+++ b/packages/core-container/package.json
@@ -42,8 +42,7 @@
         "@types/lodash.get": "^4.4.6",
         "@types/lodash.isstring": "^4.0.6",
         "@types/lodash.set": "^4.3.6",
-        "@types/semver": "^6.0.0",
-        "jest-mock-process": "^1.2.0"
+        "@types/semver": "^6.0.0"
     },
     "publishConfig": {
         "access": "public"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7964,11 +7964,6 @@ jest-message-util@^24.7.1:
     slash "^2.0.0"
     stack-utils "^1.0.1"
 
-jest-mock-process@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/jest-mock-process/-/jest-mock-process-1.2.0.tgz#8ac1818cb8aad05164b1f955036849369ee580d4"
-  integrity sha512-pfC9mUReieMVCBYNd9xM+4wsKxKQtHNRukXwV02v+cDI9BLkA5hbbBAQZis232hCJQHvL/Dd2oWbBaLrDlR9Kg==
-
 jest-mock@^24.7.0:
   version "24.7.0"
   resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-24.7.0.tgz#e49ce7262c12d7f5897b0d8af77f6db8e538023b"


### PR DESCRIPTION
## Proposed changes

Remove the no-longer used `jest-mock-process` dependency.

## Types of changes

- [x] Other

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes