### PR TITLE
fix(core): parse only the last line of pm2 stdout

### DIFF
--- a/packages/core/src/process-manager.ts
+++ b/packages/core/src/process-manager.ts
@@ -29,7 +29,7 @@ class ProcessManager {
         try {
             const { stdout } = shellSync("pm2 jlist");
 
-            return JSON.parse(stdout).find(p => p.name === name);
+            return JSON.parse(stdout.split("\n").pop()).find(p => p.name === name);
         } catch (error) {
             return undefined;
         }
@@ -77,7 +77,7 @@ class ProcessManager {
         try {
             const { stdout } = shellSync("pm2 jlist");
 
-            return Object.values(JSON.parse(stdout)).filter((p: ProcessDescription) => p.name.startsWith(token));
+            return Object.values(JSON.parse(stdout.split("\n").pop())).filter((p: ProcessDescription) => p.name.startsWith(token));
         } catch (error) {
             return undefined;
         }


### PR DESCRIPTION
Fixes instances of `Error: The "XXX" process has entered an unknown state. (undefined)`

This is because sometimes the in-memory pm2 gets out of date (e.g. if multiple pm2 instances are installed on the system). When this happens, an error is printed to stdout prior to the JSON from `pm2 jlist` being dumped. This prevents `JSON.parse` from parsing the response properly. By only processing the last line of the output from `pm2 jlist`, we exclude the error text, so `JSON.parse` succeeds.

(The JSON output from `pm2 jlist` never contains newlines or carriage returns.)

<!-- Please don't delete this template and read our contribution guidelines at https://docs.ark.io/guidebook/contribution-guidelines/contributing.html -->

## Summary

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

## What kind of change does this PR introduce?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [x] Bugfix
- [ ] New feature
- [ ] Refactoring / Performance Improvements
- [ ] Build-related changes
- [ ] Documentation
- [ ] Tests / Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [ ] Yes
- [x] No

## Does this PR release a new version?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [ ] Yes
  - [ ] All tests are passing
  - [ ] All benchmarks are passing without any _major_ regressions
  - [ ] Sync from 0 works on mainnet
  - [ ] Sync from 0 works on devnet
  - [ ] Starting a new network and forging on it work
  - [ ] Explorer is fully functional
  - [ ] Wallets are fully functional
- [x] No

## Checklist

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation _(if appropriate)_

<!--
## Other information

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
-->
