### PR TITLE
fix(core-snapshots): don't append duplicate rounds rows to a snapshot

### DIFF
--- a/packages/core-snapshots/src/db/index.ts
+++ b/packages/core-snapshots/src/db/index.ts
@@ -82,9 +82,16 @@ export class Database {
         return this.getLastBlock();
     }
 
-    public async getExportQueries(startHeight, endHeight) {
-        const startBlock = await this.getBlockByHeight(startHeight);
-        const endBlock = await this.getBlockByHeight(endHeight);
+    public async getExportQueries(meta: {
+        startHeight: number,
+        endHeight: number,
+        startRoundId: number,
+        skipCompression: boolean,
+        folder: string
+    }) {
+
+        const startBlock = await this.getBlockByHeight(meta.startHeight);
+        const endBlock = await this.getBlockByHeight(meta.endHeight);
 
         if (!startBlock || !endBlock) {
             app.forceExit(
@@ -92,8 +99,8 @@ export class Database {
             );
         }
 
-        const roundInfoStart: Shared.IRoundInfo = roundCalculator.calculateRound(startHeight);
-        const roundInfoEnd: Shared.IRoundInfo = roundCalculator.calculateRound(endHeight);
+        const roundInfoStart: Shared.IRoundInfo = roundCalculator.calculateRound(meta.startHeight);
+        const roundInfoEnd: Shared.IRoundInfo = roundCalculator.calculateRound(meta.endHeight);
 
         return {
             blocks: rawQuery(this.pgp, queries.blocks.heightRange, {
@@ -105,8 +112,9 @@ export class Database {
                 end: endBlock.timestamp,
             }),
             rounds: rawQuery(this.pgp, queries.rounds.roundRange, {
-                start: roundInfoStart.round,
-                end: roundInfoEnd.round,
+                startRound: roundInfoStart.round,
+                endRound: roundInfoEnd.round,
+                startId: meta.startRoundId
             }),
         };
     }

--- a/packages/core-snapshots/src/db/queries/rounds/round-range.sql
+++ b/packages/core-snapshots/src/db/queries/rounds/round-range.sql
@@ -6,6 +6,7 @@ SELECT
 FROM
   rounds
 WHERE
-  round BETWEEN ${start} AND ${end}
+  round BETWEEN ${startRound} AND ${endRound} AND
+  id >= ${startId}
 ORDER BY
-  round
+  id

--- a/packages/core-snapshots/src/manager.ts
+++ b/packages/core-snapshots/src/manager.ts
@@ -148,7 +148,7 @@ export class SnapshotManager {
             }
 
             params.meta = utils.setSnapshotInfo(params, lastBlock);
-            params.queries = await this.database.getExportQueries(params.meta.startHeight, params.meta.endHeight);
+            params.queries = await this.database.getExportQueries(params.meta);
 
             if (params.blocks) {
                 if (options.blocks === params.meta.folder) {

--- a/packages/core-snapshots/src/utils.ts
+++ b/packages/core-snapshots/src/utils.ts
@@ -90,6 +90,7 @@ export const setSnapshotInfo = (options, lastBlock) => {
     const meta = {
         startHeight: options.start !== -1 ? options.start : 1,
         endHeight: options.end !== -1 ? options.end : lastBlock.height,
+        startRoundId: 1,
         skipCompression: options.skipCompression || false,
         folder: "",
     };
@@ -99,6 +100,7 @@ export const setSnapshotInfo = (options, lastBlock) => {
     if (options.blocks) {
         const oldMeta = this.getSnapshotInfo(options.blocks);
         meta.startHeight = oldMeta.endHeight + 1;
+        meta.startRoundId = oldMeta.rounds.count + 1;
         meta.folder = `${oldMeta.startHeight}-${meta.endHeight}`;
     }
 


### PR DESCRIPTION
When appending to an existent snapshot, only append rows with higher id
than already in the (old) snapshot. Otherwise the snapshot would contain
rows with duplciate rounds.id values and would not be importable.

This patch assumes no gaps in rounds.id and monotonically increasing
rounds.id when new rounds are being added.

<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->



<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Does this PR release a new version?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch
- [ ] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
