### PR TITLE
fix(core-transaction-pool): use temporary wallets for transaction validation

### DIFF
--- a/__tests__/unit/core-transaction-pool/connection.forging.test.ts
+++ b/__tests__/unit/core-transaction-pool/connection.forging.test.ts
@@ -90,12 +90,10 @@ describe("Connection", () => {
         addTransactionsToMemory(transactions);
 
         const forgingTransactions = await connection.getTransactionsForForging(100);
-        const offset = transactions.length - countGood;
-
         expect(forgingTransactions).toHaveLength(countGood);
         expect(forgingTransactions).toEqual(
             transactions
-                .slice(sliceBeginning ? 0 : offset, sliceBeginning ? offset + 1 : undefined)
+                .slice(sliceBeginning ? 0 : transactions.length - countGood, sliceBeginning ? countGood : undefined)
                 .map(({ serialized }) => serialized.toString("hex")),
         );
 
@@ -185,7 +183,7 @@ describe("Connection", () => {
             expect(spy).toHaveBeenCalled();
         });
 
-        it.only("should remove transactions that cannot be applied", async () => {
+        it("should remove multiple transactions of same sender that cannot be applied due to previous transaction", async () => {
             const transactions = TransactionFactory.transfer()
                 .withPassphrase(delegates[20].passphrase)
                 .build(5);
@@ -194,6 +192,28 @@ describe("Connection", () => {
             sender.balance = transactions[0].data.amount.plus(transactions[0].data.fee).times(3);
 
             await expectForgingTransactions(transactions, 3, true);
+        });
+
+        it("should remove transactions that cannot be applied due to previous transaction", async () => {
+            const transactionA = TransactionFactory.transfer(delegates[21].address, 101 * 1e8)
+                .withPassphrase(delegates[20].passphrase)
+                .build(1)[0];
+
+            const transactionBs = TransactionFactory.transfer(delegates[20].address, 100 * 1e8)
+                .withPassphrase(delegates[21].passphrase)
+                .build(5);
+
+            const walletA = databaseWalletManager.findByPublicKey(delegates[20].publicKey);
+            walletA.balance = transactionA.data.amount.plus(transactionA.data.fee);
+
+            const walletB = databaseWalletManager.findByPublicKey(delegates[21].publicKey);
+            walletB.balance = Utils.BigNumber.ZERO;
+
+            await expectForgingTransactions([transactionBs[0], transactionA], 1);
+
+            memory.flush();
+
+            await expectForgingTransactions([transactionA, ...transactionBs], 2, true);
         });
 
         it("should remove transactions that have malformed bytes", async () => {

--- a/__tests__/unit/core-transaction-pool/connection.test.ts
+++ b/__tests__/unit/core-transaction-pool/connection.test.ts
@@ -746,7 +746,7 @@ describe("Connection", () => {
             expect(getTransaction).toHaveBeenCalled();
             expect(findByPublicKey).not.toHaveBeenCalled();
             expect(canBeApplied).toHaveBeenCalled();
-            expect(applyToSenderInPool).not.toHaveBeenCalled();
+            expect(applyToSenderInPool).toHaveBeenCalled();
         });
 
         it("should not apply transaction to wallet if canBeApplied() failed", async () => {

--- a/packages/core-transaction-pool/package.json
+++ b/packages/core-transaction-pool/package.json
@@ -40,6 +40,7 @@
         "delay": "^4.2.0",
         "fs-extra": "^8.0.1",
         "lodash.camelcase": "^4.3.0",
+        "lodash.clonedeep": "^4.5.0",
         "pluralize": "^7.0.0"
     },
     "devDependencies": {

--- a/packages/core-transaction-pool/src/connection.ts
+++ b/packages/core-transaction-pool/src/connection.ts
@@ -533,11 +533,13 @@ export class Connection implements TransactionPool.IConnection {
             localWalletManager.reindex(sender);
         }
 
-        if (localWalletManager.hasByAddress(recipientId)) {
-            recipient = localWalletManager.findByAddress(recipientId);
-        } else {
-            recipient = clonedeep(databaseWalletManager.findByAddress(recipientId));
-            localWalletManager.reindex(recipient);
+        if (recipient) {
+            if (localWalletManager.hasByAddress(recipientId)) {
+                recipient = localWalletManager.findByAddress(recipientId);
+            } else {
+                recipient = clonedeep(databaseWalletManager.findByAddress(recipientId));
+                localWalletManager.reindex(recipient);
+            }
         }
 
         return { sender, recipient };

--- a/packages/core-transaction-pool/src/connection.ts
+++ b/packages/core-transaction-pool/src/connection.ts
@@ -533,7 +533,7 @@ export class Connection implements TransactionPool.IConnection {
             localWalletManager.reindex(sender);
         }
 
-        if (recipient) {
+        if (recipientId) {
             if (localWalletManager.hasByAddress(recipientId)) {
                 recipient = localWalletManager.findByAddress(recipientId);
             } else {

--- a/packages/core-transaction-pool/src/connection.ts
+++ b/packages/core-transaction-pool/src/connection.ts
@@ -1,10 +1,13 @@
+import { strictEqual } from "assert";
+import dayjs, { Dayjs } from "dayjs";
+import clonedeep from "lodash.clonedeep";
+
 import { app } from "@arkecosystem/core-container";
 import { ApplicationEvents } from "@arkecosystem/core-event-emitter";
 import { Database, EventEmitter, Logger, State, TransactionPool } from "@arkecosystem/core-interfaces";
+import { Wallets } from "@arkecosystem/core-state";
 import { Handlers } from "@arkecosystem/core-transactions";
 import { Enums, Interfaces, Transactions, Utils } from "@arkecosystem/crypto";
-import { strictEqual } from "assert";
-import dayjs, { Dayjs } from "dayjs";
 import { ITransactionsProcessed } from "./interfaces";
 import { Memory } from "./memory";
 import { Processor } from "./processor";
@@ -138,19 +141,19 @@ export class Connection implements TransactionPool.IConnection {
     }
 
     public async getTransactions(start: number, size: number, maxBytes?: number): Promise<Buffer[]> {
-        return (await this.getValidTransactions(start, size, maxBytes)).map(
+        return (await this.getValidatedTransactions(start, size, maxBytes)).map(
             (transaction: Interfaces.ITransaction) => transaction.serialized,
         );
     }
 
     public async getTransactionsForForging(blockSize: number): Promise<string[]> {
-        return (await this.getValidTransactions(0, blockSize, this.options.maxTransactionBytes)).map(transaction =>
+        return (await this.getValidatedTransactions(0, blockSize, this.options.maxTransactionBytes)).map(transaction =>
             transaction.serialized.toString("hex"),
         );
     }
 
     public async getTransactionIdsForForging(start: number, size: number): Promise<string[]> {
-        return (await this.getValidTransactions(start, size, this.options.maxTransactionBytes)).map(
+        return (await this.getValidatedTransactions(start, size, this.options.maxTransactionBytes)).map(
             (transaction: Interfaces.ITransaction) => transaction.id,
         );
     }
@@ -364,7 +367,7 @@ export class Connection implements TransactionPool.IConnection {
         return false;
     }
 
-    private async getValidTransactions(
+    private async getValidatedTransactions(
         start: number,
         size: number,
         maxBytes: number = 0,
@@ -481,6 +484,9 @@ export class Connection implements TransactionPool.IConnection {
             (transaction: Interfaces.ITransaction) => !forgedIds.includes(transaction.id),
         );
 
+        const databaseWalletManager: State.IWalletManager = this.databaseService.walletManager;
+        const localWalletManager: Wallets.WalletManager = new Wallets.WalletManager();
+
         for (const transaction of unforgedTransactions) {
             try {
                 const deserialized: Interfaces.ITransaction = Transactions.TransactionFactory.fromBytes(
@@ -489,9 +495,16 @@ export class Connection implements TransactionPool.IConnection {
 
                 strictEqual(transaction.id, deserialized.id);
 
-                const walletManager: State.IWalletManager = this.databaseService.walletManager;
-                const sender: State.IWallet = walletManager.findByPublicKey(transaction.data.senderPublicKey);
-                Handlers.Registry.get(transaction.type).canBeApplied(transaction, sender, walletManager);
+                const { sender, recipient } = this.getSenderAndRecipient(transaction, localWalletManager);
+
+                const handler: Handlers.TransactionHandler = Handlers.Registry.get(transaction.type);
+                handler.canBeApplied(transaction, sender, databaseWalletManager);
+
+                handler.applyToSenderInPool(transaction, localWalletManager);
+
+                if (recipient && sender.address !== recipient.address) {
+                    handler.applyToRecipientInPool(transaction, localWalletManager);
+                }
 
                 validTransactions.push(deserialized.serialized.toString("hex"));
             } catch (error) {
@@ -501,6 +514,33 @@ export class Connection implements TransactionPool.IConnection {
         }
 
         return validTransactions;
+    }
+
+    private getSenderAndRecipient(
+        transaction: Interfaces.ITransaction,
+        localWalletManager: State.IWalletManager,
+    ): { sender: State.IWallet; recipient: State.IWallet } {
+        const databaseWalletManager: State.IWalletManager = this.databaseService.walletManager;
+        const { senderPublicKey, recipientId } = transaction.data;
+
+        let sender: State.IWallet;
+        let recipient: State.IWallet;
+
+        if (localWalletManager.hasByPublicKey(senderPublicKey)) {
+            sender = localWalletManager.findByPublicKey(senderPublicKey);
+        } else {
+            sender = clonedeep(databaseWalletManager.findByPublicKey(senderPublicKey));
+            localWalletManager.reindex(sender);
+        }
+
+        if (localWalletManager.hasByAddress(recipientId)) {
+            recipient = localWalletManager.findByAddress(recipientId);
+        } else {
+            recipient = clonedeep(databaseWalletManager.findByAddress(recipientId));
+            localWalletManager.reindex(recipient);
+        }
+
+        return { sender, recipient };
     }
 
     private async removeForgedTransactions(transactions: Interfaces.ITransaction[]): Promise<string[]> {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->
Calling only `canBeApplied` is not sufficient when transactions affect the sender/recipient of a following transaction. It is necessary keep track of the state changes by creating temporary wallets.

See also added tests.

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

## Does this PR release a new version?

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `develop` branch, _not_ the `master` branch
- [ ] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
