### PR TITLE
fix(core-tester-cli): use public API for auto-configuration

### DIFF
--- a/__tests__/integration/core-tester-cli/commands/send/delegate-registration.test.ts
+++ b/__tests__/integration/core-tester-cli/commands/send/delegate-registration.test.ts
@@ -1,5 +1,7 @@
-import { httpie } from "@arkecosystem/core-utils";
 import "jest-extended";
+
+import { httpie } from "@arkecosystem/core-utils";
+import { Managers } from "@arkecosystem/crypto";
 import nock from "nock";
 import pokemon from "pokemon";
 import { DelegateRegistrationCommand } from "../../../../../packages/core-tester-cli/src/commands/send/delegate-registration";
@@ -12,10 +14,10 @@ beforeEach(() => {
         .thrice()
         .reply(200, { data: { constants: {} } });
 
-    nock("http://localhost:4000")
-        .get("/config")
+    nock("http://localhost:4003")
+        .get("/api/v2/node/configuration/crypto")
         .thrice()
-        .reply(200, { data: { network: { name: "unitnet" } } });
+        .reply(200, { data: Managers.configManager.getPreset("unitnet") });
 
     jest.spyOn(httpie, "get");
     jest.spyOn(httpie, "post");

--- a/__tests__/integration/core-tester-cli/commands/send/multi-signature-registration.test.ts
+++ b/__tests__/integration/core-tester-cli/commands/send/multi-signature-registration.test.ts
@@ -1,6 +1,7 @@
-import { httpie } from "@arkecosystem/core-utils";
-import { Transactions } from "@arkecosystem/crypto";
 import "jest-extended";
+
+import { httpie } from "@arkecosystem/core-utils";
+import { Managers, Transactions } from "@arkecosystem/crypto";
 import nock from "nock";
 import { MultiSignatureRegistrationCommand } from "../../../../../packages/core-tester-cli/src/commands/send/multi-signature-registration";
 import { arkToSatoshi, captureTransactions, expectTransactions, toFlags } from "../../shared";
@@ -12,10 +13,10 @@ beforeEach(() => {
         .thrice()
         .reply(200, { data: { constants: {} } });
 
-    nock("http://localhost:4000")
-        .get("/config")
+    nock("http://localhost:4003")
+        .get("/api/v2/node/configuration/crypto")
         .thrice()
-        .reply(200, { data: { network: { name: "testnet" } } });
+        .reply(200, { data: Managers.configManager.getPreset("unitnet") });
 
     jest.spyOn(httpie, "get");
     jest.spyOn(httpie, "post");

--- a/__tests__/integration/core-tester-cli/commands/send/second-signature.test.ts
+++ b/__tests__/integration/core-tester-cli/commands/send/second-signature.test.ts
@@ -1,5 +1,7 @@
-import { httpie } from "@arkecosystem/core-utils";
 import "jest-extended";
+
+import { httpie } from "@arkecosystem/core-utils";
+import { Managers } from "@arkecosystem/crypto";
 import nock from "nock";
 import { SecondSignatureRegistrationCommand } from "../../../../../packages/core-tester-cli/src/commands/send/second-signature-registration";
 import { arkToSatoshi, captureTransactions, expectTransactions, toFlags } from "../../shared";
@@ -11,10 +13,10 @@ beforeEach(() => {
         .thrice()
         .reply(200, { data: { constants: {} } });
 
-    nock("http://localhost:4000")
-        .get("/config")
+    nock("http://localhost:4003")
+        .get("/api/v2/node/configuration/crypto")
         .thrice()
-        .reply(200, { data: { network: { name: "unitnet" } } });
+        .reply(200, { data: Managers.configManager.getPreset("unitnet") });
 
     jest.spyOn(httpie, "get");
     jest.spyOn(httpie, "post");

--- a/__tests__/integration/core-tester-cli/commands/send/transfer.test.ts
+++ b/__tests__/integration/core-tester-cli/commands/send/transfer.test.ts
@@ -1,5 +1,7 @@
-import { httpie } from "@arkecosystem/core-utils";
 import "jest-extended";
+
+import { httpie } from "@arkecosystem/core-utils";
+import { Managers } from "@arkecosystem/crypto";
 import nock from "nock";
 import { TransferCommand } from "../../../../../packages/core-tester-cli/src/commands/send/transfer";
 import { arkToSatoshi, captureTransactions, expectTransactions, toFlags } from "../../shared";
@@ -11,10 +13,10 @@ beforeEach(() => {
         .twice()
         .reply(200, { data: { constants: {} } });
 
-    nock("http://localhost:4000")
-        .get("/config")
+    nock("http://localhost:4003")
+        .get("/api/v2/node/configuration/crypto")
         .twice()
-        .reply(200, { data: { network: { name: "unitnet" } } });
+        .reply(200, { data: Managers.configManager.getPreset("unitnet") });
 
     jest.spyOn(httpie, "post");
 });

--- a/__tests__/integration/core-tester-cli/commands/send/vote.test.ts
+++ b/__tests__/integration/core-tester-cli/commands/send/vote.test.ts
@@ -1,5 +1,7 @@
-import { httpie } from "@arkecosystem/core-utils";
 import "jest-extended";
+
+import { httpie } from "@arkecosystem/core-utils";
+import { Managers } from "@arkecosystem/crypto";
 import nock from "nock";
 import { VoteCommand } from "../../../../../packages/core-tester-cli/src/commands/send/vote";
 import { arkToSatoshi, captureTransactions, expectTransactions, toFlags } from "../../shared";
@@ -11,10 +13,10 @@ beforeEach(() => {
         .thrice()
         .reply(200, { data: { constants: {} } });
 
-    nock("http://localhost:4000")
-        .get("/config")
+    nock("http://localhost:4003")
+        .get("/api/v2/node/configuration/crypto")
         .thrice()
-        .reply(200, { data: { network: { name: "unitnet" } } });
+        .reply(200, { data: Managers.configManager.getPreset("unitnet") });
 
     jest.spyOn(httpie, "get");
     jest.spyOn(httpie, "post");

--- a/packages/core-api/src/versions/2/node/controller.ts
+++ b/packages/core-api/src/versions/2/node/controller.ts
@@ -1,5 +1,6 @@
 import { app } from "@arkecosystem/core-container";
 import { Database } from "@arkecosystem/core-interfaces";
+import { Managers } from "@arkecosystem/crypto";
 import Boom from "@hapi/boom";
 import Hapi from "@hapi/hapi";
 import groupBy from "lodash.groupby";
@@ -63,6 +64,16 @@ export class NodeController extends Controller {
                         dynamicFees: dynamicFees.enabled ? dynamicFees : { enabled: false },
                     },
                 },
+            };
+        } catch (error) {
+            return Boom.badImplementation(error);
+        }
+    }
+
+    public async configurationCrypto() {
+        try {
+            return {
+                data: Managers.configManager.getPreset(this.config.get("network").name),
             };
         } catch (error) {
             return Boom.badImplementation(error);

--- a/packages/core-api/src/versions/2/node/routes.ts
+++ b/packages/core-api/src/versions/2/node/routes.ts
@@ -26,6 +26,12 @@ export const registerRoutes = (server: Hapi.Server): void => {
 
     server.route({
         method: "GET",
+        path: "/node/configuration/crypto",
+        handler: controller.configurationCrypto,
+    });
+
+    server.route({
+        method: "GET",
         path: "/node/fees",
         handler: controller.fees,
         options: {

--- a/packages/core-tester-cli/src/commands/command.ts
+++ b/packages/core-tester-cli/src/commands/command.ts
@@ -16,10 +16,6 @@ export abstract class BaseCommand extends Command {
             description: "API port",
             default: 4003,
         }),
-        portP2P: flags.integer({
-            description: "P2P port",
-            default: 4000,
-        }),
     };
 
     public static flagsSend = {
@@ -66,21 +62,20 @@ export abstract class BaseCommand extends Command {
     };
 
     protected api: HttpClient;
-    protected p2p: HttpClient;
     protected signer: Signer;
-    protected network: Record<string, any>;
     protected constants: Record<string, any>;
+
+    protected get network(): number {
+        return this.constants.pubKeyHash;
+    }
 
     protected async make(command): Promise<any> {
         const { args, flags } = this.parse(command);
 
         this.api = new HttpClient(`${flags.host}:${flags.portAPI}/api/v2/`);
-        this.p2p = new HttpClient(`${flags.host}:${flags.portP2P}/`);
 
-        await this.setupConstants();
-        await this.setupNetwork();
-
-        Managers.configManager.setFromPreset(this.network.name);
+        await this.setupConfiguration();
+        await this.setupConfigurationForCrypto();
 
         this.signer = new Signer(this.network);
 
@@ -92,7 +87,7 @@ export abstract class BaseCommand extends Command {
 
         Managers.configManager.setFromPreset(flags.network as Types.NetworkName);
 
-        this.signer = new Signer(Managers.configManager.all());
+        this.signer = new Signer(Managers.configManager.all().network.pubKeyHash);
 
         return { args, flags };
     }
@@ -106,7 +101,7 @@ export abstract class BaseCommand extends Command {
             let recipientId = transaction.recipientId;
 
             if (!recipientId) {
-                recipientId = Identities.Address.fromPublicKey(transaction.senderPublicKey, this.network.version);
+                recipientId = Identities.Address.fromPublicKey(transaction.senderPublicKey, this.network);
             }
 
             logger.info(
@@ -201,7 +196,7 @@ export abstract class BaseCommand extends Command {
         return Utils.formatSatoshi(satoshi);
     }
 
-    private async setupConstants() {
+    private async setupConfiguration() {
         try {
             const { data } = await this.api.get("node/configuration");
 
@@ -212,11 +207,11 @@ export abstract class BaseCommand extends Command {
         }
     }
 
-    private async setupNetwork() {
+    private async setupConfigurationForCrypto() {
         try {
-            const { data } = await this.p2p.get("config");
+            const { data: dataCrypto } = await this.api.get("node/configuration/crypto");
 
-            this.network = data.network;
+            Managers.configManager.setConfig(dataCrypto);
         } catch (error) {
             logger.error(error.message);
             process.exit(1);

--- a/packages/core-tester-cli/src/commands/send/delegate-registration.ts
+++ b/packages/core-tester-cli/src/commands/send/delegate-registration.ts
@@ -54,7 +54,7 @@ export class DelegateRegistrationCommand extends SendCommand {
 
     protected async expectBalances(transactions, wallets): Promise<void> {
         for (const transaction of transactions) {
-            const recipientId = Identities.Address.fromPublicKey(transaction.senderPublicKey, this.network.version);
+            const recipientId = Identities.Address.fromPublicKey(transaction.senderPublicKey, this.network);
 
             const currentBalance = await this.getWalletBalance(recipientId);
             wallets[recipientId].expectedBalance = currentBalance.minus(transaction.fee);
@@ -66,7 +66,7 @@ export class DelegateRegistrationCommand extends SendCommand {
             const wasCreated = await this.knockTransaction(transaction.id);
 
             if (wasCreated) {
-                const recipientId = Identities.Address.fromPublicKey(transaction.senderPublicKey, this.network.version);
+                const recipientId = Identities.Address.fromPublicKey(transaction.senderPublicKey, this.network);
 
                 await this.knockBalance(recipientId, wallets[recipientId].expectedBalance);
                 await this.knockUsername(recipientId, wallets[recipientId].username);

--- a/packages/core-tester-cli/src/commands/send/multi-signature-registration.ts
+++ b/packages/core-tester-cli/src/commands/send/multi-signature-registration.ts
@@ -66,7 +66,7 @@ export class MultiSignatureRegistrationCommand extends SendCommand {
 
     protected async expectBalances(transactions, wallets): Promise<void> {
         for (const transaction of transactions) {
-            const recipientId = Identities.Address.fromPublicKey(transaction.senderPublicKey, this.network.version);
+            const recipientId = Identities.Address.fromPublicKey(transaction.senderPublicKey, this.network);
 
             const currentBalance = await this.getWalletBalance(recipientId);
             wallets[recipientId].expectedBalance = currentBalance.minus(transaction.fee);
@@ -78,7 +78,7 @@ export class MultiSignatureRegistrationCommand extends SendCommand {
             const wasCreated = await this.knockTransaction(transaction.id);
 
             if (wasCreated) {
-                const recipientId = Identities.Address.fromPublicKey(transaction.senderPublicKey, this.network.version);
+                const recipientId = Identities.Address.fromPublicKey(transaction.senderPublicKey, this.network);
 
                 await this.knockBalance(recipientId, wallets[recipientId].expectedBalance);
                 await this.knockSignature(recipientId, wallets[recipientId].secondPublicKey);

--- a/packages/core-tester-cli/src/commands/send/second-signature-registration.ts
+++ b/packages/core-tester-cli/src/commands/send/second-signature-registration.ts
@@ -50,7 +50,7 @@ export class SecondSignatureRegistrationCommand extends SendCommand {
 
     protected async expectBalances(transactions, wallets): Promise<void> {
         for (const transaction of transactions) {
-            const recipientId = Identities.Address.fromPublicKey(transaction.senderPublicKey, this.network.version);
+            const recipientId = Identities.Address.fromPublicKey(transaction.senderPublicKey, this.network);
 
             const currentBalance = await this.getWalletBalance(recipientId);
             wallets[recipientId].expectedBalance = currentBalance.minus(transaction.fee);
@@ -62,7 +62,7 @@ export class SecondSignatureRegistrationCommand extends SendCommand {
             const wasCreated = await this.knockTransaction(transaction.id);
 
             if (wasCreated) {
-                const recipientId = Identities.Address.fromPublicKey(transaction.senderPublicKey, this.network.version);
+                const recipientId = Identities.Address.fromPublicKey(transaction.senderPublicKey, this.network);
 
                 await this.knockBalance(recipientId, wallets[recipientId].expectedBalance);
                 await this.knockSignature(recipientId, wallets[recipientId].secondPublicKey);

--- a/packages/core-tester-cli/src/commands/send/vote.ts
+++ b/packages/core-tester-cli/src/commands/send/vote.ts
@@ -53,7 +53,7 @@ export class VoteCommand extends SendCommand {
 
     protected async expectBalances(transactions, wallets): Promise<void> {
         for (const transaction of transactions) {
-            const recipientId = Identities.Address.fromPublicKey(transaction.senderPublicKey, this.network.version);
+            const recipientId = Identities.Address.fromPublicKey(transaction.senderPublicKey, this.network);
 
             const currentBalance = await this.getWalletBalance(recipientId);
             wallets[recipientId].expectedBalance = currentBalance.minus(transaction.fee);
@@ -65,7 +65,7 @@ export class VoteCommand extends SendCommand {
             const wasCreated = await this.knockTransaction(transaction.id);
 
             if (wasCreated) {
-                const recipientId = Identities.Address.fromPublicKey(transaction.senderPublicKey, this.network.version);
+                const recipientId = Identities.Address.fromPublicKey(transaction.senderPublicKey, this.network);
 
                 await this.knockBalance(recipientId, wallets[recipientId].expectedBalance);
                 await this.knockVote(recipientId, wallets[recipientId].vote);

--- a/packages/core-tester-cli/src/signer.ts
+++ b/packages/core-tester-cli/src/signer.ts
@@ -1,16 +1,16 @@
 import { Identities, Transactions, Utils } from "@arkecosystem/crypto";
 
 export class Signer {
-    protected network: Record<string, any>;
+    protected network: number;
 
-    public constructor(network) {
+    public constructor(network: number) {
         this.network = network;
     }
 
     public makeTransfer(opts: Record<string, any>): any {
         const transaction = Transactions.BuilderFactory.transfer()
             .fee(this.toSatoshi(opts.transferFee))
-            .network(this.network.version)
+            .network(this.network)
             .recipientId(opts.recipient)
             .amount(this.toSatoshi(opts.amount));
 
@@ -30,7 +30,7 @@ export class Signer {
     public makeDelegate(opts: Record<string, any>): any {
         const transaction = Transactions.BuilderFactory.delegateRegistration()
             .fee(this.toSatoshi(opts.delegateFee))
-            .network(this.network.version)
+            .network(this.network)
             .usernameAsset(opts.username)
             .sign(opts.passphrase);
 
@@ -44,7 +44,7 @@ export class Signer {
     public makeSecondSignature(opts: Record<string, any>): any {
         return Transactions.BuilderFactory.secondSignature()
             .fee(this.toSatoshi(opts.signatureFee))
-            .network(this.network.version)
+            .network(this.network)
             .signatureAsset(opts.secondPassphrase)
             .sign(opts.passphrase)
             .getStruct();
@@ -54,7 +54,7 @@ export class Signer {
         const transaction = Transactions.BuilderFactory.vote()
             .fee(this.toSatoshi(opts.voteFee))
             .votesAsset([`+${opts.delegate}`])
-            .network(this.network.version)
+            .network(this.network)
             .sign(opts.passphrase);
 
         if (opts.secondPassphrase) {
@@ -71,7 +71,7 @@ export class Signer {
                 publicKeys: opts.participants.split(","),
             })
             .senderPublicKey(Identities.PublicKey.fromPassphrase(opts.passphrase))
-            .network(this.network.version);
+            .network(this.network);
 
         opts.passphrases.split(",").forEach((passphrase, index) => {
             transaction.multiSign(passphrase, index);

--- a/packages/crypto/src/networks/unitnet/milestones.json
+++ b/packages/crypto/src/networks/unitnet/milestones.json
@@ -23,7 +23,8 @@
                 "delegateResignation": 0
             }
         },
-        "vendorFieldLength": 64
+        "vendorFieldLength": 64,
+        "aip11": true
     },
     {
         "height": 75600,


### PR DESCRIPTION
<!-- Please don't delete this template and read our contribution guidelines at https://docs.ark.io/guidebook/contribution-guidelines/contributing.html -->

## Summary

`core-tester-cli` previously was using the P2P API for auto-configuration of the crypto package but the endpoint it was using is gone with the migration to WebSockets.

This PR introduces a new endpoint at `:4003/api/v2/node/configuration/crypto` which returns the full crypto configuration for the network the node is running on which we then use to configure the CLI.

## What kind of change does this PR introduce?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [x] Bugfix
- [ ] New feature
- [ ] Refactoring / Performance Improvements
- [ ] Build-related changes
- [ ] Documentation
- [ ] Tests / Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [x] Yes
- [ ] No

## Does this PR release a new version?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [ ] Yes
  - [ ] All tests are passing
  - [ ] All benchmarks are passing without any _major_ regressions
  - [ ] Sync from 0 works on mainnet
  - [ ] Sync from 0 works on devnet
  - [ ] Starting a new network and forging on it work
  - [ ] Explorer is fully functional
  - [ ] Wallets are fully functional
- [x] No

## Checklist

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation _(if appropriate)_

<!--
## Other information

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
-->
