### PR TITLE
fix(core-snapshots): avoid trying to INSERT duplicates in rounds

### DIFF
--- a/packages/core-snapshots/src/db/index.ts
+++ b/packages/core-snapshots/src/db/index.ts
@@ -34,7 +34,12 @@ export class Database {
         return this.db.oneOrNone(queries.blocks.latest);
     }
 
-    public async getLastRound() {
+    /**
+     * Get the row with the highest id from the rounds table.
+     * @return Object latest row
+     * @return null if the table is empty.
+     */
+    public async getLastRound(): Promise<{ id: number, public_key: string, balance: string, round: string } | null> {
         return this.db.oneOrNone(queries.rounds.latest);
     }
 

--- a/packages/core-snapshots/src/db/index.ts
+++ b/packages/core-snapshots/src/db/index.ts
@@ -34,6 +34,10 @@ export class Database {
         return this.db.oneOrNone(queries.blocks.latest);
     }
 
+    public async getLastRound() {
+        return this.db.oneOrNone(queries.rounds.latest);
+    }
+
     public async getBlockByHeight(height) {
         return this.db.oneOrNone(queries.blocks.findByHeight, { height });
     }

--- a/packages/core-snapshots/src/db/queries/index.ts
+++ b/packages/core-snapshots/src/db/queries/index.ts
@@ -14,6 +14,7 @@ export const queries = {
     },
     rounds: {
         deleteFromRound: loadQueryFile(__dirname, "./rounds/delete-from-round.sql"),
+        latest: loadQueryFile(__dirname, "./rounds/latest.sql"),
         roundRange: loadQueryFile(__dirname, "./rounds/round-range.sql"),
     },
     truncate: table => `TRUNCATE TABLE ${table} RESTART IDENTITY`,

--- a/packages/core-snapshots/src/db/queries/rounds/latest.sql
+++ b/packages/core-snapshots/src/db/queries/rounds/latest.sql
@@ -1,0 +1,3 @@
+SELECT *
+FROM rounds
+ORDER BY id DESC LIMIT 1

--- a/packages/core-snapshots/src/manager.ts
+++ b/packages/core-snapshots/src/manager.ts
@@ -139,6 +139,7 @@ export class SnapshotManager {
 
         const lastBlock = await this.database.getLastBlock();
         params.lastBlock = lastBlock;
+        params.lastRound = await this.database.getLastRound();
         params.chunkSize = this.options.chunkSize || 50000;
 
         if (exportAction) {

--- a/packages/core-snapshots/src/manager.ts
+++ b/packages/core-snapshots/src/manager.ts
@@ -49,7 +49,7 @@ export class SnapshotManager {
 
         if (params.truncate) {
             await this.database.truncate();
-            params.lastBlock = undefined;
+            params.lastBlock = null;
         }
 
         await importTable("blocks", params);

--- a/packages/core-snapshots/src/manager.ts
+++ b/packages/core-snapshots/src/manager.ts
@@ -49,7 +49,7 @@ export class SnapshotManager {
 
         if (params.truncate) {
             await this.database.truncate();
-            params.lastBlock = null;
+            params.lastBlock = undefined;
         }
 
         await importTable("blocks", params);

--- a/packages/core-snapshots/src/transport/index.ts
+++ b/packages/core-snapshots/src/transport/index.ts
@@ -91,7 +91,7 @@ export const importTable = async (table, options) => {
             app.forceExit(`Error verifying data. Payload ${JSON.stringify(record, undefined, 2)}`);
         }
 
-        if (canImportRecord(table, record, options.lastBlock)) {
+        if (canImportRecord(table, record, options)) {
             values.push(record);
         }
 

--- a/packages/core-snapshots/src/transport/verification.ts
+++ b/packages/core-snapshots/src/transport/verification.ts
@@ -65,7 +65,7 @@ export const verifyData = (context, data, prevData, verifySignatures) => {
 };
 
 export const canImportRecord = (context, data, options) => {
-    if (!options.lastBlock) {
+    if (options.lastBlock === null) {
         return true;
     }
 
@@ -78,7 +78,7 @@ export const canImportRecord = (context, data, options) => {
     }
 
     if (context === "rounds") {
-        if (options.lastRound === undefined) {
+        if (options.lastRound === null) {
             return true;
         }
         return data.id > options.lastRound.id;

--- a/packages/core-snapshots/src/transport/verification.ts
+++ b/packages/core-snapshots/src/transport/verification.ts
@@ -65,7 +65,7 @@ export const verifyData = (context, data, prevData, verifySignatures) => {
 };
 
 export const canImportRecord = (context, data, options) => {
-    if (options.lastBlock === null) {
+    if (!options.lastBlock) {
         return true;
     }
 

--- a/packages/core-snapshots/src/transport/verification.ts
+++ b/packages/core-snapshots/src/transport/verification.ts
@@ -64,21 +64,24 @@ export const verifyData = (context, data, prevData, verifySignatures) => {
     return false;
 };
 
-export const canImportRecord = (context, data, lastBlock) => {
-    if (!lastBlock) {
+export const canImportRecord = (context, data, options) => {
+    if (!options.lastBlock) {
         return true;
     }
 
     if (context === "blocks") {
-        return data.height > lastBlock.height;
+        return data.height > options.lastBlock.height;
     }
 
     if (context === "transactions") {
-        return data.timestamp > lastBlock.timestamp;
+        return data.timestamp > options.lastBlock.timestamp;
     }
 
     if (context === "rounds") {
-        return true;
+        if (options.lastRound === undefined) {
+            return true;
+        }
+        return data.id > options.lastRound.id;
     }
 
     return false;


### PR DESCRIPTION
Follow the logic of INSERTing into blocks and transactions also for
rounds: only INSERT a row during snapshot restore if its identifier
is higher than the highest in the database (ie a sloppy check whether
a row is in the database).

<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

A summary of what changes this PR introduces and why they were made.

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

## Does this PR release a new version?

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `develop` branch, _not_ the `master` branch
- [ ] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
