### PR TITLE
refactor: change hasExceededMaxTransactions()'s argument type

### DIFF
--- a/__tests__/integration/core-transaction-pool/processor.test.ts
+++ b/__tests__/integration/core-transaction-pool/processor.test.ts
@@ -1119,7 +1119,7 @@ describe("Transaction Guard", () => {
     //             .withPassphrase(wallets[10].passphrase)
     //             .create(3);
 
-    //         jest.spyOn(processor.pool, "hasExceededMaxTransactions").mockImplementationOnce(tx => true);
+    //         jest.spyOn(processor.pool, "hasExceededMaxTransactions").mockImplementationOnce(senderPublicKey => true);
 
     //         processor.__filterAndTransformTransactions(transactions);
 

--- a/__tests__/unit/core-transaction-pool/__stubs__/connection.ts
+++ b/__tests__/unit/core-transaction-pool/__stubs__/connection.ts
@@ -98,7 +98,7 @@ export class Connection implements TransactionPool.IConnection {
         return;
     }
 
-    public hasExceededMaxTransactions(transaction: Interfaces.ITransactionData): boolean {
+    public hasExceededMaxTransactions(senderPublicKey: string): boolean {
         return true;
     }
 

--- a/__tests__/unit/core-transaction-pool/connection.test.ts
+++ b/__tests__/unit/core-transaction-pool/connection.test.ts
@@ -347,7 +347,7 @@ describe("Connection", () => {
             ]);
 
             expect(connection.getPoolSize()).toBe(7);
-            const exceeded = connection.hasExceededMaxTransactions(mockData.dummy3.data);
+            const exceeded = connection.hasExceededMaxTransactions(mockData.dummy3.data.senderPublicKey);
             expect(exceeded).toBeTrue();
         });
 
@@ -358,7 +358,7 @@ describe("Connection", () => {
             addTransactions([mockData.dummy4, mockData.dummy5, mockData.dummy6]);
 
             expect(connection.getPoolSize()).toBe(3);
-            const exceeded = connection.hasExceededMaxTransactions(mockData.dummy3.data);
+            const exceeded = connection.hasExceededMaxTransactions(mockData.dummy3.data.senderPublicKey);
             expect(exceeded).toBeFalse();
         });
 
@@ -377,7 +377,7 @@ describe("Connection", () => {
             ]);
 
             expect(connection.getPoolSize()).toBe(7);
-            const exceeded = connection.hasExceededMaxTransactions(mockData.dummy3.data);
+            const exceeded = connection.hasExceededMaxTransactions(mockData.dummy3.data.senderPublicKey);
             expect(exceeded).toBeFalse();
         });
     });
@@ -830,11 +830,9 @@ describe("Connection", () => {
 
             for (let i = 0; i < testSize * 2; i++) {
                 connection.getPoolSize();
-                for (const sender of ["nonexistent", mockData.dummy1.data.senderPublicKey]) {
-                    connection.getSenderSize(sender);
-                    // @FIXME: Uhm excuse me, what the?
-                    // @ts-ignore
-                    connection.hasExceededMaxTransactions(sender);
+                for (const senderPublicKey of ["nonexistent", mockData.dummy1.data.senderPublicKey]) {
+                    connection.getSenderSize(senderPublicKey);
+                    connection.hasExceededMaxTransactions(senderPublicKey);
                 }
                 connection.getTransaction(fakeTransactionId(i));
                 connection.getTransactions(0, i);

--- a/packages/core-interfaces/src/core-transaction-pool/connection.ts
+++ b/packages/core-interfaces/src/core-transaction-pool/connection.ts
@@ -34,7 +34,7 @@ export interface IConnection {
     getTransactionsData<T>(start: number, size: number, property: string, maxBytes?: number): T[];
     getTransactionsForForging(blockSize: number): string[];
     has(transactionId: string): any;
-    hasExceededMaxTransactions(transaction: Interfaces.ITransactionData): boolean;
+    hasExceededMaxTransactions(senderPublicKey: string): boolean;
     isSenderBlocked(senderPublicKey: string): boolean;
     purgeByBlock(block: Interfaces.IBlock): void;
     purgeByPublicKey(senderPublicKey: string): void;

--- a/packages/core-transaction-pool/src/connection.ts
+++ b/packages/core-transaction-pool/src/connection.ts
@@ -197,24 +197,24 @@ export class Connection implements TransactionPool.IConnection {
     }
 
     // @TODO: move this to a more appropriate place
-    public hasExceededMaxTransactions(transaction: Interfaces.ITransactionData): boolean {
+    public hasExceededMaxTransactions(senderPublicKey: string): boolean {
         this.purgeExpired();
 
-        if (this.options.allowedSenders.includes(transaction.senderPublicKey)) {
-            if (!this.loggedAllowedSenders.includes(transaction.senderPublicKey)) {
+        if (this.options.allowedSenders.includes(senderPublicKey)) {
+            if (!this.loggedAllowedSenders.includes(senderPublicKey)) {
                 this.logger.debug(
                     `Transaction pool: allowing sender public key: ${
-                        transaction.senderPublicKey
+                        senderPublicKey
                     } (listed in options.allowedSenders), thus skipping throttling.`,
                 );
 
-                this.loggedAllowedSenders.push(transaction.senderPublicKey);
+                this.loggedAllowedSenders.push(senderPublicKey);
             }
 
             return false;
         }
 
-        return this.memory.getBySender(transaction.senderPublicKey).size >= this.options.maxTransactionsPerSender;
+        return this.memory.getBySender(senderPublicKey).size >= this.options.maxTransactionsPerSender;
     }
 
     public flush(): void {

--- a/packages/core-transaction-pool/src/processor.ts
+++ b/packages/core-transaction-pool/src/processor.ts
@@ -117,7 +117,7 @@ export class Processor implements TransactionPool.IProcessor {
                     "ERR_TOO_LARGE",
                     `Transaction ${transaction.id} is larger than ${maxTransactionBytes} bytes.`,
                 );
-            } else if (this.pool.hasExceededMaxTransactions(transaction)) {
+            } else if (this.pool.hasExceededMaxTransactions(transaction.senderPublicKey)) {
                 this.excess.push(transaction.id);
             } else if (this.validateTransaction(transaction)) {
                 try {


### PR DESCRIPTION
refactor: change hasExceededMaxTransactions()'s argument type

hasExceededMaxTransactions() was taking an argument of type
Interfaces.ITransactionData and was just using its .senderPublicKey
member. Change it to take "senderPublicKey: string".

This makes it easier to use hasExceededMaxTransactions() from unit tests
with bogus senderPublicKey because no dummy transaction object is
necessary.
