### PR TITLE
chore(lint): enable ban rule for tslint

### DIFF
--- a/__tests__/e2e/lib/test-runner.js
+++ b/__tests__/e2e/lib/test-runner.js
@@ -178,7 +178,7 @@ class TestRunner {
 
         const blockHeight = await testUtils.getHeight();
         const lastBlockHeight = blocksDone.length ? blocksDone[blocksDone.length - 1].height : blockHeight;
-        blocksDone.push({ height: blockHeight, timestamp: Date.now()});
+        blocksDone.push({ height: blockHeight, timestamp: Date.now() });
 
         if (blockHeight > lastBlockHeight) {
             // new block !
@@ -213,8 +213,10 @@ class TestRunner {
 
         await delay(2000);
 
-        if (blocksDone.length
-            && Date.now() - blocksDone.filter(b => b.height === blockHeight)[0].timestamp > 1000 * 60 * 2) {
+        if (
+            blocksDone.length &&
+            Date.now() - blocksDone.filter(b => b.height === blockHeight)[0].timestamp > 1000 * 60 * 2
+        ) {
             return false; // we stop test execution because now new blocks came in the last 2min
         }
         return this.executeTests(blocksDone);

--- a/packages/core-api/src/versions/2/transactions/controller.ts
+++ b/packages/core-api/src/versions/2/transactions/controller.ts
@@ -109,6 +109,8 @@ export class TransactionsController extends Controller {
             // Remove reverse mapping from TransactionTypes enum.
             const { TransactionTypes } = Enums;
             const data = Object.assign({}, TransactionTypes);
+
+            // tslint:disable-next-line: ban
             Object.values(TransactionTypes)
                 .filter(value => typeof value === "string")
                 .map((type: string) => data[type])

--- a/packages/core-blockchain/src/blockchain.ts
+++ b/packages/core-blockchain/src/blockchain.ts
@@ -121,7 +121,7 @@ export class Blockchain implements blockchain.IBlockchain {
 
         this.state.blockchain = nextState;
 
-        nextState.actions.forEach(actionKey => {
+        for (const actionKey of nextState.actions) {
             const action = this.actions[actionKey];
 
             if (action) {
@@ -129,7 +129,7 @@ export class Blockchain implements blockchain.IBlockchain {
             } else {
                 logger.error(`No action '${actionKey}' found`);
             }
-        });
+        }
 
         return nextState;
     }

--- a/packages/core-blockchain/src/processor/block-processor.ts
+++ b/packages/core-blockchain/src/processor/block-processor.ts
@@ -65,10 +65,10 @@ export class BlockProcessor {
     private verifyBlock(block: Interfaces.IBlock): boolean {
         // TODO: refactor block verification
         if (block.verification.containsMultiSignatures) {
-            block.transactions.forEach(transaction => {
+            for (const transaction of block.transactions) {
                 const handler: Handlers.TransactionHandler = Handlers.Registry.get(transaction.type);
                 handler.verify(transaction, this.blockchain.database.walletManager);
-            });
+            }
 
             block.verification = block.verify();
         }

--- a/packages/core-container/src/config/file-loader.ts
+++ b/packages/core-container/src/config/file-loader.ts
@@ -94,11 +94,11 @@ export class FileLoader {
                 configFile.list = [];
             }
 
-            fetchedList.forEach(peer => {
+            for (const peer of fetchedList) {
                 if (!configFile.list.some(seed => seed.ip === peer.ip && seed.port === peer.port)) {
                     configFile.list.push(peer);
                 }
-            });
+            }
 
             const path = `${resolve(process.env.CORE_PATH_CONFIG)}/peers.json`;
             writeFileSync(path, JSON.stringify(configFile, undefined, 2));

--- a/packages/core-container/src/container.ts
+++ b/packages/core-container/src/container.ts
@@ -182,6 +182,8 @@ export class Container implements container.IContainer {
         };
 
         // Handle exit events
-        exitEvents.forEach(eventType => process.on(eventType as any, handleExit));
+        for (const eventType of exitEvents) {
+            process.on(eventType as any, handleExit);
+        }
     }
 }

--- a/packages/core-container/src/registrars/plugin.ts
+++ b/packages/core-container/src/registrars/plugin.ts
@@ -138,12 +138,12 @@ export class PluginRegistrar {
         const blacklist: any = [];
         const regex = new RegExp(/^\d+$/);
 
-        Object.keys(options).forEach(key => {
+        for (const key of Object.keys(options)) {
             const value = options[key];
             if (isString(value) && !blacklist.includes(key) && regex.test(value)) {
                 options[key] = +value;
             }
-        });
+        }
 
         return options;
     }

--- a/packages/core-database-postgres/src/integrity-verifier.ts
+++ b/packages/core-database-postgres/src/integrity-verifier.ts
@@ -129,20 +129,20 @@ export class IntegrityVerifier {
         // Register...
         const transactions = await this.query.manyOrNone(queries.integrityVerifier.delegates);
 
-        transactions.forEach(transaction => {
+        for (const transaction of transactions) {
             const wallet = this.walletManager.findByPublicKey(transaction.senderPublicKey);
             wallet.username = transaction.asset.delegate.username;
             this.walletManager.reindex(wallet);
-        });
+        }
 
         // Forged Blocks...
         const forgedBlocks = await this.query.manyOrNone(queries.integrityVerifier.delegatesForgedBlocks);
-        forgedBlocks.forEach(block => {
+        for (const block of forgedBlocks) {
             const wallet = this.walletManager.findByPublicKey(block.generatorPublicKey);
             wallet.forgedFees = wallet.forgedFees.plus(block.totalFees);
             wallet.forgedRewards = wallet.forgedRewards.plus(block.totalRewards);
             wallet.producedBlocks = +block.totalProduced;
-        });
+        }
 
         this.walletManager.buildDelegateRanking(this.walletManager.allByUsername());
     }

--- a/packages/core-database-postgres/src/models/model.ts
+++ b/packages/core-database-postgres/src/models/model.ts
@@ -15,13 +15,15 @@ export abstract class Model implements Database.IModel {
         if (!this.columnSet) {
             this.columnSet = this.createColumnSet(
                 this.columnsDescriptor.map(col => {
-                    const colDef: IColumnDescriptor = { name: col.name };
+                    const colDef: IColumnDescriptor = {
+                        name: col.name,
+                    };
 
-                    ["prop", "init", "def"].forEach(prop => {
+                    for (const prop of ["prop", "init", "def"]) {
                         if (col.hasOwnProperty(prop)) {
                             colDef[prop] = col[prop];
                         }
-                    });
+                    }
 
                     return colDef;
                 }),

--- a/packages/core-database-postgres/src/repositories/repository.ts
+++ b/packages/core-database-postgres/src/repositories/repository.ts
@@ -53,7 +53,9 @@ export abstract class Repository implements Database.IRepository {
         orderBy?: Database.ISearchOrderBy[],
     ): Promise<{ rows: T; count: number }> {
         if (!!orderBy) {
-            orderBy.forEach(o => selectQuery.order(this.query[o.field][o.direction]));
+            for (const o of orderBy) {
+                selectQuery.order(this.query[o.field][o.direction]);
+            }
         }
 
         if (!paginate || (!paginate.limit && !paginate.offset)) {

--- a/packages/core-database-postgres/src/repositories/transactions.ts
+++ b/packages/core-database-postgres/src/repositories/transactions.ts
@@ -129,7 +129,7 @@ export class TransactionsRepository extends Repository implements Database.ITran
                 }
             }
 
-            customOps.forEach(o => {
+            for (const o of customOps) {
                 if (o.field === "ownerWallet") {
                     const wallet: State.IWallet = o.value;
 
@@ -145,7 +145,7 @@ export class TransactionsRepository extends Repository implements Database.ITran
                             .or(this.query.recipient_id.equals(wallet.address));
                     }
                 }
-            });
+            }
         }
         return this.findManyWithCount(selectQuery, parameters.paginate, parameters.orderBy);
     }

--- a/packages/core-database/src/database-service.ts
+++ b/packages/core-database/src/database-service.ts
@@ -77,7 +77,9 @@ export class DatabaseService implements Database.IDatabaseService {
 
         await this.applyRound(block.data.height);
 
-        block.transactions.forEach((transaction: Interfaces.ITransaction) => this.emitTransactionEvents(transaction));
+        for (const transaction of block.transactions) {
+            this.emitTransactionEvents(transaction);
+        }
 
         this.emitter.emit("block.applied", block.data);
     }
@@ -649,13 +651,13 @@ export class DatabaseService implements Database.IDatabaseService {
                 const wallet = await this.connection.walletsRepository.findByAddress(coldWallet.address);
 
                 if (wallet) {
-                    Object.keys(wallet).forEach(key => {
+                    for (const key of Object.keys(wallet)) {
                         if (["balance"].indexOf(key) !== -1) {
                             return;
                         }
 
                         coldWallet[key] = key !== "voteBalance" ? wallet[key] : Utils.BigNumber.make(wallet[key]);
-                    });
+                    }
                 }
             } catch (err) {
                 this.logger.error(err);

--- a/packages/core-database/src/repositories/utils/search-parameter-converter.ts
+++ b/packages/core-database/src/repositories/utils/search-parameter-converter.ts
@@ -80,7 +80,7 @@ export class SearchParameterConverter implements Database.IISearchParameterConve
                     operator: Database.SearchOperator.OP_CUSTOM,
                     value: params[fieldName],
                 });
-                return;
+                continue;
             }
 
             if (fieldDescriptor.supportedOperators.includes(Database.SearchOperator.OP_LIKE)) {
@@ -89,7 +89,7 @@ export class SearchParameterConverter implements Database.IISearchParameterConve
                     operator: Database.SearchOperator.OP_LIKE,
                     value: `%${params[fieldName]}%`,
                 });
-                return;
+                continue;
             }
 
             // 'between'
@@ -104,7 +104,7 @@ export class SearchParameterConverter implements Database.IISearchParameterConve
                         operator: Database.SearchOperator.OP_EQ,
                         value: params[fieldName],
                     });
-                    return;
+                    continue;
                 } else {
                     if (params[fieldName].hasOwnProperty("from")) {
                         searchParameters.parameters.push({
@@ -120,7 +120,7 @@ export class SearchParameterConverter implements Database.IISearchParameterConve
                             value: params[fieldName].to,
                         });
                     }
-                    return;
+                    continue;
                 }
             }
 
@@ -134,7 +134,7 @@ export class SearchParameterConverter implements Database.IISearchParameterConve
                     operator: Database.SearchOperator.OP_IN,
                     value: params[fieldName],
                 });
-                return;
+                continue;
             }
 
             // if the field supports EQ, then ignore any others.
@@ -144,7 +144,7 @@ export class SearchParameterConverter implements Database.IISearchParameterConve
                     operator: Database.SearchOperator.OP_EQ,
                     value: params[fieldName],
                 });
-                return;
+                continue;
             }
         }
     }

--- a/packages/core-database/src/repositories/utils/search-parameter-converter.ts
+++ b/packages/core-database/src/repositories/utils/search-parameter-converter.ts
@@ -64,87 +64,88 @@ export class SearchParameterConverter implements Database.IISearchParameterConve
             orderBy, limit and offset are parsed earlier.
             page, pagination are added automatically by hapi-pagination
          */
-        Object.keys(params)
-            .filter(value => !["orderBy", "limit", "offset", "page", "pagination"].includes(value))
-            .forEach(fieldName => {
-                const fieldDescriptor = mapByFieldName[fieldName] as Database.ISearchableField;
+        const fieldNames: string[] = Object.keys(params).filter(
+            value => !["orderBy", "limit", "offset", "page", "pagination"].includes(value),
+        );
+        for (const fieldName of fieldNames) {
+            const fieldDescriptor = mapByFieldName[fieldName] as Database.ISearchableField;
 
-                /* null op means that the business repo doesn't know how to categorize what to do w/ with this field so
+            /* null op means that the business repo doesn't know how to categorize what to do w/ with this field so
                 let the repo layer decide how it will handle querying this field
                 i.e Transactions repo, when parameters contains 'ownerId', some extra logic is done.
                  */
-                if (!fieldDescriptor) {
-                    searchParameters.parameters.push({
-                        field: fieldName,
-                        operator: Database.SearchOperator.OP_CUSTOM,
-                        value: params[fieldName],
-                    });
-                    return;
-                }
+            if (!fieldDescriptor) {
+                searchParameters.parameters.push({
+                    field: fieldName,
+                    operator: Database.SearchOperator.OP_CUSTOM,
+                    value: params[fieldName],
+                });
+                return;
+            }
 
-                if (fieldDescriptor.supportedOperators.includes(Database.SearchOperator.OP_LIKE)) {
-                    searchParameters.parameters.push({
-                        field: fieldName,
-                        operator: Database.SearchOperator.OP_LIKE,
-                        value: `%${params[fieldName]}%`,
-                    });
-                    return;
-                }
+            if (fieldDescriptor.supportedOperators.includes(Database.SearchOperator.OP_LIKE)) {
+                searchParameters.parameters.push({
+                    field: fieldName,
+                    operator: Database.SearchOperator.OP_LIKE,
+                    value: `%${params[fieldName]}%`,
+                });
+                return;
+            }
 
-                // 'between'
-                if (
-                    fieldDescriptor.supportedOperators.includes(Database.SearchOperator.OP_GTE) ||
-                    fieldDescriptor.supportedOperators.includes(Database.SearchOperator.OP_LTE)
-                ) {
-                    // check if we have 'to' & 'from', if not, default to OP_EQ
-                    if (!params[fieldName].hasOwnProperty("from") && !params[fieldName].hasOwnProperty("to")) {
-                        searchParameters.parameters.push({
-                            field: fieldName,
-                            operator: Database.SearchOperator.OP_EQ,
-                            value: params[fieldName],
-                        });
-                        return;
-                    } else {
-                        if (params[fieldName].hasOwnProperty("from")) {
-                            searchParameters.parameters.push({
-                                field: fieldName,
-                                operator: Database.SearchOperator.OP_GTE,
-                                value: params[fieldName].from,
-                            });
-                        }
-                        if (params[fieldName].hasOwnProperty("to")) {
-                            searchParameters.parameters.push({
-                                field: fieldName,
-                                operator: Database.SearchOperator.OP_LTE,
-                                value: params[fieldName].to,
-                            });
-                        }
-                        return;
-                    }
-                }
-
-                // If we support 'IN', then the value must be an array(of values)
-                if (
-                    fieldDescriptor.supportedOperators.includes(Database.SearchOperator.OP_IN) &&
-                    Array.isArray(params[fieldName])
-                ) {
-                    searchParameters.parameters.push({
-                        field: fieldName,
-                        operator: Database.SearchOperator.OP_IN,
-                        value: params[fieldName],
-                    });
-                    return;
-                }
-
-                // if the field supports EQ, then ignore any others.
-                if (fieldDescriptor.supportedOperators.includes(Database.SearchOperator.OP_EQ)) {
+            // 'between'
+            if (
+                fieldDescriptor.supportedOperators.includes(Database.SearchOperator.OP_GTE) ||
+                fieldDescriptor.supportedOperators.includes(Database.SearchOperator.OP_LTE)
+            ) {
+                // check if we have 'to' & 'from', if not, default to OP_EQ
+                if (!params[fieldName].hasOwnProperty("from") && !params[fieldName].hasOwnProperty("to")) {
                     searchParameters.parameters.push({
                         field: fieldName,
                         operator: Database.SearchOperator.OP_EQ,
                         value: params[fieldName],
                     });
                     return;
+                } else {
+                    if (params[fieldName].hasOwnProperty("from")) {
+                        searchParameters.parameters.push({
+                            field: fieldName,
+                            operator: Database.SearchOperator.OP_GTE,
+                            value: params[fieldName].from,
+                        });
+                    }
+                    if (params[fieldName].hasOwnProperty("to")) {
+                        searchParameters.parameters.push({
+                            field: fieldName,
+                            operator: Database.SearchOperator.OP_LTE,
+                            value: params[fieldName].to,
+                        });
+                    }
+                    return;
                 }
-            });
+            }
+
+            // If we support 'IN', then the value must be an array(of values)
+            if (
+                fieldDescriptor.supportedOperators.includes(Database.SearchOperator.OP_IN) &&
+                Array.isArray(params[fieldName])
+            ) {
+                searchParameters.parameters.push({
+                    field: fieldName,
+                    operator: Database.SearchOperator.OP_IN,
+                    value: params[fieldName],
+                });
+                return;
+            }
+
+            // if the field supports EQ, then ignore any others.
+            if (fieldDescriptor.supportedOperators.includes(Database.SearchOperator.OP_EQ)) {
+                searchParameters.parameters.push({
+                    field: fieldName,
+                    operator: Database.SearchOperator.OP_EQ,
+                    value: params[fieldName],
+                });
+                return;
+            }
+        }
     }
 }

--- a/packages/core-elasticsearch/src/indices/base.ts
+++ b/packages/core-elasticsearch/src/indices/base.ts
@@ -54,11 +54,11 @@ export abstract class Index {
     protected bulkUpsert(rows) {
         const actions = [];
 
-        rows.forEach(item => {
+        for (const item of rows) {
             const { action, document } = this.getUpsertQuery(item);
             actions.push(action);
             actions.push(document);
-        });
+        }
 
         return client.bulk(actions);
     }

--- a/packages/core-elasticsearch/src/indices/wallets.ts
+++ b/packages/core-elasticsearch/src/indices/wallets.ts
@@ -20,9 +20,9 @@ export class Wallets extends Index {
                 this.logger.info(`[ES] Indexing ${rows.length} wallets`);
 
                 try {
-                    rows.forEach(row => {
+                    for (const row of rows) {
                         row.id = row.address;
-                    });
+                    }
 
                     await this.bulkUpsert(rows);
                 } catch (error) {

--- a/packages/core-forger/src/delegate.ts
+++ b/packages/core-forger/src/delegate.ts
@@ -89,11 +89,11 @@ export class Delegate {
 
             const payloadBuffers: Buffer[] = [];
             const sortedTransactions = Utils.sortTransactions(transactions);
-            sortedTransactions.forEach(transaction => {
+            for (const transaction of sortedTransactions) {
                 transactionData.amount = transactionData.amount.plus(transaction.amount);
                 transactionData.fee = transactionData.fee.plus(transaction.fee);
                 payloadBuffers.push(Buffer.from(transaction.id, "hex"));
-            });
+            }
 
             if (this.bip38) {
                 this.decryptKeysWithOtp();

--- a/packages/core-forger/src/manager.ts
+++ b/packages/core-forger/src/manager.ts
@@ -162,7 +162,9 @@ export class ForgerManager {
 
         this.client.emitEvent("block.forged", block.data);
 
-        transactions.forEach(transaction => this.client.emitEvent("transaction.forged", transaction));
+        for (const transaction of transactions) {
+            this.client.emitEvent("transaction.forged", transaction);
+        }
     }
 
     public async getTransactionsForForging(): Promise<Interfaces.ITransactionData[]> {

--- a/packages/core-p2p/src/network-monitor.ts
+++ b/packages/core-p2p/src/network-monitor.ts
@@ -150,10 +150,10 @@ export class NetworkMonitor implements P2P.INetworkMonitor {
             }),
         );
 
-        Object.keys(peerErrors).forEach((key: any) => {
+        for (const key of Object.keys(peerErrors)) {
             const peerCount = peerErrors[key].length;
             this.logger.debug(`Removed ${peerCount} ${pluralize("peers", peerCount)} because of "${key}"`);
-        });
+        }
 
         if (this.initializing) {
             this.logger.info(`${max - unresponsivePeers} of ${max} peers on the network are responsive`);
@@ -460,11 +460,11 @@ export class NetworkMonitor implements P2P.INetworkMonitor {
 
         const peerCache: IPeerData[] = restorePeers();
         if (peerCache) {
-            peerCache.forEach(peerA => {
+            for (const peerA of peerCache) {
                 if (!peers.some(peerB => peerA.ip === peerB.ip && peerA.port === peerB.port)) {
                     peers.push(peerA);
                 }
-            });
+            }
         }
 
         return Promise.all(

--- a/packages/core-p2p/src/peer-communicator.ts
+++ b/packages/core-p2p/src/peer-communicator.ts
@@ -109,9 +109,9 @@ export class PeerCommunicator implements P2P.IPeerCommunicator {
     }
 
     private parseHeaders(peer: P2P.IPeer, response): void {
-        ["nethash", "os", "version"].forEach(key => {
+        for (const key of ["nethash", "os", "version"]) {
             peer[key] = response.headers[key] || peer[key];
-        });
+        }
 
         if (response.headers.height) {
             peer.state.height = +response.headers.height;

--- a/packages/core-p2p/src/peer-verifier.ts
+++ b/packages/core-p2p/src/peer-verifier.ts
@@ -215,7 +215,9 @@ export class PeerVerifier {
             }
 
             // Make sure getBlocksByHeight() returned a block for every height we asked.
-            heightsToProbe.forEach(h => assert.strictEqual(typeof probesIdByHeight[h], "string"));
+            for (const height of heightsToProbe) {
+                assert.strictEqual(typeof probesIdByHeight[height], "string");
+            }
 
             const ourBlocksPrint = ourBlocks.map(b => `{ height=${b.height}, id=${b.id} }`).join(", ");
             const rangePrint = `[${ourBlocks[0].height}, ${ourBlocks[ourBlocks.length - 1].height}]`;

--- a/packages/core-p2p/src/socket-server/versions/peer.ts
+++ b/packages/core-p2p/src/socket-server/versions/peer.ts
@@ -10,9 +10,9 @@ import { InvalidTransactionsError, UnchainedBlockError } from "../errors";
 export const acceptNewPeer = async ({ service, req }: { service: P2P.IPeerService; req }): Promise<void> => {
     const peer = { ip: req.data.ip };
 
-    ["nethash", "version", "port", "os"].forEach(key => {
+    for (const key of ["nethash", "version", "port", "os"]) {
         peer[key] = req.headers[key];
-    });
+    }
 
     await service.getProcessor().validateAndAcceptPeer(peer);
 };

--- a/packages/core-state/src/stores/state.ts
+++ b/packages/core-state/src/stores/state.ts
@@ -144,7 +144,9 @@ export class StateStore implements State.IStateStore {
     public getCommonBlocks(ids: string[]): Interfaces.IBlockData[] {
         const idsHash = {};
 
-        ids.forEach(id => (idsHash[id] = true));
+        for (const id of ids) {
+            idsHash[id] = true;
+        }
 
         return this.getLastBlocksData()
             .filter(block => idsHash[block.id])
@@ -167,7 +169,9 @@ export class StateStore implements State.IStateStore {
         });
 
         this.cachedTransactionIds = this.cachedTransactionIds.withMutations(cache => {
-            added.forEach(tx => cache.add(tx.id));
+            for (const tx of added) {
+                cache.add(tx.id);
+            }
         });
 
         // Cap the Set of last transaction ids to maxLastTransactionIds

--- a/packages/core-state/src/wallets/wallet-manager.ts
+++ b/packages/core-state/src/wallets/wallet-manager.ts
@@ -193,10 +193,10 @@ export class WalletManager implements State.IWalletManager {
         const appliedTransactions: Interfaces.ITransaction[] = [];
 
         try {
-            block.transactions.forEach(transaction => {
+            for (const transaction of block.transactions) {
                 this.applyTransaction(transaction);
                 appliedTransactions.push(transaction);
-            });
+            }
 
             const applied: boolean = delegate.applyBlock(block.data);
 
@@ -212,9 +212,9 @@ export class WalletManager implements State.IWalletManager {
             this.logger.error("Failed to apply all transactions in block - reverting previous transactions");
 
             // Revert the applied transactions from last to first
-            appliedTransactions
-                .reverse()
-                .forEach((transaction: Interfaces.ITransaction) => this.revertTransaction(transaction));
+            for (const transaction of appliedTransactions.reverse()) {
+                this.revertTransaction(transaction);
+            }
 
             // for (let i = appliedTransactions.length - 1; i >= 0; i--) {
             //     this.revertTransaction(appliedTransactions[i]);
@@ -256,9 +256,9 @@ export class WalletManager implements State.IWalletManager {
         } catch (error) {
             this.logger.error(error.stack);
 
-            revertedTransactions
-                .reverse()
-                .forEach((transaction: Interfaces.ITransaction) => this.applyTransaction(transaction));
+            for (const transaction of revertedTransactions.reverse()) {
+                this.applyTransaction(transaction);
+            }
 
             throw error;
         }

--- a/packages/core-tester-cli/src/signer.ts
+++ b/packages/core-tester-cli/src/signer.ts
@@ -73,9 +73,9 @@ export class Signer {
             .senderPublicKey(Identities.PublicKey.fromPassphrase(opts.passphrase))
             .network(this.network);
 
-        opts.passphrases.split(",").forEach((passphrase, index) => {
+        for (const [index, passphrase] of opts.passphrases.split(",").entries()) {
             transaction.multiSign(passphrase, index);
-        });
+        }
 
         transaction.sign(opts.passphrase);
 

--- a/packages/core-transaction-pool/src/storage.ts
+++ b/packages/core-transaction-pool/src/storage.ts
@@ -73,7 +73,8 @@ export class Storage {
             .all();
 
         const transactions: Interfaces.ITransaction[] = [];
-        rows.forEach(row => {
+
+        for (const row of rows) {
             try {
                 const transaction = Transactions.TransactionFactory.fromHex(row.serialized);
                 if (transaction.verified) {
@@ -82,7 +83,7 @@ export class Storage {
             } catch {
                 //
             }
-        });
+        }
 
         return transactions;
     }

--- a/packages/crypto/src/blocks/block.ts
+++ b/packages/crypto/src/blocks/block.ts
@@ -168,7 +168,10 @@ export class Block implements IBlock {
             const invalidTransactions: ITransaction[] = this.transactions.filter(tx => !tx.verified);
             if (invalidTransactions.length > 0) {
                 result.errors.push("One or more transactions are not verified:");
-                invalidTransactions.forEach(tx => result.errors.push(`=> ${tx.serialized.toString("hex")}`));
+
+                for (const invalidTransaction of invalidTransactions) {
+                    result.errors.push(`=> ${invalidTransaction.serialized.toString("hex")}`);
+                }
 
                 result.containsMultiSignatures = invalidTransactions.some(tx => !!tx.data.signatures);
             }
@@ -190,7 +193,7 @@ export class Block implements IBlock {
             let totalFee: BigNumber = BigNumber.ZERO;
 
             const payloadBuffers: Buffer[] = [];
-            this.transactions.forEach(transaction => {
+            for (const transaction of this.transactions) {
                 const bytes: Buffer = Buffer.from(transaction.data.id, "hex");
 
                 if (appliedTransactions[transaction.data.id]) {
@@ -204,7 +207,7 @@ export class Block implements IBlock {
                 size += bytes.length;
 
                 payloadBuffers.push(bytes);
-            });
+            }
 
             if (!totalAmount.isEqualTo(block.totalAmount)) {
                 result.errors.push("Invalid total amount");

--- a/packages/crypto/src/blocks/deserializer.ts
+++ b/packages/crypto/src/blocks/deserializer.ts
@@ -91,12 +91,12 @@ class Deserializer {
 
         const transactions: ITransaction[] = [];
         block.transactions = [];
-        transactionLengths.forEach(length => {
+        for (const length of transactionLengths) {
             const transactionBytes = buf.readBytes(length).toBuffer();
             const transaction = TransactionFactory.fromBytes(transactionBytes);
             transactions.push(transaction);
             block.transactions.push(transaction.data);
-        });
+        }
 
         return transactions;
     }

--- a/packages/crypto/src/crypto/bip38.ts
+++ b/packages/crypto/src/crypto/bip38.ts
@@ -117,7 +117,7 @@ const decryptECMult = (buffer: Buffer, passphrase: string): IDecryptResult => {
     const compressed = (flag & 0x20) !== 0;
     const hasLotSeq = (flag & 0x04) !== 0;
 
-    assert.equal(flag & 0x24, flag, "Invalid private key.");
+    assert.strictEqual(flag & 0x24, flag, "Invalid private key.");
 
     const addressHash = buffer.slice(2, 6);
     const ownerEntropy = buffer.slice(6, 14);

--- a/packages/crypto/src/crypto/hash-algorithms.ts
+++ b/packages/crypto/src/crypto/hash-algorithms.ts
@@ -15,9 +15,9 @@ export class HashAlgorithms {
 
             sha256.init();
 
-            buffer.forEach(element => {
+            for (const element of buffer) {
                 sha256 = sha256.update(element);
-            });
+            }
 
             return sha256.final();
         }

--- a/packages/crypto/src/identities/public-key.ts
+++ b/packages/crypto/src/identities/public-key.ts
@@ -19,11 +19,11 @@ export class PublicKey {
     public static fromMultiSignatureAsset(asset: IMultiSignatureAsset): string {
         const { min, publicKeys }: IMultiSignatureAsset = asset;
 
-        publicKeys.forEach(publicKey => {
+        for (const publicKey of publicKeys) {
             if (!/^[0-9A-Fa-f]{66}$/.test(publicKey)) {
                 throw new PublicKeyError(publicKey);
             }
-        });
+        }
 
         if (min < 1 || min > publicKeys.length) {
             throw new InvalidMultiSignatureAssetError();

--- a/packages/crypto/src/transactions/builders/transactions/transaction.ts
+++ b/packages/crypto/src/transactions/builders/transactions/transaction.ts
@@ -170,13 +170,15 @@ export abstract class TransactionBuilder<TBuilder extends TransactionBuilder<TBu
     protected abstract instance(): TBuilder;
 
     private getSigningObject(): ITransactionData {
-        const data: ITransactionData = { ...this.data };
+        const data: ITransactionData = {
+            ...this.data,
+        };
 
-        Object.keys(data).forEach(key => {
+        for (const key of Object.keys(data)) {
             if (["model", "network", "id"].includes(key)) {
                 delete data[key];
             }
-        });
+        }
 
         return data;
     }

--- a/packages/crypto/src/transactions/types/multi-payment.ts
+++ b/packages/crypto/src/transactions/types/multi-payment.ts
@@ -18,10 +18,11 @@ export class MultiPaymentTransaction extends Transaction {
         const buffer: ByteBuffer = new ByteBuffer(64, true);
 
         buffer.writeUint32(data.asset.payments.length);
-        data.asset.payments.forEach(p => {
+
+        for (const p of data.asset.payments) {
             buffer.writeUint64(+BigNumber.make(p.amount).toFixed());
             buffer.append(bs58check.decode(p.recipientId));
-        });
+        }
 
         return buffer;
     }

--- a/packages/crypto/src/validation/index.ts
+++ b/packages/crypto/src/validation/index.ts
@@ -16,13 +16,23 @@ export class Validator {
 
     private constructor(options: Record<string, any>) {
         const ajv = new Ajv({
-            ...{ $data: true, schemas, removeAdditional: true, extendRefs: true },
+            ...{
+                $data: true,
+                schemas,
+                removeAdditional: true,
+                extendRefs: true,
+            },
             ...options,
         });
         ajvKeywords(ajv);
 
-        keywords.forEach(addKeyword => addKeyword(ajv));
-        formats.forEach(addFormat => addFormat(ajv));
+        for (const addKeyword of keywords) {
+            addKeyword(ajv);
+        }
+
+        for (const addFormat of formats) {
+            addFormat(ajv);
+        }
 
         this.ajv = ajv;
     }

--- a/tslint.json
+++ b/tslint.json
@@ -1,6 +1,17 @@
 {
     "extends": ["tslint:recommended", "tslint-config-prettier"],
     "rules": {
+        "ban": [
+            true,
+            {
+                "name": ["assert", "equal"],
+                "message": "Use 'strictEqual' instead."
+            },
+            {
+                "name": ["*", "forEach"],
+                "message": "Use a regular for loop instead."
+            }
+        ],
         "no-console": false,
         "no-default-export": true,
         "no-null-keyword": true,


### PR DESCRIPTION
<!-- Please don't delete this template and read our contribution guidelines at https://docs.ark.io/guidebook/contribution-guidelines/contributing.html -->

## Summary

Enable the `ban` rule for tslint and ban the use of `.forEach` as it is slower than `for-of` loops.

https://palantir.github.io/tslint/rules/ban/

## What kind of change does this PR introduce?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [ ] Bugfix
- [ ] New feature
- [x] Refactoring / Performance Improvements
- [ ] Build-related changes
- [ ] Documentation
- [ ] Tests / Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [ ] Yes
- [x] No

## Does this PR release a new version?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [ ] Yes
  - [ ] All tests are passing
  - [ ] All benchmarks are passing without any _major_ regressions
  - [ ] Sync from 0 works on mainnet
  - [ ] Sync from 0 works on devnet
  - [ ] Starting a new network and forging on it work
  - [ ] Explorer is fully functional
  - [ ] Wallets are fully functional
- [x] No

## Checklist

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation _(if appropriate)_

<!--
## Other information

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
-->
