### PR TITLE
fix(core-api): return senderPublicKey on v2 transaction endpoints

### DIFF
--- a/__tests__/integration/core-api/v2/utils.ts
+++ b/__tests__/integration/core-api/v2/utils.ts
@@ -80,6 +80,7 @@ class Helpers {
         expect(transaction).toHaveProperty("amount");
         expect(transaction).toHaveProperty("fee");
         expect(transaction).toHaveProperty("sender");
+        expect(transaction).toHaveProperty("senderPublicKey");
 
         if ([1, 2].indexOf(transaction.type) === -1) {
             expect(transaction.recipient).toBeString();

--- a/packages/core-api/src/versions/2/transactions/transformer.ts
+++ b/packages/core-api/src/versions/2/transactions/transformer.ts
@@ -21,6 +21,7 @@ export function transformTransaction(model) {
         fee: +data.fee,
         sender,
         recipient: data.recipientId,
+        senderPublicKey: data.senderPublicKey,
         signature: data.signature,
         signSignature: data.signSignature,
         signatures: data.signatures,


### PR DESCRIPTION
<!-- Please don't delete this template and read our contribution guidelines at https://docs.ark.io/guidebook/contribution-guidelines/contributing.html -->

## Summary

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

## What kind of change does this PR introduce?

<!-- _Put an `x` in the boxes that apply. -->

- [X] Bugfix
- [ ] New feature
- [ ] Refactoring / Performance Improvements
- [ ] Build-related changes
- [ ] Documentation
- [ ] Tests / Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

<!-- _Put an `x` in the boxes that apply. -->

- [ ] Yes
- [ ] No

## Checklist

<!-- _Put an `x` in the boxes that apply. -->

- [ ] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation _(if appropriate)_

## Other information

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
-->
