### PR TITLE
refactor(core-p2p): remove redundant p2p port from broadcast

### DIFF
--- a/__tests__/helpers/peers.ts
+++ b/__tests__/helpers/peers.ts
@@ -4,7 +4,7 @@ import { makePeerService } from "../../packages/core-p2p/src/plugin";
 
 export const createStubPeer = (stub): P2P.IPeer => {
     const peer: P2P.IPeer = new Peer(stub.ip);
-    peer.ports.p2p = stub.port;
+    (peer as any).port = stub.port;
 
     delete stub.port;
 

--- a/__tests__/integration/core-api/v1/handlers/peers.test.ts
+++ b/__tests__/integration/core-api/v1/handlers/peers.test.ts
@@ -11,7 +11,7 @@ beforeAll(async () => {
     await setUp();
 
     const peerMock = new Peer(mockAddress);
-    peerMock.ports.p2p = mockPort;
+    (peerMock as any).port = mockPort;
 
     app.resolvePlugin("p2p")
         .getStorage()
@@ -58,7 +58,7 @@ describe("API 1.0 - Peers", () => {
             expect(response).toBeSuccessfulResponse();
             expect(response.data).toBeObject();
             expect(response.data.peer.ip).toBe(mockAddress);
-            expect(response.data.peer.ports.p2p).toBe(mockPort);
+            expect(response.data.peer.port).toBe(mockPort);
         });
 
         it("should fail using known ip address with no port", async () => {

--- a/__tests__/integration/core-api/v1/handlers/peers.test.ts
+++ b/__tests__/integration/core-api/v1/handlers/peers.test.ts
@@ -5,7 +5,7 @@ import { setUp, tearDown } from "../../__support__/setup";
 import { utils } from "../utils";
 
 const mockAddress = "1.0.0.99";
-const mockPort = 4002;
+const mockPort = 4000;
 
 beforeAll(async () => {
     await setUp();

--- a/__tests__/integration/core-api/v2/handlers/peers.test.ts
+++ b/__tests__/integration/core-api/v2/handlers/peers.test.ts
@@ -23,7 +23,7 @@ beforeAll(async () => {
     const peerMocks = peers
         .map(mock => {
             const peerMock = new Peer(mock.ip);
-            peerMock.ports.p2p = mock.port;
+            (peerMock as any).port = mock.port;
             peerMock.version = mock.version;
             return peerMock;
         })

--- a/__tests__/integration/core-api/v2/handlers/peers.test.ts
+++ b/__tests__/integration/core-api/v2/handlers/peers.test.ts
@@ -7,12 +7,12 @@ import { utils } from "../utils";
 const peers = [
     {
         ip: "1.0.0.99",
-        port: 4002,
+        port: 4000,
         version: "2.4.0-next.3",
     },
     {
         ip: "1.0.0.98",
-        port: 4002,
+        port: 4000,
         version: "2.4.0-next.1",
     },
 ];

--- a/__tests__/integration/core-p2p/network-monitor.test.ts
+++ b/__tests__/integration/core-p2p/network-monitor.test.ts
@@ -47,7 +47,7 @@ describe("NetworkMonitor", () => {
     describe("cleansePeers", () => {
         it("should be ok", async () => {
             const peer: P2P.IPeer = new Peer("0.0.0.11");
-            peer.ports.p2p = 4444;
+            (peer as any).port = 4444;
 
             storage.setPeer(peer);
 

--- a/packages/core-api/src/versions/1/peers/transformer.ts
+++ b/packages/core-api/src/versions/1/peers/transformer.ts
@@ -1,7 +1,7 @@
 export const transformPeerLegacy = model => {
     return {
         ip: model.ip,
-        port: model.ports.p2p,
+        port: model.port,
         ports: model.ports,
         version: model.version,
         height: model.height,

--- a/packages/core-api/src/versions/1/peers/transformer.ts
+++ b/packages/core-api/src/versions/1/peers/transformer.ts
@@ -1,7 +1,11 @@
+import { app } from "@arkecosystem/core-container";
+
+const port = +app.resolveOptions("p2p").server.port;
+
 export const transformPeerLegacy = model => {
     return {
         ip: model.ip,
-        port: model.port,
+        port,
         ports: model.ports,
         version: model.version,
         height: model.height,

--- a/packages/core-api/src/versions/2/peers/transformer.ts
+++ b/packages/core-api/src/versions/2/peers/transformer.ts
@@ -1,7 +1,11 @@
+import { app } from "@arkecosystem/core-container";
+
+const port = +app.resolveOptions("p2p").server.port;
+
 export const transformPeer = model => {
     return {
         ip: model.ip,
-        port: model.port,
+        port,
         ports: model.ports,
         version: model.version,
         height: model.state ? model.state.height : model.height,

--- a/packages/core-api/src/versions/2/peers/transformer.ts
+++ b/packages/core-api/src/versions/2/peers/transformer.ts
@@ -1,7 +1,7 @@
 export const transformPeer = model => {
     return {
         ip: model.ip,
-        port: +model.ports.p2p,
+        port: model.port,
         ports: model.ports,
         version: model.version,
         height: model.state ? model.state.height : model.height,

--- a/packages/core-interfaces/src/core-p2p/peer.ts
+++ b/packages/core-interfaces/src/core-p2p/peer.ts
@@ -2,7 +2,6 @@ import { Dayjs } from "dayjs";
 import { IPeerVerificationResult } from "./peer-verifier";
 
 export interface IPeerPorts {
-    p2p: number;
     [name: string]: number;
 }
 

--- a/packages/core-p2p/src/peer.ts
+++ b/packages/core-p2p/src/peer.ts
@@ -1,12 +1,9 @@
-import { app } from "@arkecosystem/core-container";
 import { P2P } from "@arkecosystem/core-interfaces";
 import dayjs, { Dayjs } from "dayjs";
 import { PeerVerificationResult } from "./peer-verifier";
 
 export class Peer implements P2P.IPeer {
-    public readonly ports: P2P.IPeerPorts = {
-        p2p: +app.resolveOptions("p2p").server.port,
-    };
+    public readonly ports: P2P.IPeerPorts = {};
 
     public version: string;
     public latency: number;

--- a/packages/core-p2p/src/peer.ts
+++ b/packages/core-p2p/src/peer.ts
@@ -1,14 +1,17 @@
+import { app } from "@arkecosystem/core-container";
 import { P2P } from "@arkecosystem/core-interfaces";
 import dayjs, { Dayjs } from "dayjs";
 import { PeerVerificationResult } from "./peer-verifier";
 
 export class Peer implements P2P.IPeer {
     public readonly ports: P2P.IPeerPorts = {};
+    public readonly port: number = +app.resolveOptions("p2p").server.port;
 
     public version: string;
     public latency: number;
     public lastPinged: Dayjs | undefined;
     public verificationResult: PeerVerificationResult | undefined;
+
     public state: P2P.IPeerState = {
         height: undefined,
         forgingAllowed: undefined,
@@ -20,10 +23,6 @@ export class Peer implements P2P.IPeer {
 
     get url(): string {
         return `${this.port % 443 === 0 ? "https://" : "http://"}${this.ip}:${this.port}`;
-    }
-
-    get port(): number {
-        return this.ports.p2p;
     }
 
     public isVerified(): boolean {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->
Removes the redundant `p2p` entry from `ports`:

![image](https://user-images.githubusercontent.com/1311798/58802647-ff740080-860d-11e9-93f3-0b4615ce2e76.png)

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [X] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

## Does this PR release a new version?

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `develop` branch, _not_ the `master` branch
- [ ] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
