### PR TITLE
fix(core-blockchain): chain replay stopped working after dependency update

### DIFF
--- a/packages/core-blockchain/src/replay/replay-blockchain.ts
+++ b/packages/core-blockchain/src/replay/replay-blockchain.ts
@@ -31,7 +31,8 @@ export class ReplayBlockchain extends Blockchain {
         this.localDatabase.walletManager = this.walletManager;
 
         this.queue.kill();
-        this.queue.drain = undefined;
+        // @ts-ignore
+        this.queue.drain(() => undefined);
     }
 
     public get p2p(): P2P.IPeerService {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

Fixes `TypeError: Cannot assign to read only property 'drain' of object '#<Object>'` which is apparently readonly in [async 3.0](https://github.com/caolan/async/releases/tag/v3.0.0) which got released a few days ago.


<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

## Does this PR release a new version?

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `develop` branch, _not_ the `master` branch
- [ ] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
