### PR TITLE
fix(core-api): off by one error in transaction confirmations

### DIFF
--- a/packages/core-api/src/versions/2/transactions/transformer.ts
+++ b/packages/core-api/src/versions/2/transactions/transformer.ts
@@ -26,7 +26,7 @@ export const transformTransaction = model => {
         signatures: data.signatures,
         vendorField: data.vendorField,
         asset: data.asset,
-        confirmations: model.block ? lastBlock.data.height - model.block.height : 0,
+        confirmations: model.block ? lastBlock.data.height - model.block.height + 1 : 0,
         timestamp: formatTimestamp(data.timestamp),
     };
 };


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

It is my understanding that forged transactions must have a positive confirmation count. If that is indeed the case, there is an off-by-one error in the transaction count. This manifests itself by looking at transactions forged in the most recent block, which will show zero confirmations.

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Does this PR release a new version?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch
- [x] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
