### PR TITLE
refactor: use ApplicationEvents enum instead of string

### DIFF
--- a/__tests__/integration/core-webhooks/server.test.ts
+++ b/__tests__/integration/core-webhooks/server.test.ts
@@ -1,3 +1,4 @@
+import { ApplicationEvents } from "@arkecosystem/core-event-emitter";
 import "jest-extended";
 import { setUp, tearDown } from "./__support__/setup";
 import * as utils from "./__support__/utils";
@@ -11,7 +12,7 @@ afterAll(async () => {
 });
 
 const postData = {
-    event: "block.forged",
+    event: ApplicationEvents.BlockForged,
     target: "https://httpbin.org/post",
     enabled: true,
     conditions: [
@@ -48,7 +49,7 @@ describe("API 2.0 - Webhooks", () => {
 
     it("should POST a new webhook with a complex condition", async () => {
         const response = await createWebhook({
-            event: "block.forged",
+            event: ApplicationEvents.BlockForged,
             target: "https://httpbin.org/post",
             enabled: true,
             conditions: [
@@ -68,7 +69,7 @@ describe("API 2.0 - Webhooks", () => {
 
     it("should POST a new webhook with an empty array as condition", async () => {
         const response = await createWebhook({
-            event: "block.forged",
+            event: ApplicationEvents.BlockForged,
             target: "https://httpbin.org/post",
             enabled: true,
             conditions: [],

--- a/__tests__/unit/core-database/database-service.test.ts
+++ b/__tests__/unit/core-database/database-service.test.ts
@@ -2,6 +2,7 @@ import "jest-extended";
 import "./mocks/core-container";
 
 import { app } from "@arkecosystem/core-container";
+import { ApplicationEvents } from "@arkecosystem/core-event-emitter";
 import { Database, EventEmitter, State } from "@arkecosystem/core-interfaces";
 import { Handlers } from "@arkecosystem/core-transactions";
 import { Blocks, Constants, Enums, Identities, Transactions, Utils } from "@arkecosystem/crypto";
@@ -48,8 +49,8 @@ describe("Database Service", () => {
 
         databaseService = createService();
 
-        expect(emitter.on).toHaveBeenCalledWith("state.started", expect.toBeFunction());
-        expect(emitter.on).toHaveBeenCalledWith("wallet.created.cold", expect.toBeFunction());
+        expect(emitter.on).toHaveBeenCalledWith(ApplicationEvents.StateStarted, expect.toBeFunction());
+        expect(emitter.on).toHaveBeenCalledWith(ApplicationEvents.WalletColdCreated, expect.toBeFunction());
     });
 
     describe("applyBlock", () => {
@@ -63,9 +64,9 @@ describe("Database Service", () => {
             await databaseService.applyBlock(genesisBlock);
 
             expect(walletManager.applyBlock).toHaveBeenCalledWith(genesisBlock);
-            expect(emitter.emit).toHaveBeenCalledWith("block.applied", genesisBlock.data);
+            expect(emitter.emit).toHaveBeenCalledWith(ApplicationEvents.BlockApplied, genesisBlock.data);
             genesisBlock.transactions.forEach(tx =>
-                expect(emitter.emit).toHaveBeenCalledWith("transaction.applied", tx.data),
+                expect(emitter.emit).toHaveBeenCalledWith(ApplicationEvents.TransactionApplied, tx.data),
             );
         });
     });

--- a/__tests__/unit/core-forger/manager.test.ts
+++ b/__tests__/unit/core-forger/manager.test.ts
@@ -2,6 +2,7 @@ import "jest-extended";
 
 import "./mocks/core-container";
 
+import { ApplicationEvents } from "@arkecosystem/core-event-emitter";
 import { NetworkState, NetworkStateStatus } from "@arkecosystem/core-p2p";
 import { Transactions } from "@arkecosystem/crypto";
 import { defaults } from "../../../packages/core-forger/src/defaults";
@@ -61,8 +62,14 @@ describe("Forger Manager", () => {
                     reward: round.reward.toFixed(),
                 }),
             );
-            expect(forgeManager.client.emitEvent).toHaveBeenCalledWith("block.forged", expect.any(Object));
-            expect(forgeManager.client.emitEvent).toHaveBeenCalledWith("transaction.forged", expect.any(Object));
+            expect(forgeManager.client.emitEvent).toHaveBeenCalledWith(
+                ApplicationEvents.BlockForged,
+                expect.any(Object),
+            );
+            expect(forgeManager.client.emitEvent).toHaveBeenCalledWith(
+                ApplicationEvents.TransactionForged,
+                expect.any(Object),
+            );
         });
     });
 
@@ -73,7 +80,7 @@ describe("Forger Manager", () => {
             setTimeout(() => forgeManager.stopForging(), 1000);
             await forgeManager.checkSlot();
 
-            expect(forgeManager.client.emitEvent).toHaveBeenCalledWith("forger.failed", "oh bollocks");
+            expect(forgeManager.client.emitEvent).toHaveBeenCalledWith(ApplicationEvents.ForgerFailed, "oh bollocks");
         });
     });
 

--- a/packages/core-blockchain/package.json
+++ b/packages/core-blockchain/package.json
@@ -24,6 +24,7 @@
     "dependencies": {
         "@arkecosystem/core-container": "^2.4.0-next.3",
         "@arkecosystem/core-database": "^2.4.0-next.3",
+        "@arkecosystem/core-event-emitter": "^2.4.0-next.3",
         "@arkecosystem/core-interfaces": "^2.4.0-next.3",
         "@arkecosystem/core-transactions": "^2.4.0-next.3",
         "@arkecosystem/core-utils": "^2.4.0-next.3",

--- a/packages/core-blockchain/src/blockchain.ts
+++ b/packages/core-blockchain/src/blockchain.ts
@@ -1,5 +1,6 @@
 /* tslint:disable:max-line-length */
 import { app } from "@arkecosystem/core-container";
+import { ApplicationEvents } from "@arkecosystem/core-event-emitter";
 import {
     Blockchain as blockchain,
     Database,
@@ -251,11 +252,11 @@ export class Blockchain implements blockchain.IBlockchain {
             this.dispatch("NEWBLOCK");
             this.enqueueBlocks([block]);
 
-            emitter.emit("block.received", block);
+            emitter.emit(ApplicationEvents.BlockReceived, block);
         } else {
             logger.info(`Block disregarded because blockchain is not ready`);
 
-            emitter.emit("block.disregarded", block);
+            emitter.emit(ApplicationEvents.BlockDisregarded, block);
         }
     }
 

--- a/packages/core-database/src/database-service.ts
+++ b/packages/core-database/src/database-service.ts
@@ -81,7 +81,7 @@ export class DatabaseService implements Database.IDatabaseService {
             this.emitTransactionEvents(transaction);
         }
 
-        this.emitter.emit("block.applied", block.data);
+        this.emitter.emit(ApplicationEvents.BlockApplied, block.data);
     }
 
     public async applyRound(height: number): Promise<void> {
@@ -111,7 +111,7 @@ export class DatabaseService implements Database.IDatabaseService {
 
                     this.blocksInCurrentRound.length = 0;
 
-                    this.emitter.emit("round.applied");
+                    this.emitter.emit(ApplicationEvents.RoundApplied);
                 } catch (error) {
                     // trying to leave database state has it was
                     await this.deleteRound(round);
@@ -415,7 +415,7 @@ export class DatabaseService implements Database.IDatabaseService {
 
         assert(this.blocksInCurrentRound.pop().data.id === block.data.id);
 
-        this.emitter.emit("block.reverted", block.data);
+        this.emitter.emit(ApplicationEvents.BlockReverted, block.data);
     }
 
     public async revertRound(height: number): Promise<void> {
@@ -449,7 +449,7 @@ export class DatabaseService implements Database.IDatabaseService {
 
         await this.connection.roundsRepository.insert(activeDelegates);
 
-        this.emitter.emit("round.created", activeDelegates);
+        this.emitter.emit(ApplicationEvents.RoundCreated, activeDelegates);
     }
 
     public updateDelegateStats(delegates: State.IDelegateWallet[]): void {
@@ -474,7 +474,7 @@ export class DatabaseService implements Database.IDatabaseService {
 
                     this.logger.debug(`Delegate ${wallet.username} (${wallet.publicKey}) just missed a block.`);
 
-                    this.emitter.emit("forger.missing", {
+                    this.emitter.emit(ApplicationEvents.ForgerMissing, {
                         delegate: wallet,
                     });
                 }
@@ -636,7 +636,7 @@ export class DatabaseService implements Database.IDatabaseService {
     }
 
     private emitTransactionEvents(transaction: Interfaces.ITransaction): void {
-        this.emitter.emit("transaction.applied", transaction.data);
+        this.emitter.emit(ApplicationEvents.TransactionApplied, transaction.data);
 
         Handlers.Registry.get(transaction.type).emitEvents(transaction, this.emitter);
     }

--- a/packages/core-forger/package.json
+++ b/packages/core-forger/package.json
@@ -22,6 +22,7 @@
     },
     "dependencies": {
         "@arkecosystem/core-container": "^2.4.0-next.3",
+        "@arkecosystem/core-event-emitter": "^2.4.0-next.3",
         "@arkecosystem/core-interfaces": "^2.4.0-next.3",
         "@arkecosystem/core-p2p": "^2.4.0-next.3",
         "@arkecosystem/core-utils": "^2.4.0-next.3",

--- a/packages/core-forger/src/manager.ts
+++ b/packages/core-forger/src/manager.ts
@@ -1,4 +1,5 @@
 import { app } from "@arkecosystem/core-container";
+import { ApplicationEvents } from "@arkecosystem/core-event-emitter";
 import { Logger, P2P } from "@arkecosystem/core-interfaces";
 import { NetworkStateStatus } from "@arkecosystem/core-p2p";
 import { Blocks, Crypto, Interfaces, Managers, Transactions, Types } from "@arkecosystem/crypto";
@@ -124,7 +125,7 @@ export class ForgerManager {
                     );
                 }
 
-                this.client.emitEvent("forger.failed", error.message);
+                this.client.emitEvent(ApplicationEvents.ForgerFailed, error.message);
             }
 
             // no idea when this will be ok, so waiting 2s before checking again
@@ -161,10 +162,10 @@ export class ForgerManager {
 
         await this.client.broadcastBlock(block.toJson());
 
-        this.client.emitEvent("block.forged", block.data);
+        this.client.emitEvent(ApplicationEvents.BlockForged, block.data);
 
         for (const transaction of transactions) {
-            this.client.emitEvent("transaction.forged", transaction);
+            this.client.emitEvent(ApplicationEvents.TransactionForged, transaction);
         }
     }
 

--- a/packages/core-p2p/package.json
+++ b/packages/core-p2p/package.json
@@ -24,6 +24,7 @@
     },
     "dependencies": {
         "@arkecosystem/core-container": "^2.4.0-next.3",
+        "@arkecosystem/core-event-emitter": "^2.4.0-next.3",
         "@arkecosystem/core-http-utils": "^2.4.0-next.3",
         "@arkecosystem/core-interfaces": "^2.4.0-next.3",
         "@arkecosystem/core-transaction-pool": "^2.4.0-next.3",

--- a/packages/core-p2p/src/network-monitor.ts
+++ b/packages/core-p2p/src/network-monitor.ts
@@ -1,6 +1,7 @@
 /* tslint:disable:max-line-length */
 
 import { app } from "@arkecosystem/core-container";
+import { ApplicationEvents } from "@arkecosystem/core-event-emitter/dist";
 import { Blockchain, EventEmitter, Logger, P2P } from "@arkecosystem/core-interfaces";
 import { Interfaces } from "@arkecosystem/crypto";
 import { dato, Dato } from "@faustbrian/dato";
@@ -149,7 +150,7 @@ export class NetworkMonitor implements P2P.INetworkMonitor {
                         peerErrors[error] = [peer];
                     }
 
-                    this.emitter.emit("peer.removed", peer);
+                    this.emitter.emit(ApplicationEvents.PeerRemoved, peer);
 
                     this.storage.forgetPeer(peer);
 

--- a/packages/core-p2p/src/peer-processors.ts
+++ b/packages/core-p2p/src/peer-processors.ts
@@ -1,6 +1,7 @@
 /* tslint:disable:max-line-length */
 
 import { app } from "@arkecosystem/core-container";
+import { ApplicationEvents } from "@arkecosystem/core-event-emitter";
 import { EventEmitter, Logger, P2P } from "@arkecosystem/core-interfaces";
 import { dato } from "@faustbrian/dato";
 import prettyMs from "pretty-ms";
@@ -157,7 +158,7 @@ export class PeerProcessor implements P2P.IPeerProcessor {
                 this.logger.debug(`Accepted new peer ${newPeer.ip}:${newPeer.port}`);
             }
 
-            this.emitter.emit("peer.added", newPeer);
+            this.emitter.emit(ApplicationEvents.PeerAdded, newPeer);
         } catch (error) {
             if (error instanceof PeerPingTimeoutError) {
                 newPeer.latency = -1;

--- a/packages/core-transaction-pool/package.json
+++ b/packages/core-transaction-pool/package.json
@@ -26,6 +26,7 @@
     "dependencies": {
         "@arkecosystem/core-container": "^2.4.0-next.3",
         "@arkecosystem/core-database": "^2.4.0-next.3",
+        "@arkecosystem/core-event-emitter": "^2.4.0-next.3",
         "@arkecosystem/core-interfaces": "^2.4.0-next.3",
         "@arkecosystem/core-transactions": "^2.4.0-next.3",
         "@arkecosystem/crypto": "^2.4.0-next.3",

--- a/packages/core-transaction-pool/src/connection.ts
+++ b/packages/core-transaction-pool/src/connection.ts
@@ -1,4 +1,5 @@
 import { app } from "@arkecosystem/core-container";
+import { ApplicationEvents } from "@arkecosystem/core-event-emitter";
 import { Database, EventEmitter, Logger, State, TransactionPool } from "@arkecosystem/core-interfaces";
 import { Handlers } from "@arkecosystem/core-transactions";
 import { Enums, Interfaces, Utils } from "@arkecosystem/crypto";
@@ -103,11 +104,11 @@ export class Connection implements TransactionPool.IConnection {
         }
 
         if (added.length > 0) {
-            this.emitter.emit("transaction.pool.added", added);
+            this.emitter.emit(ApplicationEvents.TransactionPoolAdded, added);
         }
 
         if (notAdded.length > 0) {
-            this.emitter.emit("transaction.pool.rejected", notAdded);
+            this.emitter.emit(ApplicationEvents.TransactionPoolRejected, notAdded);
         }
 
         return { added, notAdded };
@@ -122,7 +123,7 @@ export class Connection implements TransactionPool.IConnection {
 
         this.syncToPersistentStorageIfNecessary();
 
-        this.emitter.emit("transaction.pool.removed", id);
+        this.emitter.emit(ApplicationEvents.TransactionPoolRemoved, id);
     }
 
     public removeTransactionsById(ids: string[]): void {
@@ -384,7 +385,7 @@ export class Connection implements TransactionPool.IConnection {
     }
 
     public purgeInvalidTransactions(): void {
-        this.purgeTransactions("transaction.pool.removed", this.memory.getInvalid());
+        this.purgeTransactions(ApplicationEvents.TransactionPoolRemoved, this.memory.getInvalid());
     }
 
     public senderHasTransactionsOfType(senderPublicKey: string, transactionType: Enums.TransactionTypes): boolean {
@@ -465,7 +466,7 @@ export class Connection implements TransactionPool.IConnection {
     }
 
     private purgeExpired(): void {
-        this.purgeTransactions("transaction.expired", this.memory.getExpired(this.options.maxTransactionAge));
+        this.purgeTransactions(ApplicationEvents.TransactionExpired, this.memory.getExpired(this.options.maxTransactionAge));
     }
 
     private purgeTransactions(event: string, transactions: Interfaces.ITransaction[]): void {

--- a/packages/core-transactions/package.json
+++ b/packages/core-transactions/package.json
@@ -19,6 +19,7 @@
         "prepublishOnly": "yarn build"
     },
     "dependencies": {
+        "@arkecosystem/core-event-emitter": "^2.4.0-next.3",
         "@arkecosystem/core-interfaces": "^2.4.0-next.3",
         "@arkecosystem/crypto": "^2.4.0-next.3",
         "bs58check": "^2.1.2"

--- a/packages/core-transactions/src/handlers/delegate-registration.ts
+++ b/packages/core-transactions/src/handlers/delegate-registration.ts
@@ -1,3 +1,4 @@
+import { ApplicationEvents } from "@arkecosystem/core-event-emitter";
 import { Database, EventEmitter, State, TransactionPool } from "@arkecosystem/core-interfaces";
 import { Enums, Interfaces, Transactions } from "@arkecosystem/crypto";
 import {
@@ -69,7 +70,7 @@ export class DelegateRegistrationTransactionHandler extends TransactionHandler {
     }
 
     public emitEvents(transaction: Interfaces.ITransaction, emitter: EventEmitter.EventEmitter): void {
-        emitter.emit("delegate.registered", transaction.data);
+        emitter.emit(ApplicationEvents.DelegateRegistered, transaction.data);
     }
 
     public canEnterTransactionPool(

--- a/packages/core-transactions/src/handlers/delegate-resignation.ts
+++ b/packages/core-transactions/src/handlers/delegate-resignation.ts
@@ -1,3 +1,4 @@
+import { ApplicationEvents } from "@arkecosystem/core-event-emitter";
 import { Database, EventEmitter, State, TransactionPool } from "@arkecosystem/core-interfaces";
 import { Interfaces, Transactions } from "@arkecosystem/crypto";
 import { WalletAlreadyResignedError, WalletUsernameEmptyError } from "../errors";
@@ -33,7 +34,7 @@ export class DelegateResignationTransactionHandler extends TransactionHandler {
     }
 
     public emitEvents(transaction: Interfaces.ITransaction, emitter: EventEmitter.EventEmitter): void {
-        emitter.emit("delegate.resigned", transaction.data);
+        emitter.emit(ApplicationEvents.DelegateResigned, transaction.data);
     }
 
     public canEnterTransactionPool(


### PR DESCRIPTION
## Summary

Use ApplicationEvents enum instead of strings.

## What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] New feature
- [x] Refactoring / Performance Improvements
- [ ] Build-related changes
- [ ] Documentation
- [ ] Tests / Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Does this PR release a new version?

- [ ] Yes
  - [ ] All tests are passing
  - [ ] All benchmarks are passing without any _major_ regressions
  - [ ] Sync from 0 works on mainnet
  - [ ] Sync from 0 works on devnet
  - [ ] Starting a new network and forging on it work
  - [ ] Explorer is fully functional
  - [ ] Wallets are fully functional
- [x] No

## Checklist

- [ ] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation _(if appropriate)_
