### PR TITLE
fix: divide blocks into smaller chunks for batch processing

### DIFF
--- a/__tests__/unit/core-blockchain/processor/handlers/unchained-handler.test.ts
+++ b/__tests__/unit/core-blockchain/processor/handlers/unchained-handler.test.ts
@@ -41,7 +41,7 @@ describe("Exception handler", () => {
             const handler = new UnchainedHandler(blockchain as any, BlockFactory.fromData(blocks2to100[5]), true);
 
             expect(await handler.execute()).toBe(BlockProcessorResult.DiscardedButCanBeBroadcasted);
-            expect(loggerDebug).toHaveBeenCalledWith("Discarded 5 downloaded blocks.");
+            expect(loggerDebug).toHaveBeenCalledWith("Discarded 5 chunks of downloaded blocks.");
         });
     });
 });

--- a/__tests__/unit/core-blockchain/state-machine.test.ts
+++ b/__tests__/unit/core-blockchain/state-machine.test.ts
@@ -60,9 +60,9 @@ describe("State Machine", () => {
                 await expect(actionMap.checkLastDownloadedBlockSynced).toDispatch(blockchain, "NOTSYNCED");
             });
 
-            it('should dispatch the event "PAUSED" if the blockchain process queue is more than 10000 long', async () => {
+            it('should dispatch the event "PAUSED" if the blockchain process queue is more than 100 long', async () => {
                 blockchain.isSynced = jest.fn(() => false);
-                blockchain.queue.length = jest.fn(() => 10001);
+                blockchain.queue.length = jest.fn(() => 101);
                 await expect(actionMap.checkLastDownloadedBlockSynced).toDispatch(blockchain, "PAUSED");
             });
 

--- a/packages/core-blockchain/src/processor/handlers/unchained-handler.ts
+++ b/packages/core-blockchain/src/processor/handlers/unchained-handler.ts
@@ -112,7 +112,7 @@ export class UnchainedHandler extends BlockHandler {
             // NOTE: This isn't really elegant, but still better than spamming the log with
             //       useless `not ready to accept` messages.
             if (this.blockchain.queue.length() > 0) {
-                this.logger.debug(`Discarded ${this.blockchain.queue.length()} downloaded blocks.`);
+                this.logger.debug(`Discarded ${this.blockchain.queue.length()} chunks of downloaded blocks.`);
             }
 
             // If we consecutively fail to accept the same block, our chain is likely forked. In this

--- a/packages/core-blockchain/src/state-machine.ts
+++ b/packages/core-blockchain/src/state-machine.ts
@@ -47,9 +47,9 @@ blockchainMachine.actionMap = (blockchain: Blockchain) => ({
 
     async checkLastDownloadedBlockSynced() {
         let event = "NOTSYNCED";
-        logger.debug(`Queued blocks (process: ${blockchain.queue.length()})`);
+        logger.debug(`Queued chunks of blocks (process: ${blockchain.queue.length()})`);
 
-        if (blockchain.queue.length() > 10000) {
+        if (blockchain.queue.length() > 100) {
             event = "PAUSED";
         }
 


### PR DESCRIPTION
<!-- Please don't delete this template and read our contribution guidelines at https://docs.ark.io/guidebook/contribution-guidelines/contributing.html -->

## Summary

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Divide blocks into smaller chunks (based on number of transactions and number of blocks) before batch processing them.
This will avoid blocking the whole application while processing the blocks.

## What kind of change does this PR introduce?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [x] Bugfix
- [ ] New feature
- [ ] Refactoring / Performance Improvements
- [ ] Build-related changes
- [ ] Documentation
- [ ] Tests / Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [ ] Yes
- [x] No

## Does this PR release a new version?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [ ] Yes
  - [ ] All tests are passing
  - [ ] All benchmarks are passing without any _major_ regressions
  - [ ] Sync from 0 works on mainnet
  - [ ] Sync from 0 works on devnet
  - [ ] Starting a new network and forging on it work
  - [ ] Explorer is fully functional
  - [ ] Wallets are fully functional
- [x] No

## Checklist

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation _(if appropriate)_

<!--
## Other information

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
-->
