### PR TITLE
fix(core-forger): update configManager height

### DIFF
--- a/packages/core-forger/src/manager.ts
+++ b/packages/core-forger/src/manager.ts
@@ -149,6 +149,8 @@ export class ForgerManager {
      * Creates new block by the delegate and sends it to relay node for verification and broadcast
      */
     public async forgeNewBlock(delegate: models.Delegate, round, networkState: NetworkState) {
+        configManager.setHeight(networkState.nodeHeight);
+
         const transactions = await this.getTransactionsForForging();
 
         const previousBlock = {
@@ -157,7 +159,7 @@ export class ForgerManager {
             height: networkState.nodeHeight,
         };
 
-        if (configManager.getMilestone(networkState.nodeHeight).block.idFullSha256) {
+        if (configManager.getMilestone().block.idFullSha256) {
             previousBlock.idHex = previousBlock.id;
         } else {
             previousBlock.idHex = models.Block.toBytesHex(previousBlock.id);


### PR DESCRIPTION
<!-- Please don't delete this template and read our contribution guidelines at https://docs.ark.io/guidebook/contribution-guidelines/contributing.html -->

## Summary

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->
We need to ensure the configManager is always on the same height as the block that is about to be forged. Otherwise the forger can run into trouble when milestones alter the transaction validation. Currently this is only guaranteed when forger and relay run in the same process.

## What kind of change does this PR introduce?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [X] Bugfix
- [ ] New feature
- [ ] Refactoring / Performance Improvements
- [ ] Build-related changes
- [ ] Documentation
- [ ] Tests / Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [ ] Yes
- [ ] No

## Does this PR release a new version?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [ ] Yes
  - [ ] All tests are passing
  - [ ] All benchmarks are passing without any _major_ regressions
  - [ ] Sync from 0 works on mainnet
  - [ ] Sync from 0 works on devnet
  - [ ] Starting a new network and forging on it work
  - [ ] Explorer is fully functional
  - [ ] Wallets are fully functional
- [ ] No

## Checklist

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [ ] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation _(if appropriate)_

<!--
## Other information

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
-->
