### PR TITLE
refactor(core-transaction-pool): deserialize transactions before they leave the pool

### DIFF
--- a/__tests__/unit/core-p2p/mocks/blockchain.ts
+++ b/__tests__/unit/core-p2p/mocks/blockchain.ts
@@ -5,7 +5,6 @@ export const blockchain = {
     getLastDownloadedBlock: jest.fn(),
     forceWakeup: jest.fn(),
     handleIncomingBlock: jest.fn(),
-    getUnconfirmedTransactions: jest.fn().mockReturnValue([]),
     pingBlock: jest.fn().mockReturnValue(false),
     pushPingBlock: jest.fn(),
     getBlockPing: jest.fn(),

--- a/__tests__/unit/core-p2p/mocks/core-container.ts
+++ b/__tests__/unit/core-p2p/mocks/core-container.ts
@@ -7,6 +7,7 @@ import { eventEmitter } from "./event-emitter";
 import { logger } from "./logger";
 import { p2p } from "./p2p";
 import { state } from "./state";
+import { transactionPool } from "./transaction-pool";
 
 Managers.configManager.setFromPreset("unitnet");
 
@@ -63,6 +64,10 @@ jest.mock("@arkecosystem/core-container", () => {
 
                 if (name === "state") {
                     return state;
+                }
+
+                if (name === "transaction-pool") {
+                    return transactionPool;
                 }
 
                 return {};

--- a/__tests__/unit/core-p2p/mocks/transaction-pool.ts
+++ b/__tests__/unit/core-p2p/mocks/transaction-pool.ts
@@ -1,0 +1,4 @@
+export const transactionPool = {
+    getTransactionsForForging: jest.fn(),
+    getPoolSize: jest.fn(),
+};

--- a/__tests__/unit/core-p2p/socket-server/versions/internal/handlers/transactions.test.ts
+++ b/__tests__/unit/core-p2p/socket-server/versions/internal/handlers/transactions.test.ts
@@ -1,6 +1,6 @@
 import "../../../../mocks/core-container";
 
-import { blockchain } from "../../../../mocks/blockchain";
+import { transactionPool } from "../../../../mocks/transaction-pool";
 
 import { getUnconfirmedTransactions } from "../../../../../../../packages/core-p2p/src/socket-server/versions/internal";
 
@@ -9,9 +9,10 @@ jest.mock("../../../../../../../packages/core-p2p/src/socket-server/utils/valida
 describe("Internal handlers - transactions", () => {
     describe("getUnconfirmedTransactions", () => {
         it("should return unconfirmed transactions", () => {
-            blockchain.getUnconfirmedTransactions = jest.fn().mockReturnValue(["111"]);
-            const result = getUnconfirmedTransactions();
-            expect(result).toEqual(["111"]);
+            transactionPool.getTransactionsForForging = jest.fn().mockReturnValue(["111"]);
+            transactionPool.getPoolSize = jest.fn().mockReturnValue(1);
+
+            expect(getUnconfirmedTransactions()).toEqual({ count: 1, poolSize: 1, transactions: ["111"] });
         });
     });
 });

--- a/__tests__/unit/core-p2p/socket-server/versions/internal/handlers/transactions.test.ts
+++ b/__tests__/unit/core-p2p/socket-server/versions/internal/handlers/transactions.test.ts
@@ -12,7 +12,7 @@ describe("Internal handlers - transactions", () => {
             transactionPool.getTransactionsForForging = jest.fn().mockReturnValue(["111"]);
             transactionPool.getPoolSize = jest.fn().mockReturnValue(1);
 
-            expect(getUnconfirmedTransactions()).toEqual({ count: 1, poolSize: 1, transactions: ["111"] });
+            expect(getUnconfirmedTransactions()).toEqual({ poolSize: 1, transactions: ["111"] });
         });
     });
 });

--- a/__tests__/unit/core-transaction-pool/__stubs__/connection.ts
+++ b/__tests__/unit/core-transaction-pool/__stubs__/connection.ts
@@ -86,7 +86,7 @@ export class Connection implements TransactionPool.IConnection {
         return undefined;
     }
 
-    public getTransactionsData<T>(start: number, size: number, property: string, maxBytes?: number): T[] {
+    public getTransactionsData(start: number, size: number, maxBytes?: number): Interfaces.ITransaction[] {
         return undefined;
     }
 

--- a/__tests__/unit/core-transaction-pool/connection.test.ts
+++ b/__tests__/unit/core-transaction-pool/connection.test.ts
@@ -24,7 +24,6 @@ const { SATOSHI } = Constants;
 const { TransactionTypes } = Enums;
 
 const delegatesSecrets = delegates.map(d => d.secret);
-const maxTransactionAge = 4036608000;
 
 let connection: Connection;
 let memory: Memory;
@@ -47,7 +46,7 @@ beforeEach(() => connection.flush());
 describe("Connection", () => {
     const addTransactions = transactions => {
         for (const t of transactions) {
-            memory.remember(t, maxTransactionAge);
+            memory.remember(t);
         }
     };
 
@@ -59,11 +58,11 @@ describe("Connection", () => {
         it("should return 2 if transactions were added", () => {
             expect(connection.getPoolSize()).toBe(0);
 
-            memory.remember(mockData.dummy1, maxTransactionAge);
+            memory.remember(mockData.dummy1);
 
             expect(connection.getPoolSize()).toBe(1);
 
-            memory.remember(mockData.dummy2, maxTransactionAge);
+            memory.remember(mockData.dummy2);
 
             expect(connection.getPoolSize()).toBe(2);
         });
@@ -79,11 +78,11 @@ describe("Connection", () => {
 
             expect(connection.getSenderSize(senderPublicKey)).toBe(0);
 
-            memory.remember(mockData.dummy1, maxTransactionAge);
+            memory.remember(mockData.dummy1);
 
             expect(connection.getSenderSize(senderPublicKey)).toBe(1);
 
-            memory.remember(mockData.dummy3, maxTransactionAge);
+            memory.remember(mockData.dummy3);
 
             expect(connection.getSenderSize(senderPublicKey)).toBe(2);
         });
@@ -271,7 +270,7 @@ describe("Connection", () => {
 
     describe("removeTransaction", () => {
         it("should remove the specified transaction from the pool", () => {
-            memory.remember(mockData.dummy1, maxTransactionAge);
+            memory.remember(mockData.dummy1);
 
             expect(connection.getPoolSize()).toBe(1);
 
@@ -283,7 +282,7 @@ describe("Connection", () => {
 
     describe("removeTransactionById", () => {
         it("should remove the specified transaction from the pool (by id)", () => {
-            memory.remember(mockData.dummy1, maxTransactionAge);
+            memory.remember(mockData.dummy1);
 
             expect(connection.getPoolSize()).toBe(1);
 
@@ -293,7 +292,7 @@ describe("Connection", () => {
         });
 
         it("should do nothing when asked to delete a non-existent transaction", () => {
-            memory.remember(mockData.dummy1, maxTransactionAge);
+            memory.remember(mockData.dummy1);
 
             connection.removeTransactionById("nonexistenttransactionid");
 

--- a/__tests__/utils/config/testnet/plugins.js
+++ b/__tests__/utils/config/testnet/plugins.js
@@ -15,9 +15,6 @@ module.exports = {
         enabled: !process.env.CORE_TRANSACTION_POOL_DISABLED,
         maxTransactionsPerSender: process.env.CORE_TRANSACTION_POOL_MAX_PER_SENDER || 300,
         allowedSenders: [],
-        // 100+ years in the future to avoid our hardcoded transactions used in the
-        // tests to expire immediately
-        maxTransactionAge: 4036608000,
         dynamicFees: {
             minFeePool: 1000,
             minFeeBroadcast: 1000,

--- a/__tests__/utils/config/unitnet/plugins.js
+++ b/__tests__/utils/config/unitnet/plugins.js
@@ -15,9 +15,6 @@ module.exports = {
         enabled: !process.env.CORE_TRANSACTION_POOL_DISABLED,
         maxTransactionsPerSender: process.env.CORE_TRANSACTION_POOL_MAX_PER_SENDER || 300,
         allowedSenders: [],
-        // 100+ years in the future to avoid our hardcoded transactions used in the
-        // tests to expire immediately
-        maxTransactionAge: 4036608000,
         dynamicFees: {
             minFeePool: 1000,
             minFeeBroadcast: 1000,

--- a/packages/core-api/src/versions/2/node/controller.ts
+++ b/packages/core-api/src/versions/2/node/controller.ts
@@ -60,7 +60,6 @@ export class NodeController extends Controller {
                     ports: super.toResource(request, this.config, "ports"),
                     constants: this.config.getMilestone(this.blockchain.getLastHeight()),
                     transactionPool: {
-                        maxTransactionAge: app.resolveOptions("transaction-pool").maxTransactionAge,
                         dynamicFees: dynamicFees.enabled ? dynamicFees : { enabled: false },
                     },
                 },

--- a/packages/core-blockchain/src/blockchain.ts
+++ b/packages/core-blockchain/src/blockchain.ts
@@ -456,22 +456,6 @@ export class Blockchain implements blockchain.IBlockchain {
     }
 
     /**
-     * Get unconfirmed transactions for the specified block size.
-     * @param  {Number}  blockSize
-     * @param  {Boolean} forForging
-     * @return {Object}
-     */
-    public getUnconfirmedTransactions(blockSize: number): { transactions: string[]; poolSize: number; count: number } {
-        const transactions: string[] = this.transactionPool.getTransactionsForForging(blockSize);
-
-        return {
-            transactions,
-            poolSize: this.transactionPool.getPoolSize(),
-            count: transactions ? transactions.length : -1,
-        };
-    }
-
-    /**
      * Determine if the blockchain is synced.
      */
     public isSynced(block?: Interfaces.IBlock): boolean {

--- a/packages/core-forger/src/manager.ts
+++ b/packages/core-forger/src/manager.ts
@@ -178,7 +178,7 @@ export class ForgerManager {
         }
 
         const transactions: Interfaces.ITransactionData[] = response.transactions.map(
-            serializedTx => Transactions.TransactionFactory.fromHex(serializedTx).data,
+            hex => Transactions.TransactionFactory.fromBytesUnsafe(Buffer.from(hex, "hex")).data,
         );
 
         this.logger.debug(

--- a/packages/core-forger/src/manager.ts
+++ b/packages/core-forger/src/manager.ts
@@ -178,7 +178,7 @@ export class ForgerManager {
         }
 
         const transactions: Interfaces.ITransactionData[] = response.transactions.map(
-            hex => Transactions.TransactionFactory.fromBytesUnsafe(Buffer.from(hex, "hex")).data,
+            (hex: string) => Transactions.TransactionFactory.fromBytesUnsafe(Buffer.from(hex, "hex")).data,
         );
 
         this.logger.debug(

--- a/packages/core-interfaces/src/core-blockchain/blockchain.ts
+++ b/packages/core-interfaces/src/core-blockchain/blockchain.ts
@@ -103,20 +103,6 @@ export interface IBlockchain {
     forkBlock(block: Interfaces.IBlock): void;
 
     /**
-     * Get unconfirmed transactions for the specified block size.
-     * @param  {Number}  blockSize
-     * @param  {Boolean} forForging
-     * @return {Object}
-     */
-    getUnconfirmedTransactions(
-        blockSize: number,
-    ): {
-        transactions: string[];
-        poolSize: number;
-        count: number;
-    };
-
-    /**
      * Determine if the blockchain is synced.
      * @param  {Block} [block=getLastBlock()]  block
      * @return {Boolean}

--- a/packages/core-interfaces/src/core-transaction-pool/connection.ts
+++ b/packages/core-interfaces/src/core-transaction-pool/connection.ts
@@ -31,7 +31,7 @@ export interface IConnection {
     getTransactionIdsForForging(start: number, size: number): string[];
     getTransactions(start: number, size: number, maxBytes?: number): Buffer[];
     getTransactionsByType(type: any): any;
-    getTransactionsData<T>(start: number, size: number, maxBytes?: number): Interfaces.ITransaction[];
+    getTransactionsData(start: number, size: number, maxBytes?: number): Interfaces.ITransaction[];
     getTransactionsForForging(blockSize: number): string[];
     has(transactionId: string): any;
     hasExceededMaxTransactions(senderPublicKey: string): boolean;

--- a/packages/core-interfaces/src/core-transaction-pool/connection.ts
+++ b/packages/core-interfaces/src/core-transaction-pool/connection.ts
@@ -31,7 +31,7 @@ export interface IConnection {
     getTransactionIdsForForging(start: number, size: number): string[];
     getTransactions(start: number, size: number, maxBytes?: number): Buffer[];
     getTransactionsByType(type: any): any;
-    getTransactionsData<T>(start: number, size: number, property: string, maxBytes?: number): T[];
+    getTransactionsData<T>(start: number, size: number, maxBytes?: number): Interfaces.ITransaction[];
     getTransactionsForForging(blockSize: number): string[];
     has(transactionId: string): any;
     hasExceededMaxTransactions(senderPublicKey: string): boolean;

--- a/packages/core-p2p/src/socket-server/versions/internal.ts
+++ b/packages/core-p2p/src/socket-server/versions/internal.ts
@@ -10,7 +10,6 @@ export const emitEvent = ({ req }): void => {
 export const getUnconfirmedTransactions = (): {
     transactions: string[];
     poolSize: number;
-    count: number;
 } => {
     const blockchain = app.resolvePlugin<Blockchain.IBlockchain>("blockchain");
     const { maxTransactions } = app.getConfig().getMilestone(blockchain.getLastBlock().data.height).block;
@@ -19,12 +18,9 @@ export const getUnconfirmedTransactions = (): {
         "transaction-pool",
     );
 
-    const transactions: string[] = transactionPool.getTransactionsForForging(maxTransactions);
-
     return {
-        transactions,
+        transactions: transactionPool.getTransactionsForForging(maxTransactions),
         poolSize: transactionPool.getPoolSize(),
-        count: transactions ? transactions.length : -1,
     };
 };
 

--- a/packages/core-p2p/src/socket-server/versions/internal.ts
+++ b/packages/core-p2p/src/socket-server/versions/internal.ts
@@ -1,5 +1,5 @@
 import { app } from "@arkecosystem/core-container";
-import { Blockchain, Database, EventEmitter, Logger, P2P } from "@arkecosystem/core-interfaces";
+import { Blockchain, Database, EventEmitter, Logger, P2P, TransactionPool } from "@arkecosystem/core-interfaces";
 import { roundCalculator } from "@arkecosystem/core-utils";
 import { Crypto } from "@arkecosystem/crypto";
 
@@ -15,7 +15,17 @@ export const getUnconfirmedTransactions = (): {
     const blockchain = app.resolvePlugin<Blockchain.IBlockchain>("blockchain");
     const { maxTransactions } = app.getConfig().getMilestone(blockchain.getLastBlock().data.height).block;
 
-    return blockchain.getUnconfirmedTransactions(maxTransactions);
+    const transactionPool: TransactionPool.IConnection = app.resolvePlugin<TransactionPool.IConnection>(
+        "transaction-pool",
+    );
+
+    const transactions: string[] = transactionPool.getTransactionsForForging(maxTransactions);
+
+    return {
+        transactions,
+        poolSize: transactionPool.getPoolSize(),
+        count: transactions ? transactions.length : -1,
+    };
 };
 
 export const getCurrentRound = async (): Promise<P2P.ICurrentRound> => {

--- a/packages/core-transaction-pool/src/connection.ts
+++ b/packages/core-transaction-pool/src/connection.ts
@@ -2,8 +2,8 @@ import { app } from "@arkecosystem/core-container";
 import { ApplicationEvents } from "@arkecosystem/core-event-emitter";
 import { Database, EventEmitter, Logger, State, TransactionPool } from "@arkecosystem/core-interfaces";
 import { Handlers } from "@arkecosystem/core-transactions";
-import { Enums, Interfaces, Utils } from "@arkecosystem/crypto";
-import assert from "assert";
+import { Enums, Interfaces, Transactions, Utils } from "@arkecosystem/crypto";
+import { strictEqual } from "assert";
 import dayjs, { Dayjs } from "dayjs";
 import { ITransactionsProcessed } from "./interfaces";
 import { Memory } from "./memory";
@@ -50,7 +50,7 @@ export class Connection implements TransactionPool.IConnection {
         const all: Interfaces.ITransaction[] = this.storage.loadAll();
 
         for (const transaction of all) {
-            this.memory.remember(transaction, this.options.maxTransactionAge, true);
+            this.memory.remember(transaction, true);
         }
 
         this.purgeExpired();
@@ -139,21 +139,49 @@ export class Connection implements TransactionPool.IConnection {
     }
 
     public getTransactions(start: number, size: number, maxBytes?: number): Buffer[] {
-        return this.getTransactionsData<Buffer>(start, size, "serialized", maxBytes);
+        return this.getTransactionsData(start, size, maxBytes).map(
+            (transaction: Interfaces.ITransaction) => transaction.serialized,
+        );
     }
 
     public getTransactionsForForging(blockSize: number): string[] {
-        return this.getTransactions(0, blockSize, this.options.maxTransactionBytes).map(tx => tx.toString("hex"));
+        const transactionMemory: Interfaces.ITransaction[] = this.getTransactionsData(
+            0,
+            blockSize,
+            this.options.maxTransactionBytes,
+        );
+
+        const transactions: string[] = [];
+
+        for (const transaction of transactionMemory) {
+            try {
+                const deserialized: Interfaces.ITransaction = Transactions.TransactionFactory.fromBytes(
+                    transaction.serialized,
+                );
+
+                strictEqual(transaction.id, deserialized.id);
+
+                transactions.push(deserialized.serialized.toString("hex"));
+            } catch (error) {
+                this.removeTransactionById(transaction.id);
+
+                this.logger.error(`Removed ${transaction.id} before forging because it resulted in malformed data.`);
+            }
+        }
+
+        return transactions;
     }
 
     public getTransactionIdsForForging(start: number, size: number): string[] {
-        return this.getTransactionsData<string>(start, size, "id", this.options.maxTransactionBytes);
+        return this.getTransactionsData(start, size, this.options.maxTransactionBytes).map(
+            (transaction: Interfaces.ITransaction) => transaction.id,
+        );
     }
 
-    public getTransactionsData<T>(start: number, size: number, property: string, maxBytes: number = 0): T[] {
+    public getTransactionsData(start: number, size: number, maxBytes: number = 0): Interfaces.ITransaction[] {
         this.purgeExpired();
 
-        const data: T[] = [];
+        const data: Interfaces.ITransaction[] = [];
 
         let transactionBytes: number = 0;
 
@@ -165,8 +193,6 @@ export class Connection implements TransactionPool.IConnection {
 
             if (i >= start) {
                 let pushTransaction: boolean = false;
-
-                assert.notStrictEqual(transaction[property], undefined);
 
                 if (maxBytes > 0) {
                     const transactionSize: number = JSON.stringify(transaction.data).length;
@@ -180,7 +206,7 @@ export class Connection implements TransactionPool.IConnection {
                 }
 
                 if (pushTransaction) {
-                    data.push(transaction[property]);
+                    data.push(transaction);
                     i++;
                 }
             } else {
@@ -436,7 +462,7 @@ export class Connection implements TransactionPool.IConnection {
             }
         }
 
-        this.memory.remember(transaction, this.options.maxTransactionAge);
+        this.memory.remember(transaction);
 
         try {
             this.walletManager.throwIfApplyingFails(transaction);
@@ -466,10 +492,7 @@ export class Connection implements TransactionPool.IConnection {
     }
 
     private purgeExpired(): void {
-        this.purgeTransactions(
-            ApplicationEvents.TransactionExpired,
-            this.memory.getExpired(this.options.maxTransactionAge),
-        );
+        this.purgeTransactions(ApplicationEvents.TransactionExpired, this.memory.getExpired());
     }
 
     private purgeTransactions(event: string, transactions: Interfaces.ITransaction[]): void {

--- a/packages/core-transaction-pool/src/defaults.ts
+++ b/packages/core-transaction-pool/src/defaults.ts
@@ -11,10 +11,6 @@ export const defaults = {
     allowedSenders: [],
     maxTransactionsPerRequest: process.env.CORE_TRANSACTION_POOL_MAX_PER_REQUEST || 40,
     maxTransactionBytes: process.env.CORE_TRANSACTION_POOL_MAX_TRANSACTIONS_SIZE || 1047876,
-    // Max transaction age in number of blocks produced since receiving a transaction.
-    // If a transaction stays that long in the pool without being included in any block,
-    // then it will be removed.
-    maxTransactionAge: 2700,
     dynamicFees: {
         enabled: true,
         minFeePool: 3000,

--- a/packages/core-transaction-pool/src/memory.ts
+++ b/packages/core-transaction-pool/src/memory.ts
@@ -53,7 +53,7 @@ export class Memory {
         return this.all;
     }
 
-    public getExpired(maxTransactionAge: number): Interfaces.ITransaction[] {
+    public getExpired(): Interfaces.ITransaction[] {
         if (!this.byExpirationIsSorted) {
             this.byExpiration.sort((a, b) => a.data.expiration - b.data.expiration);
             this.byExpirationIsSorted = true;
@@ -111,7 +111,7 @@ export class Memory {
         return new Set();
     }
 
-    public remember(transaction: Interfaces.ITransaction, maxTransactionAge: number, databaseReady?: boolean): void {
+    public remember(transaction: Interfaces.ITransaction, databaseReady?: boolean): void {
         assert.strictEqual(this.byId[transaction.id], undefined);
 
         this.all.push(transaction);

--- a/packages/crypto/src/blocks/deserializer.ts
+++ b/packages/crypto/src/blocks/deserializer.ts
@@ -13,7 +13,10 @@ class Deserializer {
         const block = {} as IBlockData;
         let transactions: ITransaction[] = [];
 
-        const buf: ByteBuffer = ByteBuffer.fromHex(serializedHex, true);
+        const buffer = Buffer.from(serializedHex, "hex");
+        const buf: ByteBuffer = new ByteBuffer(buffer.length, true);
+        buf.append(buffer);
+        buf.reset();
 
         this.deserializeHeader(block, buf);
 

--- a/packages/crypto/src/transactions/deserializer.ts
+++ b/packages/crypto/src/transactions/deserializer.ts
@@ -77,7 +77,12 @@ class Deserializer {
 
             buf.reset();
 
-            return parseInt(lengthHex, 16) + 2;
+            const length = parseInt(lengthHex, 16) + 2;
+            if (isNaN(length)) {
+                throw new MalformedTransactionBytesError();
+            }
+
+            return length;
         };
 
         // Signature

--- a/packages/crypto/src/transactions/deserializer.ts
+++ b/packages/crypto/src/transactions/deserializer.ts
@@ -76,13 +76,7 @@ class Deserializer {
                 .toString("hex");
 
             buf.reset();
-
-            const length: number = parseInt(lengthHex, 16) + 2;
-            if (isNaN(length)) {
-                throw new MalformedTransactionBytesError();
-            }
-
-            return length;
+            return parseInt(lengthHex, 16) + 2;
         };
 
         // Signature
@@ -161,14 +155,13 @@ class Deserializer {
     }
 
     private getByteBuffer(serialized: Buffer | string): ByteBuffer {
-        let buffer: ByteBuffer;
-        if (serialized instanceof Buffer) {
-            buffer = new ByteBuffer(serialized.length, true);
-            buffer.append(serialized);
-            buffer.reset();
-        } else {
-            buffer = ByteBuffer.fromHex(serialized, true);
+        if (!(serialized instanceof Buffer)) {
+            serialized = Buffer.from(serialized, "hex");
         }
+
+        const buffer: ByteBuffer = new ByteBuffer(serialized.length, true);
+        buffer.append(serialized);
+        buffer.reset();
 
         return buffer;
     }

--- a/packages/crypto/src/transactions/deserializer.ts
+++ b/packages/crypto/src/transactions/deserializer.ts
@@ -77,7 +77,7 @@ class Deserializer {
 
             buf.reset();
 
-            const length = parseInt(lengthHex, 16) + 2;
+            const length: number = parseInt(lengthHex, 16) + 2;
             if (isNaN(length)) {
                 throw new MalformedTransactionBytesError();
             }

--- a/packages/crypto/src/transactions/factory.ts
+++ b/packages/crypto/src/transactions/factory.ts
@@ -13,8 +13,8 @@ export class TransactionFactory {
         return this.fromSerialized(hex);
     }
 
-    public static fromBytes(buffer: Buffer): ITransaction {
-        return this.fromSerialized(buffer ? buffer.toString("hex") : undefined);
+    public static fromBytes(buffer: Buffer, strict: boolean = true): ITransaction {
+        return this.fromSerialized(buffer ? buffer.toString("hex") : undefined, strict);
     }
 
     /**
@@ -60,18 +60,15 @@ export class TransactionFactory {
 
         Serializer.serialize(transaction);
 
-        data.id = Utils.getId(data);
-        transaction.isVerified = transaction.verify();
-
-        return transaction;
+        return this.fromBytes(transaction.serialized, strict);
     }
 
-    private static fromSerialized(serialized: string): ITransaction {
+    private static fromSerialized(serialized: string, strict: boolean = true): ITransaction {
         try {
             const transaction = deserializer.deserialize(serialized);
             transaction.data.id = Utils.getId(transaction.data);
 
-            const { value, error } = Verifier.verifySchema(transaction.data, true);
+            const { value, error } = Verifier.verifySchema(transaction.data, strict);
 
             if (error && !isException(value)) {
                 throw new TransactionSchemaError(error);

--- a/yarn.lock
+++ b/yarn.lock
@@ -803,10 +803,10 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@elastic/elasticsearch@^7.0.1":
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/@elastic/elasticsearch/-/elasticsearch-7.0.1.tgz#25b656f6f523f5a61af35c75c179d5284411fd9d"
-  integrity sha512-cnUqsZhhxpfiGduhI2kgEh/EuWmPagcmzFXfBdkSa8UiL+s9vGeCIYWCm55g6nXTEdqeWRr7GirOLmdM+JFnHQ==
+"@elastic/elasticsearch@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@elastic/elasticsearch/-/elasticsearch-7.1.0.tgz#e6f940e634d034cc0613050a1b4232cd0b4d95cc"
+  integrity sha512-evfs+W6hrC0wu11w/0xL1ZXADHiCbWnVBUbAhZe3xjaFKDfOGioHkPULaEE8uALe7PPPNAMuFErWzutAwwcU9g==
   dependencies:
     debug "^4.1.1"
     decompress-response "^4.2.0"
@@ -822,10 +822,10 @@
   dependencies:
     benchmark "^2.1.4"
 
-"@faustbrian/foreman@^0.1.2":
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/@faustbrian/foreman/-/foreman-0.1.2.tgz#9c387d6228426a0b57de63d3532710cc38f4d1ab"
-  integrity sha512-JwI04M1jv+Ws01tQ3jUlCsZIgmo9/NLhoYnJ0Kq2d1I8FbEAaHjIDrYT5tfab40zNnP0HNB2zEUl0IdG6/Mj0w==
+"@faustbrian/foreman@^0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@faustbrian/foreman/-/foreman-0.1.3.tgz#b1b7fcd2961bae73ffe2ccee646806cb0c041d60"
+  integrity sha512-11zUFNBOahfIK35FE+a35EfA8JYRtNsY7zRcszbR6O1+tq7qwI63AfbvH+wwpaM83e7tLASDXs4VvJrJ3ixB2Q==
   dependencies:
     execa "^1.0.0"
 
@@ -893,7 +893,7 @@
     "@hapi/boom" "7.x.x"
     "@hapi/hoek" "6.x.x"
 
-"@hapi/bourne@1.x.x":
+"@hapi/bourne@1.x.x", "@hapi/bourne@^1.3.2":
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/@hapi/bourne/-/bourne-1.3.2.tgz#0a7095adea067243ce3283e1b56b8a8f453b242a"
   integrity sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA==
@@ -2235,44 +2235,44 @@
   dependencies:
     any-observable "^0.3.0"
 
-"@sentry/core@5.2.0":
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-5.2.0.tgz#06e932fd338a25d2e13de7671f277f059b461705"
-  integrity sha512-s6rnJpJZMDIutcj2EIxyzJBjuYn3omVSjL2F8vOfw2oMZgTGJzQdz7a43iYokX/zFgzEDqz5zWGrhJ1wX/I8/w==
+"@sentry/core@5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-5.3.0.tgz#554c4f8cec42ed3ca8b28c717959bf8685b82696"
+  integrity sha512-m4kB1RB5Ilx7/QTvhfRblyEfyGdV8dDLqE6CS3ftqjbFG0lhkqHjhj3Zai7wphfRnnZsfLGpYT8VJOgS9jUQuQ==
   dependencies:
-    "@sentry/hub" "5.2.0"
-    "@sentry/minimal" "5.2.0"
+    "@sentry/hub" "5.3.0"
+    "@sentry/minimal" "5.3.0"
     "@sentry/types" "5.2.0"
-    "@sentry/utils" "5.2.0"
+    "@sentry/utils" "5.3.0"
     tslib "^1.9.3"
 
-"@sentry/hub@5.2.0":
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-5.2.0.tgz#4fde4b8b97aec3d6375d000f1151600c42cd2d72"
-  integrity sha512-vMHDHmhKWGMsPqQUaN6f+9p4XuGrLBTB30dV8ZFOXkVbQOSG20rjI9nMaSoDkELCmFFCIu9cL+mvuxLcA7TRug==
+"@sentry/hub@5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-5.3.0.tgz#36ae86d78f3bb64aef0371e7917a72df907b287f"
+  integrity sha512-FT+V5bScUoKbiMVZGOYcj81A7F7kQGbMXG+/94yO5s/6s/XJw4AbX5asR/N3Y57QNeeUYWQ2O4eDCjMeRdwXLw==
   dependencies:
     "@sentry/types" "5.2.0"
-    "@sentry/utils" "5.2.0"
+    "@sentry/utils" "5.3.0"
     tslib "^1.9.3"
 
-"@sentry/minimal@5.2.0":
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-5.2.0.tgz#6aad5f63cebceef51ee2b3b0010aee1e810a82b0"
-  integrity sha512-bMoT/+nctMSLo/qNOroTUILojIq/9FhGyW4tvTeHjDCYQorsg+FQqNLEpXo19IHi488Oy51qtBcBeldpxzN4bQ==
+"@sentry/minimal@5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-5.3.0.tgz#ba900bd793e969e293d1ee60ddf5f1905c6b1b90"
+  integrity sha512-s1ok1AI7FQZx+zvgFVjcj1on090VSHo6Bf3f8idGRI2EvAB868q8DJoEcMXJGdJE59zZQ6YCEF5PXAmBm/h9Uw==
   dependencies:
-    "@sentry/hub" "5.2.0"
+    "@sentry/hub" "5.3.0"
     "@sentry/types" "5.2.0"
     tslib "^1.9.3"
 
-"@sentry/node@^5.2.0":
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-5.2.0.tgz#f4fa9ca924385f8c4564ffc5bc387fc305e029b8"
-  integrity sha512-pEXRGwwtnr33wGmbrKjvcwrfMWvE5vj9wqQ1nsrPSuGeMgkj9tOpxilfFVUq+hnz9am1L0C2/p17mn1d3tO/nw==
+"@sentry/node@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-5.3.0.tgz#fd103e1d83f80a693d54f21b192327f0db33af2e"
+  integrity sha512-7TSDW0rsQUUoClT1oAuNKEaBPKOFDkoetdXtlkqF4YkL903WJQL8mt2vxPQ6rQcLM+DpBUppDOlzdBSrieQ0RQ==
   dependencies:
-    "@sentry/core" "5.2.0"
-    "@sentry/hub" "5.2.0"
+    "@sentry/core" "5.3.0"
+    "@sentry/hub" "5.3.0"
     "@sentry/types" "5.2.0"
-    "@sentry/utils" "5.2.0"
+    "@sentry/utils" "5.3.0"
     cookie "0.3.1"
     https-proxy-agent "2.2.1"
     lru_map "0.3.3"
@@ -2283,10 +2283,10 @@
   resolved "https://registry.yarnpkg.com/@sentry/types/-/types-5.2.0.tgz#e42f2ad95c1c10f50656e6b668ff8c8aa06b99d5"
   integrity sha512-QzMVYgONsScAiEGY5XRtSeMwH8464oRdaxCMTtXBuYfF9muvxHqQyF094GVRiconpgKelok5ke9HwrbNUEiE7w==
 
-"@sentry/utils@5.2.0":
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-5.2.0.tgz#1b97fbe9a9bf2f9a355670da6531dcac79d9e748"
-  integrity sha512-/0gWzWSot22P/Zkfz2lxXvuOiHAtM4uwkADlt1yN3mMPTaHD8feV9MTwjg+Z3KxKSZ005riJFncCO+PZQaydSQ==
+"@sentry/utils@5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-5.3.0.tgz#9f86b6addcb762e53c7b659bba9298ac498ccb6b"
+  integrity sha512-4nfv6p2/PPWt7jk/AE73K7YydFHiBs3GvJLpO+PHgNyU3GBtQGST5HggdkGy+mCbtoBdkCIf1CRNeabCxTZ92g==
   dependencies:
     "@sentry/types" "5.2.0"
     tslib "^1.9.3"
@@ -2405,10 +2405,10 @@
   dependencies:
     "@types/node" "*"
 
-"@types/bluebird@^3.5.26":
-  version "3.5.26"
-  resolved "https://registry.yarnpkg.com/@types/bluebird/-/bluebird-3.5.26.tgz#a38c438ae84fa02431d6892edf86e46edcbca291"
-  integrity sha512-aj2mrBLn5ky0GmAg6IPXrQjnN0iB/ulozuJ+oZdrHRAzRbXjGmu4UXsNCjFvPbSaaPZmniocdOzsM392qLOlmQ==
+"@types/bluebird@^3.5.27":
+  version "3.5.27"
+  resolved "https://registry.yarnpkg.com/@types/bluebird/-/bluebird-3.5.27.tgz#61eb4d75dc6bfbce51cf49ee9bbebe941b2cb5d0"
+  integrity sha512-6BmYWSBea18+tSjjSC3QIyV93ZKAeNWGM7R6aYt1ryTZXrlHF+QLV0G2yV0viEGVyRkyQsWfMoJ0k/YghBX5sQ==
 
 "@types/body-parser@*":
   version "1.17.0"
@@ -3449,10 +3449,10 @@ aggregate-error@^3.0.0:
     clean-stack "^2.0.0"
     indent-string "^3.2.0"
 
-airbrake-js@^1.6.7:
-  version "1.6.7"
-  resolved "https://registry.yarnpkg.com/airbrake-js/-/airbrake-js-1.6.7.tgz#96a029de94687fa3c1cf3063bb8f1493f338d6a6"
-  integrity sha512-KDOLboqC1VfNkj6f23rYQLNhJD4KO6MrnL6ePEJycPOpHQjRtx92jIT3fZidKLGEmc3BMix3NRZ85+MJt+ioRA==
+airbrake-js@^1.6.8:
+  version "1.6.8"
+  resolved "https://registry.yarnpkg.com/airbrake-js/-/airbrake-js-1.6.8.tgz#a2b7e7587ebd8b578bce8cb5214b060b385c66fc"
+  integrity sha512-ru2A1lyXv1cqAPbN3T27cUT4HphH0eFQzp0xDVzXpiaUy3pMEBU6i06cGueHavK4CyEEhL6mKQrIshcNsIqwlg==
 
 ajv-keywords@^3.4.0:
   version "3.4.0"
@@ -3986,16 +3986,16 @@ bindings@^1.3.0:
   dependencies:
     file-uri-to-path "1.0.0"
 
-bip32@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/bip32/-/bip32-2.0.2.tgz#7f131b84fb2b84cf8a52aa206def6a8f1037f82b"
-  integrity sha512-Wws0wBYp+KViCTJLLalmOUhefd1puJslme6ks1HPRuEEXGA28HNRVcx6aIGnH0VNYr/NqoUMYf/QakCjbXcElQ==
+bip32@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/bip32/-/bip32-2.0.3.tgz#02575a78e25decec5c31ee950ecd5839508c6d3e"
+  integrity sha512-Tg4dHUXiYBkJyCQq4g++C2PqKcZRveVqy7cKxyl88Uai7MmmknFGaF88odYrXcXk5EMyrlXLuAMC3yEiLxRnNA==
   dependencies:
     "@types/node" "10.12.18"
     bs58check "^2.1.1"
     create-hash "^1.2.0"
     create-hmac "^1.1.7"
-    tiny-secp256k1 "^1.0.0"
+    tiny-secp256k1 "^1.1.0"
     typeforce "^1.11.5"
     wif "^2.0.6"
 
@@ -4017,10 +4017,15 @@ bl@^1.0.0:
     readable-stream "^2.3.5"
     safe-buffer "^5.1.1"
 
-bluebird@^3.5.1, bluebird@^3.5.3, bluebird@^3.5.4:
+bluebird@^3.5.1, bluebird@^3.5.3:
   version "3.5.4"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.4.tgz#d6cc661595de30d5b3af5fcedd3c0b3ef6ec5714"
   integrity sha512-FG+nFEZChJrbQ9tIccIfZJBz3J7mLrAhxakAbnrJWn8d7aKOC+LWifa0G+p4ZqKp4y13T7juYvdhq9NzKdsrjw==
+
+bluebird@^3.5.5:
+  version "3.5.5"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.5.tgz#a8d0afd73251effbbd5fe384a77d73003c17a71f"
+  integrity sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==
 
 bn.js@^4.11.8, bn.js@^4.4.0:
   version "4.11.8"
@@ -4058,7 +4063,7 @@ bounce@1.x.x:
     boom "7.x.x"
     hoek "6.x.x"
 
-bourne@1.x.x, bourne@^1.1.2:
+bourne@1.x.x:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/bourne/-/bourne-1.1.2.tgz#e290b5bd7166635632eaf8ef12b006b2d4a75b83"
   integrity sha512-b2dgVkTZhkQirNMohgC00rWfpVqEi9y5tKM1k3JvoNx05ODtfQoPPd4js9CYFQoY0IM8LAmnJulEuWv74zjUOg==
@@ -9642,10 +9647,10 @@ netmask@^1.0.6:
   resolved "https://registry.yarnpkg.com/netmask/-/netmask-1.0.6.tgz#20297e89d86f6f6400f250d9f4f6b4c1945fcd35"
   integrity sha1-ICl+idhvb2QA8lDZ9Pa0wZRfzTU=
 
-newrelic@^5.8.0:
-  version "5.8.0"
-  resolved "https://registry.yarnpkg.com/newrelic/-/newrelic-5.8.0.tgz#9a1861d855cf7fb8e5435eb70ed230c4fc019fb6"
-  integrity sha512-dj04tHSZPy6jRZ7W8gqYwL9Y+Os0N9hs5Nb1q9mBUpNK8kizedIn36vGKSW3RjrvADtmLZSG70P9HcRuZGq12g==
+newrelic@^5.9.0:
+  version "5.9.0"
+  resolved "https://registry.yarnpkg.com/newrelic/-/newrelic-5.9.0.tgz#6262e1889d08f500d8e948cc5b308e666f1f2169"
+  integrity sha512-a1JyPuNhrAK7Vewl53wH5siElbrdmR48nWKVh+jwB8wVZTScbJ/1Op/m0m47U6RSu5t3nMmUs6DSPZtSwh6QbA==
   dependencies:
     "@newrelic/koa" "^1.0.8"
     "@newrelic/superagent" "^1.0.2"
@@ -9731,10 +9736,10 @@ node-fetch@^2.2.0, node-fetch@^2.3.0:
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.3.0.tgz#1a1d940bbfb916a1d3e0219f037e89e71f8c5fa5"
   integrity sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA==
 
-node-forge@^0.8.3:
-  version "0.8.3"
-  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.8.3.tgz#c714c51d9f95b13fee8039bf78da3195efef5b64"
-  integrity sha512-5lv9UKmvTBog+m4AWL8XpZnr3WbNKxYL2M77i903ylY/huJIooSTDHyUWQ/OppFuKQpAGMk6qNtDymSJNRIEIg==
+node-forge@^0.8.4:
+  version "0.8.4"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.8.4.tgz#d6738662b661be19e2711ef01aa3b18212f13030"
+  integrity sha512-UOfdpxivIYY4g5tqp5FNRNgROVNxRACUxxJREntJLFaJr1E0UEqFtUIk0F/jYx/E+Y6sVXd0KDi/m5My0yGCVw==
 
 node-gyp@^4.0.0:
   version "4.0.0"
@@ -10702,13 +10707,13 @@ pinkie@^2.0.0:
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
   integrity sha1-clVrgM+g1IqXToDnckjoDtT3+HA=
 
-pino-pretty@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/pino-pretty/-/pino-pretty-3.0.0.tgz#915a8fb6ecab609535809a08f3e3f0c70dc17409"
-  integrity sha512-OQCKEit08mVgTQbxBZHScNiwdodJIPgxKFPIStQBZXj09yg94h4OHsbgFCotwn7Ew26ASTbaW4CzWFpsBeynhA==
+pino-pretty@^3.0.1:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/pino-pretty/-/pino-pretty-3.1.0.tgz#8309ea065f40dab8df0c2638b4fbbafd8148d1e7"
+  integrity sha512-/cquelJ9tul0PWDnZMi0PDEmoy9DVjWFdg7euCV6fAFQ5pWBIAayxKSfWimeAArPjXSdLiPKojH5eie3Ch4pbw==
   dependencies:
+    "@hapi/bourne" "^1.3.2"
     args "^5.0.1"
-    bourne "^1.1.2"
     chalk "^2.4.2"
     dateformat "^3.0.3"
     fast-safe-stringify "^2.0.6"
@@ -10934,6 +10939,14 @@ prompts@^2.0.1, prompts@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.0.4.tgz#179f9d4db3128b9933aa35f93a800d8fce76a682"
   integrity sha512-HTzM3UWp/99A0gk51gAegwo1QRYA7xjcZufMNe33rCclFszUYAuHe1fIN/3ZmiHeGPkUsNaRyQm1hHOfM0PKxA==
+  dependencies:
+    kleur "^3.0.2"
+    sisteransi "^1.0.0"
+
+prompts@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.1.0.tgz#bf90bc71f6065d255ea2bdc0fe6520485c1b45db"
+  integrity sha512-+x5TozgqYdOwWsQFZizE/Tra3fKvAoy037kOyU6cgz84n8f6zxngLOV4O32kTwt9FcLCxAqw0P/c8rOr9y+Gfg==
   dependencies:
     kleur "^3.0.2"
     sisteransi "^1.0.0"
@@ -11646,10 +11659,10 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
-rollbar@^2.7.0:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/rollbar/-/rollbar-2.7.0.tgz#6c2ad649b4f294681c70b5ec23eded77b2a76554"
-  integrity sha512-xMEZRcebflLiE6PqAm4h980FXH5J20R1tJ1s/cWDB9s0Uaw4rSSRX5oodtb3JkXblG7abTJRmku9Iz2WADOw3w==
+rollbar@^2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/rollbar/-/rollbar-2.7.1.tgz#4de388f76b69081a8ff0db68c98c2668f3f77492"
+  integrity sha512-xYKTyjgqUjObu8dMkmKqLuyfuJuTnRAJj8E2BIFZtUHdBHmHaZB3JFMgdJ9fHGMN26sN69eV2/gSZlNKVS1wfA==
   dependencies:
     async "~1.2.1"
     console-polyfill "0.3.0"
@@ -11861,6 +11874,11 @@ semver@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.0.0.tgz#05e359ee571e5ad7ed641a6eec1e547ba52dea65"
   integrity sha512-0UewU+9rFapKFnlbirLi3byoOuhrSsli/z/ihNnvM24vgF+8sNBiI1LZPBSH9wJKUwaUbw+s3hToDLCXkrghrQ==
+
+semver@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-6.1.0.tgz#e95dc415d45ecf03f2f9f83b264a6b11f49c0cca"
+  integrity sha512-kCqEOOHoBcFs/2Ccuk4Xarm/KiWRSLEX9CAZF8xkJ6ZPlIoTZ8V5f7J16vYLJqDbR7KrxTJpR2lqjIEm2Qx9cQ==
 
 semver@~5.3.0:
   version "5.3.0"
@@ -12986,16 +13004,24 @@ tiny-glob@^0.2.6:
     globalyzer "^0.1.0"
     globrex "^0.1.1"
 
-tiny-secp256k1@^1.0.0:
+tiny-secp256k1-native@1.1.x:
   version "1.1.0"
-  resolved "https://registry.yarnpkg.com/tiny-secp256k1/-/tiny-secp256k1-1.1.0.tgz#86bf932e153641d6fd23c3faa470bf8c727452e3"
-  integrity sha512-DIl0SCUIVcPrk/oOiq8/YgQ69Beayw4XSW2icyXJN8xfKMmxo5XM8gXVG1Ex+rYsHg2xuEpNFeeU6J4CtqQFrA==
+  resolved "https://registry.yarnpkg.com/tiny-secp256k1-native/-/tiny-secp256k1-native-1.1.0.tgz#b554a73061836a0914e7f9461fc336dd7386de73"
+  integrity sha512-ZEt41e4pvq52Zs6MqNZpbDH3qg5fQkOCH9bzGsVPtlLeo9tdfNFz2XfjiKzo1Rc+Yvv4cb0lzy7ClQ3FbE4kKg==
   dependencies:
     bindings "^1.3.0"
+    nan "^2.13.2"
+
+tiny-secp256k1@^1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/tiny-secp256k1/-/tiny-secp256k1-1.1.2.tgz#b8c852a7c9d93285dd2a0adb148af60f2dfc1fc9"
+  integrity sha512-InukePecGvfngAEmPR/AIVpAmBTBCdO7tFuMKCpQDE6Zr+lQVT/hDArPkUUolPPpCgwbN/yk2rSAGhJsoIl4hA==
+  dependencies:
     bn.js "^4.11.8"
     create-hmac "^1.1.7"
     elliptic "^6.4.0"
-    nan "^2.12.1"
+  optionalDependencies:
+    tiny-secp256k1-native "1.1.x"
 
 tmp@0.0.33, tmp@0.0.x, tmp@^0.0.33:
   version "0.0.33"
@@ -13853,10 +13879,10 @@ xregexp@2.0.0:
   resolved "https://registry.yarnpkg.com/xregexp/-/xregexp-2.0.0.tgz#52a63e56ca0b84a7f3a5f3d61872f126ad7a5943"
   integrity sha1-UqY+VsoLhKfzpfPWGHLxJq16WUM=
 
-xstate@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/xstate/-/xstate-4.5.0.tgz#469116d4c3b58412c9d5822543a3c1e2c26bdbe1"
-  integrity sha512-7vShhDqfYUWTb1NXZFjk61KTIg6Gi3r21P0M6ApAPCYTJP+pLtbu+uD5Vxaae8Nz21cSu3/OZfvMqN88AkJpHw==
+xstate@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/xstate/-/xstate-4.6.0.tgz#67415832a39d6fdb4d3a2e81eda357f8184d7a50"
+  integrity sha512-1bPy5an0QLUX3GiqtJB68VgBrLIotxZwpItDBO3vbakgzEY0D8UG1hsbM4MJM3BN1Y43pnac3ChmPL5s+Bca0A==
 
 xtend@^4.0.0, xtend@~4.0.1:
   version "4.0.1"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

## Summary

Currently the assumption is that all data that is in the transaction pool is valid as it otherwise could not enter, which is obviously not true. In order to resolve that issue a few things have been changed.

- When the node loads all transactions from the the pool on boot every transaction that fails to deserialised or results in an unexpected id gets removed.
- Deserialise transactions before they leave the pool and apply the same rules as during boot
- The forger now calls `fromBytesUnsafe` instead of `fromBytes` because the relay will ensure that all data it sends out is valid

## What kind of change does this PR introduce? (check at least one)

- [ ] Bugfix
- [ ] Feature
- [x] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build-related change
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change? (check one)

- [ ] Yes
- [x] No

## Does this PR release a new version?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch
- [x] All tests are passing
- [ ] New/updated tests are included