### PR TITLE
fix(crypto): deserialize type > 0 with vendor field instead of skipping it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.3.1] - 2019-04-23
+
+### Fixed
+
+-   Deserialize type > 0 with vendor field instead of skipping it ([#2459])
+
 ## [2.3.0] - 2019-04-23
 
 ### Breaking Changes
@@ -285,6 +291,7 @@ Closed security vulnerabilities:
 -   Initial Release
 
 [unreleased]: https://github.com/ARKEcosystem/core/compare/2.3.0...develop
+[2.3.1]: https://github.com/ARKEcosystem/core/compare/2.3.0...2.3.1
 [2.3.0]: https://github.com/ARKEcosystem/core/compare/2.2.2...2.3.0
 [2.2.2]: https://github.com/ARKEcosystem/core/compare/2.2.1...2.2.2
 [2.2.1]: https://github.com/ARKEcosystem/core/compare/2.2.0...2.2.1
@@ -437,3 +444,4 @@ Closed security vulnerabilities:
 [#2404]: https://github.com/ARKEcosystem/core/pull/2404
 [#2405]: https://github.com/ARKEcosystem/core/pull/2405
 [#2458]: https://github.com/ARKEcosystem/core/pull/2458
+[#2459]: https://github.com/ARKEcosystem/core/pull/2459

--- a/packages/crypto/src/transactions/deserializers/transaction.ts
+++ b/packages/crypto/src/transactions/deserializers/transaction.ts
@@ -3,6 +3,7 @@ import { Transaction, TransactionRegistry } from "..";
 import { TransactionTypes } from "../../constants";
 import { crypto } from "../../crypto";
 import { TransactionVersionError } from "../../errors";
+import { configManager } from "../../managers";
 import { Bignum } from "../../utils";
 import { ITransactionData } from "../interfaces";
 
@@ -47,11 +48,6 @@ class TransactionDeserializer {
     }
 
     private deserializeVendorField(transaction: Transaction, buf: ByteBuffer): void {
-        if (!transaction.hasVendorField()) {
-            buf.skip(1);
-            return;
-        }
-
         const vendorFieldLength = buf.readUint8();
         if (vendorFieldLength > 0) {
             transaction.data.vendorFieldHex = buf.readBytes(vendorFieldLength).toString("hex");


### PR DESCRIPTION
<!-- Please don't delete this template and read our contribution guidelines at https://docs.ark.io/guidebook/contribution-guidelines/contributing.html -->

## Summary
There's one tx on mainnet which fails to deserialize otherwise.

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

## What kind of change does this PR introduce?

<!-- _Put an `x` in the boxes that apply. -->

- [X] Bugfix
- [ ] New feature
- [ ] Refactoring / Performance Improvements
- [ ] Build-related changes
- [ ] Documentation
- [ ] Tests / Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

<!-- _Put an `x` in the boxes that apply. -->

- [ ] Yes
- [ ] No

## Checklist

<!-- _Put an `x` in the boxes that apply. -->

- [ ] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation _(if appropriate)_

## Other information

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
-->
