### PR TITLE
refactor(core-p2p): remove peer.os property

### DIFF
--- a/__tests__/integration/core-api/v1/handlers/peers.test.ts
+++ b/__tests__/integration/core-api/v1/handlers/peers.test.ts
@@ -37,7 +37,6 @@ describe("API 1.0 - Peers", () => {
         it("should fail using invalid parameters", async () => {
             const response = await utils.request("GET", "peers", {
                 state: "invalid",
-                os: "invalid",
                 shared: "invalid",
                 version: "invalid",
                 limit: "invalid",

--- a/__tests__/unit/core-p2p/peer.test.ts
+++ b/__tests__/unit/core-p2p/peer.test.ts
@@ -21,12 +21,10 @@ describe("Peer", () => {
     it("should set and get the headers", () => {
         stubPeer.setHeaders({
             nethash: "nethash",
-            os: "os",
             version: "version",
         });
 
         expect(stubPeer.nethash).toEqual("nethash");
-        expect(stubPeer.os).toEqual("os");
         expect(stubPeer.version).toEqual("version");
     });
 });

--- a/packages/core-api/src/versions/1/peers/controller.ts
+++ b/packages/core-api/src/versions/1/peers/controller.ts
@@ -17,11 +17,6 @@ export class PeersController extends Controller {
 
             let peers = allPeers.sort((a, b) => a.latency - b.latency);
             // @ts-ignore
-            peers = request.query.os
-                ? // @ts-ignore
-                  allPeers.filter(peer => peer.os === (request.query as any).os)
-                : peers;
-            // @ts-ignore
             peers = request.query.port
                 ? // @ts-ignore
                   allPeers.filter(peer => peer.port === (request.query as any).port)
@@ -38,7 +33,7 @@ export class PeersController extends Controller {
             if (request.query.orderBy) {
                 // @ts-ignore
                 const order = request.query.orderBy.split(":");
-                if (["port", "status", "os", "version"].includes(order[0])) {
+                if (["port", "status", "version"].includes(order[0])) {
                     peers =
                         order[1].toUpperCase() === "ASC"
                             ? peers.sort((a, b) => a[order[0]] - b[order[0]])

--- a/packages/core-api/src/versions/1/peers/schema.ts
+++ b/packages/core-api/src/versions/1/peers/schema.ts
@@ -10,10 +10,6 @@ export const getPeers: object = {
             type: "string",
             maxLength: 20,
         },
-        os: {
-            type: "string",
-            maxLength: 64,
-        },
         version: {
             type: "string",
             maxLength: 11,

--- a/packages/core-api/src/versions/1/peers/transformer.ts
+++ b/packages/core-api/src/versions/1/peers/transformer.ts
@@ -4,7 +4,6 @@ export const transformPeerLegacy = model => {
         port: model.port,
         version: model.version,
         height: model.height,
-        os: model.os,
         delay: model.latency,
     };
 };

--- a/packages/core-api/src/versions/2/peers/controller.ts
+++ b/packages/core-api/src/versions/2/peers/controller.ts
@@ -10,11 +10,6 @@ export class PeersController extends Controller {
 
             let result = allPeers.sort((a, b) => a.latency - b.latency);
             // @ts-ignore
-            result = request.query.os
-                ? // @ts-ignore
-                  result.filter(peer => peer.os === (request.query as any).os)
-                : result;
-            // @ts-ignore
             result = request.query.port
                 ? // @ts-ignore
                   result.filter(peer => peer.port === (request.query as any).port)
@@ -32,7 +27,7 @@ export class PeersController extends Controller {
                 // @ts-ignore
                 const order = request.query.orderBy.split(":");
 
-                if (["port", "status", "os"].includes(order[0])) {
+                if (["port", "status"].includes(order[0])) {
                     result =
                         order[1].toUpperCase() === "ASC"
                             ? result.sort((a, b) => a[order[0]] - b[order[0]])

--- a/packages/core-api/src/versions/2/peers/schema.ts
+++ b/packages/core-api/src/versions/2/peers/schema.ts
@@ -6,7 +6,6 @@ export const index: object = {
         ...pagination,
         ...{
             ip: Joi.string().ip(),
-            os: Joi.string(),
             status: Joi.string(),
             port: Joi.number().port(),
             version: Joi.string(),

--- a/packages/core-api/src/versions/2/peers/transformer.ts
+++ b/packages/core-api/src/versions/2/peers/transformer.ts
@@ -4,7 +4,6 @@ export const transformPeer = model => {
         port: +model.port,
         version: model.version,
         height: model.state ? model.state.height : model.height,
-        os: model.os,
         latency: model.latency,
     };
 };

--- a/packages/core-interfaces/src/core-p2p/peer.ts
+++ b/packages/core-interfaces/src/core-p2p/peer.ts
@@ -9,7 +9,6 @@ export interface IPeer {
 
     nethash: string;
     version: string;
-    os: string;
 
     latency: number;
     headers: Record<string, string | number>;
@@ -31,7 +30,6 @@ export interface IPeerBroadcast {
     port: number;
     nethash: string;
     version: string;
-    os: string;
     height: number;
     latency: number;
 }

--- a/packages/core-p2p/src/peer-communicator.ts
+++ b/packages/core-p2p/src/peer-communicator.ts
@@ -109,7 +109,7 @@ export class PeerCommunicator implements P2P.IPeerCommunicator {
     }
 
     private parseHeaders(peer: P2P.IPeer, response): void {
-        for (const key of ["nethash", "os", "version"]) {
+        for (const key of ["nethash", "version"]) {
             peer[key] = response.headers[key] || peer[key];
         }
 

--- a/packages/core-p2p/src/peer.ts
+++ b/packages/core-p2p/src/peer.ts
@@ -6,7 +6,6 @@ import { PeerVerificationResult } from "./peer-verifier";
 export class Peer implements P2P.IPeer {
     public nethash: string;
     public version: string;
-    public os: string;
     public latency: number;
     public headers: Record<string, string | number>;
     public lastPinged: Dato | undefined;
@@ -33,7 +32,7 @@ export class Peer implements P2P.IPeer {
     }
 
     public setHeaders(headers: Record<string, string>): void {
-        for (const key of ["nethash", "os", "version"]) {
+        for (const key of ["nethash", "version"]) {
             this[key] = headers[key] || this[key];
         }
     }
@@ -56,7 +55,6 @@ export class Peer implements P2P.IPeer {
             port: +this.port,
             nethash: this.nethash,
             version: this.version,
-            os: this.os,
             height: this.state.height,
             latency: this.latency,
         };

--- a/packages/core-p2p/src/socket-server/utils/get-headers.ts
+++ b/packages/core-p2p/src/socket-server/utils/get-headers.ts
@@ -6,7 +6,6 @@ export const getHeaders = () => {
         nethash: app.getConfig().get("network.nethash"),
         version: app.getVersion(),
         port: app.resolveOptions("p2p").port,
-        os: require("os").platform(),
         height: undefined,
     };
 

--- a/packages/core-p2p/src/socket-server/utils/validate-headers.ts
+++ b/packages/core-p2p/src/socket-server/utils/validate-headers.ts
@@ -17,10 +17,6 @@ export const validateHeaders = headers => {
                 minimum: 1,
                 maximum: 65535,
             },
-            os: {
-                type: "string",
-                maxLength: 64,
-            },
             nethash: {
                 type: "string",
                 maxLength: 64,

--- a/packages/core-p2p/src/socket-server/versions/peer.ts
+++ b/packages/core-p2p/src/socket-server/versions/peer.ts
@@ -10,7 +10,7 @@ import { InvalidTransactionsError, UnchainedBlockError } from "../errors";
 export const acceptNewPeer = async ({ service, req }: { service: P2P.IPeerService; req }): Promise<void> => {
     const peer = { ip: req.data.ip };
 
-    for (const key of ["nethash", "version", "port", "os"]) {
+    for (const key of ["nethash", "version", "port"]) {
         peer[key] = req.headers[key];
     }
 


### PR DESCRIPTION
<!-- Please don't delete this template and read our contribution guidelines at https://docs.ark.io/guidebook/contribution-guidelines/contributing.html -->

## Summary

Remove the `os` property from a peer as it isn't used for anything, was a leftover from `ark-node`.

## What kind of change does this PR introduce?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [ ] Bugfix
- [ ] New feature
- [x] Refactoring / Performance Improvements
- [ ] Build-related changes
- [ ] Documentation
- [ ] Tests / Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [ ] Yes
- [x] No

## Does this PR release a new version?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [ ] Yes
  - [ ] All tests are passing
  - [ ] All benchmarks are passing without any _major_ regressions
  - [ ] Sync from 0 works on mainnet
  - [ ] Sync from 0 works on devnet
  - [ ] Starting a new network and forging on it work
  - [ ] Explorer is fully functional
  - [ ] Wallets are fully functional
- [x] No

## Checklist

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation _(if appropriate)_

<!--
## Other information

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
-->
