### PR TITLE
refactor(core-api): register /api/v2 as a transition period fallback

### DIFF
--- a/packages/core-api/src/defaults.ts
+++ b/packages/core-api/src/defaults.ts
@@ -1,5 +1,3 @@
-import { resolve } from "path";
-
 export const defaults = {
     enabled: false,
     host: process.env.CORE_API_HOST || "0.0.0.0",
@@ -64,10 +62,5 @@ export const defaults = {
         ],
     },
     whitelist: ["127.0.0.1", "::ffff:127.0.0.1"],
-    plugins: [
-        {
-            plugin: resolve(__dirname, "./handlers"),
-            routes: { prefix: "/api" },
-        },
-    ],
+    plugins: [],
 };

--- a/packages/core-api/src/handlers/index.ts
+++ b/packages/core-api/src/handlers/index.ts
@@ -18,5 +18,5 @@ export = {
         }
     },
     name: "Public API",
-    version: "2.0.0 ",
+    version: "2.0.0",
 };

--- a/packages/core-api/src/handlers/index.ts
+++ b/packages/core-api/src/handlers/index.ts
@@ -9,16 +9,14 @@ import * as Transactions from "./transactions";
 import * as Votes from "./votes";
 import * as Wallets from "./wallets";
 
-const register = async (server: Hapi.Server): Promise<void> => {
-    const modules = [Blockchain, Blocks, Delegates, Node, Peers, Rounds, Transactions, Votes, Wallets];
-
-    for (const module of modules) {
-        module.register(server);
-    }
-};
-
 export = {
-    register,
+    async register(server: Hapi.Server): Promise<void> {
+        const modules = [Blockchain, Blocks, Delegates, Node, Peers, Rounds, Transactions, Votes, Wallets];
+
+        for (const module of modules) {
+            module.register(server);
+        }
+    },
     name: "Public API",
-    version: "2.0.0",
+    version: "2.0.0 ",
 };

--- a/packages/core-api/src/server.ts
+++ b/packages/core-api/src/server.ts
@@ -124,6 +124,11 @@ export class Server {
             },
         });
 
+        await server.register({
+            plugin: require("./handlers"),
+            routes: { prefix: "/api" },
+        });
+
         for (const plugin of this.config.plugins) {
             if (typeof plugin.plugin === "string") {
                 plugin.plugin = require(plugin.plugin);
@@ -131,6 +136,15 @@ export class Server {
 
             await server.register(plugin);
         }
+
+        // @TODO: remove this with the release of 3.0 - adds support for /api and /api/v2
+        server.ext("onRequest", (request: Hapi.Request, h: Hapi.ResponseToolkit) => {
+            const path: string = request.url.pathname.replace("/v2", "");
+
+            request.setUrl(request.url.search ? `${path}${request.url.search}` : path);
+
+            return h.continue;
+        });
 
         await mountServer(`Public ${name.toUpperCase()} API`, server);
     }


### PR DESCRIPTION
<!-- Please don't delete this template and read our contribution guidelines at https://docs.ark.io/guidebook/contribution-guidelines/contributing.html -->

## Summary

Support `/api` and `/api/v2` as some people use the URL paths even though the docs advise against it.

**This will be removed with the release of 3.0 later this year and only `/api` will be supported.**

## What kind of change does this PR introduce?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [ ] Bugfix
- [ ] New feature
- [x] Refactoring / Performance Improvements
- [ ] Build-related changes
- [ ] Documentation
- [ ] Tests / Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [ ] Yes
- [x] No

## Does this PR release a new version?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [ ] Yes
  - [ ] All tests are passing
  - [ ] All benchmarks are passing without any _major_ regressions
  - [ ] Sync from 0 works on mainnet
  - [ ] Sync from 0 works on devnet
  - [ ] Starting a new network and forging on it work
  - [ ] Explorer is fully functional
  - [ ] Wallets are fully functional
- [x] No

## Checklist

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation _(if appropriate)_

<!--
## Other information

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
-->
