### PR TITLE
fix(core-json-rpc): avoid getting stuck on a unresponsive peer by picking a random one each time

### DIFF
--- a/packages/core-json-rpc/src/index.ts
+++ b/packages/core-json-rpc/src/index.ts
@@ -19,8 +19,6 @@ export const plugin: Container.PluginDescriptor = {
 
         database.init(options.database);
 
-        await network.init();
-
         return startServer(options);
     },
     async deregister(container: Container.IContainer, options) {

--- a/packages/core-json-rpc/src/server/methods/blocks/info.ts
+++ b/packages/core-json-rpc/src/server/methods/blocks/info.ts
@@ -5,7 +5,7 @@ import { network } from "../../services/network";
 export const blockInfo = {
     name: "blocks.info",
     async method(params) {
-        const response = await network.sendRequest(`blocks/${params.id}`);
+        const response = await network.sendGET(`blocks/${params.id}`);
 
         return response ? response.data : Boom.notFound(`Block ${params.id} could not be found.`);
     },

--- a/packages/core-json-rpc/src/server/methods/blocks/latest.ts
+++ b/packages/core-json-rpc/src/server/methods/blocks/latest.ts
@@ -4,7 +4,7 @@ import { network } from "../../services/network";
 export const blockLatest = {
     name: "blocks.latest",
     async method() {
-        const response = await network.sendRequest("blocks", { orderBy: "height:desc", limit: 1 });
+        const response = await network.sendGET("blocks", { orderBy: "height:desc", limit: 1 });
 
         return response ? response.data[0] : Boom.notFound(`Latest block could not be found.`);
     },

--- a/packages/core-json-rpc/src/server/methods/blocks/transactions.ts
+++ b/packages/core-json-rpc/src/server/methods/blocks/transactions.ts
@@ -5,7 +5,7 @@ import { network } from "../../services/network";
 export const blockTransactions = {
     name: "blocks.transactions",
     async method(params) {
-        const response = await network.sendRequest(`blocks/${params.id}/transactions`, {
+        const response = await network.sendGET(`blocks/${params.id}/transactions`, {
             offset: params.offset,
             orderBy: "timestamp:desc",
         });

--- a/packages/core-json-rpc/src/server/methods/transactions/broadcast.ts
+++ b/packages/core-json-rpc/src/server/methods/transactions/broadcast.ts
@@ -17,7 +17,9 @@ export const transactionBroadcast = {
             return Boom.badData();
         }
 
-        await network.broadcast(transaction);
+        await network.sendPOST("transactions", {
+            transactions: [transaction],
+        });
 
         return transaction;
     },

--- a/packages/core-json-rpc/src/server/methods/transactions/info.ts
+++ b/packages/core-json-rpc/src/server/methods/transactions/info.ts
@@ -5,7 +5,7 @@ import { network } from "../../services/network";
 export const transactionInfo = {
     name: "transactions.info",
     async method(params) {
-        const response = await network.sendRequest(`transactions/${params.id}`);
+        const response = await network.sendGET(`transactions/${params.id}`);
 
         return response ? response.data : Boom.notFound(`Transaction ${params.id} could not be found.`);
     },

--- a/packages/core-json-rpc/src/server/methods/wallets/info.ts
+++ b/packages/core-json-rpc/src/server/methods/wallets/info.ts
@@ -5,7 +5,7 @@ import { network } from "../../services/network";
 export const walletInfo = {
     name: "wallets.info",
     async method(params) {
-        const response = await network.sendRequest(`wallets/${params.address}`);
+        const response = await network.sendGET(`wallets/${params.address}`);
 
         return response ? response.data : Boom.notFound(`Wallet ${params.address} could not be found.`);
     },

--- a/packages/core-json-rpc/src/server/methods/wallets/transactions.ts
+++ b/packages/core-json-rpc/src/server/methods/wallets/transactions.ts
@@ -5,7 +5,7 @@ import { network } from "../../services/network";
 export const walletTransactions = {
     name: "wallets.transactions",
     async method(params) {
-        const response = await network.sendRequest("transactions", {
+        const response = await network.sendGET("transactions", {
             offset: params.offset || 0,
             orderBy: "timestamp:desc",
             ownerId: params.address,

--- a/packages/core-json-rpc/src/server/services/network.ts
+++ b/packages/core-json-rpc/src/server/services/network.ts
@@ -6,116 +6,78 @@ import isReachable from "is-reachable";
 import sample from "lodash.sample";
 
 class Network {
-    private peers: any;
-    private server: any;
-
     private readonly network: any = configManager.all();
     private readonly logger: Logger.ILogger = app.resolvePlugin<Logger.ILogger>("logger");
     private readonly p2p: P2P.IMonitor = app.resolvePlugin<P2P.IMonitor>("p2p");
 
-    private readonly requestOpts: Record<string, any> = {
-        headers: {
-            Accept: "application/vnd.core-api.v2+json",
-            "Content-Type": "application/json",
-        },
-        timeout: 3000,
-    };
-
-    public async init() {
-        this.loadRemotePeers();
+    public async sendGET(path, query = {}) {
+        return this.sendRequest("get", path, { query });
     }
 
-    public setServer() {
-        this.server = this.getRandomPeer();
+    public async sendPOST(path, body) {
+        return this.sendRequest("post", path, { body });
     }
 
-    public async sendRequest(url, query = {}) {
-        if (!this.server) {
-            this.setServer();
-        }
-
-        const peer = await this.selectResponsivePeer(this.server);
-        const uri = `http://${peer.ip}:${peer.port}/api/${url}`;
-
+    private async sendRequest(method, url, opts, tries = 0) {
         try {
+            const peer: { ip: string; port: number } = await this.getPeer();
+            const uri: string = `http://${peer.ip}:${peer.port}/api/${url}`;
+
             this.logger.info(`Sending request on "${this.network.name}" to "${uri}"`);
 
-            const response = await httpie.get(uri, { query, ...this.requestOpts });
-
-            return response.body;
+            return (await httpie[method](uri, {
+                ...opts,
+                ...{
+                    headers: {
+                        Accept: "application/vnd.core-api.v2+json",
+                        "Content-Type": "application/json",
+                    },
+                    timeout: 3000,
+                },
+            })).body;
         } catch (error) {
             this.logger.error(error.message);
-        }
-    }
 
-    public async broadcast(transaction) {
-        return httpie.post(`http://${this.server.ip}:${this.server.port}/api/transactions`, {
-            body: {
-                transactions: [transaction],
-            },
-            ...this.requestOpts.headers,
-        });
-    }
+            if (tries > 3) {
+                this.logger.error(`Failed to find a responsive peer after 3 tries.`);
 
-    public async connect(): Promise<any> {
-        if (this.server) {
-            // this.logger.info(`Server is already configured as "${this.server.ip}:${this.server.port}"`)
-            return true;
-        }
-
-        this.setServer();
-
-        try {
-            const peerPort = app.resolveOptions("p2p").port;
-            const response = await httpie.get(`http://${this.server.ip}:${peerPort}/config`);
-
-            const plugin = response.body.data.plugins["@arkecosystem/core-api"];
-
-            if (!plugin.enabled) {
-                const index = this.peers.findIndex(peer => peer.ip === this.server.ip);
-                this.peers.splice(index, 1);
-
-                if (!this.peers.length) {
-                    this.loadRemotePeers();
-                }
-
-                return this.connect();
+                return undefined;
             }
 
-            this.server.port = plugin.port;
-        } catch (error) {
-            return this.connect();
+            tries++;
+
+            return this.sendRequest(method, url, opts, tries);
         }
     }
 
-    private getRandomPeer() {
-        this.loadRemotePeers();
-
-        return sample(this.peers);
-    }
-
-    private loadRemotePeers() {
-        this.peers =
-            this.network.name === "testnet"
-                ? [{ ip: "localhost", port: app.resolveOptions("api").port }]
-                : this.p2p.getPeers();
-
-        if (!this.peers.length) {
-            this.logger.error("No peers found. Shutting down...");
-            process.exit();
-        }
-    }
-
-    private async selectResponsivePeer(peer) {
-        const reachable = await isReachable(`${peer.ip}:${peer.port}`);
+    private async getPeer(): Promise<{ ip: string; port: number }> {
+        const peer: { ip: string; port: number } = sample(this.getPeers());
+        const reachable: boolean = await isReachable(`${peer.ip}:${peer.port}`);
 
         if (!reachable) {
             this.logger.warn(`${peer} is unresponsive. Choosing new peer.`);
 
-            return this.selectResponsivePeer(this.getRandomPeer());
+            return this.getPeer();
         }
 
         return peer;
+    }
+
+    private getPeers(): Array<{ ip: string; port: number }> {
+        const peers =
+            this.network.name === "testnet"
+                ? [{ ip: "localhost", port: app.resolveOptions("api").port }]
+                : this.p2p.getPeers();
+
+        if (!peers.length) {
+            throw new Error("No peers found. Shutting down...");
+        }
+
+        for (const peer of peers) {
+            peer.port = app.resolveOptions("api").port;
+        }
+
+        return peers;
     }
 }
 

--- a/packages/core-json-rpc/src/server/services/processor.ts
+++ b/packages/core-json-rpc/src/server/services/processor.ts
@@ -1,6 +1,5 @@
 import Joi from "joi";
 import get from "lodash.get";
-import { network } from "./network";
 
 export class Processor {
     public async resource(server, payload) {
@@ -36,8 +35,6 @@ export class Processor {
                     return this.createErrorResponse(id, -32602, error);
                 }
             }
-
-            await network.connect();
 
             const result = await targetMethod(params);
 


### PR DESCRIPTION
<!-- Please don't delete this template and read our contribution guidelines at https://docs.ark.io/guidebook/contribution-guidelines/contributing.html -->

## Summary

Select a random peer every time we send a request and try to do so up to 3 times before giving up.

## What kind of change does this PR introduce?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [x] Bugfix
- [ ] New feature
- [ ] Refactoring / Performance Improvements
- [ ] Build-related changes
- [ ] Documentation
- [ ] Tests / Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [ ] Yes
- [x] No

## Does this PR release a new version?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [ ] Yes
  - [ ] All tests are passing
  - [ ] All benchmarks are passing without any _major_ regressions
  - [ ] Sync from 0 works on mainnet
  - [ ] Sync from 0 works on devnet
  - [ ] Starting a new network and forging on it work
  - [ ] Explorer is fully functional
  - [ ] Wallets are fully functional
- [x] No

## Checklist

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation _(if appropriate)_

<!--
## Other information

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
-->
