### PR TITLE
feat(core-api): accept block height to list block transactions

### DIFF
--- a/__tests__/integration/core-api/v2/handlers/blocks.test.ts
+++ b/__tests__/integration/core-api/v2/handlers/blocks.test.ts
@@ -119,6 +119,23 @@ describe("API 2.0 - Blocks", () => {
         );
     });
 
+    describe("GET /blocks/:height/transactions", () => {
+        describe.each([["API-Version", "request"], ["Accept", "requestWithAcceptHeader"]])(
+            'using the "%s" header',
+            (header, request) => {
+                it("should GET all the transactions for the given block by id", async () => {
+                    const response = await utils[request]("GET", `blocks/${genesisBlock.height}/transactions`);
+                    expect(response).toBeSuccessfulResponse();
+                    expect(response.data.data).toBeArray();
+
+                    const transaction = response.data.data[0];
+                    utils.expectTransaction(transaction);
+                    expect(transaction.blockId).toBe(genesisBlock.id);
+                });
+            },
+        );
+    });
+
     describe("POST /blocks/search", () => {
         describe.each([["API-Version", "request"], ["Accept", "requestWithAcceptHeader"]])(
             "using the %s header",

--- a/packages/core-api/src/versions/2/blocks/methods.ts
+++ b/packages/core-api/src/versions/2/blocks/methods.ts
@@ -28,7 +28,7 @@ const show = async request => {
 };
 
 const transactions = async request => {
-    const block = await blocksRepository.findById(request.params.id);
+    const block = await blocksRepository.findByIdOrHeight(request.params.id);
 
     if (!block) {
         return Boom.notFound("Block not found");


### PR DESCRIPTION
<!-- Please don't delete this template and read our contribution guidelines at https://docs.ark.io/guidebook/contribution-guidelines/contributing.html -->

## Summary

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Reading [doc](https://docs.ark.io/api/public/v2/blocks.html#list-all-transactions-in-a-block) we can get all transactions of block at specific height. 
That feature was not implemented. 

## What kind of change does this PR introduce?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [ ] Bugfix
- [x] New feature
- [ ] Refactoring / Performance Improvements
- [ ] Build-related changes
- [ ] Documentation
- [ ] Tests / Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [ ] Yes
- [x] No

## Does this PR release a new version?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [ ] Yes
  - [ ] All tests are passing
  - [ ] All benchmarks are passing without any _major_ regressions
  - [ ] Sync from 0 works on mainnet
  - [ ] Sync from 0 works on devnet
  - [ ] Starting a new network and forging on it work
  - [ ] Explorer is fully functional
  - [ ] Wallets are fully functional
- [x] No

## Checklist

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [ ] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation _(if appropriate)_

<!--
## Other information

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
-->
