### PR TITLE
refactor(core-container): require a minimum of 0 as pubKeyHash

### DIFF
--- a/packages/core-container/src/config/index.ts
+++ b/packages/core-container/src/config/index.ts
@@ -73,7 +73,7 @@ export class Config {
                             .required(),
                     }),
                     pubKeyHash: Joi.number()
-                        .positive()
+                        .min(0)
                         .required(),
                     nethash: Joi.string()
                         .hex()


### PR DESCRIPTION
This allows for those using the ARK Deployer to use pubKeyHash 0.

## What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

## Does this PR release a new version?

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `develop` branch, _not_ the `master` branch
- [ ] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
