### PR TITLE
fix(core): dont pass suffix flag to bip38 and bip39 command

### DIFF
--- a/packages/core/src/commands/config/forger/index.ts
+++ b/packages/core/src/commands/config/forger/index.ts
@@ -53,6 +53,8 @@ $ ark config:forger --method=bip39
             this.abortWithInvalidInput();
         }
 
+        delete flags.suffix;
+
         response = { ...flags, ...response };
 
         if (response.method === "bip38") {


### PR DESCRIPTION
<!-- Please don't delete this template and read our contribution guidelines at https://docs.ark.io/guidebook/contribution-guidelines/contributing.html -->

## Summary
`ark config:forger` works again.

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

## What kind of change does this PR introduce?

<!-- _Put an `x` in the boxes that apply. -->

- [X] Bugfix
- [ ] New feature
- [ ] Refactoring / Performance Improvements
- [ ] Build-related changes
- [ ] Documentation
- [ ] Tests / Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

<!-- _Put an `x` in the boxes that apply. -->

- [ ] Yes
- [ ] No

## Checklist

<!-- _Put an `x` in the boxes that apply. -->

- [ ] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation _(if appropriate)_

## Other information

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
-->
