### PR TITLE
fix(core-api): return transaction timestamp instead of block timestamp

### DIFF
--- a/packages/core-api/src/versions/2/transactions/transformer.ts
+++ b/packages/core-api/src/versions/2/transactions/transformer.ts
@@ -27,6 +27,6 @@ export function transformTransaction(model) {
         vendorField: data.vendorField,
         asset: data.asset,
         confirmations: model.block ? lastBlock.data.height - model.block.height : 0,
-        timestamp: formatTimestamp(model.timestamp || data.timestamp),
+        timestamp: formatTimestamp(data.timestamp),
     };
 }


### PR DESCRIPTION
<!-- Please don't delete this template and read our contribution guidelines at https://docs.ark.io/guidebook/contribution-guidelines/contributing.html -->

## Summary
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Always return the transaction timestamp instead of preferring the block timestamp so that a transaction can be properly verified. Only changed the v2 endpoint, since the v1 endpoint is deprecated anyway.

## What kind of change does this PR introduce?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [X] Bugfix
- [ ] New feature
- [ ] Refactoring / Performance Improvements
- [ ] Build-related changes
- [ ] Documentation
- [ ] Tests / Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [ ] Yes
- [ ] No

## Does this PR release a new version?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [ ] Yes
  - [ ] All tests are passing
  - [ ] All benchmarks are passing without any _major_ regressions
  - [ ] Sync from 0 works on mainnet
  - [ ] Sync from 0 works on devnet
  - [ ] Starting a new network and forging on it work
  - [ ] Explorer is fully functional
  - [ ] Wallets are fully functional
- [ ] No

## Checklist

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [ ] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation _(if appropriate)_

<!--
## Other information

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
-->
