### PR TITLE
refactor(crypto): move base58 functions to utils

### DIFF
--- a/__tests__/unit/core-transaction-pool/connection.forging.test.ts
+++ b/__tests__/unit/core-transaction-pool/connection.forging.test.ts
@@ -139,7 +139,7 @@ describe("Connection", () => {
         // only for transfer right now
         writeUint64("amount", +transaction.amount);
         writeUint32("expiration", transaction.expiration || 0);
-        append("recipientId", Identities.Address.decodeCheck(transaction.recipientId));
+        append("recipientId", Utils.Base58.decodeCheck(transaction.recipientId));
 
         // signatures
         if (transaction.signature || options.signature) {

--- a/__tests__/unit/core-transactions/handler-registry.test.ts
+++ b/__tests__/unit/core-transactions/handler-registry.test.ts
@@ -42,7 +42,7 @@ class TestTransaction extends Transactions.Transaction {
         const buffer = new ByteBuffer(24, true);
         buffer.writeUint64(+data.amount);
         buffer.writeUint32(data.expiration || 0);
-        buffer.append(Identities.Address.decodeCheck(data.recipientId));
+        buffer.append(Utils.Base58.decodeCheck(data.recipientId));
         buffer.writeInt32(data.asset.test);
 
         return buffer;
@@ -52,7 +52,7 @@ class TestTransaction extends Transactions.Transaction {
         const { data } = this;
         data.amount = Utils.BigNumber.make(buf.readUint64().toString());
         data.expiration = buf.readUint32();
-        data.recipientId = Identities.Address.encodeCheck(buf.readBytes(21).toBuffer());
+        data.recipientId = Utils.Base58.encodeCheck(buf.readBytes(21).toBuffer());
         data.asset = {
             test: buf.readInt32(),
         };
@@ -84,11 +84,11 @@ class TestTransactionHandler extends TransactionHandler {
         return true;
     }
 
-    public applyToRecipient(transaction: Interfaces.ITransaction, walletManager: State.IWalletManager): void {
-    }
+    // tslint:disable-next-line: no-empty
+    public applyToRecipient(transaction: Interfaces.ITransaction, walletManager: State.IWalletManager): void {}
 
-    public revertForRecipient(transaction: Interfaces.ITransaction, walletManager: State.IWalletManager): void {
-    }
+    // tslint:disable-next-line: no-empty
+    public revertForRecipient(transaction: Interfaces.ITransaction, walletManager: State.IWalletManager): void {}
 }
 
 beforeAll(() => {

--- a/__tests__/unit/crypto/crypto/bip38.test.ts
+++ b/__tests__/unit/crypto/crypto/bip38.test.ts
@@ -4,21 +4,21 @@ import { base58 } from "bstring";
 import ByteBuffer from "bytebuffer";
 import wif from "wif";
 import { bip38 } from "../../../../packages/crypto/src/crypto";
-import { Address } from "../../../../packages/crypto/src/identities";
+import { Base58 } from "../../../../packages/crypto/src/utils";
 
 import * as errors from "../../../../packages/crypto/src/errors";
 import fixtures from "./fixtures/bip38.json";
 
 describe("BIP38", () => {
     describe("decrypt", () => {
-        fixtures.valid.forEach(fixture => {
+        for (const fixture of fixtures.valid) {
             it(`should decrypt '${fixture.description}'`, () => {
                 const result = bip38.decrypt(fixture.bip38, fixture.passphrase);
                 expect(wif.encode(0x80, result.privateKey, result.compressed)).toEqual(fixture.wif);
             });
-        });
+        }
 
-        fixtures.invalid.verify.forEach(fixture => {
+        for (const fixture of fixtures.invalid.verify) {
             it(`should not decrypt '${fixture.description}'`, () => {
                 try {
                     bip38.decrypt(fixture.base58, "foobar");
@@ -27,10 +27,10 @@ describe("BIP38", () => {
                     expect(error.message).toEqual(fixture.error.message);
                 }
             });
-        });
+        }
 
         it("should throw if compression flag is different than 0xe0 0xc0", () => {
-            jest.spyOn(Address, "decodeCheck").mockImplementation(() => {
+            jest.spyOn(Base58, "decodeCheck").mockImplementation(() => {
                 const byteBuffer = new ByteBuffer(512, true);
                 byteBuffer.writeUint8(0x01);
                 byteBuffer.writeUint8(0x42); // type
@@ -52,17 +52,17 @@ describe("BIP38", () => {
     });
 
     describe("encrypt", () => {
-        fixtures.valid.forEach(fixture => {
+        for (const fixture of fixtures.valid) {
             if (fixture.decryptOnly) {
                 return;
             }
 
             it(`should encrypt '${fixture.description}'`, () => {
-                const buffer = Address.decodeCheck(fixture.wif);
+                const buffer = Base58.decodeCheck(fixture.wif);
                 const actual = bip38.encrypt(buffer.slice(1, 33), !!buffer[33], fixture.passphrase);
                 expect(actual).toEqual(fixture.bip38);
             });
-        });
+        }
 
         it("should throw if private key buffer length is different than 32", () => {
             const byteBuffer = new ByteBuffer(512, true);
@@ -74,17 +74,17 @@ describe("BIP38", () => {
     });
 
     describe("verify", () => {
-        fixtures.valid.forEach(fixture => {
+        for (const fixture of fixtures.valid) {
             it(`should verify '${fixture.bip38}'`, () => {
                 expect(bip38.verify(fixture.bip38)).toBeTrue();
             });
-        });
+        }
 
-        fixtures.invalid.verify.forEach(fixture => {
+        for (const fixture of fixtures.invalid.verify) {
             it(`should not verify '${fixture.description}'`, () => {
                 expect(bip38.verify(fixture.base58)).toBeFalse();
             });
-        });
+        }
 
         it("should return false if encrypted WIF flag is different than 0xc0 0xe0", () => {
             jest.spyOn(base58, "decode").mockImplementation(() => {

--- a/__tests__/unit/crypto/utils/base58.test.ts
+++ b/__tests__/unit/crypto/utils/base58.test.ts
@@ -3,7 +3,7 @@ import "jest-extended";
 import { HashAlgorithms } from "../../../../packages/crypto/src/crypto";
 import { Base58 } from "../../../../packages/crypto/src/utils/base58";
 
-const createPaayload = () => {
+const createPayload = () => {
     const buffer: Buffer = HashAlgorithms.ripemd160(
         Buffer.from("034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed192", "hex"),
     );
@@ -17,10 +17,10 @@ const createPaayload = () => {
 
 describe("Base58", () => {
     it("encodeCheck", () => {
-        expect(Base58.encodeCheck(createPaayload())).toBe("D61mfSggzbvQgTUe6JhYKH2doHaqJ3Dyib");
+        expect(Base58.encodeCheck(createPayload())).toBe("D61mfSggzbvQgTUe6JhYKH2doHaqJ3Dyib");
     });
 
     it("decodeCheck", () => {
-        expect(Base58.decodeCheck("D61mfSggzbvQgTUe6JhYKH2doHaqJ3Dyib")).toEqual(createPaayload());
+        expect(Base58.decodeCheck("D61mfSggzbvQgTUe6JhYKH2doHaqJ3Dyib")).toEqual(createPayload());
     });
 });

--- a/__tests__/unit/crypto/utils/base58.test.ts
+++ b/__tests__/unit/crypto/utils/base58.test.ts
@@ -1,0 +1,26 @@
+import "jest-extended";
+
+import { HashAlgorithms } from "../../../../packages/crypto/src/crypto";
+import { Base58 } from "../../../../packages/crypto/src/utils/base58";
+
+const createPaayload = () => {
+    const buffer: Buffer = HashAlgorithms.ripemd160(
+        Buffer.from("034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed192", "hex"),
+    );
+    const payload: Buffer = Buffer.alloc(21);
+
+    payload.writeUInt8(30, 0);
+    buffer.copy(payload, 1);
+
+    return payload;
+};
+
+describe("Base58", () => {
+    it("encodeCheck", () => {
+        expect(Base58.encodeCheck(createPaayload())).toBe("D61mfSggzbvQgTUe6JhYKH2doHaqJ3Dyib");
+    });
+
+    it("decodeCheck", () => {
+        expect(Base58.decodeCheck("D61mfSggzbvQgTUe6JhYKH2doHaqJ3Dyib")).toEqual(createPaayload());
+    });
+});

--- a/packages/core-api/src/formats.ts
+++ b/packages/core-api/src/formats.ts
@@ -1,5 +1,5 @@
 import { app } from "@arkecosystem/core-container";
-import { Identities } from "@arkecosystem/crypto";
+import { Utils } from "@arkecosystem/crypto";
 import { Ajv } from "ajv";
 import * as ipAddress from "ip";
 
@@ -10,7 +10,7 @@ export const registerFormats = (ajv: Ajv) => {
         type: "string",
         validate: value => {
             try {
-                return Identities.Address.decodeCheck(value)[0] === config.get("network.pubKeyHash");
+                return Utils.Base58.decodeCheck(value)[0] === config.get("network.pubKeyHash");
             } catch (e) {
                 return false;
             }

--- a/packages/core-transactions/src/utils.ts
+++ b/packages/core-transactions/src/utils.ts
@@ -1,5 +1,8 @@
-import { Identities, Interfaces, Managers } from "@arkecosystem/crypto";
+import { Interfaces, Managers, Utils } from "@arkecosystem/crypto";
 
 export const isRecipientOnActiveNetwork = (transaction: Interfaces.ITransactionData): boolean => {
-    return Identities.Address.decodeCheck(transaction.recipientId).readUInt8(0) === Managers.configManager.get("network.pubKeyHash");
+    return (
+        Utils.Base58.decodeCheck(transaction.recipientId).readUInt8(0) ===
+        Managers.configManager.get("network.pubKeyHash")
+    );
 };

--- a/packages/crypto/src/crypto/bip38.ts
+++ b/packages/crypto/src/crypto/bip38.ts
@@ -17,8 +17,9 @@ import {
     Bip38TypeError,
     PrivateKeyLengthError,
 } from "../errors";
-import { Address, Keys } from "../identities";
+import { Keys } from "../identities";
 import { IDecryptResult } from "../interfaces";
+import { Base58 } from "../utils";
 
 const SCRYPT_PARAMS = {
     N: 16384, // specified by BIP38
@@ -39,13 +40,13 @@ const getAddressPrivate = (privateKey: Buffer, compressed: boolean): string => {
     payload.writeUInt8(0x00, 0);
     buffer.copy(payload, 1);
 
-    return Address.encodeCheck(payload);
+    return Base58.encodeCheck(payload);
 };
 
 export const verify = (bip38: string): boolean => {
     let decoded: Buffer;
     try {
-        decoded = Address.decodeCheck(bip38);
+        decoded = Base58.decodeCheck(bip38);
     } catch {
         return false;
     }
@@ -233,9 +234,9 @@ const decryptRaw = (buffer: Buffer, passphrase: string): IDecryptResult => {
 };
 
 export const encrypt = (privateKey: Buffer, compressed: boolean, passphrase: string): string => {
-    return Address.encodeCheck(encryptRaw(privateKey, compressed, passphrase));
+    return Base58.encodeCheck(encryptRaw(privateKey, compressed, passphrase));
 };
 
 export const decrypt = (bip38: string, passphrase): IDecryptResult => {
-    return decryptRaw(Address.decodeCheck(bip38), passphrase);
+    return decryptRaw(Base58.decodeCheck(bip38), passphrase);
 };

--- a/packages/crypto/src/identities/address.ts
+++ b/packages/crypto/src/identities/address.ts
@@ -1,8 +1,8 @@
-import { base58 } from "bstring";
 import { HashAlgorithms } from "../crypto";
 import { PublicKeyError } from "../errors";
 import { IMultiSignatureAsset } from "../interfaces";
 import { configManager } from "../managers";
+import { Base58 } from "../utils";
 import { PublicKey } from "./public-key";
 
 export class Address {
@@ -25,7 +25,7 @@ export class Address {
         payload.writeUInt8(networkVersion, 0);
         buffer.copy(payload, 1);
 
-        return this.encodeCheck(payload);
+        return Base58.encodeCheck(payload);
     }
 
     public static fromMultiSignatureAsset(asset: IMultiSignatureAsset, networkVersion?: number): string {
@@ -36,30 +36,13 @@ export class Address {
         return Address.fromPublicKey(privateKey.publicKey, networkVersion);
     }
 
-    public static encodeCheck(buffer: Buffer): string {
-        const checksum: Buffer = HashAlgorithms.hash256(buffer);
-        return base58.encode(Buffer.concat([buffer, checksum], buffer.length + 4));
-    }
-
-    public static decodeCheck(address: string): Buffer {
-        const buffer: Buffer = base58.decode(address);
-        const payload: Buffer = buffer.slice(0, -4);
-        const checksum: Buffer = HashAlgorithms.hash256(payload);
-
-        if (checksum.readUInt32LE(0) !== buffer.slice(-4).readUInt32LE(0)) {
-            throw new Error("Invalid checksum");
-        }
-
-        return payload;
-    }
-
     public static validate(address: string, networkVersion?: number): boolean {
         if (!networkVersion) {
             networkVersion = configManager.get("network.pubKeyHash");
         }
 
         try {
-            return this.decodeCheck(address)[0] === networkVersion;
+            return Base58.decodeCheck(address)[0] === networkVersion;
         } catch (err) {
             return false;
         }

--- a/packages/crypto/src/transactions/serializer.ts
+++ b/packages/crypto/src/transactions/serializer.ts
@@ -7,6 +7,7 @@ import { Address } from "../identities";
 import { ISerializeOptions } from "../interfaces";
 import { ITransaction, ITransactionData } from "../interfaces";
 import { configManager } from "../managers";
+import { Base58 } from "../utils";
 import { TransactionTypeFactory } from "./types";
 
 // Reference: https://github.com/ArkEcosystem/AIPs/blob/master/AIPS/aip-11.md
@@ -120,7 +121,7 @@ export class Serializer {
         if (isBrokenTransaction || (transaction.recipientId && transaction.type !== 1 && transaction.type !== 4)) {
             const recipientId =
                 transaction.recipientId || Address.fromPublicKey(transaction.senderPublicKey, transaction.network);
-            const recipient = Address.decodeCheck(recipientId);
+            const recipient = Base58.decodeCheck(recipientId);
             for (const byte of recipient) {
                 bb.writeByte(byte);
             }

--- a/packages/crypto/src/transactions/types/multi-payment.ts
+++ b/packages/crypto/src/transactions/types/multi-payment.ts
@@ -1,8 +1,7 @@
 import ByteBuffer from "bytebuffer";
 import { TransactionTypes } from "../../enums";
-import { Address } from "../../identities";
 import { IMultiPaymentItem, ISerializeOptions } from "../../interfaces";
-import { BigNumber } from "../../utils";
+import { Base58, BigNumber } from "../../utils";
 import * as schemas from "./schemas";
 import { Transaction } from "./transaction";
 
@@ -21,7 +20,7 @@ export class MultiPaymentTransaction extends Transaction {
 
         for (const p of data.asset.payments) {
             buffer.writeUint64(+BigNumber.make(p.amount).toFixed());
-            buffer.append(Address.decodeCheck(p.recipientId));
+            buffer.append(Base58.decodeCheck(p.recipientId));
         }
 
         return buffer;
@@ -35,7 +34,7 @@ export class MultiPaymentTransaction extends Transaction {
         for (let j = 0; j < total; j++) {
             payments.push({
                 amount: BigNumber.make(buf.readUint64().toString()),
-                recipientId: Address.encodeCheck(buf.readBytes(21).toBuffer()),
+                recipientId: Base58.encodeCheck(buf.readBytes(21).toBuffer()),
             });
         }
 

--- a/packages/crypto/src/transactions/types/timelock-transfer.ts
+++ b/packages/crypto/src/transactions/types/timelock-transfer.ts
@@ -1,8 +1,7 @@
 import ByteBuffer from "bytebuffer";
 import { TransactionTypes } from "../../enums";
-import { Address } from "../../identities";
 import { ISerializeOptions } from "../../interfaces";
-import { BigNumber } from "../../utils";
+import { Base58, BigNumber } from "../../utils";
 import * as schemas from "./schemas";
 import { Transaction } from "./transaction";
 
@@ -20,7 +19,7 @@ export class TimelockTransferTransaction extends Transaction {
         buffer.writeUint64(+data.amount.toFixed());
         buffer.writeByte(data.timelockType);
         buffer.writeUint64(data.timelock);
-        buffer.append(Address.decodeCheck(data.recipientId));
+        buffer.append(Base58.decodeCheck(data.recipientId));
         return buffer;
     }
 
@@ -29,6 +28,6 @@ export class TimelockTransferTransaction extends Transaction {
         data.amount = BigNumber.make(buf.readUint64().toString());
         data.timelockType = buf.readUint8();
         data.timelock = buf.readUint64().toNumber();
-        data.recipientId = Address.encodeCheck(buf.readBytes(21).toBuffer());
+        data.recipientId = Base58.encodeCheck(buf.readBytes(21).toBuffer());
     }
 }

--- a/packages/crypto/src/transactions/types/transfer.ts
+++ b/packages/crypto/src/transactions/types/transfer.ts
@@ -1,8 +1,7 @@
 import ByteBuffer from "bytebuffer";
 import { TransactionTypes } from "../../enums";
-import { Address } from "../../identities";
 import { ISerializeOptions } from "../../interfaces";
-import { BigNumber } from "../../utils";
+import { Base58, BigNumber } from "../../utils";
 import * as schemas from "./schemas";
 import { Transaction } from "./transaction";
 
@@ -22,7 +21,7 @@ export class TransferTransaction extends Transaction {
         const buffer: ByteBuffer = new ByteBuffer(24, true);
         buffer.writeUint64(+data.amount);
         buffer.writeUint32(data.expiration || 0);
-        buffer.append(Address.decodeCheck(data.recipientId));
+        buffer.append(Base58.decodeCheck(data.recipientId));
 
         return buffer;
     }
@@ -31,6 +30,6 @@ export class TransferTransaction extends Transaction {
         const { data } = this;
         data.amount = BigNumber.make(buf.readUint64().toString());
         data.expiration = buf.readUint32();
-        data.recipientId = Address.encodeCheck(buf.readBytes(21).toBuffer());
+        data.recipientId = Base58.encodeCheck(buf.readBytes(21).toBuffer());
     }
 }

--- a/packages/crypto/src/utils/base58.ts
+++ b/packages/crypto/src/utils/base58.ts
@@ -1,0 +1,22 @@
+import { base58 } from "bstring";
+import { HashAlgorithms } from "../crypto";
+
+export class Base58 {
+    public static encodeCheck(buffer: Buffer): string {
+        const checksum: Buffer = HashAlgorithms.hash256(buffer);
+
+        return base58.encode(Buffer.concat([buffer, checksum], buffer.length + 4));
+    }
+
+    public static decodeCheck(address: string): Buffer {
+        const buffer: Buffer = base58.decode(address);
+        const payload: Buffer = buffer.slice(0, -4);
+        const checksum: Buffer = HashAlgorithms.hash256(payload);
+
+        if (checksum.readUInt32LE(0) !== buffer.slice(-4).readUInt32LE(0)) {
+            throw new Error("Invalid checksum");
+        }
+
+        return payload;
+    }
+}

--- a/packages/crypto/src/utils/index.ts
+++ b/packages/crypto/src/utils/index.ts
@@ -1,6 +1,7 @@
 import { SATOSHI } from "../constants";
 import { IBlockData, ITransactionData } from "../interfaces";
 import { configManager } from "../managers";
+import { Base58 } from "./base58";
 import { BigNumber } from "./bignum";
 
 /**
@@ -75,4 +76,4 @@ export const numberToHex = (num: number, padding = 2): string => {
 
 export const maxVendorFieldLength = (height?: number): number => configManager.getMilestone(height).vendorFieldLength;
 
-export { BigNumber };
+export { Base58, BigNumber };


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

Move the `base58` specific code out of the address identity because identities shouldn't expose anything besides methods to generate/validate the type of identity it is.

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [x] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

## Does this PR release a new version?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch
- [x] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
