### PR TITLE
fix: do not sort transactions in forger / update purgeByBlock logic for handling nonces

### DIFF
--- a/__tests__/unit/core-forger/delegate.test.ts
+++ b/__tests__/unit/core-forger/delegate.test.ts
@@ -2,9 +2,7 @@ import "jest-extended";
 
 import { Types, Utils } from "@arkecosystem/crypto";
 import { Delegate } from "../../../packages/core-forger/src/delegate";
-import { ITransactionData } from "../../../packages/crypto/src/interfaces";
 import { testnet } from "../../../packages/crypto/src/networks";
-import { sortTransactions } from "../../../packages/crypto/src/utils";
 import { TransactionFactory } from "../../helpers/transaction-factory";
 
 const dummy = {
@@ -137,15 +135,6 @@ describe("Delegate", () => {
         });
     });
 
-    describe("sortTransactions", () => {
-        it("returns the transactions ordered by type and id", () => {
-            const ordered = [{ type: 1, id: "2" }, { type: 1, id: "8" }, { type: 2, id: "5" }, { type: 2, id: "9" }];
-            const unordered = [ordered[3], ordered[2], ordered[1], ordered[0]] as ITransactionData[];
-
-            expect(sortTransactions(unordered)).toEqual(ordered);
-        });
-    });
-
     describe("forge", () => {
         const optionsDefault = {
             timestamp: 12345689,
@@ -175,9 +164,9 @@ describe("Delegate", () => {
 
             const block = delegate.forge(transactions, optionsDefault);
 
-            Object.keys(expectedBlockData).forEach(key => {
+            for (const key of Object.keys(expectedBlockData)) {
                 expect(block.data[key]).toEqual(expectedBlockData[key]);
-            });
+            }
             expect(block.verification).toEqual({
                 containsMultiSignatures: false,
                 errors: [],
@@ -198,9 +187,9 @@ describe("Delegate", () => {
             expect(spyDecryptKeys).toHaveBeenCalledTimes(1);
             expect(spyEncryptKeys).toHaveBeenCalledTimes(1);
 
-            Object.keys(expectedBlockData).forEach(key => {
+            for (const key of Object.keys(expectedBlockData)) {
                 expect(block.data[key]).toEqual(expectedBlockData[key]);
-            });
+            }
             expect(block.verification).toEqual({
                 containsMultiSignatures: false,
                 errors: [],
@@ -227,6 +216,25 @@ describe("Delegate", () => {
 
             const block = delegate.forge(transactions, optionsDefault);
             expect(block).toBeUndefined();
+        });
+
+        it("should forge a block with transactions ordered by nonce", () => {
+            const transfers = TransactionFactory.transfer()
+                .withPassphrase(dummy.plainPassphrase)
+                .create(10);
+
+            const delegate = new Delegate(dummy.plainPassphrase, testnet.network);
+
+            const block = delegate.forge(transfers, optionsDefault);
+
+            expect(block.verification).toEqual({
+                containsMultiSignatures: false,
+                errors: [],
+                verified: true,
+            });
+            expect(block.transactions.map(tx => tx.data.nonce)).toEqual(
+                [1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map(n => new Utils.BigNumber(n)),
+            );
         });
     });
 });

--- a/__tests__/unit/core-transaction-pool/connection.test.ts
+++ b/__tests__/unit/core-transaction-pool/connection.test.ts
@@ -1185,6 +1185,29 @@ describe("Connection", () => {
 
             jest.restoreAllMocks();
         });
+
+        it("should also purge transactions with higher nonces than the transactions from block", async () => {
+            const revertTransactionForSender = jest
+                .spyOn(connection.walletManager, "revertTransactionForSender")
+                .mockReturnValue();
+
+            const transactions = TransactionFactory.transfer(mockData.dummy1.data.recipientId)
+                .withNetwork("unitnet")
+                .withPassphrase(delegatesSecrets[0])
+                .build(5);
+
+            const block = { transactions: transactions.slice(0, 3) } as Blocks.Block;
+
+            addTransactions(transactions);
+
+            expect(connection.getPoolSize()).toBe(5);
+
+            connection.purgeByBlock(block);
+            expect(revertTransactionForSender).toHaveBeenCalledTimes(5);
+            expect(connection.getPoolSize()).toBe(0);
+
+            jest.restoreAllMocks();
+        });
     });
 
     describe("purgeInvalidTransactions", () => {

--- a/packages/core-forger/src/delegate.ts
+++ b/packages/core-forger/src/delegate.ts
@@ -88,8 +88,7 @@ export class Delegate {
             };
 
             const payloadBuffers: Buffer[] = [];
-            const sortedTransactions = Utils.sortTransactions(transactions);
-            for (const transaction of sortedTransactions) {
+            for (const transaction of transactions) {
                 transactionData.amount = transactionData.amount.plus(transaction.amount);
                 transactionData.fee = transactionData.fee.plus(transaction.fee);
                 payloadBuffers.push(Buffer.from(transaction.id, "hex"));
@@ -107,13 +106,13 @@ export class Delegate {
                     previousBlock: options.previousBlock.id,
                     previousBlockHex: options.previousBlock.idHex,
                     height: options.previousBlock.height + 1,
-                    numberOfTransactions: sortedTransactions.length,
+                    numberOfTransactions: transactions.length,
                     totalAmount: transactionData.amount,
                     totalFee: transactionData.fee,
                     reward: options.reward,
-                    payloadLength: 32 * sortedTransactions.length,
+                    payloadLength: 32 * transactions.length,
                     payloadHash: Crypto.HashAlgorithms.sha256(payloadBuffers).toString("hex"),
-                    transactions: sortedTransactions,
+                    transactions,
                 },
                 this.keys,
             );

--- a/packages/core-transaction-pool/src/connection.ts
+++ b/packages/core-transaction-pool/src/connection.ts
@@ -328,15 +328,7 @@ export class Connection implements TransactionPool.IConnection {
     }
 
     public purgeByBlock(block: Interfaces.IBlock): void {
-        // Revert in reverse order so that we don't violate nonce rules.
-        for (let i = block.transactions.length - 1; i >= 0; i--) {
-            const transaction = block.transactions[i];
-            if (this.has(transaction.id)) {
-                this.removeTransaction(transaction);
-
-                this.walletManager.revertTransactionForSender(transaction);
-            }
-        }
+        this.purgeTransactions(ApplicationEvents.TransactionPoolRemoved, block.transactions);
     }
 
     public purgeByPublicKey(senderPublicKey: string): void {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

A few fixes related to nonces :
- (core-forger) do not sort transactions when forging (we already get sorted transactions from relay)
- (core-transaction-pool) update purgeByBlock to manage reverting transactions with higher nonces

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Does this PR release a new version?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch
- [x] All tests are passing
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
