### PR TITLE
refactor(core-p2p): remove peer.nethash property

### DIFF
--- a/__tests__/integration/core-p2p/__support__/mock-socket-server/manager.ts
+++ b/__tests__/integration/core-p2p/__support__/mock-socket-server/manager.ts
@@ -37,7 +37,6 @@ export class MockSocketManager {
                 headers: headers || {
                     version: "2.2.1",
                     port: 4000,
-                    nethash: "a63b5a3858afbca23edefac885be74d59f1a26985548a4082f4f479e74fcc348",
                     height: 1,
                     "Content-Type": "application/json",
                 },

--- a/__tests__/integration/core-p2p/__support__/utils.ts
+++ b/__tests__/integration/core-p2p/__support__/utils.ts
@@ -5,7 +5,6 @@ class Helpers {
     public headers: any;
     constructor() {
         this.headers = {
-            nethash: "d9acd04bde4234a81addb8482333b4ac906bed7be5a9970ce8ada428bd083192",
             port: 4000,
             version: "2.0.0",
         };

--- a/__tests__/integration/core-p2p/peer-communicator.test.ts
+++ b/__tests__/integration/core-p2p/peer-communicator.test.ts
@@ -30,7 +30,6 @@ beforeEach(() => {
     ({ communicator, storage } = createPeerService());
 
     stubPeer = createStubPeer({ ip: "127.0.0.1", port: 4009 });
-    stubPeer.nethash = "a63b5a3858afbca23edefac885be74d59f1a26985548a4082f4f479e74fcc348";
     storage.setPeer(stubPeer);
 });
 

--- a/__tests__/integration/core-p2p/socket-server/peer.test.ts
+++ b/__tests__/integration/core-p2p/socket-server/peer.test.ts
@@ -22,7 +22,6 @@ let emit;
 const headers = {
     version: "2.1.0",
     port: "4009",
-    nethash: "a63b5a3858afbca23edefac885be74d59f1a26985548a4082f4f479e74fcc348",
     height: 1,
     "Content-Type": "application/json",
 };

--- a/__tests__/unit/core-p2p/peer-guard.test.ts
+++ b/__tests__/unit/core-p2p/peer-guard.test.ts
@@ -21,7 +21,6 @@ beforeAll(async () => {
 beforeEach(async () => {
     peerMock = createStubPeer({ ip: "1.0.0.99", port: 4002 });
     Object.assign(peerMock, peerMock.headers);
-    peerMock.nethash = "a63b5a3858afbca23edefac885be74d59f1a26985548a4082f4f479e74fcc348";
 });
 
 describe("PeerGuard", () => {
@@ -57,7 +56,6 @@ describe("PeerGuard", () => {
 
         const dummy = createStubPeer({
             ip: "dummy-ip-addr",
-            nethash: "a63b5a3858afbca23edefac885be74d59f1a26985548a4082f4f479e74fcc348",
             version: "2.1.1",
             status: 200,
             state: {},

--- a/__tests__/unit/core-p2p/peer.test.ts
+++ b/__tests__/unit/core-p2p/peer.test.ts
@@ -20,12 +20,10 @@ describe("Peer", () => {
 
     it("should set and get the headers", () => {
         stubPeer.setHeaders({
-            nethash: "nethash",
             os: "os",
             version: "version",
         });
 
-        expect(stubPeer.nethash).toEqual("nethash");
         expect(stubPeer.os).toEqual("os");
         expect(stubPeer.version).toEqual("version");
     });

--- a/packages/core-forger/src/client.ts
+++ b/packages/core-forger/src/client.ts
@@ -14,11 +14,9 @@ export class Client {
     private headers: {
         version: string;
         port: number;
-        nethash: string;
         "Content-Type": "application/json";
     } = {
         version: app.getVersion(),
-        nethash: app.getConfig().get("network.nethash"),
         port: undefined,
         "Content-Type": "application/json",
     };

--- a/packages/core-interfaces/src/core-p2p/peer-guard.ts
+++ b/packages/core-interfaces/src/core-p2p/peer-guard.ts
@@ -6,7 +6,6 @@ export interface IPeerGuard {
     analyze(peer: IPeer): IPunishment;
     isWhitelisted(peer: IPeer): boolean;
     isValidVersion(peer: IPeer): boolean;
-    isValidNetwork(peer: IPeer): boolean;
     isValidPort(peer: IPeer): boolean;
 }
 

--- a/packages/core-interfaces/src/core-p2p/peer.ts
+++ b/packages/core-interfaces/src/core-p2p/peer.ts
@@ -7,7 +7,6 @@ export interface IPeer {
     ip: string;
     port: number;
 
-    nethash: string;
     version: string;
     os: string;
 
@@ -29,7 +28,6 @@ export interface IPeer {
 export interface IPeerBroadcast {
     ip: string;
     port: number;
-    nethash: string;
     version: string;
     os: string;
     height: number;

--- a/packages/core-p2p/src/peer-communicator.ts
+++ b/packages/core-p2p/src/peer-communicator.ts
@@ -109,7 +109,7 @@ export class PeerCommunicator implements P2P.IPeerCommunicator {
     }
 
     private parseHeaders(peer: P2P.IPeer, response): void {
-        for (const key of ["nethash", "os", "version"]) {
+        for (const key of ["os", "version"]) {
             peer[key] = response.headers[key] || peer[key];
         }
 

--- a/packages/core-p2p/src/peer-guard.ts
+++ b/packages/core-p2p/src/peer-guard.ts
@@ -86,10 +86,6 @@ export class PeerGuard implements P2P.IPeerGuard {
             return this.createPunishment(this.offences.highLatency);
         }
 
-        if (!this.isValidNetwork(peer)) {
-            return this.createPunishment(this.offences.invalidNetwork);
-        }
-
         if (!this.isValidVersion(peer)) {
             return this.createPunishment(this.offences.invalidVersion);
         }

--- a/packages/core-p2p/src/peer-guard.ts
+++ b/packages/core-p2p/src/peer-guard.ts
@@ -113,12 +113,6 @@ export class PeerGuard implements P2P.IPeerGuard {
             .minimumVersions.some((minimumVersion: string) => semver.satisfies(version, minimumVersion));
     }
 
-    public isValidNetwork(peer: P2P.IPeer): boolean {
-        const nethash = peer.nethash || (peer.headers && peer.headers.nethash);
-
-        return nethash === app.getConfig().get("network.nethash");
-    }
-
     public isValidPort(peer: P2P.IPeer): boolean {
         return peer.port === app.resolveOptions("p2p").port;
     }

--- a/packages/core-p2p/src/peer-processors.ts
+++ b/packages/core-p2p/src/peer-processors.ts
@@ -13,7 +13,6 @@ export class PeerProcessor implements P2P.IPeerProcessor {
     public server: any;
     public nextUpdateNetworkStatusScheduled: boolean;
 
-    private readonly appConfig = app.getConfig();
     private readonly logger: Logger.ILogger = app.resolvePlugin<Logger.ILogger>("logger");
     private readonly emitter: EventEmitter.EventEmitter = app.resolvePlugin<EventEmitter.EventEmitter>("event-emitter");
 

--- a/packages/core-p2p/src/peer-processors.ts
+++ b/packages/core-p2p/src/peer-processors.ts
@@ -69,16 +69,6 @@ export class PeerProcessor implements P2P.IPeerProcessor {
             return false;
         }
 
-        if (!this.guard.isValidNetwork(peer) && !options.seed) {
-            this.logger.debug(
-                `Rejected peer ${peer.ip} as it isn't on the same network. Expected: ${this.appConfig.get(
-                    "network.nethash",
-                )} - Received: ${peer.nethash}`,
-            );
-
-            return false;
-        }
-
         if (
             this.storage.getSameSubnetPeers(peer.ip).length >= app.resolveOptions("p2p").maxSameSubnetPeers &&
             !options.seed

--- a/packages/core-p2p/src/peer.ts
+++ b/packages/core-p2p/src/peer.ts
@@ -4,7 +4,6 @@ import { Dato, dato } from "@faustbrian/dato";
 import { PeerVerificationResult } from "./peer-verifier";
 
 export class Peer implements P2P.IPeer {
-    public nethash: string;
     public version: string;
     public os: string;
     public latency: number;
@@ -22,7 +21,6 @@ export class Peer implements P2P.IPeer {
         this.headers = {
             version: app.getVersion(),
             port,
-            nethash: app.getConfig().get("network.nethash"),
             height: undefined,
             "Content-Type": "application/json",
         };
@@ -33,7 +31,7 @@ export class Peer implements P2P.IPeer {
     }
 
     public setHeaders(headers: Record<string, string>): void {
-        for (const key of ["nethash", "os", "version"]) {
+        for (const key of ["os", "version"]) {
             this[key] = headers[key] || this[key];
         }
     }
@@ -54,7 +52,6 @@ export class Peer implements P2P.IPeer {
         return {
             ip: this.ip,
             port: +this.port,
-            nethash: this.nethash,
             version: this.version,
             os: this.os,
             height: this.state.height,

--- a/packages/core-p2p/src/socket-server/utils/get-headers.ts
+++ b/packages/core-p2p/src/socket-server/utils/get-headers.ts
@@ -3,7 +3,6 @@ import { Blockchain } from "@arkecosystem/core-interfaces";
 
 export const getHeaders = () => {
     const headers = {
-        nethash: app.getConfig().get("network.nethash"),
         version: app.getVersion(),
         port: app.resolveOptions("p2p").port,
         os: require("os").platform(),

--- a/packages/core-p2p/src/socket-server/utils/validate-headers.ts
+++ b/packages/core-p2p/src/socket-server/utils/validate-headers.ts
@@ -21,15 +21,11 @@ export const validateHeaders = headers => {
                 type: "string",
                 maxLength: 64,
             },
-            nethash: {
-                type: "string",
-                maxLength: 64,
-            },
             version: {
                 type: "string",
                 maxLength: 16,
             },
         },
-        required: ["version", "nethash", "port"],
+        required: ["version", "port"],
     });
 };

--- a/packages/core-p2p/src/socket-server/versions/peer.ts
+++ b/packages/core-p2p/src/socket-server/versions/peer.ts
@@ -10,7 +10,7 @@ import { InvalidTransactionsError, UnchainedBlockError } from "../errors";
 export const acceptNewPeer = async ({ service, req }: { service: P2P.IPeerService; req }): Promise<void> => {
     const peer = { ip: req.data.ip };
 
-    for (const key of ["nethash", "version", "port", "os"]) {
+    for (const key of ["version", "port", "os"]) {
         peer[key] = req.headers[key];
     }
 


### PR DESCRIPTION
<!-- Please don't delete this template and read our contribution guidelines at https://docs.ark.io/guidebook/contribution-guidelines/contributing.html -->

## Summary

Remove the `peer.nethash` property and instead let the peer verifier decide if a peer is on the same network as we are.

## What kind of change does this PR introduce?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [ ] Bugfix
- [ ] New feature
- [x] Refactoring / Performance Improvements
- [ ] Build-related changes
- [ ] Documentation
- [ ] Tests / Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [ ] Yes
- [x] No

## Does this PR release a new version?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [ ] Yes
  - [ ] All tests are passing
  - [ ] All benchmarks are passing without any _major_ regressions
  - [ ] Sync from 0 works on mainnet
  - [ ] Sync from 0 works on devnet
  - [ ] Starting a new network and forging on it work
  - [ ] Explorer is fully functional
  - [ ] Wallets are fully functional
- [x] No

## Checklist

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation _(if appropriate)_

<!--
## Other information

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
-->
