### PR TITLE
feat(core-api): search transactions by asset

### DIFF
--- a/__tests__/integration/core-api/handlers/transactions.test.ts
+++ b/__tests__/integration/core-api/handlers/transactions.test.ts
@@ -416,6 +416,42 @@ describe("API 2.0 - Transactions", () => {
             expect(response.data.data).toBeArray();
             utils.expectTransaction(response.data.data[0]);
         });
+
+        it("should POST a search for transactions with an asset matching any delegate", async () => {
+            const response = await utils.request("POST", "transactions/search", {
+                asset: {
+                    delegate: {},
+                },
+            });
+            expect(response).toBeSuccessfulResponse();
+            expect(response.data.data).toBeArray();
+            expect(response.data.data).toHaveLength(51);
+            utils.expectTransaction(response.data.data[0]);
+        });
+
+        it("should POST a search for transactions with an asset matching any delegate and sender public key", async () => {
+            const response = await utils.request("POST", "transactions/search", {
+                asset: {
+                    delegate: {},
+                },
+                senderPublicKey: "0377f81a18d25d77b100cb17e829a72259f08334d064f6c887298917a04df8f647",
+            });
+            expect(response).toBeSuccessfulResponse();
+            expect(response.data.data).toBeArray();
+            expect(response.data.data).toHaveLength(1);
+            utils.expectTransaction(response.data.data[0]);
+        });
+
+        it("should POST a search for transactions with an wrong asset", async () => {
+            const response = await utils.request("POST", "transactions/search", {
+                asset: {
+                    garbage: {},
+                },
+            });
+            expect(response).toBeSuccessfulResponse();
+            expect(response.data.data).toBeArray();
+            expect(response.data.data).toHaveLength(0);
+        });
     });
 
     describe("POST /transactions", () => {

--- a/packages/core-api/src/handlers/transactions/schema.ts
+++ b/packages/core-api/src/handlers/transactions/schema.ts
@@ -145,5 +145,6 @@ export const search: object = {
                 .integer()
                 .min(0),
         }),
+        asset: Joi.object(),
     },
 };

--- a/packages/core-database-postgres/src/models/transaction.ts
+++ b/packages/core-database-postgres/src/models/transaction.ts
@@ -78,7 +78,7 @@ export class Transaction extends Model {
             init: col => {
                 return col.value;
             },
-            supportedOperators: [Database.SearchOperator.OP_EQ],
+            supportedOperators: [Database.SearchOperator.OP_CONTAINS],
         },
     ];
 

--- a/packages/core-database/src/repositories/utils/search-parameter-converter.ts
+++ b/packages/core-database/src/repositories/utils/search-parameter-converter.ts
@@ -146,6 +146,17 @@ export class SearchParameterConverter implements Database.IISearchParameterConve
                 });
                 continue;
             }
+
+            // if the field supports CONTAINS (@>), then ignore any others.
+            if (fieldDescriptor.supportedOperators.includes(Database.SearchOperator.OP_CONTAINS)) {
+                searchParameters.parameters.push({
+                    field: fieldName,
+                    operator: Database.SearchOperator.OP_CONTAINS,
+                    value: params[fieldName],
+                });
+
+                continue;
+            }
         }
     }
 }

--- a/packages/core-interfaces/src/core-database/search/search-parameters.ts
+++ b/packages/core-interfaces/src/core-database/search/search-parameters.ts
@@ -4,6 +4,7 @@ export enum SearchOperator {
     OP_GTE = "gte",
     OP_LTE = "lte",
     OP_LIKE = "like",
+    OP_CONTAINS = "contains",
     // placeholder. For parameters that require custom(not a 1-to-1 field to column mapping) filtering logic on the data-layer repo
     OP_CUSTOM = "custom_operator",
 }


### PR DESCRIPTION
<!-- Please don't delete this template and read our contribution guidelines at https://docs.ark.io/guidebook/contribution-guidelines/contributing.html -->

## Summary

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->
The `/transactions/search` endpoint now accepts an `asset` object.

Internally it uses the `@>` (contains) operator for comparing the payload against the `jsonb` column.
For example this payload:
```
{"asset": {} }
```
returns all transactions with an asset.

Whereas this one:
```
{"asset": {"delegate": {} } }
```
only returns type 2 transactions. 

And lastly this
```
{"asset": {"delegate": { "username": "boldninja" } } }
```
returns one matching transaction.

Note: Due to how `@>` works it is not possible to e.g. search for all assets with a username starting with "b" or with a number greater or equal something. Another limiting factor is our used sql query builder which makes it difficult to impossible to express more sophisticated statements.

## What kind of change does this PR introduce?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [ ] Bugfix
- [X] New feature
- [ ] Refactoring / Performance Improvements
- [ ] Build-related changes
- [ ] Documentation
- [ ] Tests / Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [ ] Yes
- [X] No

## Does this PR release a new version?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [ ] Yes
  - [ ] All tests are passing
  - [ ] All benchmarks are passing without any _major_ regressions
  - [ ] Sync from 0 works on mainnet
  - [ ] Sync from 0 works on devnet
  - [ ] Starting a new network and forging on it work
  - [ ] Explorer is fully functional
  - [ ] Wallets are fully functional
- [ ] No

## Checklist

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

- [ ] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation _(if appropriate)_

<!--
## Other information

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
-->
