### PR TITLE
refactor(core-transaction-pool): expire transactions that don't have …

### DIFF
--- a/__tests__/integration/core-blockchain/__support__/setup.ts
+++ b/__tests__/integration/core-blockchain/__support__/setup.ts
@@ -5,6 +5,9 @@ jest.setTimeout(60000);
 
 process.env.CORE_RESET_DATABASE = "1";
 
-export const setUp = async () => setUpContainer({ exit: "@arkecosystem/core-blockchain" });
+export const setUp = async (options = {}) => setUpContainer({
+    ...options,
+    exit: "@arkecosystem/core-blockchain"
+});
 
 export const tearDown = async (): Promise<void> => app.tearDown();

--- a/__tests__/integration/core-blockchain/blockchain.test.ts
+++ b/__tests__/integration/core-blockchain/blockchain.test.ts
@@ -65,7 +65,12 @@ const indexWalletWithSufficientBalance = (transaction: Interfaces.ITransaction):
 
 describe("Blockchain", () => {
     beforeAll(async () => {
-        container = await setUp();
+        container = await setUp({
+            options: {
+                // 100 years worth of blocks, so that the genesis transactions don't get expired
+                "@arkecosystem/core-transaction-pool": { maxTransactionAge: 394200000 }
+            }
+        });
 
         blockchain = container.resolvePlugin("blockchain");
 
@@ -112,7 +117,7 @@ describe("Blockchain", () => {
             await blockchain.postTransactions(transferTransactions);
             const transactions = await blockchain.transactionPool.getTransactions(0, 200);
 
-            expect(transactions.length).toBe(transferTransactions.length);
+            expect(transactions).toHaveLength(transferTransactions.length);
 
             expect(transactions).toIncludeAllMembers(transferTransactions.map(transaction => transaction.serialized));
 

--- a/__tests__/unit/core-transaction-pool/connection.forging.test.ts
+++ b/__tests__/unit/core-transaction-pool/connection.forging.test.ts
@@ -24,7 +24,8 @@ let databaseWalletManager: Wallets.WalletManager;
 beforeAll(async () => {
     Managers.configManager.setFromPreset("testnet");
 
-    memory = new Memory();
+    const maxTransactionAge = 2700;
+    memory = new Memory(maxTransactionAge);
     poolWalletManager = new WalletManager();
     connection = new Connection({
         options: defaults,

--- a/__tests__/unit/core-transaction-pool/connection.test.ts
+++ b/__tests__/unit/core-transaction-pool/connection.test.ts
@@ -38,7 +38,8 @@ const indexWalletWithSufficientBalance = (transaction: Interfaces.ITransaction):
 };
 
 beforeAll(async () => {
-    memory = new Memory();
+    const maxTransactionAge = 2700;
+    memory = new Memory(maxTransactionAge);
 
     connection = new Connection({
         options: defaults,

--- a/__tests__/unit/core-transaction-pool/connection.test.ts
+++ b/__tests__/unit/core-transaction-pool/connection.test.ts
@@ -5,7 +5,7 @@ import { state } from "./mocks/state";
 
 import { Wallets } from "@arkecosystem/core-state";
 import { Handlers } from "@arkecosystem/core-transactions";
-import { Blocks, Constants, Enums, Interfaces, Managers, Transactions, Utils } from "@arkecosystem/crypto";
+import { Blocks, Constants, Crypto, Enums, Interfaces, Managers, Transactions, Utils } from "@arkecosystem/crypto";
 import dayjs from "dayjs";
 import cloneDeep from "lodash.clonedeep";
 import randomSeed from "random-seed";
@@ -25,6 +25,7 @@ const { TransactionTypes } = Enums;
 
 const delegatesSecrets = delegates.map(d => d.secret);
 
+const maxTransactionAge: number = 2700;
 let connection: Connection;
 let memory: Memory;
 
@@ -38,7 +39,6 @@ const indexWalletWithSufficientBalance = (transaction: Interfaces.ITransaction):
 };
 
 beforeAll(async () => {
-    const maxTransactionAge = 2700;
     memory = new Memory(maxTransactionAge);
 
     connection = new Connection({
@@ -230,14 +230,23 @@ describe("Connection", () => {
             jest.restoreAllMocks();
         });
 
-        it("should add the transactions to the pool and they should expire", async () => {
-            const heightAtStart = 42;
+        it.each([1, 2])("should correctly expire transactions (v%i)", async (transactionVersion) => {
+
+            const setHeight = (height) => {
+                jest.spyOn(state, "getStore").mockReturnValue({
+                    ...state.getStore(),
+                    ...{ getLastHeight: () => height },
+                });
+                jest.spyOn(Crypto.Slots, "getTime").mockReturnValue(
+                    height * Managers.configManager.getMilestone(height).blocktime
+                );
+            };
 
             jest.spyOn(container.app, "has").mockReturnValue(true);
-            jest.spyOn(state, "getStore").mockReturnValue({
-                ...state.getStore(),
-                ...{ getLastHeight: () => heightAtStart },
-            });
+
+            const heightAtStart = 42;
+
+            setHeight(heightAtStart);
 
             expect(connection.getPoolSize()).toBe(0);
 
@@ -246,40 +255,50 @@ describe("Connection", () => {
 
             const transactions: Interfaces.ITransaction[] = [];
 
-            transactions.push(Transactions.TransactionFactory.fromData(cloneDeep(mockData.dummyExp1.data)));
-            transactions[transactions.length - 1].data.expiration = expiration;
-
-            transactions.push(Transactions.TransactionFactory.fromData(cloneDeep(mockData.dummy1.data)));
-
-            // Workaround: Increase balance of sender wallet to succeed
-            const insufficientBalanceTx: any = Transactions.TransactionFactory.fromData(
-                cloneDeep(mockData.dummyExp2.data),
-            );
-            insufficientBalanceTx.data.expiration = expiration;
-            transactions.push(insufficientBalanceTx);
-
-            transactions.push(mockData.dummy2);
+            for (const [i, exp] of [0, expiration, expiration + 5].entries()) {
+                transactions.push(
+                    TransactionFactory.transfer(mockData.dummy1.data.recipientId)
+                        .withNetwork("unitnet")
+                        .withPassphrase(delegatesSecrets[0])
+                        .withFee(SATOSHI + i)
+                        .withVersion(transactionVersion)
+                        .withExpiration(exp)
+                        .build(1)[0]
+                );
+            }
 
             const { added, notAdded } = connection.addTransactions(transactions);
 
-            expect(added).toHaveLength(4);
             expect(notAdded).toBeEmpty();
+            expect(added).toHaveLength(3);
 
-            expect(connection.getPoolSize()).toBe(4);
+            expect(connection.getPoolSize()).toBe(3);
 
-            jest.spyOn(state, "getStore").mockReturnValue({
-                ...state.getStore(),
-                ...{ getLastHeight: () => expiration - 1 },
-            });
+            setHeight(expiration - 1);
 
-            expect(connection.getPoolSize()).toBe(4);
+            expect(connection.getPoolSize()).toBe(3);
 
-            jest.spyOn(state, "getStore").mockReturnValue({
-                ...state.getStore(),
-                ...{ getLastHeight: () => expiration },
-            });
+            setHeight(expiration);
 
-            expect(connection.getPoolSize()).toBe(2);
+            switch (transactionVersion) {
+                case 1:
+                    expect(connection.getPoolSize()).toBe(3);
+                    break;
+                case 2:
+                    expect(connection.getPoolSize()).toBe(2);
+                    break;
+            }
+
+            setHeight(heightAtStart + maxTransactionAge);
+
+            switch (transactionVersion) {
+                case 1:
+                    expect(connection.getPoolSize()).toBe(0);
+                    break;
+                case 2:
+                    expect(connection.getPoolSize()).toBe(0);
+                    break;
+            }
 
             for (const t of transactions) {
                 connection.removeTransactionById(t.id);

--- a/__tests__/unit/core-transaction-pool/manager.test.ts
+++ b/__tests__/unit/core-transaction-pool/manager.test.ts
@@ -7,10 +7,11 @@ import { Connection } from "./__stubs__/connection";
 
 const manager: ConnectionManager = new ConnectionManager();
 
+const maxTransactionAge = 2700;
 const args = {
     options: defaults,
     walletManager: new WalletManager(),
-    memory: new Memory(),
+    memory: new Memory(maxTransactionAge),
     storage: new Storage(),
 };
 

--- a/packages/core-transaction-pool/src/defaults.ts
+++ b/packages/core-transaction-pool/src/defaults.ts
@@ -11,6 +11,10 @@ export const defaults = {
     allowedSenders: [],
     maxTransactionsPerRequest: process.env.CORE_TRANSACTION_POOL_MAX_PER_REQUEST || 40,
     maxTransactionBytes: process.env.CORE_TRANSACTION_POOL_MAX_TRANSACTIONS_SIZE || 1047876,
+    // Max transaction age in number of blocks produced since the transaction was created.
+    // If a transaction stays that long in the pool without being included in any block,
+    // then it will be removed.
+    maxTransactionAge: 2700,
     dynamicFees: {
         enabled: true,
         minFeePool: 3000,

--- a/packages/core-transaction-pool/src/memory.ts
+++ b/packages/core-transaction-pool/src/memory.ts
@@ -1,6 +1,6 @@
 import { app } from "@arkecosystem/core-container";
 import { State } from "@arkecosystem/core-interfaces";
-import { Enums, Interfaces, Utils } from "@arkecosystem/crypto";
+import { Crypto, Enums, Interfaces, Managers, Utils } from "@arkecosystem/crypto";
 import assert from "assert";
 
 export class Memory {
@@ -17,7 +17,7 @@ export class Memory {
     private bySender: { [key: string]: Set<Interfaces.ITransaction> } = {};
     private byType: { [key: number]: Set<Interfaces.ITransaction> } = {};
     /**
-     * Contains only transactions that have expiration, possibly sorted by height (lower first).
+     * Contains only transactions that expire, possibly sorted by height (lower first).
      */
     private byExpiration: Interfaces.ITransaction[] = [];
     private byExpirationIsSorted: boolean = true;
@@ -26,8 +26,17 @@ export class Memory {
         removed: new Set(),
     };
 
+    constructor(private readonly maxTransactionAge: number) {}
+
     public allSortedByFee(): Interfaces.ITransaction[] {
         if (!this.allIsSorted) {
+            const currentHeight: number = this.currentHeight();
+            const expirationContext = {
+                blockTime: Managers.configManager.getMilestone(currentHeight).blocktime,
+                currentHeight: currentHeight,
+                now: Crypto.Slots.getTime()
+            };
+
             this.all.sort((a, b) => {
                 const feeA: Utils.BigNumber = a.data.fee;
                 const feeB: Utils.BigNumber = b.data.fee;
@@ -40,8 +49,11 @@ export class Memory {
                     return 1;
                 }
 
-                if (a.data.expiration > 0 && b.data.expiration > 0) {
-                    return a.data.expiration - b.data.expiration;
+                const expirationA: number = this.calcTxExpiration(a, expirationContext);
+                const expirationB: number = this.calcTxExpiration(b, expirationContext);
+
+                if (expirationA !== null && expirationB !== null) {
+                    return expirationA - expirationB;
                 }
 
                 return 0;
@@ -54,16 +66,24 @@ export class Memory {
     }
 
     public getExpired(): Interfaces.ITransaction[] {
+        const currentHeight: number = this.currentHeight();
+        const expirationContext = {
+            blockTime: Managers.configManager.getMilestone(currentHeight).blocktime,
+            currentHeight: currentHeight,
+            now: Crypto.Slots.getTime()
+        };
+
         if (!this.byExpirationIsSorted) {
-            this.byExpiration.sort((a, b) => a.data.expiration - b.data.expiration);
+            this.byExpiration.sort(
+                (a, b) => this.calcTxExpiration(a, expirationContext) - this.calcTxExpiration(b, expirationContext)
+            );
             this.byExpirationIsSorted = true;
         }
 
-        const currentHeight: number = this.currentHeight();
         const transactions: Interfaces.ITransaction[] = [];
 
         for (const transaction of this.byExpiration) {
-            if (transaction.data.expiration > currentHeight) {
+            if (this.calcTxExpiration(transaction, expirationContext) > currentHeight) {
                 break;
             }
 
@@ -138,11 +158,16 @@ export class Memory {
             this.byType[type].add(transaction);
         }
 
-        if (type !== Enums.TransactionTypes.TimelockTransfer) {
-            if (transaction.data.expiration > 0) {
-                this.byExpiration.push(transaction);
-                this.byExpirationIsSorted = false;
-            }
+        const currentHeight: number = this.currentHeight();
+        const expirationContext = {
+            blockTime: Managers.configManager.getMilestone(currentHeight).blocktime,
+            currentHeight: currentHeight,
+            now: Crypto.Slots.getTime()
+        };
+        const expiration: number = this.calcTxExpiration(transaction, expirationContext);
+        if (expiration !== null) {
+            this.byExpiration.push(transaction);
+            this.byExpirationIsSorted = false;
         }
 
         if (!databaseReady) {
@@ -249,5 +274,44 @@ export class Memory {
             .resolvePlugin<State.IStateService>("state")
             .getStore()
             .getLastHeight();
+    }
+
+    /**
+     * Calculate the expiration height of a transaction.
+     * An expiration height H means that the transaction cannot be included in block at height
+     * H or any higher block.
+     * If the user did not specify an expiration height when creating the transaction then
+     * we calculate one from the timestamp of the transaction creation and the configured
+     * maximum transaction age.
+     * @return number expiration height or null if the transaction does not expire
+     */
+    private calcTxExpiration(
+        transaction: Interfaces.ITransaction,
+        context: {
+            blockTime: number,
+            currentHeight: number,
+            now: number,
+        }
+    ): number {
+        if (transaction.type === Enums.TransactionTypes.TimelockTransfer) {
+            return null;
+        }
+
+        if (transaction.data.expiration > 0) {
+            return transaction.data.expiration;
+        }
+
+        // Since the user did not specify an expiration we set one by calculating
+        // approximately the height of the chain as of the time the transaction was
+        // created and adding maxTransactionAge to that.
+
+        // Both now and transaction.data.timestamp use [number of seconds since the genesis block].
+        const txCreatedSecondsAgo: number = context.now - transaction.data.timestamp;
+
+        const txCreatedBlocksAgo: number = Math.floor(txCreatedSecondsAgo / context.blockTime);
+
+        const txCreatedAtHeight: number = context.currentHeight - txCreatedBlocksAgo;
+
+        return txCreatedAtHeight + this.maxTransactionAge;
     }
 }

--- a/packages/core-transaction-pool/src/memory.ts
+++ b/packages/core-transaction-pool/src/memory.ts
@@ -33,7 +33,7 @@ export class Memory {
             const currentHeight: number = this.currentHeight();
             const expirationContext = {
                 blockTime: Managers.configManager.getMilestone(currentHeight).blocktime,
-                currentHeight: currentHeight,
+                currentHeight,
                 now: Crypto.Slots.getTime()
             };
 
@@ -69,7 +69,7 @@ export class Memory {
         const currentHeight: number = this.currentHeight();
         const expirationContext = {
             blockTime: Managers.configManager.getMilestone(currentHeight).blocktime,
-            currentHeight: currentHeight,
+            currentHeight,
             now: Crypto.Slots.getTime()
         };
 
@@ -163,7 +163,7 @@ export class Memory {
         const currentHeight: number = this.currentHeight();
         const expirationContext = {
             blockTime: Managers.configManager.getMilestone(currentHeight).blocktime,
-            currentHeight: currentHeight,
+            currentHeight,
             now: Crypto.Slots.getTime()
         };
         const expiration: number = this.calculateTransactionExpiration(transaction, expirationContext);
@@ -296,6 +296,7 @@ export class Memory {
         }
     ): number {
         if (transaction.type === Enums.TransactionTypes.TimelockTransfer) {
+            // tslint:disable-next-line:no-null-keyword
             return null;
         }
 

--- a/packages/core-transaction-pool/src/memory.ts
+++ b/packages/core-transaction-pool/src/memory.ts
@@ -297,7 +297,9 @@ export class Memory {
             return null;
         }
 
-        if (transaction.data.expiration > 0) {
+        // We ignore data.expiration in v1 transactions because it is not signed
+        // by the transaction creator.
+        if (transaction.version >= 2 && transaction.data.expiration > 0) {
             return transaction.data.expiration;
         }
 

--- a/packages/core-transaction-pool/src/plugin.ts
+++ b/packages/core-transaction-pool/src/plugin.ts
@@ -18,7 +18,7 @@ export const plugin: Container.IPluginDescriptor = {
             new Connection({
                 options,
                 walletManager: new WalletManager(),
-                memory: new Memory(),
+                memory: new Memory(options.maxTransactionAge as number),
                 storage: new Storage(),
             }),
         );


### PR DESCRIPTION
…expiration

If a transaction does not have an expiration value set by the user, then
we would keep it for a long time in the pool and also it could possibly
be re-sent by somebody (not the author) long time after it was created,
if it has not been forged yet.

Change this to expire after 6h even transactions that don't have an
user-set expiration. 6h considered since the transaction creation time.

<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->



<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [x] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Does this PR release a new version?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch
- [ ] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
