### PR TITLE
fix(core): set the correct channel if core was directly installed with @next

### DIFF
--- a/packages/core/src/commands/config/cli.ts
+++ b/packages/core/src/commands/config/cli.ts
@@ -31,7 +31,7 @@ $ ark config:cli --channel=next
         const { flags } = this.parse(CommandLineInterfaceCommand);
 
         if (flags.token) {
-            configManager.update({ token: flags.token });
+            configManager.set("token", flags.token as string);
         }
 
         if (flags.channel) {
@@ -47,7 +47,7 @@ $ ark config:cli --channel=next
             return;
         }
 
-        configManager.update({ channel: newChannel });
+        configManager.set("channel", newChannel);
 
         const pkg = `${this.config.name}@${newChannel}`;
 

--- a/packages/core/src/helpers/config.ts
+++ b/packages/core/src/helpers/config.ts
@@ -5,18 +5,22 @@ class ConfigManager {
     private config;
     private file: string;
 
-    public setup(config) {
+    public setup(config: Record<string, any>) {
         this.config = config;
         this.file = `${config.configDir}/config.json`;
 
         this.ensureDefaults();
     }
 
-    public get(key) {
+    public get(key: string): string {
         return this.read()[key];
     }
 
-    public update(data): void {
+    public set(key: string, value: string): void {
+        this.update({ [key]: value });
+    }
+
+    public update(data: Record<string, string>): void {
         this.write({ ...this.read(), ...data });
     }
 

--- a/packages/core/src/hooks/init/config.ts
+++ b/packages/core/src/hooks/init/config.ts
@@ -4,4 +4,8 @@ import { configManager } from "../../helpers/config";
 // tslint:disable-next-line:only-arrow-functions
 export const init: Hook<"init"> = async function({ config }) {
     configManager.setup(config);
+
+    if (config.version.includes("next") && configManager.get("channel") !== "next") {
+        configManager.set("channel", "next");
+    }
 };


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

If the `next` release is installed via `yarn global add @arkecosystem/core@next` instead of using the `ark config:cli --channel=next` flag the `channel` will default to `latest`.

This PR adds a check on start to switch the channel in the configuration so that `ark update` can be used.

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Does this PR release a new version?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch
- [x] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
