### PR TITLE
chore(benchmark): fix imports for hash algos

### DIFF
--- a/benchmark/crypto/hash-algorithms.js
+++ b/benchmark/crypto/hash-algorithms.js
@@ -1,16 +1,16 @@
 const {
-    HashAlgorithms,
+    Crypto,
     Transactions
 } = require('@arkecosystem/crypto')
-
 const createHash = require("create-hash");
+
 const nodeSha256 = (bytes) => createHash("sha256").update(bytes).digest()
 
 const data = require('../helpers').getJSONFixture('transaction/deserialized/0');
 const transactionBytes = Transactions.Utils.toBytes(data);
 
 exports['bcrypto.sha256'] = () => {
-    HashAlgorithms.sha256(transactionBytes);
+    Crypto.HashAlgorithms.sha256(transactionBytes);
 };
 
 exports['node.sha256'] = () => {
@@ -18,7 +18,7 @@ exports['node.sha256'] = () => {
 };
 
 exports['bcrypto.sha1'] = () => {
-    HashAlgorithms.sha1(transactionBytes);
+    Crypto.HashAlgorithms.sha1(transactionBytes);
 };
 
 exports['node.sha1'] = () => {
@@ -26,7 +26,7 @@ exports['node.sha1'] = () => {
 };
 
 exports['bcrypto.ripemd160'] = () => {
-    HashAlgorithms.ripemd160(transactionBytes);
+    Crypto.HashAlgorithms.ripemd160(transactionBytes);
 };
 
 exports['node.ripemd160'] = () => {
@@ -34,7 +34,7 @@ exports['node.ripemd160'] = () => {
 };
 
 exports['bcrypto.hash160'] = () => {
-    HashAlgorithms.hash160(transactionBytes);
+    Crypto.HashAlgorithms.hash160(transactionBytes);
 };
 
 exports['node.hash160'] = () => {
@@ -42,7 +42,7 @@ exports['node.hash160'] = () => {
 };
 
 exports['bcrypto.hash256'] = () => {
-    HashAlgorithms.hash256(transactionBytes);
+    Crypto.HashAlgorithms.hash256(transactionBytes);
 };
 
 exports['node.hash256'] = () => {

--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -27,7 +27,6 @@ benchmarker('core', [{
         name: 'Block.deserialize (150 transactions)',
         scenarios: require('./block/deserialize/150')
     },
-
     {
         name: 'new Transaction (Type 0)',
         scenarios: require('./transaction/create/0')


### PR DESCRIPTION
<!-- Please don't delete this template and read our contribution guidelines at https://docs.ark.io/guidebook/contribution-guidelines/contributing.html -->

## Summary

Fix the benchmark imports for hash algos so we get results again.

## What kind of change does this PR introduce?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [x] Bugfix
- [ ] New feature
- [ ] Refactoring / Performance Improvements
- [ ] Build-related changes
- [ ] Documentation
- [ ] Tests / Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [ ] Yes
- [x] No

## Does this PR release a new version?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [ ] Yes
  - [ ] All tests are passing
  - [ ] All benchmarks are passing without any _major_ regressions
  - [ ] Sync from 0 works on mainnet
  - [ ] Sync from 0 works on devnet
  - [ ] Starting a new network and forging on it work
  - [ ] Explorer is fully functional
  - [ ] Wallets are fully functional
- [x] No

## Checklist

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation _(if appropriate)_

<!--
## Other information

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
-->
