### PR TITLE
fix(core-p2p): forget peer when socket is disconnected

### DIFF
--- a/packages/core-p2p/src/event-listener.ts
+++ b/packages/core-p2p/src/event-listener.ts
@@ -6,8 +6,12 @@ export class EventListener {
 
     public constructor(service: P2P.IPeerService) {
         const connector: P2P.IPeerConnector = service.getConnector();
+        const storage: P2P.IPeerStorage = service.getStorage();
 
-        this.emitter.on("internal.p2p.disconnectPeer", ({ peer }) => connector.disconnect(peer));
+        this.emitter.on("internal.p2p.disconnectPeer", ({ peer }) => {
+            connector.disconnect(peer);
+            storage.forgetPeer(peer);
+        });
 
         const exitHandler = () => service.getMonitor().stopServer();
 

--- a/packages/core-p2p/src/peer-communicator.ts
+++ b/packages/core-p2p/src/peer-communicator.ts
@@ -214,9 +214,13 @@ export class PeerCommunicator implements P2P.IPeerCommunicator {
             case SocketErrors.Validation:
                 this.logger.error(`Socket data validation error (peer ${peer.ip}) : ${error.message}`);
                 break;
+            case "Error":
+                if (process.env.CORE_P2P_PEER_VERIFIER_DEBUG_EXTRA) {
+                    this.logger.debug(`Response error (peer ${peer.ip}) : ${error.message}`);
+                }
+                break;
             case SocketErrors.Timeout:
             case "TimeoutError":
-            case "Error":
             case "CoreSocketNotOpenError":
                 this.emitter.emit("internal.p2p.disconnectPeer", { peer });
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->
Do not disconnect from a peer for plain errors. Also forget a peer if we disconnect from it.

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

## Does this PR release a new version?

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `develop` branch, _not_ the `master` branch
- [ ] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
