### PR TITLE
fix(core-wallet-api): return plugins with package names

### DIFF
--- a/__tests__/unit/core-utils/transform-plugins.test.ts
+++ b/__tests__/unit/core-utils/transform-plugins.test.ts
@@ -8,7 +8,18 @@ describe("transformPlugins", () => {
         const transformed = Plugins.transformPlugins(plugins);
 
         expect(transformed).toEqual({
-            api: { port: 4003 },
+            "@arkecosystem/core-api": {
+                enabled: true,
+                port: 4003,
+            },
+            "@arkecosystem/core-json-rpc": {
+                enabled: false,
+                port: 8080,
+            },
+            "@arkecosystem/core-webhooks": {
+                enabled: false,
+                port: 4004,
+            },
         });
     });
 });

--- a/packages/core-interfaces/src/core-p2p/peer.ts
+++ b/packages/core-interfaces/src/core-p2p/peer.ts
@@ -7,7 +7,7 @@ export interface IPeerPorts {
 }
 
 export interface IPeerPlugins {
-    [name: string]: { port: number };
+    [name: string]: { enabled: boolean; port: number };
 }
 
 export interface IPeer {

--- a/packages/core-utils/src/transform-plugins.ts
+++ b/packages/core-utils/src/transform-plugins.ts
@@ -11,7 +11,7 @@ export const transformPlugins = (plugins): P2P.IPeerPlugins => {
         const port: number = Number(options.port);
         const enabled: boolean = !!options.enabled;
 
-        if (isNaN(port) || name === "p2p") {
+        if (isNaN(port) || name.includes("core-p2p")) {
             continue;
         }
 

--- a/packages/core-utils/src/transform-plugins.ts
+++ b/packages/core-utils/src/transform-plugins.ts
@@ -11,7 +11,7 @@ export const transformPlugins = (plugins): P2P.IPeerPlugins => {
         const port: number = Number(options.port);
         const enabled: boolean = !!options.enabled;
 
-        if (isNaN(port) || !enabled || name === "p2p") {
+        if (isNaN(port) || name === "p2p") {
             continue;
         }
 

--- a/packages/core-utils/src/transform-plugins.ts
+++ b/packages/core-utils/src/transform-plugins.ts
@@ -8,20 +8,15 @@ export const transformPlugins = (plugins): P2P.IPeerPlugins => {
             options = options.server;
         }
 
-        if (name.includes("/")) {
-            name = name.split("/").reverse()[0];
-        }
-
-        name = name.split("-").reverse()[0];
-
-        const port = Number(options.port);
-        const enabled = !!options.enabled;
+        const port: number = Number(options.port);
+        const enabled: boolean = !!options.enabled;
 
         if (isNaN(port) || !enabled || name === "p2p") {
             continue;
         }
 
         result[name] = {
+            enabled,
             port,
         };
     }

--- a/packages/core-wallet-api/src/server/handlers.ts
+++ b/packages/core-wallet-api/src/server/handlers.ts
@@ -18,7 +18,7 @@ export const config = {
                         symbol: appConfig.get("network.client.symbol"),
                     },
                 },
-                plugins: Plugins.transformPlugins(appConfig.config),
+                plugins: Plugins.transformPlugins(appConfig.config.plugins),
             },
         };
     },


### PR DESCRIPTION
<!-- Please don't delete this template and read our contribution guidelines at https://docs.ark.io/guidebook/contribution-guidelines/contributing.html -->

## Summary

Return packages with name and port instead of using some trimmed down alias.

## What kind of change does this PR introduce?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [x] Bugfix
- [ ] New feature
- [ ] Refactoring / Performance Improvements
- [ ] Build-related changes
- [ ] Documentation
- [ ] Tests / Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [x] Yes
- [ ] No

## Does this PR release a new version?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [ ] Yes
  - [ ] All tests are passing
  - [ ] All benchmarks are passing without any _major_ regressions
  - [ ] Sync from 0 works on mainnet
  - [ ] Sync from 0 works on devnet
  - [ ] Starting a new network and forging on it work
  - [ ] Explorer is fully functional
  - [ ] Wallets are fully functional
- [x] No

## Checklist

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation _(if appropriate)_

<!--
## Other information

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
-->
