### PR TITLE
fix(core-snapshots): asset import, include rounds table

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,7 @@ jobs:
             - ./packages/core-new-relic/node_modules
             - ./packages/core-p2p/node_modules
             - ./packages/core-snapshots/node_modules
+            - ./packages/core-state/node_modules
             - ./packages/core-tester-cli/node_modules
             - ./packages/core-transaction-pool/node_modules
             - ./packages/core-transactions/node_modules
@@ -130,6 +131,7 @@ jobs:
             - ./packages/core-new-relic/node_modules
             - ./packages/core-p2p/node_modules
             - ./packages/core-snapshots/node_modules
+            - ./packages/core-state/node_modules
             - ./packages/core-tester-cli/node_modules
             - ./packages/core-transaction-pool/node_modules
             - ./packages/core-transactions/node_modules
@@ -216,6 +218,7 @@ jobs:
             - ./packages/core-new-relic/node_modules
             - ./packages/core-p2p/node_modules
             - ./packages/core-snapshots/node_modules
+            - ./packages/core-state/node_modules
             - ./packages/core-tester-cli/node_modules
             - ./packages/core-transaction-pool/node_modules
             - ./packages/core-transactions/node_modules
@@ -302,6 +305,7 @@ jobs:
             - ./packages/core-new-relic/node_modules
             - ./packages/core-p2p/node_modules
             - ./packages/core-snapshots/node_modules
+            - ./packages/core-state/node_modules
             - ./packages/core-tester-cli/node_modules
             - ./packages/core-transaction-pool/node_modules
             - ./packages/core-transactions/node_modules
@@ -388,6 +392,7 @@ jobs:
             - ./packages/core-new-relic/node_modules
             - ./packages/core-p2p/node_modules
             - ./packages/core-snapshots/node_modules
+            - ./packages/core-state/node_modules
             - ./packages/core-tester-cli/node_modules
             - ./packages/core-transaction-pool/node_modules
             - ./packages/core-transactions/node_modules
@@ -474,6 +479,7 @@ jobs:
             - ./packages/core-new-relic/node_modules
             - ./packages/core-p2p/node_modules
             - ./packages/core-snapshots/node_modules
+            - ./packages/core-state/node_modules
             - ./packages/core-tester-cli/node_modules
             - ./packages/core-transaction-pool/node_modules
             - ./packages/core-transactions/node_modules
@@ -560,6 +566,7 @@ jobs:
             - ./packages/core-new-relic/node_modules
             - ./packages/core-p2p/node_modules
             - ./packages/core-snapshots/node_modules
+            - ./packages/core-state/node_modules
             - ./packages/core-tester-cli/node_modules
             - ./packages/core-transaction-pool/node_modules
             - ./packages/core-transactions/node_modules
@@ -671,6 +678,7 @@ jobs:
             - ./packages/core-new-relic/node_modules
             - ./packages/core-p2p/node_modules
             - ./packages/core-snapshots/node_modules
+            - ./packages/core-state/node_modules
             - ./packages/core-tester-cli/node_modules
             - ./packages/core-transaction-pool/node_modules
             - ./packages/core-transactions/node_modules
@@ -776,6 +784,7 @@ jobs:
             - ./packages/core-new-relic/node_modules
             - ./packages/core-p2p/node_modules
             - ./packages/core-snapshots/node_modules
+            - ./packages/core-state/node_modules
             - ./packages/core-tester-cli/node_modules
             - ./packages/core-transaction-pool/node_modules
             - ./packages/core-transactions/node_modules
@@ -887,6 +896,7 @@ jobs:
             - ./packages/core-new-relic/node_modules
             - ./packages/core-p2p/node_modules
             - ./packages/core-snapshots/node_modules
+            - ./packages/core-state/node_modules
             - ./packages/core-tester-cli/node_modules
             - ./packages/core-transaction-pool/node_modules
             - ./packages/core-transactions/node_modules

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,6 @@ jobs:
             - ./packages/core-new-relic/node_modules
             - ./packages/core-p2p/node_modules
             - ./packages/core-snapshots/node_modules
-            - ./packages/core-state/node_modules
             - ./packages/core-tester-cli/node_modules
             - ./packages/core-transaction-pool/node_modules
             - ./packages/core-transactions/node_modules
@@ -131,7 +130,6 @@ jobs:
             - ./packages/core-new-relic/node_modules
             - ./packages/core-p2p/node_modules
             - ./packages/core-snapshots/node_modules
-            - ./packages/core-state/node_modules
             - ./packages/core-tester-cli/node_modules
             - ./packages/core-transaction-pool/node_modules
             - ./packages/core-transactions/node_modules
@@ -218,7 +216,6 @@ jobs:
             - ./packages/core-new-relic/node_modules
             - ./packages/core-p2p/node_modules
             - ./packages/core-snapshots/node_modules
-            - ./packages/core-state/node_modules
             - ./packages/core-tester-cli/node_modules
             - ./packages/core-transaction-pool/node_modules
             - ./packages/core-transactions/node_modules
@@ -305,7 +302,6 @@ jobs:
             - ./packages/core-new-relic/node_modules
             - ./packages/core-p2p/node_modules
             - ./packages/core-snapshots/node_modules
-            - ./packages/core-state/node_modules
             - ./packages/core-tester-cli/node_modules
             - ./packages/core-transaction-pool/node_modules
             - ./packages/core-transactions/node_modules
@@ -392,7 +388,6 @@ jobs:
             - ./packages/core-new-relic/node_modules
             - ./packages/core-p2p/node_modules
             - ./packages/core-snapshots/node_modules
-            - ./packages/core-state/node_modules
             - ./packages/core-tester-cli/node_modules
             - ./packages/core-transaction-pool/node_modules
             - ./packages/core-transactions/node_modules
@@ -479,7 +474,6 @@ jobs:
             - ./packages/core-new-relic/node_modules
             - ./packages/core-p2p/node_modules
             - ./packages/core-snapshots/node_modules
-            - ./packages/core-state/node_modules
             - ./packages/core-tester-cli/node_modules
             - ./packages/core-transaction-pool/node_modules
             - ./packages/core-transactions/node_modules
@@ -566,7 +560,6 @@ jobs:
             - ./packages/core-new-relic/node_modules
             - ./packages/core-p2p/node_modules
             - ./packages/core-snapshots/node_modules
-            - ./packages/core-state/node_modules
             - ./packages/core-tester-cli/node_modules
             - ./packages/core-transaction-pool/node_modules
             - ./packages/core-transactions/node_modules
@@ -678,7 +671,6 @@ jobs:
             - ./packages/core-new-relic/node_modules
             - ./packages/core-p2p/node_modules
             - ./packages/core-snapshots/node_modules
-            - ./packages/core-state/node_modules
             - ./packages/core-tester-cli/node_modules
             - ./packages/core-transaction-pool/node_modules
             - ./packages/core-transactions/node_modules
@@ -784,7 +776,6 @@ jobs:
             - ./packages/core-new-relic/node_modules
             - ./packages/core-p2p/node_modules
             - ./packages/core-snapshots/node_modules
-            - ./packages/core-state/node_modules
             - ./packages/core-tester-cli/node_modules
             - ./packages/core-transaction-pool/node_modules
             - ./packages/core-transactions/node_modules
@@ -896,7 +887,6 @@ jobs:
             - ./packages/core-new-relic/node_modules
             - ./packages/core-p2p/node_modules
             - ./packages/core-snapshots/node_modules
-            - ./packages/core-state/node_modules
             - ./packages/core-tester-cli/node_modules
             - ./packages/core-transaction-pool/node_modules
             - ./packages/core-transactions/node_modules

--- a/packages/core-snapshots/src/db/index.ts
+++ b/packages/core-snapshots/src/db/index.ts
@@ -2,6 +2,7 @@ import { app } from "@arkecosystem/core-container";
 import { PostgresConnection } from "@arkecosystem/core-database-postgres";
 import { Logger, Shared } from "@arkecosystem/core-interfaces";
 
+import { roundCalculator } from "../../../core-utils/dist";
 import { queries } from "./queries";
 import { rawQuery } from "./utils";
 
@@ -12,6 +13,7 @@ export class Database {
     public pgp: any;
     public blocksColumnSet: any;
     public transactionsColumnSet: any;
+    public roundsColumnSet: any;
 
     public async make(connection: PostgresConnection) {
         this.db = connection.db;
@@ -81,6 +83,9 @@ export class Database {
             );
         }
 
+        const roundInfoStart = roundCalculator.calculateRound(startHeight);
+        const roundInfoEnd = roundCalculator.calculateRound(endHeight);
+
         return {
             blocks: rawQuery(this.pgp, queries.blocks.heightRange, {
                 start: startBlock.height,
@@ -89,6 +94,10 @@ export class Database {
             transactions: rawQuery(this.pgp, queries.transactions.timestampRange, {
                 start: startBlock.timestamp,
                 end: endBlock.timestamp,
+            }),
+            rounds: rawQuery(this.pgp, queries.rounds.roundRange, {
+                start: roundInfoStart.round,
+                end: roundInfoEnd.round,
             }),
         };
     }
@@ -105,6 +114,8 @@ export class Database {
                 return this.blocksColumnSet;
             case "transactions":
                 return this.transactionsColumnSet;
+            case "rounds":
+                return this.roundsColumnSet;
             default:
                 throw new Error("Invalid table name");
         }
@@ -150,6 +161,10 @@ export class Database {
             ],
             { table: "transactions" },
         );
+
+        this.roundsColumnSet = new this.pgp.helpers.ColumnSet(["id", "public_key", "balance", "round"], {
+            table: "rounds",
+        });
     }
 }
 

--- a/packages/core-snapshots/src/db/index.ts
+++ b/packages/core-snapshots/src/db/index.ts
@@ -2,7 +2,7 @@ import { app } from "@arkecosystem/core-container";
 import { PostgresConnection } from "@arkecosystem/core-database-postgres";
 import { Logger, Shared } from "@arkecosystem/core-interfaces";
 
-import { roundCalculator } from "../../../core-utils/dist";
+import { roundCalculator } from "@arkecosystem/core-utils";
 import { queries } from "./queries";
 import { rawQuery } from "./utils";
 
@@ -83,8 +83,8 @@ export class Database {
             );
         }
 
-        const roundInfoStart = roundCalculator.calculateRound(startHeight);
-        const roundInfoEnd = roundCalculator.calculateRound(endHeight);
+        const roundInfoStart: Shared.IRoundInfo = roundCalculator.calculateRound(startHeight);
+        const roundInfoEnd: Shared.IRoundInfo = roundCalculator.calculateRound(endHeight);
 
         return {
             blocks: rawQuery(this.pgp, queries.blocks.heightRange, {

--- a/packages/core-snapshots/src/db/queries/index.ts
+++ b/packages/core-snapshots/src/db/queries/index.ts
@@ -14,6 +14,7 @@ export const queries = {
     },
     rounds: {
         deleteFromRound: loadQueryFile(__dirname, "./rounds/delete-from-round.sql"),
+        roundRange: loadQueryFile(__dirname, "./rounds/round-range.sql"),
     },
     truncate: table => `TRUNCATE TABLE ${table} RESTART IDENTITY`,
 };

--- a/packages/core-snapshots/src/db/queries/rounds/round-range.sql
+++ b/packages/core-snapshots/src/db/queries/rounds/round-range.sql
@@ -1,0 +1,11 @@
+SELECT
+  id,
+  public_key,
+  balance,
+  round
+FROM
+  rounds
+WHERE
+  round BETWEEN ${start} AND ${end}
+ORDER BY
+  round

--- a/packages/core-snapshots/src/manager.ts
+++ b/packages/core-snapshots/src/manager.ts
@@ -71,6 +71,8 @@ export class SnapshotManager {
             );
         }
 
+        await this.database.db.one("SELECT setval('rounds_id_seq', (SELECT MAX(id) FROM rounds) + 1)");
+
         this.database.close();
     }
 

--- a/packages/core-snapshots/src/manager.ts
+++ b/packages/core-snapshots/src/manager.ts
@@ -34,6 +34,7 @@ export class SnapshotManager {
         const metaInfo = {
             blocks: await exportTable("blocks", params),
             transactions: await exportTable("transactions", params),
+            rounds: await exportTable("rounds", params),
             folder: params.meta.folder,
             skipCompression: params.meta.skipCompression,
         };
@@ -53,6 +54,7 @@ export class SnapshotManager {
 
         await importTable("blocks", params);
         await importTable("transactions", params);
+        await importTable("rounds", params);
 
         const lastBlock = await this.database.getLastBlock();
         const height = lastBlock.height as number;

--- a/packages/core-snapshots/src/transport/codec.ts
+++ b/packages/core-snapshots/src/transport/codec.ts
@@ -6,7 +6,7 @@ function encodeBlock(block) {
     return models.Block.serialize(camelizeKeys(block), true);
 }
 
-function decodeBlock(buffer) {
+function decodeBlock(buffer: Buffer) {
     const block = models.Block.deserialize(buffer.toString("hex"), true);
     block.totalAmount = (block.totalAmount as Bignum).toFixed();
     block.totalFee = (block.totalFee as Bignum).toFixed();
@@ -27,7 +27,7 @@ function encodeTransaction(transaction) {
     ]);
 }
 
-function decodeTransaction(buffer) {
+function decodeTransaction(buffer: Buffer) {
     const [id, blockId, sequence, timestamp, serialized] = decode(buffer);
 
     const transaction: any = Transaction.fromBytesUnsafe(serialized, id).data;
@@ -50,6 +50,21 @@ function decodeTransaction(buffer) {
     return decamelized;
 }
 
+function encodeRound(round) {
+    return encode([round.id, round.public_key, round.balance, round.round]);
+}
+
+function decodeRound(buffer: Buffer) {
+    const [id, publicKey, balance, round] = decode(buffer);
+
+    return decamelizeKeys({
+        id,
+        publicKey,
+        balance,
+        round,
+    });
+}
+
 export class Codec {
     static get blocks() {
         const codec = createCodec();
@@ -63,6 +78,14 @@ export class Codec {
         const codec = createCodec();
         codec.addExtPacker(0x4f, Object, encodeTransaction);
         codec.addExtUnpacker(0x4f, decodeTransaction);
+
+        return codec;
+    }
+
+    static get rounds() {
+        const codec = createCodec();
+        codec.addExtPacker(0x5f, Object, encodeRound);
+        codec.addExtUnpacker(0x5f, decodeRound);
 
         return codec;
     }

--- a/packages/core-snapshots/src/transport/codec.ts
+++ b/packages/core-snapshots/src/transport/codec.ts
@@ -31,6 +31,9 @@ function decodeTransaction(buffer) {
     const [id, blockId, sequence, timestamp, serialized] = decode(buffer);
 
     const transaction: any = Transaction.fromBytesUnsafe(serialized, id).data;
+    const { asset } = transaction;
+    transaction.asset = null;
+
     transaction.block_id = blockId;
     transaction.sequence = sequence;
     transaction.timestamp = timestamp;
@@ -38,11 +41,12 @@ function decodeTransaction(buffer) {
     transaction.fee = transaction.fee.toFixed();
     transaction.vendorFieldHex = transaction.vendorFieldHex ? transaction.vendorFieldHex : null;
     transaction.recipientId = transaction.recipientId ? transaction.recipientId : null;
-    transaction.asset = transaction.asset ? transaction.asset : null;
     transaction.serialized = serialized;
 
     const decamelized = decamelizeKeys(transaction);
     decamelized.serialized = serialized; // FIXME: decamelizeKeys mutilates Buffers
+    decamelized.asset = asset ? asset : null;
+
     return decamelized;
 }
 

--- a/packages/core-snapshots/src/transport/codec.ts
+++ b/packages/core-snapshots/src/transport/codec.ts
@@ -51,7 +51,7 @@ function decodeTransaction(buffer: Buffer) {
 }
 
 function encodeRound(round) {
-    return encode([round.id, round.public_key, round.balance, round.round]);
+    return encode([round.id, round.public_key || round.publicKey, round.balance, round.round]);
 }
 
 function decodeRound(buffer: Buffer) {

--- a/packages/core-snapshots/src/transport/verification.ts
+++ b/packages/core-snapshots/src/transport/verification.ts
@@ -58,6 +58,10 @@ export const verifyData = (context, data, prevData, verifySignatures) => {
         return Transaction.fromBytes(data.serialized).verified;
     }
 
+    if (context === "rounds") {
+        return true;
+    }
+
     return false;
 };
 
@@ -72,6 +76,10 @@ export const canImportRecord = (context, data, lastBlock) => {
 
     if (context === "transactions") {
         return data.timestamp > lastBlock.timestamp;
+    }
+
+    if (context === "rounds") {
+        return true;
     }
 
     return false;

--- a/packages/core-snapshots/src/utils.ts
+++ b/packages/core-snapshots/src/utils.ts
@@ -19,22 +19,30 @@ export const copySnapshot = (sourceFolder, destFolder) => {
         source: {
             blocks: this.getFilePath("blocks", sourceFolder),
             transactions: this.getFilePath("transactions", sourceFolder),
+            rounds: this.getFilePath("rounds", sourceFolder),
         },
         dest: {
             blocks: this.getFilePath("blocks", destFolder),
             transactions: this.getFilePath("transactions", destFolder),
+            rounds: this.getFilePath("rounds", destFolder),
         },
     };
 
     ensureFileSync(paths.dest.blocks);
     ensureFileSync(paths.dest.transactions);
+    ensureFileSync(paths.dest.rounds);
 
-    if (!existsSync(paths.source.blocks) || !existsSync(paths.source.transactions)) {
+    if (
+        !existsSync(paths.source.blocks) ||
+        !existsSync(paths.source.transactions) ||
+        !existsSync(paths.source.rounds)
+    ) {
         app.forceExit(`Unable to copy snapshot from ${sourceFolder} as it doesn't exist`);
     }
 
     copyFileSync(paths.source.blocks, paths.dest.blocks);
     copyFileSync(paths.source.transactions, paths.dest.transactions);
+    copyFileSync(paths.source.rounds, paths.dest.rounds);
 };
 
 export const calcRecordCount = (table, currentCount, sourceFolder) => {
@@ -63,6 +71,7 @@ export const getSnapshotInfo = folder => {
         folder: snapshotInfo.folder,
         blocks: snapshotInfo.blocks,
         transactions: snapshotInfo.transactions,
+        rounds: snapshotInfo.rounds,
         skipCompression: snapshotInfo.skipCompression,
     };
 };


### PR DESCRIPTION
<!-- Please don't delete this template and read our contribution guidelines at https://docs.ark.io/guidebook/contribution-guidelines/contributing.html -->

## Summary
Fixes assets that were incorrectly imported, because of `decamelizeKeys`. This PR also changes the `SnapshotManager` to include the rounds table when taking a snapshot since the `PeerVerifier` does not work properly without it. Theoretically we could regenerate the rounds table from the blocks and transactions table alone, but it takes approx. 1 hours for mainnet so this is not an option.

**This PR invalidates all existing snapshots.**

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

## What kind of change does this PR introduce?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [X] Bugfix
- [ ] New feature
- [ ] Refactoring / Performance Improvements
- [ ] Build-related changes
- [ ] Documentation
- [ ] Tests / Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [X] Yes
- [ ] No

## Does this PR release a new version?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [ ] Yes
  - [ ] All tests are passing
  - [ ] All benchmarks are passing without any _major_ regressions
  - [ ] Sync from 0 works on mainnet
  - [ ] Sync from 0 works on devnet
  - [ ] Starting a new network and forging on it work
  - [ ] Explorer is fully functional
  - [ ] Wallets are fully functional
- [x] No

## Checklist

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation _(if appropriate)_

<!--
## Other information

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
-->
