### PR TITLE
feat(core): require the user to choose a snapshot if the blocks flag is missing

### DIFF
--- a/packages/core/src/commands/snapshot/restore.ts
+++ b/packages/core/src/commands/snapshot/restore.ts
@@ -3,7 +3,7 @@ import { EventEmitter } from "@arkecosystem/core-interfaces";
 import { SnapshotManager } from "@arkecosystem/core-snapshots";
 import { flags } from "@oclif/command";
 import cliProgress from "cli-progress";
-import { setUpLite } from "../../helpers/snapshot";
+import { chooseSnapshot, setUpLite } from "../../helpers/snapshot";
 import { CommandFlags } from "../../types";
 import { BaseCommand } from "../command";
 
@@ -14,7 +14,6 @@ export class RestoreCommand extends BaseCommand {
         ...BaseCommand.flagsSnapshot,
         blocks: flags.string({
             description: "blocks to import, corelates to folder name",
-            required: true,
         }),
         truncate: flags.boolean({
             description: "empty all tables before running import",
@@ -34,6 +33,14 @@ export class RestoreCommand extends BaseCommand {
 
         if (!app.has("snapshots")) {
             this.error("The @arkecosystem/core-snapshots plugin is not installed.");
+        }
+
+        if (!flags.blocks) {
+            try {
+                await chooseSnapshot(flags, "What snapshot do you want to restore?");
+            } catch (error) {
+                this.error(error.message);
+            }
         }
 
         const emitter = app.resolvePlugin<EventEmitter.EventEmitter>("event-emitter");

--- a/packages/core/src/commands/snapshot/verify.ts
+++ b/packages/core/src/commands/snapshot/verify.ts
@@ -1,7 +1,7 @@
 import { app } from "@arkecosystem/core-container";
 import { SnapshotManager } from "@arkecosystem/core-snapshots";
 import { flags } from "@oclif/command";
-import { setUpLite } from "../../helpers/snapshot";
+import { chooseSnapshot, setUpLite } from "../../helpers/snapshot";
 import { CommandFlags } from "../../types";
 import { BaseCommand } from "../command";
 
@@ -12,7 +12,6 @@ export class VerifyCommand extends BaseCommand {
         ...BaseCommand.flagsSnapshot,
         blocks: flags.string({
             description: "blocks to verify, corelates to folder name",
-            required: true,
         }),
         verifySignatures: flags.boolean({
             description: "signature verification",
@@ -26,6 +25,14 @@ export class VerifyCommand extends BaseCommand {
 
         if (!app.has("snapshots")) {
             this.error("The @arkecosystem/core-snapshots plugin is not installed.");
+        }
+
+        if (!flags.blocks) {
+            try {
+                await chooseSnapshot(flags, "What snapshot do you want to verify?");
+            } catch (error) {
+                this.error(error.message);
+            }
         }
 
         await app.resolvePlugin<SnapshotManager>("snapshots").verify(flags);

--- a/packages/core/src/helpers/snapshot.ts
+++ b/packages/core/src/helpers/snapshot.ts
@@ -1,5 +1,8 @@
 import { app } from "@arkecosystem/core-container";
 import { Container } from "@arkecosystem/core-interfaces";
+import { lstatSync, readdirSync } from "fs";
+import prompts from "prompts";
+import { CommandFlags } from "../types";
 
 // tslint:disable-next-line:no-var-requires
 const { version } = require("../../package.json");
@@ -16,4 +19,41 @@ export const setUpLite = async (options): Promise<Container.IContainer> => {
     });
 
     return app;
+};
+
+export const chooseSnapshot = async (flags: CommandFlags, message: string) => {
+    const source: string = `${process.env.CORE_PATH_DATA}/snapshots`;
+
+    const snapshots: string[] = readdirSync(source).filter((name: string) =>
+        lstatSync(`${source}/${name}`).isDirectory(),
+    );
+
+    if (!snapshots) {
+        throw new Error("Failed to find any snapshots.");
+    }
+
+    if (snapshots.length === 1) {
+        flags.blocks = snapshots[0];
+        return;
+    }
+
+    const response = await prompts([
+        {
+            type: "select",
+            name: "blocks",
+            message,
+            choices: snapshots.map((name: string) => ({ title: name, value: name })),
+        },
+        {
+            type: "confirm",
+            name: "confirm",
+            message: "Can you confirm?",
+        },
+    ]);
+
+    if (!response.blocks) {
+        throw new Error("Please select a snapshot and try again.");
+    }
+
+    flags.blocks = response.blocks;
 };


### PR DESCRIPTION
<!-- Please don't delete this template and read our contribution guidelines at https://docs.ark.io/guidebook/contribution-guidelines/contributing.html -->

## Summary

Make the `--blocks` optional to make @adrian69 life easier with snapshots :trollface:

1. If `--blocks` is available it will use that value
2. If the `--blocks` flag is missing and only 1 snapshot exists it will use that for restore and verify
3. If the `--blocks` flag is missing and multiple snapshots exist it will prompt the user to select one

## What kind of change does this PR introduce?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [ ] Bugfix
- [x] New feature
- [ ] Refactoring / Performance Improvements
- [ ] Build-related changes
- [ ] Documentation
- [ ] Tests / Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [ ] Yes
- [x] No

## Does this PR release a new version?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [ ] Yes
  - [ ] All tests are passing
  - [ ] All benchmarks are passing without any _major_ regressions
  - [ ] Sync from 0 works on mainnet
  - [ ] Sync from 0 works on devnet
  - [ ] Starting a new network and forging on it work
  - [ ] Explorer is fully functional
  - [ ] Wallets are fully functional
- [x] No

## Checklist

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation _(if appropriate)_

<!--
## Other information

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
-->
