### PR TITLE
chore(core-p2p): allow 2.4 and 2.5 nodes

### DIFF
--- a/__tests__/unit/core-p2p/utils/is-valid-version.test.ts
+++ b/__tests__/unit/core-p2p/utils/is-valid-version.test.ts
@@ -22,7 +22,6 @@ describe("isValidVersion", () => {
         expect(isValidVersion({ ...peerMock, ...{ version: "2.8.0" } })).toBeTrue();
         expect(isValidVersion({ ...peerMock, ...{ version: "2.9.0" } })).toBeTrue();
         expect(isValidVersion({ ...peerMock, ...{ version: "2.9.934" } })).toBeTrue();
-        expect(isValidVersion({ ...peerMock, ...{ version: "3.0.0" } })).toBeTrue();
     });
 
     it("should be an invalid version", () => {

--- a/packages/core-p2p/src/defaults.ts
+++ b/packages/core-p2p/src/defaults.ts
@@ -8,7 +8,7 @@ export const defaults = {
     /**
      * The minimum peer version we expect
      */
-    minimumVersions: [">=2.4.0", ">=2.4.0-next.0"],
+    minimumVersions: ["^2.4 || ^2.5"],
     /**
      * The number of peers we expect to be available to start a relay
      */


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

For a smooth 2.5 migration the 2.4 nodes need to allow 2.5 nodes.

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [x] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Does this PR release a new version?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `develop` branch, _not_ the `master` branch
- [x] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
