### PR TITLE
fix(core-snapshots): transform numerical values to BigNumber before serializing

### DIFF
--- a/packages/core-snapshots/src/transport/codec.ts
+++ b/packages/core-snapshots/src/transport/codec.ts
@@ -1,8 +1,12 @@
-import { Blocks, Transactions } from "@arkecosystem/crypto";
+import { Blocks, Transactions, Utils } from "@arkecosystem/crypto";
 import { createCodec, decode, encode } from "msgpack-lite";
 import { camelizeKeys, decamelizeKeys } from "xcase";
 
 const encodeBlock = block => {
+    block.total_amount = Utils.BigNumber.make(block.total_amount);
+    block.total_fee = Utils.BigNumber.make(block.total_fee);
+    block.reward = Utils.BigNumber.make(block.reward);
+
     return Blocks.Block.serialize(camelizeKeys(block), true);
 };
 

--- a/packages/core/src/helpers/snapshot.ts
+++ b/packages/core/src/helpers/snapshot.ts
@@ -9,6 +9,7 @@ export const setUpLite = async (options): Promise<Container.IContainer> => {
         include: [
             "@arkecosystem/core-event-emitter",
             "@arkecosystem/core-logger-pino",
+            "@arkecosystem/core-state",
             "@arkecosystem/core-database-postgres",
             "@arkecosystem/core-snapshots",
         ],


### PR DESCRIPTION
<!-- Please don't delete this template and read our contribution guidelines at https://docs.ark.io/guidebook/contribution-guidelines/contributing.html -->

## Summary

Make sure the numerical values of blocks are instances of `Utils.BigNumber` before serializing them.

## What kind of change does this PR introduce?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [x] Bugfix
- [ ] New feature
- [ ] Refactoring / Performance Improvements
- [ ] Build-related changes
- [ ] Documentation
- [ ] Tests / Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [ ] Yes
- [x] No

## Does this PR release a new version?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [ ] Yes
  - [ ] All tests are passing
  - [ ] All benchmarks are passing without any _major_ regressions
  - [ ] Sync from 0 works on mainnet
  - [ ] Sync from 0 works on devnet
  - [ ] Starting a new network and forging on it work
  - [ ] Explorer is fully functional
  - [ ] Wallets are fully functional
- [x] No

## Checklist

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation _(if appropriate)_

<!--
## Other information

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
-->
