### PR TITLE
fix(core-container): handle failing optional plugins gracefully

### DIFF
--- a/packages/core-blockchain/src/plugin.ts
+++ b/packages/core-blockchain/src/plugin.ts
@@ -11,6 +11,7 @@ import { ReplayBlockchain } from "./replay";
 export const plugin: Container.IPluginDescriptor = {
     pkg: require("../package.json"),
     defaults,
+    required: true,
     alias: "blockchain",
     async register(container: Container.IContainer, options: Container.IPluginOptions) {
         let blockchain: Blockchain;

--- a/packages/core-container/src/registrars/plugin.ts
+++ b/packages/core-container/src/registrars/plugin.ts
@@ -1,20 +1,22 @@
-import { Container } from "@arkecosystem/core-interfaces";
+import { Container, Logger } from "@arkecosystem/core-interfaces";
 import Hoek from "@hapi/hoek";
 import { asValue } from "awilix";
 import isString from "lodash.isstring";
 import semver from "semver";
 
 export class PluginRegistrar {
-    private container: any;
+    private container: Container.IContainer;
     private plugins: any;
     private options: any;
     private deregister: any;
+    private failedPlugins: Record<string, Error>;
 
     constructor(container: Container.IContainer, options: Record<string, any> = {}) {
         this.container = container;
         this.plugins = container.config.get("plugins");
         this.options = this.castOptions(options);
         this.deregister = [];
+        this.failedPlugins = {};
     }
 
     /**
@@ -27,6 +29,16 @@ export class PluginRegistrar {
 
             if ((this.options.exit && this.options.exit === name) || this.container.shuttingDown) {
                 break;
+            }
+        }
+
+        const failedPlugins: number = Object.keys(this.failedPlugins).length;
+        if (failedPlugins > 0) {
+            const logger = this.container.resolvePlugin<Logger.ILogger>("logger");
+            logger.warn(`Failed to load ${failedPlugins} optional plugins.`);
+
+            for (const [name, error] of Object.entries(this.failedPlugins)) {
+                logger.warn(`Plugin '${name}': ${error.message}`);
             }
         }
     }
@@ -47,16 +59,20 @@ export class PluginRegistrar {
      * @param  {Object} options
      * @return {void}
      */
-    public async register(name, options = {}) {
-        if (!this.shouldBeRegistered(name)) {
-            return;
-        }
+    private async register(name, options = {}) {
+        try {
+            if (!this.shouldBeRegistered(name)) {
+                return;
+            }
 
-        if (this.plugins[name]) {
-            options = Hoek.applyToDefaults(this.plugins[name], options);
-        }
+            if (this.plugins[name]) {
+                options = Hoek.applyToDefaults(this.plugins[name], options);
+            }
 
-        return this.registerWithContainer(name, options);
+            return this.registerWithContainer(name, options);
+        } catch (error) {
+            this.failedPlugins[name] = error;
+        }
     }
 
     /**
@@ -66,7 +82,13 @@ export class PluginRegistrar {
      * @return {void}
      */
     private async registerWithContainer(plugin, options = {}) {
-        const item: any = this.resolve(plugin);
+        let item: any;
+        try {
+            item = this.resolve(plugin);
+        } catch (error) {
+            this.failedPlugins[plugin] = error;
+            return;
+        }
 
         if (!item.plugin.register) {
             return;
@@ -91,18 +113,26 @@ export class PluginRegistrar {
         options = this.applyToDefaults(name, defaults, options);
         this.container.register(`pkg.${alias || name}.opts`, asValue(options));
 
-        plugin = await item.plugin.register(this.container, options);
-        this.container.register(
-            alias || name,
-            asValue({
-                name,
-                version,
-                plugin,
-            }),
-        );
+        try {
+            plugin = await item.plugin.register(this.container, options);
+            this.container.register(
+                alias || name,
+                asValue({
+                    name,
+                    version,
+                    plugin,
+                }),
+            );
 
-        if (item.plugin.deregister) {
-            this.deregister.push({ plugin: item.plugin, options });
+            if (item.plugin.deregister) {
+                this.deregister.push({ plugin: item.plugin, options });
+            }
+        } catch (error) {
+            if (item.plugin.required) {
+                this.container.forceExit(`Failed to register required plugin '${name}'`, error);
+            } else {
+                this.failedPlugins[name] = error;
+            }
         }
     }
 

--- a/packages/core-container/src/registrars/plugin.ts
+++ b/packages/core-container/src/registrars/plugin.ts
@@ -129,7 +129,7 @@ export class PluginRegistrar {
             }
         } catch (error) {
             if (item.plugin.required) {
-                this.container.forceExit(`Failed to register required plugin '${name}'`, error);
+                this.container.forceExit(`Failed to load required plugin '${name}'`, error);
             } else {
                 this.failedPlugins[name] = error;
             }

--- a/packages/core-database-postgres/src/plugin.ts
+++ b/packages/core-database-postgres/src/plugin.ts
@@ -7,6 +7,7 @@ import { PostgresConnection } from "./postgres-connection";
 export const plugin: Container.IPluginDescriptor = {
     pkg: require("../package.json"),
     defaults,
+    required: true,
     alias: "database",
     extends: "@arkecosystem/core-database",
     async register(container: Container.IContainer, options) {

--- a/packages/core-event-emitter/src/index.ts
+++ b/packages/core-event-emitter/src/index.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from "./emitter";
 
 export const plugin = {
     pkg: require("../package.json"),
+    required: true,
     alias: "event-emitter",
     register() {
         return new EventEmitter();

--- a/packages/core-interfaces/src/core-container/container.ts
+++ b/packages/core-interfaces/src/core-container/container.ts
@@ -27,6 +27,8 @@ export interface IContainer {
 
     silentShutdown: boolean;
 
+    shuttingDown: boolean;
+
     isReady: boolean;
 
     setUp(version: string, variables: any, options?: any): Promise<void>;

--- a/packages/core-interfaces/src/core-container/container.ts
+++ b/packages/core-interfaces/src/core-container/container.ts
@@ -3,6 +3,7 @@ import { Resolver } from "awilix";
 export interface IPluginDescriptor {
     alias: string;
     pkg: any;
+    required?: boolean;
     defaults?: any;
     extends?: string;
     register(container: IContainer, options?: IPluginOptions): Promise<any>;

--- a/packages/core-logger-pino/src/plugin.ts
+++ b/packages/core-logger-pino/src/plugin.ts
@@ -6,6 +6,7 @@ import { PinoLogger } from "./driver";
 export const plugin: Container.IPluginDescriptor = {
     pkg: require("../package.json"),
     defaults,
+    required: true,
     alias: "logger",
     extends: "@arkecosystem/core-logger",
     async register(container: Container.IContainer, options) {

--- a/packages/core-p2p/src/plugin.ts
+++ b/packages/core-p2p/src/plugin.ts
@@ -23,6 +23,7 @@ export const makePeerService = (): PeerService => {
 export const plugin: Container.IPluginDescriptor = {
     pkg: require("../package.json"),
     defaults,
+    required: true,
     alias: "p2p",
     async register(container: Container.IContainer, options) {
         container.resolvePlugin<Logger.ILogger>("logger").info("Starting P2P Interface");

--- a/packages/core-state/src/plugin.ts
+++ b/packages/core-state/src/plugin.ts
@@ -8,6 +8,7 @@ import { TransactionStore } from "./stores/transactions";
 export const plugin: Container.IPluginDescriptor = {
     pkg: require("../package.json"),
     defaults,
+    required: true,
     alias: "state",
     async register() {
         return new StateService({

--- a/packages/core-transaction-pool/src/plugin.ts
+++ b/packages/core-transaction-pool/src/plugin.ts
@@ -9,6 +9,7 @@ import { WalletManager } from "./wallet-manager";
 export const plugin: Container.IPluginDescriptor = {
     pkg: require("../package.json"),
     defaults,
+    required: true,
     alias: "transaction-pool",
     async register(container: Container.IContainer, options) {
         container.resolvePlugin<Logger.ILogger>("logger").info("Connecting to transaction pool");


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

Introduces the concept of `required` and `optional` plugins. When a required plugin throws an error during boot, Core will shutdown like before. But if an optional plugin cannot be loaded it will no longer shutdown and print a nice warning with the error instead.

Unless explicitely marked required, all plugins are considered optional.

The required plugins are:
```
@arkecosystem/core-event-emitter
@arkecosystem/core-logger-pino
@arkecosystem/core-state
@arkecosystem/core-database-postgres
@arkecosystem/core-transaction-pool
@arkecosystem/core-p2p
@arkecosystem/core-blockchain
```

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

## Does this PR release a new version?

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `develop` branch, _not_ the `master` branch
- [ ] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
