### PR TITLE
perf(crypto): replace bs58check with bstring

### DIFF
--- a/__tests__/unit/core-transaction-pool/connection.forging.test.ts
+++ b/__tests__/unit/core-transaction-pool/connection.forging.test.ts
@@ -2,7 +2,6 @@ import "jest-extended";
 
 import "./mocks/core-container";
 
-import bs58check from "bs58check";
 import ByteBuffer from "bytebuffer";
 
 import { Wallets } from "@arkecosystem/core-state";
@@ -140,7 +139,7 @@ describe("Connection", () => {
         // only for transfer right now
         writeUint64("amount", +transaction.amount);
         writeUint32("expiration", transaction.expiration || 0);
-        append("recipientId", bs58check.decode(transaction.recipientId));
+        append("recipientId", Identities.Address.decodeCheck(transaction.recipientId));
 
         // signatures
         if (transaction.signature || options.signature) {

--- a/__tests__/unit/core-transactions/handler-registry.test.ts
+++ b/__tests__/unit/core-transactions/handler-registry.test.ts
@@ -2,7 +2,6 @@ import "jest-extended";
 
 import { Database, State, TransactionPool } from "@arkecosystem/core-interfaces";
 import { Crypto, Enums, Identities, Interfaces, Managers, Transactions, Utils } from "@arkecosystem/crypto";
-import bs58check from "bs58check";
 import ByteBuffer from "bytebuffer";
 import { Errors } from "../../../packages/core-transactions/src";
 import { Registry, TransactionHandler } from "../../../packages/core-transactions/src/handlers";
@@ -43,7 +42,7 @@ class TestTransaction extends Transactions.Transaction {
         const buffer = new ByteBuffer(24, true);
         buffer.writeUint64(+data.amount);
         buffer.writeUint32(data.expiration || 0);
-        buffer.append(bs58check.decode(data.recipientId));
+        buffer.append(Identities.Address.decodeCheck(data.recipientId));
         buffer.writeInt32(data.asset.test);
 
         return buffer;
@@ -53,7 +52,7 @@ class TestTransaction extends Transactions.Transaction {
         const { data } = this;
         data.amount = Utils.BigNumber.make(buf.readUint64().toString());
         data.expiration = buf.readUint32();
-        data.recipientId = bs58check.encode(buf.readBytes(21).toBuffer());
+        data.recipientId = Identities.Address.encodeCheck(buf.readBytes(21).toBuffer());
         data.asset = {
             test: buf.readInt32(),
         };

--- a/__tests__/unit/crypto/crypto/bip38.test.ts
+++ b/__tests__/unit/crypto/crypto/bip38.test.ts
@@ -1,9 +1,10 @@
 import "jest-extended";
 
-import bs58check from "bs58check";
+import { base58 } from "bstring";
 import ByteBuffer from "bytebuffer";
 import wif from "wif";
 import { bip38 } from "../../../../packages/crypto/src/crypto";
+import { Address } from "../../../../packages/crypto/src/identities";
 
 import * as errors from "../../../../packages/crypto/src/errors";
 import fixtures from "./fixtures/bip38.json";
@@ -29,7 +30,7 @@ describe("BIP38", () => {
         });
 
         it("should throw if compression flag is different than 0xe0 0xc0", () => {
-            jest.spyOn(bs58check, "decode").mockImplementation(() => {
+            jest.spyOn(Address, "decodeCheck").mockImplementation(() => {
                 const byteBuffer = new ByteBuffer(512, true);
                 byteBuffer.writeUint8(0x01);
                 byteBuffer.writeUint8(0x42); // type
@@ -57,7 +58,7 @@ describe("BIP38", () => {
             }
 
             it(`should encrypt '${fixture.description}'`, () => {
-                const buffer = bs58check.decode(fixture.wif);
+                const buffer = Address.decodeCheck(fixture.wif);
                 const actual = bip38.encrypt(buffer.slice(1, 33), !!buffer[33], fixture.passphrase);
                 expect(actual).toEqual(fixture.bip38);
             });
@@ -86,7 +87,7 @@ describe("BIP38", () => {
         });
 
         it("should return false if encrypted WIF flag is different than 0xc0 0xe0", () => {
-            jest.spyOn(bs58check, "decodeUnsafe").mockImplementation(() => {
+            jest.spyOn(base58, "decode").mockImplementation(() => {
                 const byteBuffer = new ByteBuffer(512, true);
                 byteBuffer.writeUint8(0x01);
                 byteBuffer.writeUint8(0x42); // type
@@ -106,7 +107,7 @@ describe("BIP38", () => {
         });
 
         it("should return false if encrypted EC mult flag is different than 0x24", () => {
-            jest.spyOn(bs58check, "decodeUnsafe").mockImplementation(() => {
+            jest.spyOn(base58, "decode").mockImplementation(() => {
                 const byteBuffer = new ByteBuffer(512, true);
                 byteBuffer.writeUint8(0x01);
                 byteBuffer.writeUint8(0x43); // type
@@ -114,7 +115,7 @@ describe("BIP38", () => {
 
                 const buffer: any = Buffer.from(byteBuffer.flip().toBuffer());
                 Object.defineProperty(buffer, "length", {
-                    get: jest.fn(() => 39),
+                    get: jest.fn(() => 43),
                     set: jest.fn(),
                 });
                 return buffer;

--- a/packages/core-api/package.json
+++ b/packages/core-api/package.json
@@ -31,7 +31,6 @@
         "@hapi/boom": "^7.4.2",
         "@hapi/joi": "^15.0.3",
         "ajv": "^6.10.0",
-        "bs58check": "^2.1.2",
         "dayjs": "^1.8.14",
         "delay": "^4.2.0",
         "hapi-pagination": "https://github.com/faustbrian/hapi-pagination",

--- a/packages/core-api/src/formats.ts
+++ b/packages/core-api/src/formats.ts
@@ -1,6 +1,6 @@
 import { app } from "@arkecosystem/core-container";
+import { Identities } from "@arkecosystem/crypto/src";
 import { Ajv } from "ajv";
-import * as bs58check from "bs58check";
 import * as ipAddress from "ip";
 
 export const registerFormats = (ajv: Ajv) => {
@@ -10,7 +10,7 @@ export const registerFormats = (ajv: Ajv) => {
         type: "string",
         validate: value => {
             try {
-                return bs58check.decode(value)[0] === config.get("network.pubKeyHash");
+                return Identities.Address.decodeCheck(value)[0] === config.get("network.pubKeyHash");
             } catch (e) {
                 return false;
             }

--- a/packages/core-api/src/formats.ts
+++ b/packages/core-api/src/formats.ts
@@ -1,5 +1,5 @@
 import { app } from "@arkecosystem/core-container";
-import { Identities } from "@arkecosystem/crypto/src";
+import { Identities } from "@arkecosystem/crypto";
 import { Ajv } from "ajv";
 import * as ipAddress from "ip";
 

--- a/packages/core-transaction-pool/package.json
+++ b/packages/core-transaction-pool/package.json
@@ -35,7 +35,6 @@
         "@types/fs-extra": "^7.0.0",
         "@types/pluralize": "^0.0.29",
         "better-sqlite3": "^5.4.0",
-        "bs58check": "^2.1.2",
         "dayjs": "^1.8.14",
         "delay": "^4.2.0",
         "fs-extra": "^8.0.1",

--- a/packages/core-transactions/package.json
+++ b/packages/core-transactions/package.json
@@ -21,8 +21,7 @@
     "dependencies": {
         "@arkecosystem/core-event-emitter": "^2.4.0-next.11",
         "@arkecosystem/core-interfaces": "^2.4.0-next.11",
-        "@arkecosystem/crypto": "^2.4.0-next.11",
-        "bs58check": "^2.1.2"
+        "@arkecosystem/crypto": "^2.4.0-next.11"
     },
     "engines": {
         "node": ">=10.x"

--- a/packages/core-transactions/src/utils.ts
+++ b/packages/core-transactions/src/utils.ts
@@ -1,6 +1,5 @@
-import { Interfaces, Managers } from "@arkecosystem/crypto";
-import bs58check from "bs58check";
+import { Identities, Interfaces, Managers } from "@arkecosystem/crypto";
 
 export const isRecipientOnActiveNetwork = (transaction: Interfaces.ITransactionData): boolean => {
-    return bs58check.decode(transaction.recipientId).readUInt8(0) === Managers.configManager.get("network.pubKeyHash");
+    return Identities.Address.decodeCheck(transaction.recipientId).readUInt8(0) === Managers.configManager.get("network.pubKeyHash");
 };

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -34,8 +34,7 @@
         "bip32": "^2.0.3",
         "bip39": "^3.0.2",
         "browserify-aes": "^1.2.0",
-        "bs58": "^4.0.1",
-        "bs58check": "^2.1.2",
+        "bstring": "^0.3.9",
         "buffer-xor": "^2.0.2",
         "bytebuffer": "^5.0.1",
         "dayjs": "^1.8.14",
@@ -53,7 +52,6 @@
     "devDependencies": {
         "@types/bip32": "^1.0.2",
         "@types/bip39": "^2.4.2",
-        "@types/bs58": "^4.0.0",
         "@types/buffer-xor": "^2.0.0",
         "@types/bytebuffer": "^5.0.40",
         "@types/hapi__joi": "^15.0.1",

--- a/packages/crypto/src/transactions/serializer.ts
+++ b/packages/crypto/src/transactions/serializer.ts
@@ -1,6 +1,4 @@
 /* tslint:disable:no-shadowed-variable */
-
-import bs58check from "bs58check";
 import ByteBuffer from "bytebuffer";
 import { Utils } from "..";
 import { TransactionTypes } from "../enums";
@@ -122,7 +120,7 @@ export class Serializer {
         if (isBrokenTransaction || (transaction.recipientId && transaction.type !== 1 && transaction.type !== 4)) {
             const recipientId =
                 transaction.recipientId || Address.fromPublicKey(transaction.senderPublicKey, transaction.network);
-            const recipient = bs58check.decode(recipientId);
+            const recipient = Address.decodeCheck(recipientId);
             for (const byte of recipient) {
                 bb.writeByte(byte);
             }

--- a/packages/crypto/src/transactions/types/ipfs.ts
+++ b/packages/crypto/src/transactions/types/ipfs.ts
@@ -1,4 +1,4 @@
-import bs58 from "bs58";
+import { base58 } from "bstring";
 import ByteBuffer from "bytebuffer";
 import { TransactionTypes } from "../../enums";
 import { ISerializeOptions } from "../../interfaces";
@@ -15,7 +15,7 @@ export class IpfsTransaction extends Transaction {
     public serialize(options?: ISerializeOptions): ByteBuffer {
         const { data } = this;
 
-        const ipfsBuffer: Buffer = bs58.decode(data.asset.ipfs);
+        const ipfsBuffer: Buffer = base58.decode(data.asset.ipfs);
         const buffer: ByteBuffer = new ByteBuffer(ipfsBuffer.length, true);
 
         buffer.append(ipfsBuffer, "hex");
@@ -36,7 +36,7 @@ export class IpfsTransaction extends Transaction {
         buffer.fill(ipfsHash, 2);
 
         data.asset = {
-            ipfs: bs58.encode(buffer),
+            ipfs: base58.encode(buffer),
         };
     }
 }

--- a/packages/crypto/src/transactions/types/multi-payment.ts
+++ b/packages/crypto/src/transactions/types/multi-payment.ts
@@ -1,6 +1,6 @@
-import bs58check from "bs58check";
 import ByteBuffer from "bytebuffer";
 import { TransactionTypes } from "../../enums";
+import { Address } from "../../identities";
 import { IMultiPaymentItem, ISerializeOptions } from "../../interfaces";
 import { BigNumber } from "../../utils";
 import * as schemas from "./schemas";
@@ -21,7 +21,7 @@ export class MultiPaymentTransaction extends Transaction {
 
         for (const p of data.asset.payments) {
             buffer.writeUint64(+BigNumber.make(p.amount).toFixed());
-            buffer.append(bs58check.decode(p.recipientId));
+            buffer.append(Address.decodeCheck(p.recipientId));
         }
 
         return buffer;
@@ -35,7 +35,7 @@ export class MultiPaymentTransaction extends Transaction {
         for (let j = 0; j < total; j++) {
             payments.push({
                 amount: BigNumber.make(buf.readUint64().toString()),
-                recipientId: bs58check.encode(buf.readBytes(21).toBuffer()),
+                recipientId: Address.encodeCheck(buf.readBytes(21).toBuffer()),
             });
         }
 

--- a/packages/crypto/src/transactions/types/timelock-transfer.ts
+++ b/packages/crypto/src/transactions/types/timelock-transfer.ts
@@ -1,6 +1,6 @@
-import bs58check from "bs58check";
 import ByteBuffer from "bytebuffer";
 import { TransactionTypes } from "../../enums";
+import { Address } from "../../identities";
 import { ISerializeOptions } from "../../interfaces";
 import { BigNumber } from "../../utils";
 import * as schemas from "./schemas";
@@ -20,7 +20,7 @@ export class TimelockTransferTransaction extends Transaction {
         buffer.writeUint64(+data.amount.toFixed());
         buffer.writeByte(data.timelockType);
         buffer.writeUint64(data.timelock);
-        buffer.append(bs58check.decode(data.recipientId));
+        buffer.append(Address.decodeCheck(data.recipientId));
         return buffer;
     }
 
@@ -29,6 +29,6 @@ export class TimelockTransferTransaction extends Transaction {
         data.amount = BigNumber.make(buf.readUint64().toString());
         data.timelockType = buf.readUint8();
         data.timelock = buf.readUint64().toNumber();
-        data.recipientId = bs58check.encode(buf.readBytes(21).toBuffer());
+        data.recipientId = Address.encodeCheck(buf.readBytes(21).toBuffer());
     }
 }

--- a/packages/crypto/src/transactions/types/transfer.ts
+++ b/packages/crypto/src/transactions/types/transfer.ts
@@ -1,6 +1,6 @@
-import bs58check from "bs58check";
 import ByteBuffer from "bytebuffer";
 import { TransactionTypes } from "../../enums";
+import { Address } from "../../identities";
 import { ISerializeOptions } from "../../interfaces";
 import { BigNumber } from "../../utils";
 import * as schemas from "./schemas";
@@ -22,7 +22,7 @@ export class TransferTransaction extends Transaction {
         const buffer: ByteBuffer = new ByteBuffer(24, true);
         buffer.writeUint64(+data.amount);
         buffer.writeUint32(data.expiration || 0);
-        buffer.append(bs58check.decode(data.recipientId));
+        buffer.append(Address.decodeCheck(data.recipientId));
 
         return buffer;
     }
@@ -31,6 +31,6 @@ export class TransferTransaction extends Transaction {
         const { data } = this;
         data.amount = BigNumber.make(buf.readUint64().toString());
         data.expiration = buf.readUint32();
-        data.recipientId = bs58check.encode(buf.readBytes(21).toBuffer());
+        data.recipientId = Address.encodeCheck(buf.readBytes(21).toBuffer());
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2402,13 +2402,6 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
-"@types/base-x@*":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@types/base-x/-/base-x-3.0.0.tgz#a1365259d1d3fa3ff973ab543192a6bdd4cb2f90"
-  integrity sha512-vnqSlpsv9uFX5/z8GyKWAfWHhLGJDBkrgRRsnxlsX23DHOlNyqP/eHQiv4TwnYcZULzQIxaWA/xRWU9Dyy4qzw==
-  dependencies:
-    "@types/node" "*"
-
 "@types/better-sqlite3@^5.4.0":
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/@types/better-sqlite3/-/better-sqlite3-5.4.0.tgz#ab7336ccc2e31bd88247016c675cfcb01df99787"
@@ -2452,13 +2445,6 @@
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/braces/-/braces-3.0.0.tgz#7da1c0d44ff1c7eb660a36ec078ea61ba7eb42cb"
   integrity sha512-TbH79tcyi9FHwbyboOKeRachRq63mSuWYXOflsNO9ZyE5ClQ/JaozNKl+aWUq87qPNsXasXxi2AbgfwIJ+8GQw==
-
-"@types/bs58@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@types/bs58/-/bs58-4.0.0.tgz#baec75cb007b419ede3ec6b3410d2c8f14c92fc5"
-  integrity sha512-gYX+MHD4G/R+YGYwdhG5gbJj4LsEQGr3Vg6gVDAbe7xC5Bn8dNNG2Lpo6uDX/rT5dE7VBj0rGEFuV8L0AEx4Rg==
-  dependencies:
-    "@types/base-x" "*"
 
 "@types/buffer-xor@^2.0.0":
   version "2.0.0"
@@ -4174,14 +4160,14 @@ bs-logger@0.x:
   dependencies:
     fast-json-stable-stringify "2.x"
 
-bs58@^4.0.0, bs58@^4.0.1:
+bs58@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/bs58/-/bs58-4.0.1.tgz#be161e76c354f6f788ae4071f63f34e8c4f0a42a"
   integrity sha1-vhYedsNU9veIrkBx9j806MTwpCo=
   dependencies:
     base-x "^3.0.2"
 
-bs58check@<3.0.0, bs58check@^2.1.1, bs58check@^2.1.2:
+bs58check@<3.0.0, bs58check@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/bs58check/-/bs58check-2.1.2.tgz#53b018291228d82a5aa08e7d796fdafda54aebfc"
   integrity sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==
@@ -4201,6 +4187,15 @@ bsert@~0.0.10:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/bsert/-/bsert-0.0.10.tgz#231ac82873a1418c6ade301ab5cd9ae385895597"
   integrity sha512-NHNwlac+WPy4t2LoNh8pXk8uaIGH3NSaIUbTTRXGpE2WEbq0te/tDykYHkFK57YKLPjv/aGHmbqvnGeVWDz57Q==
+
+bstring@^0.3.9:
+  version "0.3.9"
+  resolved "https://registry.yarnpkg.com/bstring/-/bstring-0.3.9.tgz#dc50294b54e9e767c07ca5592795dcc59ef1bf2e"
+  integrity sha512-D95flI7SXL+UsQi9mW+hH+AK2AFfafIJi+3GbbyTAWMe2FqwR9keBxsjGiGd/JM+77Y9WsC+M4EhZVNVcym9jw==
+  dependencies:
+    bsert "~0.0.10"
+    loady "~0.0.1"
+    nan "^2.13.1"
 
 btoa-lite@^1.0.0:
   version "1.0.0"
@@ -9624,6 +9619,11 @@ nan@^2.12.1, nan@^2.13.2:
   version "2.13.2"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.13.2.tgz#f51dc7ae66ba7d5d55e1e6d4d8092e802c9aefe7"
   integrity sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==
+
+nan@^2.13.1:
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
+  integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
 
 nanomatch@^1.2.13, nanomatch@^1.2.9:
   version "1.2.13"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

Replaces `bs58check` which is a pure JS implementation with `bstring` which ships a native `base58` implemenation.

It is about twice as fast:
```
    ✓  bstring.base58.decode x 439,740 ops/sec ±1.76% (83 runs sampled)
    ✓  bs58check.decode x 223,122 ops/sec ±1.42% (82 runs sampled)
    ✓  bstring.base58.encode x 315,189 ops/sec ±1.10% (88 runs sampled)
    ✓  bs58check.encode x 162,822 ops/sec ±1.63% (92 runs sampled)
```


<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [X] Refactor
- [X] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

## Does this PR release a new version?

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `develop` branch, _not_ the `master` branch
- [ ] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
