### PR TITLE
fix(core-p2p): perform `acceptNewPeer` non-blocking

### DIFF
--- a/packages/core-p2p/src/socket-server/worker.ts
+++ b/packages/core-p2p/src/socket-server/worker.ts
@@ -101,7 +101,7 @@ export class Worker extends SCWorker {
                     );
                 }
             } else if (version === "peer") {
-                await this.sendToMasterAsync("p2p.peer.acceptNewPeer", {
+                this.sendToMasterAsync("p2p.peer.acceptNewPeer", {
                     data: { ip: req.socket.remoteAddress },
                     headers: req.data.headers,
                 });


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

We already fixed this with 2.3, but it somehow regressed with the switch to websockets. Blocking on `acceptNewPeer` causes issues for nodes running behind a firewall, since they don't respond to pings and therefore trigger a timeout.

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

## Does this PR release a new version?

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `develop` branch, _not_ the `master` branch
- [ ] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
