### PR TITLE
refactor: replace pokemon.random with Math.random to avoid value collision

### DIFF
--- a/__tests__/helpers/transaction-factory.ts
+++ b/__tests__/helpers/transaction-factory.ts
@@ -1,5 +1,4 @@
 import { Identities, Interfaces, Managers, Transactions, Types, Utils } from "@arkecosystem/crypto";
-import pokemon from "pokemon";
 import { secrets } from "../utils/config/testnet/delegates.json";
 
 const defaultPassphrase: string = secrets[0];
@@ -248,10 +247,9 @@ export class TransactionFactory {
     }
 
     private getRandomUsername(): string {
-        return pokemon
-            .random()
-            .toLowerCase()
-            .replace(/[^a-z0-9]/g, "_")
-            .substring(0, 20);
+        return Math.random()
+            .toString(36)
+            .substring(20)
+            .toLowerCase();
     }
 }

--- a/__tests__/helpers/transaction-factory.ts
+++ b/__tests__/helpers/transaction-factory.ts
@@ -249,7 +249,6 @@ export class TransactionFactory {
     private getRandomUsername(): string {
         return Math.random()
             .toString(36)
-            .substring(20)
             .toLowerCase();
     }
 }

--- a/__tests__/integration/core-tester-cli/commands/send/delegate-registration.test.ts
+++ b/__tests__/integration/core-tester-cli/commands/send/delegate-registration.test.ts
@@ -3,7 +3,6 @@ import "jest-extended";
 import { httpie } from "@arkecosystem/core-utils";
 import { Managers } from "@arkecosystem/crypto";
 import nock from "nock";
-import pokemon from "pokemon";
 import { DelegateRegistrationCommand } from "../../../../../packages/core-tester-cli/src/commands/send/delegate-registration";
 import { arkToSatoshi, captureTransactions, expectTransactions, toFlags } from "../../shared";
 
@@ -34,7 +33,6 @@ describe("Commands - Delegate Registration", () => {
             number: 1,
         };
 
-        const expectedDelegateName = "mr_bojangles";
         // call to delegates/{publicKey}/voters returns zero delegates
         nock("http://localhost:4003")
             .get("/api/v2/delegates")
@@ -42,7 +40,6 @@ describe("Commands - Delegate Registration", () => {
                 meta: { pageCount: 1 },
                 data: [],
             });
-        jest.spyOn(pokemon, "random").mockImplementation(() => expectedDelegateName);
 
         const expectedTransactions = [];
         captureTransactions(nock, expectedTransactions);
@@ -55,7 +52,7 @@ describe("Commands - Delegate Registration", () => {
             fee: arkToSatoshi(opts.delegateFee),
             asset: {
                 delegate: {
-                    username: expectedDelegateName,
+                    username: expectedTransactions[1].asset.delegate.username,
                 },
             },
         });

--- a/packages/core-tester-cli/package.json
+++ b/packages/core-tester-cli/package.json
@@ -40,8 +40,7 @@
         "delay": "^4.2.0",
         "pino": "^5.12.3",
         "pino-pretty": "^3.0.0",
-        "pluralize": "^7.0.0",
-        "pokemon": "^2.0.0"
+        "pluralize": "^7.0.0"
     },
     "devDependencies": {
         "@types/bip39": "^2.4.2",

--- a/packages/core-tester-cli/src/commands/send/delegate-registration.ts
+++ b/packages/core-tester-cli/src/commands/send/delegate-registration.ts
@@ -33,7 +33,6 @@ export class DelegateRegistrationCommand extends SendCommand {
         for (const [address, wallet] of Object.entries(wallets)) {
             wallets[address].username = Math.random()
                 .toString(36)
-                .substring(20)
                 .toLowerCase();
 
             transactions.push(

--- a/packages/core-tester-cli/src/commands/send/delegate-registration.ts
+++ b/packages/core-tester-cli/src/commands/send/delegate-registration.ts
@@ -1,5 +1,4 @@
 import { Identities } from "@arkecosystem/crypto";
-import pokemon from "pokemon";
 import { satoshiFlag } from "../../flags";
 import { logger } from "../../logger";
 import { SendCommand } from "../../shared/send";
@@ -32,10 +31,10 @@ export class DelegateRegistrationCommand extends SendCommand {
         const transactions = [];
 
         for (const [address, wallet] of Object.entries(wallets)) {
-            wallets[address].username = pokemon
-                .random()
-                .toLowerCase()
-                .replace(/ /g, "_");
+            wallets[address].username = Math.random()
+                .toString(36)
+                .substring(20)
+                .toLowerCase();
 
             transactions.push(
                 this.signer.makeDelegate({

--- a/yarn.lock
+++ b/yarn.lock
@@ -953,6 +953,16 @@
     "@hapi/oppsy" "2.x.x"
     pumpify "1.x.x"
 
+"@hapi/h2o2@^8.3.0":
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/@hapi/h2o2/-/h2o2-8.3.0.tgz#9783fb54005cc8e05fb75a1eba975035ad469127"
+  integrity sha512-JKFqewDvVBXwhIHFIuFjtndzW5SDA1oi7qohwYW/igqfDdOAwYq9cYlpGVPg+KeeDCESDNJCl7bPQt+oQgirOw==
+  dependencies:
+    "@hapi/boom" "7.x.x"
+    "@hapi/hoek" "6.x.x"
+    "@hapi/joi" "15.x.x"
+    "@hapi/wreck" "15.x.x"
+
 "@hapi/hapi@^18.3.1":
   version "18.3.1"
   resolved "https://registry.yarnpkg.com/@hapi/hapi/-/hapi-18.3.1.tgz#936d1e24551b11486eabd6a4974bea4ec2127669"
@@ -10306,13 +10316,6 @@ podium@3.x.x:
   dependencies:
     hoek "6.x.x"
     joi "14.x.x"
-
-pokemon@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/pokemon/-/pokemon-2.0.0.tgz#bf9c4f73ca4615df95a407f881e983ea5fb291ad"
-  integrity sha512-x+c9qNrB5y+2Ltt4mQGG56Rw6AvnzxhRm7/DRX9nSLjurTy+R7gMg3vUxzjJK2AhnaoQeFs3NPyK5fwnM3kVWg==
-  dependencies:
-    unique-random-array "^2.0.0"
 
 port-numbers@^4.0.7:
   version "4.0.8"


### PR DESCRIPTION
<!-- Please don't delete this template and read our contribution guidelines at https://docs.ark.io/guidebook/contribution-guidelines/contributing.html -->

## Summary

Tests that rely on multiple delegate registrations will randomly fail because there is a high probability of the same value ending up in the list of names.

```
 FAIL  __tests__/integration/core-transaction-pool/processor.test.ts (19.668s)
  ● Transaction Guard › validate › Sign a transaction then change some fields shouldn't pass validation › should not validate when changing fields after signing - delegate registration

    expect(received).toEqual(expected) // deep equality

    - Expected
    + Received

    @@ -1,10 +1,10 @@
      Array [
        Array [
          "b0ef0260e5011b8d451fb57a1c495febadfa8b6412146733de4359d4acaaa658",
    -     "ERR_BAD_DATA",
    -     "Transaction didn't pass the verification process.",
    +     "ERR_CONFLICT",
    +     "Multiple delegate registrations for \"ferroseed\" in transaction payload",
        ],
        Array [
          "90d938f7e7f2634ff34613da9045ad05e07fa83ba8885c5f3c5661c9ebe8375d",
          "ERR_BAD_DATA",
          "Transaction didn't pass the verification process.",
    @@ -14,12 +14,12 @@
          "ERR_BAD_DATA",
          "Transaction didn't pass the verification process.",
        ],
        Array [
          "92bd3ff4bfa7f53ce91427ea585dafca7f232f4cb846d6b11bc603172ba431de",
    -     "ERR_BAD_DATA",
    -     "Transaction didn't pass the verification process.",
    +     "ERR_CONFLICT",
    +     "Multiple delegate registrations for \"ferroseed\" in transaction payload",
        ],
        Array [
          "cd09afe78a8a230c096f672da3c024c44590c3da088481d10f8286e6217f0b0d",
          "ERR_BAD_DATA",
          "Transaction didn't pass the verification process.",

      621 |                 expect(
      622 |                     Object.keys(result.errors).map(id => [id, result.errors[id][0].type, result.errors[id][0].message]),
    > 623 |                 ).toEqual(expectedErrors);
          |                   ^
      624 |                 expect(result.invalid).toEqual(modifiedTransactions.map(transaction => transaction.id));
      625 |                 expect(result.accept).toEqual([]);
      626 |                 expect(result.broadcast).toEqual([]);

      at Object.it (__tests__/integration/core-transaction-pool/processor.test.ts:623:19)
```

## What kind of change does this PR introduce?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [ ] Bugfix
- [ ] New feature
- [ ] Refactoring / Performance Improvements
- [ ] Build-related changes
- [ ] Documentation
- [ ] Tests / Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [ ] Yes
- [ ] No

## Does this PR release a new version?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [ ] Yes
  - [ ] All tests are passing
  - [ ] All benchmarks are passing without any _major_ regressions
  - [ ] Sync from 0 works on mainnet
  - [ ] Sync from 0 works on devnet
  - [ ] Starting a new network and forging on it work
  - [ ] Explorer is fully functional
  - [ ] Wallets are fully functional
- [ ] No

## Checklist

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [ ] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation _(if appropriate)_

<!--
## Other information

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
-->
