### PR TITLE
refactor(core-p2p): broadcast api ports

### DIFF
--- a/packages/core-api/src/versions/2/shared/transformers/ports.ts
+++ b/packages/core-api/src/versions/2/shared/transformers/ports.ts
@@ -9,7 +9,7 @@ export const transformPorts = (config: any) => {
 
     const plugins = config.get("plugins");
 
-    result[keys[0]] = +plugins[keys[0]].port;
+    result[keys[0]] = +plugins[keys[0]].server.port;
 
     for (const [name, options] of Object.entries(plugins)) {
         // @ts-ignore

--- a/packages/core-interfaces/src/core-p2p/peer.ts
+++ b/packages/core-interfaces/src/core-p2p/peer.ts
@@ -7,6 +7,7 @@ export interface IPeer {
     ip: string;
     port: number;
     apiPort?: number;
+    walletApiPort?: number;
 
     nethash: string;
     version: string;
@@ -31,6 +32,7 @@ export interface IPeerBroadcast {
     ip: string;
     port: number;
     apiPort?: number;
+    walletApiPort?: number;
     nethash: string;
     version: string;
     os: string;

--- a/packages/core-interfaces/src/core-p2p/peer.ts
+++ b/packages/core-interfaces/src/core-p2p/peer.ts
@@ -6,6 +6,7 @@ export interface IPeer {
 
     ip: string;
     port: number;
+    apiPort?: number;
 
     nethash: string;
     version: string;
@@ -29,6 +30,7 @@ export interface IPeer {
 export interface IPeerBroadcast {
     ip: string;
     port: number;
+    apiPort?: number;
     nethash: string;
     version: string;
     os: string;

--- a/packages/core-p2p/src/peer.ts
+++ b/packages/core-p2p/src/peer.ts
@@ -6,6 +6,7 @@ import { PeerVerificationResult } from "./peer-verifier";
 export class Peer implements P2P.IPeer {
     public nethash: string;
     public version: string;
+    public apiPort: number;
     public os: string;
     public latency: number;
     public headers: Record<string, string | number>;
@@ -33,7 +34,7 @@ export class Peer implements P2P.IPeer {
     }
 
     public setHeaders(headers: Record<string, string>): void {
-        for (const key of ["nethash", "os", "version"]) {
+        for (const key of ["nethash", "apiPort", "os", "version"]) {
             this[key] = headers[key] || this[key];
         }
     }
@@ -54,6 +55,7 @@ export class Peer implements P2P.IPeer {
         return {
             ip: this.ip,
             port: +this.port,
+            apiPort: this.apiPort,
             nethash: this.nethash,
             version: this.version,
             os: this.os,

--- a/packages/core-p2p/src/peer.ts
+++ b/packages/core-p2p/src/peer.ts
@@ -6,7 +6,9 @@ import { PeerVerificationResult } from "./peer-verifier";
 export class Peer implements P2P.IPeer {
     public nethash: string;
     public version: string;
-    public apiPort: number;
+    public apiPort?: number;
+    public walletApiPort?: number;
+
     public os: string;
     public latency: number;
     public headers: Record<string, string | number>;
@@ -55,7 +57,8 @@ export class Peer implements P2P.IPeer {
         return {
             ip: this.ip,
             port: +this.port,
-            apiPort: this.apiPort,
+            apiPort: +this.apiPort,
+            walletApiPort: +this.walletApiPort,
             nethash: this.nethash,
             version: this.version,
             os: this.os,

--- a/packages/core-p2p/src/socket-server/utils/get-headers.ts
+++ b/packages/core-p2p/src/socket-server/utils/get-headers.ts
@@ -2,16 +2,19 @@ import { app } from "@arkecosystem/core-container";
 import { Blockchain } from "@arkecosystem/core-interfaces";
 
 export const getHeaders = () => {
-    const resolveApiPort = (): number => {
-        const options = app.has("api") ? app.resolveOptions("api") : {};
-        return options.enabled ? options.port : undefined;
+    const resolvePorts = (): { port: number; apiPort?: number; walletApiPort?: number } => {
+        const port = app.resolveOptions("p2p").port;
+        const apiOptions = app.has("api") ? app.resolveOptions("api") : {};
+        const apiPort = apiOptions.enabled ? apiOptions.port : undefined;
+        const walletApiPort = app.has("wallet-api") ? app.resolveOptions("wallet-api").port : undefined;
+
+        return { port, apiPort, walletApiPort };
     };
 
     const headers = {
         nethash: app.getConfig().get("network.nethash"),
         version: app.getVersion(),
-        port: app.resolveOptions("p2p").port,
-        apiPort: resolveApiPort(),
+        ...resolvePorts(),
         os: require("os").platform(),
         height: undefined,
     };

--- a/packages/core-p2p/src/socket-server/utils/get-headers.ts
+++ b/packages/core-p2p/src/socket-server/utils/get-headers.ts
@@ -2,10 +2,16 @@ import { app } from "@arkecosystem/core-container";
 import { Blockchain } from "@arkecosystem/core-interfaces";
 
 export const getHeaders = () => {
+    const resolveApiPort = (): number => {
+        const options = app.has("api") ? app.resolveOptions("api") : {};
+        return options.enabled ? options.port : undefined;
+    };
+
     const headers = {
         nethash: app.getConfig().get("network.nethash"),
         version: app.getVersion(),
         port: app.resolveOptions("p2p").port,
+        apiPort: resolveApiPort(),
         os: require("os").platform(),
         height: undefined,
     };

--- a/packages/core-p2p/src/socket-server/utils/validate-headers.ts
+++ b/packages/core-p2p/src/socket-server/utils/validate-headers.ts
@@ -9,6 +9,10 @@ export const validateHeaders = headers => {
         headers.apiPort = +headers.apiPort;
     }
 
+    if (headers.walletApiPort) {
+        headers.walletApiPort = +headers.walletApiPort;
+    }
+
     return validateJSON(headers, {
         type: "object",
         properties: {
@@ -22,6 +26,11 @@ export const validateHeaders = headers => {
                 maximum: 65535,
             },
             apiPort: {
+                type: "integer",
+                minimum: 1,
+                maximum: 65535,
+            },
+            walletApiPort: {
                 type: "integer",
                 minimum: 1,
                 maximum: 65535,

--- a/packages/core-p2p/src/socket-server/utils/validate-headers.ts
+++ b/packages/core-p2p/src/socket-server/utils/validate-headers.ts
@@ -5,6 +5,10 @@ export const validateHeaders = headers => {
         headers.port = +headers.port;
     }
 
+    if (headers.apiPort) {
+        headers.apiPort = +headers.apiPort;
+    }
+
     return validateJSON(headers, {
         type: "object",
         properties: {
@@ -13,6 +17,11 @@ export const validateHeaders = headers => {
                 format: "ip",
             },
             port: {
+                type: "integer",
+                minimum: 1,
+                maximum: 65535,
+            },
+            apiPort: {
                 type: "integer",
                 minimum: 1,
                 maximum: 65535,

--- a/packages/core-wallet-api/src/defaults.ts
+++ b/packages/core-wallet-api/src/defaults.ts
@@ -1,0 +1,3 @@
+export const defaults = {
+    port: process.env.CORE_WALLET_API_PORT || 4040,
+};

--- a/packages/core-wallet-api/src/plugin.ts
+++ b/packages/core-wallet-api/src/plugin.ts
@@ -1,9 +1,11 @@
 import { Container, Logger } from "@arkecosystem/core-interfaces";
+import { defaults } from "./defaults";
 import { startServer } from "./server";
 
 export const plugin: Container.IPluginDescriptor = {
     pkg: require("../package.json"),
     alias: "wallet-api",
+    defaults,
     async register(container: Container.IContainer, options) {
         container.resolvePlugin<Logger.ILogger>("logger").info("Starting Wallet API");
 

--- a/packages/core-wallet-api/src/server/index.ts
+++ b/packages/core-wallet-api/src/server/index.ts
@@ -4,7 +4,7 @@ import * as handlers from "./handlers";
 export const startServer = async config => {
     const server = await createServer({
         host: "0.0.0.0",
-        port: 4040,
+        port: config.port,
     });
 
     await server.register({


### PR DESCRIPTION
<!-- Please don't delete this template and read our contribution guidelines at https://docs.ark.io/guidebook/contribution-guidelines/contributing.html -->

## Summary

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->
#2544  introduced the initial wallet api, which is not fully developed yet. To make things easier, peers will now broadcast the api ports, so consumers don't have to ask for it. This way it is not necessary to hardcode any ports. The wallet api port can now be changed with `CORE_WALLET_API_PORT` if necessary.

## What kind of change does this PR introduce?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [ ] Bugfix
- [ ] New feature
- [X] Refactoring / Performance Improvements
- [ ] Build-related changes
- [ ] Documentation
- [ ] Tests / Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [ ] Yes
- [ ] No

## Does this PR release a new version?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [ ] Yes
  - [ ] All tests are passing
  - [ ] All benchmarks are passing without any _major_ regressions
  - [ ] Sync from 0 works on mainnet
  - [ ] Sync from 0 works on devnet
  - [ ] Starting a new network and forging on it work
  - [ ] Explorer is fully functional
  - [ ] Wallets are fully functional
- [ ] No

## Checklist

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [ ] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation _(if appropriate)_

<!--
## Other information

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
-->
