### PR TITLE
feat(core-api): allow easy retrieval of first and last block

### DIFF
--- a/__tests__/integration/core-api/handlers/blocks.test.ts
+++ b/__tests__/integration/core-api/handlers/blocks.test.ts
@@ -53,6 +53,34 @@ describe("API 2.0 - Blocks", () => {
         });
     });
 
+    describe("GET /blocks/first", () => {
+        it("should GET the first block on the chain", async () => {
+            const response = await utils.request("GET", "blocks/first");
+
+            expect(response).toBeSuccessfulResponse();
+            expect(response.data.data).toBeObject();
+
+            utils.expectBlock(response.data.data, {
+                id: genesisBlock.id,
+                transactions: genesisBlock.numberOfTransactions,
+            });
+        });
+    });
+
+    describe("GET /blocks/last", () => {
+        it("should GET the last block on the chain", async () => {
+            const response = await utils.request("GET", "blocks/last");
+
+            expect(response).toBeSuccessfulResponse();
+            expect(response.data.data).toBeObject();
+
+            utils.expectBlock(response.data.data, {
+                id: genesisBlock.id,
+                transactions: genesisBlock.numberOfTransactions,
+            });
+        });
+    });
+
     describe("GET /blocks/:id", () => {
         it("should GET a block by the given identifier", async () => {
             const response = await utils.request("GET", `blocks/${genesisBlock.id}`);

--- a/packages/core-api/src/handlers/blocks/controller.ts
+++ b/packages/core-api/src/handlers/blocks/controller.ts
@@ -1,3 +1,6 @@
+import { app } from "@arkecosystem/core-container";
+import { Blockchain } from "@arkecosystem/core-interfaces";
+import { Blocks, Managers } from "@arkecosystem/crypto";
 import Boom from "@hapi/boom";
 import Hapi from "@hapi/hapi";
 import { Controller } from "../shared/controller";
@@ -9,6 +12,30 @@ export class BlocksController extends Controller {
             const data = await request.server.methods.v2.blocks.index(request);
 
             return super.respondWithCache(data, h);
+        } catch (error) {
+            return Boom.badImplementation(error);
+        }
+    }
+
+    public async first(request: Hapi.Request, h: Hapi.ResponseToolkit) {
+        try {
+            return super.respondWithResource(
+                Blocks.BlockFactory.fromJson(Managers.configManager.get("genesisBlock")).data,
+                "block",
+                (request.query.transform as unknown) as boolean,
+            );
+        } catch (error) {
+            return Boom.badImplementation(error);
+        }
+    }
+
+    public async last(request: Hapi.Request, h: Hapi.ResponseToolkit) {
+        try {
+            return super.respondWithResource(
+                app.resolvePlugin<Blockchain.IBlockchain>("blockchain").getLastBlock().data,
+                "block",
+                (request.query.transform as unknown) as boolean,
+            );
         } catch (error) {
             return Boom.badImplementation(error);
         }

--- a/packages/core-api/src/handlers/blocks/routes.ts
+++ b/packages/core-api/src/handlers/blocks/routes.ts
@@ -17,6 +17,24 @@ export const registerRoutes = (server: Hapi.Server): void => {
 
     server.route({
         method: "GET",
+        path: "/blocks/first",
+        handler: controller.first,
+        options: {
+            validate: Schema.first,
+        },
+    });
+
+    server.route({
+        method: "GET",
+        path: "/blocks/last",
+        handler: controller.last,
+        options: {
+            validate: Schema.last,
+        },
+    });
+
+    server.route({
+        method: "GET",
         path: "/blocks/{id}",
         handler: controller.show,
         options: {

--- a/packages/core-api/src/handlers/blocks/schema.ts
+++ b/packages/core-api/src/handlers/blocks/schema.ts
@@ -43,6 +43,18 @@ export const index: object = {
     },
 };
 
+export const first: object = {
+    query: {
+        transform: Joi.bool().default(true),
+    },
+};
+
+export const last: object = {
+    query: {
+        transform: Joi.bool().default(true),
+    },
+};
+
 export const show: object = {
     params: {
         id: blockId,

--- a/packages/core-api/src/handlers/blocks/transformer.ts
+++ b/packages/core-api/src/handlers/blocks/transformer.ts
@@ -1,5 +1,5 @@
 import { app } from "@arkecosystem/core-container";
-import { Database } from "@arkecosystem/core-interfaces";
+import { Database, State } from "@arkecosystem/core-interfaces";
 import { formatTimestamp } from "@arkecosystem/core-utils";
 import { Utils } from "@arkecosystem/crypto";
 
@@ -8,8 +8,8 @@ export const transformBlock = (model, transform) => {
         return model;
     }
 
-    const databaseService = app.resolvePlugin<Database.IDatabaseService>("database");
-    const generator = databaseService.walletManager.findByPublicKey(model.generatorPublicKey);
+    const databaseService: Database.IDatabaseService = app.resolvePlugin<Database.IDatabaseService>("database");
+    const generator: State.IWallet = databaseService.walletManager.findByPublicKey(model.generatorPublicKey);
 
     model.reward = Utils.BigNumber.make(model.reward);
     model.totalFee = Utils.BigNumber.make(model.totalFee);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

Often times you just want the last forged block or the genesis block to check something. This adds 2 endpoints to the block resource that retrieves those from in-memory instead of hitting the database.

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Does this PR release a new version?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch
- [x] All tests are passing
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
