### PR TITLE
refactor(core-p2p): remove timeout banning

### DIFF
--- a/__tests__/unit/core-p2p/peer-guard.test.ts
+++ b/__tests__/unit/core-p2p/peer-guard.test.ts
@@ -48,16 +48,6 @@ describe("PeerGuard", () => {
             expect(convertToMinutes(until)).toBe(5);
         });
 
-        it('should return a 2 minutes suspension for "Timeout"', () => {
-            const { until, reason } = guard.analyze({
-                ...dummy,
-                ...{ latency: -1 },
-            });
-
-            expect(reason).toBe("Timeout");
-            expect(convertToMinutes(until)).toBe(0.5);
-        });
-
         it('should return a 1 minutes suspension for "High Latency"', () => {
             const { until, reason } = guard.analyze({
                 ...dummy,

--- a/packages/core-p2p/src/peer-communicator.ts
+++ b/packages/core-p2p/src/peer-communicator.ts
@@ -214,7 +214,6 @@ export class PeerCommunicator implements P2P.IPeerCommunicator {
                 break;
             case "TimeoutError": // socketcluster timeout error
             case SocketErrors.Timeout:
-                peer.latency = -1;
                 this.emitter.emit("internal.p2p.suspendPeer", { peer });
                 break;
             case "Error":

--- a/packages/core-p2p/src/peer-guard.ts
+++ b/packages/core-p2p/src/peer-guard.ts
@@ -25,17 +25,9 @@ export class PeerGuard implements P2P.IPeerGuard {
             until: () => dayjs().add(5, "minute"),
             reason: "Invalid Response Status",
         },
-        timeout: {
-            until: () => dayjs().add(30, "second"),
-            reason: "Timeout",
-        },
         highLatency: {
             until: () => dayjs().add(1, "minute"),
             reason: "High Latency",
-        },
-        applicationNotReady: {
-            until: () => dayjs().add(30, "second"),
-            reason: "Application is not ready",
         },
         failedBlocksDownload: {
             until: () => dayjs().add(30, "second"),
@@ -76,10 +68,6 @@ export class PeerGuard implements P2P.IPeerGuard {
 
         if (this.connector.hasError(peer, SocketErrors.AppNotReady)) {
             return undefined;
-        }
-
-        if (peer.latency === -1) {
-            return this.createPunishment(this.offences.timeout);
         }
 
         if (peer.latency > 2000) {

--- a/packages/core-p2p/src/peer-processors.ts
+++ b/packages/core-p2p/src/peer-processors.ts
@@ -159,10 +159,6 @@ export class PeerProcessor implements P2P.IPeerProcessor {
 
             this.emitter.emit(ApplicationEvents.PeerAdded, newPeer);
         } catch (error) {
-            if (error instanceof PeerPingTimeoutError) {
-                newPeer.latency = -1;
-            }
-
             this.suspend(newPeer);
         } finally {
             this.storage.forgetPendingPeer(peer);

--- a/packages/core-p2p/src/peer-processors.ts
+++ b/packages/core-p2p/src/peer-processors.ts
@@ -6,7 +6,6 @@ import { EventEmitter, Logger, P2P } from "@arkecosystem/core-interfaces";
 import dayjs from "dayjs";
 import prettyMs from "pretty-ms";
 import { SCClientSocket } from "socketcluster-client";
-import { PeerPingTimeoutError } from "./errors";
 import { Peer } from "./peer";
 import { PeerSuspension } from "./peer-suspension";
 import { isValidPeer } from "./utils";

--- a/packages/core-p2p/src/peer.ts
+++ b/packages/core-p2p/src/peer.ts
@@ -5,7 +5,7 @@ import { PeerVerificationResult } from "./peer-verifier";
 
 export class Peer implements P2P.IPeer {
     public readonly ports: P2P.IPeerPorts = {
-        p2p: app.resolveOptions("p2p").server.port,
+        p2p: +app.resolveOptions("p2p").server.port,
     };
 
     public version: string;


### PR DESCRIPTION
<!-- Please don't delete this template and read our contribution guidelines at https://docs.ark.io/guidebook/contribution-guidelines/contributing.html -->

## Summary

Remove the timeout ban as it can cause issues when the network is in bad shape.

## What kind of change does this PR introduce?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [ ] Bugfix
- [ ] New feature
- [x] Refactoring / Performance Improvements
- [ ] Build-related changes
- [ ] Documentation
- [ ] Tests / Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [x] Yes
- [ ] No

## Does this PR release a new version?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [ ] Yes
  - [ ] All tests are passing
  - [ ] All benchmarks are passing without any _major_ regressions
  - [ ] Sync from 0 works on mainnet
  - [ ] Sync from 0 works on devnet
  - [ ] Starting a new network and forging on it work
  - [ ] Explorer is fully functional
  - [ ] Wallets are fully functional
- [x] No

## Checklist

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation _(if appropriate)_

<!--
## Other information

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
-->
