### PR TITLE
fix(core-p2p): handle undefined `curr` during block download

### DIFF
--- a/packages/core-p2p/src/network-monitor.ts
+++ b/packages/core-p2p/src/network-monitor.ts
@@ -306,7 +306,7 @@ export class NetworkMonitor implements P2P.INetworkMonitor {
                                 .join()}`,
                         );
                     }),
-            )).reduce((acc, curr) => [...acc, ...curr], []);
+            )).reduce((acc, curr) => [...acc, ...(curr || [])], []);
         } catch (error) {
             this.logger.error(`Could not download blocks: ${error.message}`);
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->
Under certain circumstances `curr` can be undefined which then results in `TypeError: curr is not iterable`.

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

## Does this PR release a new version?

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `develop` branch, _not_ the `master` branch
- [ ] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
