### PR TITLE
test(e2e): specify sed extension to support macOS

### DIFF
--- a/__tests__/e2e/lib/config/docker/docker-init.sh
+++ b/__tests__/e2e/lib/config/docker/docker-init.sh
@@ -4,14 +4,26 @@ for rawdir in node*/;
   p2pPort="$(expr $(echo "$(echo "${nodeDir}" | sed 's/[^0-9]*//g') + 4000"))"
   apiPort="$(expr $(echo "$(echo "${nodeDir}" | sed 's/[^0-9]*//g') + 4300"))"
   echo "[Docker configuration] Tuning docker-compose files for ${nodeDir}";
-  sed -i "" "s;{{nodeAlias}};${nodeDir};g" ${nodeDir}/docker/testnet-e2e/docker-compose-stack.yml;
-  sed -i "" "s;{{nodeBackend}};${nodeDir}backend;g" ${nodeDir}/docker/testnet-e2e/docker-compose-stack.yml;
-  sed -i "" "s;{{hostP2pPort}};${p2pPort};g" ${nodeDir}/docker/testnet-e2e/docker-compose-stack.yml;
-  sed -i "" "s;{{hostApiPort}};${apiPort};g" ${nodeDir}/docker/testnet-e2e/docker-compose-stack.yml;
-  sed -i "" "s;{{nodeAlias}};${nodeDir};g" ${nodeDir}/docker/testnet-e2e/docker-compose.yml;
-  sed -i "" "s;{{nodeBackend}};${nodeDir}backend;g" ${nodeDir}/docker/testnet-e2e/docker-compose.yml;
-  sed -i "" "s;{{hostP2pPort}};${p2pPort};g" ${nodeDir}/docker/testnet-e2e/docker-compose.yml;
-  sed -i "" "s;{{hostApiPort}};${apiPort};g" ${nodeDir}/docker/testnet-e2e/docker-compose.yml;
+
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    sed -i "" "s;{{nodeAlias}};${nodeDir};g" ${nodeDir}/docker/testnet-e2e/docker-compose-stack.yml;
+    sed -i "" "s;{{nodeBackend}};${nodeDir}backend;g" ${nodeDir}/docker/testnet-e2e/docker-compose-stack.yml;
+    sed -i "" "s;{{hostP2pPort}};${p2pPort};g" ${nodeDir}/docker/testnet-e2e/docker-compose-stack.yml;
+    sed -i "" "s;{{hostApiPort}};${apiPort};g" ${nodeDir}/docker/testnet-e2e/docker-compose-stack.yml;
+    sed -i "" "s;{{nodeAlias}};${nodeDir};g" ${nodeDir}/docker/testnet-e2e/docker-compose.yml;
+    sed -i "" "s;{{nodeBackend}};${nodeDir}backend;g" ${nodeDir}/docker/testnet-e2e/docker-compose.yml;
+    sed -i "" "s;{{hostP2pPort}};${p2pPort};g" ${nodeDir}/docker/testnet-e2e/docker-compose.yml;
+    sed -i "" "s;{{hostApiPort}};${apiPort};g" ${nodeDir}/docker/testnet-e2e/docker-compose.yml;
+  else
+    sed -i "s;{{nodeAlias}};${nodeDir};g" ${nodeDir}/docker/testnet-e2e/docker-compose-stack.yml;
+    sed -i "s;{{nodeBackend}};${nodeDir}backend;g" ${nodeDir}/docker/testnet-e2e/docker-compose-stack.yml;
+    sed -i "s;{{hostP2pPort}};${p2pPort};g" ${nodeDir}/docker/testnet-e2e/docker-compose-stack.yml;
+    sed -i "s;{{hostApiPort}};${apiPort};g" ${nodeDir}/docker/testnet-e2e/docker-compose-stack.yml;
+    sed -i "s;{{nodeAlias}};${nodeDir};g" ${nodeDir}/docker/testnet-e2e/docker-compose.yml;
+    sed -i "s;{{nodeBackend}};${nodeDir}backend;g" ${nodeDir}/docker/testnet-e2e/docker-compose.yml;
+    sed -i "s;{{hostP2pPort}};${p2pPort};g" ${nodeDir}/docker/testnet-e2e/docker-compose.yml;
+    sed -i "s;{{hostApiPort}};${apiPort};g" ${nodeDir}/docker/testnet-e2e/docker-compose.yml;
+  fi
 done
 for nodeNumber in {0..9}
   do

--- a/__tests__/e2e/lib/config/docker/docker-init.sh
+++ b/__tests__/e2e/lib/config/docker/docker-init.sh
@@ -4,14 +4,14 @@ for rawdir in node*/;
   p2pPort="$(expr $(echo "$(echo "${nodeDir}" | sed 's/[^0-9]*//g') + 4000"))"
   apiPort="$(expr $(echo "$(echo "${nodeDir}" | sed 's/[^0-9]*//g') + 4300"))"
   echo "[Docker configuration] Tuning docker-compose files for ${nodeDir}";
-  sed -i "s;{{nodeAlias}};${nodeDir};g" ${nodeDir}/docker/testnet-e2e/docker-compose-stack.yml;
-  sed -i "s;{{nodeBackend}};${nodeDir}backend;g" ${nodeDir}/docker/testnet-e2e/docker-compose-stack.yml;
-  sed -i "s;{{hostP2pPort}};${p2pPort};g" ${nodeDir}/docker/testnet-e2e/docker-compose-stack.yml;
-  sed -i "s;{{hostApiPort}};${apiPort};g" ${nodeDir}/docker/testnet-e2e/docker-compose-stack.yml;
-  sed -i "s;{{nodeAlias}};${nodeDir};g" ${nodeDir}/docker/testnet-e2e/docker-compose.yml;
-  sed -i "s;{{nodeBackend}};${nodeDir}backend;g" ${nodeDir}/docker/testnet-e2e/docker-compose.yml;
-  sed -i "s;{{hostP2pPort}};${p2pPort};g" ${nodeDir}/docker/testnet-e2e/docker-compose.yml;
-  sed -i "s;{{hostApiPort}};${apiPort};g" ${nodeDir}/docker/testnet-e2e/docker-compose.yml;
+  sed -i "" "s;{{nodeAlias}};${nodeDir};g" ${nodeDir}/docker/testnet-e2e/docker-compose-stack.yml;
+  sed -i "" "s;{{nodeBackend}};${nodeDir}backend;g" ${nodeDir}/docker/testnet-e2e/docker-compose-stack.yml;
+  sed -i "" "s;{{hostP2pPort}};${p2pPort};g" ${nodeDir}/docker/testnet-e2e/docker-compose-stack.yml;
+  sed -i "" "s;{{hostApiPort}};${apiPort};g" ${nodeDir}/docker/testnet-e2e/docker-compose-stack.yml;
+  sed -i "" "s;{{nodeAlias}};${nodeDir};g" ${nodeDir}/docker/testnet-e2e/docker-compose.yml;
+  sed -i "" "s;{{nodeBackend}};${nodeDir}backend;g" ${nodeDir}/docker/testnet-e2e/docker-compose.yml;
+  sed -i "" "s;{{hostP2pPort}};${p2pPort};g" ${nodeDir}/docker/testnet-e2e/docker-compose.yml;
+  sed -i "" "s;{{hostApiPort}};${apiPort};g" ${nodeDir}/docker/testnet-e2e/docker-compose.yml;
 done
 for nodeNumber in {0..9}
   do


### PR DESCRIPTION
<!-- Please don't delete this template and read our contribution guidelines at https://docs.ark.io/guidebook/contribution-guidelines/contributing.html -->

## Summary

Fixes a `sed` error which prevented the configuration to be generated on macOS.

## What kind of change does this PR introduce?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [x] Bugfix
- [ ] New feature
- [ ] Refactoring / Performance Improvements
- [ ] Build-related changes
- [ ] Documentation
- [x] Tests / Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [ ] Yes
- [x] No

## Does this PR release a new version?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [ ] Yes
  - [ ] All tests are passing
  - [ ] All benchmarks are passing without any _major_ regressions
  - [ ] Sync from 0 works on mainnet
  - [ ] Sync from 0 works on devnet
  - [ ] Starting a new network and forging on it work
  - [ ] Explorer is fully functional
  - [ ] Wallets are fully functional
- [x] No

## Checklist

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation _(if appropriate)_

<!--
## Other information

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
-->
