### PR TITLE
fix(core-forger): use a static reconnect timeout

### DIFF
--- a/packages/core-forger/src/client.ts
+++ b/packages/core-forger/src/client.ts
@@ -14,7 +14,14 @@ export class Client {
 
     constructor(hosts: IRelayHost[]) {
         this.hosts = hosts.map(host => {
-            host.socket = socketCluster.create(host);
+            host.socket = socketCluster.create({
+                ...host,
+                autoReconnectOptions: {
+                    initialDelay: 1000,
+                    maxDelay: 1000,
+                },
+            });
+
             host.socket.on("error", err => {
                 if (err.message !== "Socket hung up") {
                     this.logger.error(err.message);

--- a/packages/core-forger/src/manager.ts
+++ b/packages/core-forger/src/manager.ts
@@ -53,7 +53,6 @@ export class ForgerManager {
         try {
             await this.loadRound();
             timeout = Crypto.Slots.getTimeInMsUntilNextSlot();
-            this.logger.info(`Forger Manager started with ${pluralize("forger", this.delegates.length, true)}`);
         } catch (error) {
             timeout = 2000;
             this.logger.warn("Waiting for a responsive host.");
@@ -278,7 +277,7 @@ export class ForgerManager {
         );
 
         if (activeDelegates.length > 0) {
-            this.logger.debug(
+            this.logger.info(
                 `Loaded ${pluralize("active delegate", activeDelegates.length, true)}: ${activeDelegates
                     .map(({ publicKey }) => `${this.usernames[publicKey]} (${publicKey})`)
                     .join(", ")}`,
@@ -290,11 +289,13 @@ export class ForgerManager {
                 .filter(delegate => !activeDelegates.includes(delegate))
                 .map(delegate => delegate.publicKey);
 
-            this.logger.debug(
+            this.logger.info(
                 `Loaded ${pluralize("inactive delegate", inactiveDelegates.length, true)}: ${inactiveDelegates.join(
                     ", ",
                 )}`,
             );
         }
+
+        this.logger.info(`Forger Manager started.`);
     }
 }

--- a/packages/core-p2p/src/peer-processors.ts
+++ b/packages/core-p2p/src/peer-processors.ts
@@ -100,7 +100,7 @@ export class PeerProcessor implements P2P.IPeerProcessor {
         this.connector.disconnect(peer);
 
         if (!punishment) {
-            this.logger.debug(`Disconnecting from ${peer.ip}:${peer.port} without punishment.`);
+            this.logger.debug(`Disconnecting from ${peer.ip}:${peer.port}.`);
             return;
         }
 


### PR DESCRIPTION
<!-- Please don't delete this template and read our contribution guidelines at https://docs.ark.io/guidebook/contribution-guidelines/contributing.html -->

## Summary

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->
By default the timeout between reconnects increases with each attempt up to a maximum of 60 seconds. Now the forger tries to reconnect every second.

## What kind of change does this PR introduce?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [X] Bugfix
- [ ] New feature
- [ ] Refactoring / Performance Improvements
- [ ] Build-related changes
- [ ] Documentation
- [ ] Tests / Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [ ] Yes
- [X] No

## Does this PR release a new version?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [ ] Yes
  - [ ] All tests are passing
  - [ ] All benchmarks are passing without any _major_ regressions
  - [ ] Sync from 0 works on mainnet
  - [ ] Sync from 0 works on devnet
  - [ ] Starting a new network and forging on it work
  - [ ] Explorer is fully functional
  - [ ] Wallets are fully functional
- [ ] No

## Checklist

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [ ] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation _(if appropriate)_

<!--
## Other information

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
-->
