### PR TITLE
fix(blockchain): use resolveOptions("blockchain") to get databaseRollback options

### DIFF
--- a/__tests__/unit/core-blockchain/mocks/container.ts
+++ b/__tests__/unit/core-blockchain/mocks/container.ts
@@ -58,7 +58,7 @@ export const container = {
 
             return undefined;
         },
-        resolveOptions: () => ({}),
+        resolveOptions: plugin => ({}),
         has: () => true,
         forceExit: () => undefined,
     },

--- a/packages/core-blockchain/src/state-machine.ts
+++ b/packages/core-blockchain/src/state-machine.ts
@@ -291,7 +291,7 @@ blockchainMachine.actionMap = (blockchain: Blockchain) => ({
     async rollbackDatabase() {
         logger.info("Trying to restore database integrity");
 
-        const { maxBlockRewind, steps } = app.resolveOptions("p2p").databaseRollback;
+        const { maxBlockRewind, steps } = app.resolveOptions("blockchain").databaseRollback;
 
         for (let i = maxBlockRewind; i >= 0; i -= steps) {
             await blockchain.removeTopBlocks(steps);


### PR DESCRIPTION
## Summary

Use `resolveOptions("blockchain")` to get _databaseRollback_ options. (instead of `resolveOptions("p2p")` which was not getting anything)

## What kind of change does this PR introduce?

- [x] Bugfix
- [ ] New feature
- [ ] Refactoring / Performance Improvements
- [ ] Build-related changes
- [ ] Documentation
- [ ] Tests / Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Does this PR release a new version?

- [ ] Yes
  - [ ] All tests are passing
  - [ ] All benchmarks are passing without any _major_ regressions
  - [ ] Sync from 0 works on mainnet
  - [ ] Sync from 0 works on devnet
  - [ ] Starting a new network and forging on it work
  - [ ] Explorer is fully functional
  - [ ] Wallets are fully functional
- [x] No

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation _(if appropriate)_
