### PR TITLE
refactor(core-p2p): delay peer discovery until after state initialization is done

### DIFF
--- a/__tests__/helpers/peers.ts
+++ b/__tests__/helpers/peers.ts
@@ -12,7 +12,7 @@ export const createStubPeer = (stub): P2P.IPeer => {
 };
 
 export const createPeerService = () => {
-    const service = makePeerService();
+    const service = makePeerService({});
 
     return {
         service,

--- a/__tests__/unit/core-blockchain/mocks/p2p/network-monitor.ts
+++ b/__tests__/unit/core-blockchain/mocks/p2p/network-monitor.ts
@@ -4,6 +4,7 @@ export const getMonitor = {
     // tslint:disable-next-line: no-empty
     checkNetworkHealth: () => {},
     syncWithNetwork: () => [],
+    start: () => undefined,
     refreshPeersAfterFork: () => undefined,
     broadcastBlock: () => undefined,
     hasPeers: () => false,

--- a/__tests__/unit/core-p2p/network-monitor.test.ts
+++ b/__tests__/unit/core-p2p/network-monitor.test.ts
@@ -28,7 +28,7 @@ describe("NetworkMonitor", () => {
 
             jest.spyOn(processor, "validatePeerIp").mockReturnValueOnce(true);
 
-            await monitor.start({ networkStart: false });
+            await monitor.start();
 
             expect(validateAndAcceptPeer).toHaveBeenCalledWith(
                 {

--- a/packages/core-blockchain/src/state-machine.ts
+++ b/packages/core-blockchain/src/state-machine.ts
@@ -186,6 +186,8 @@ blockchainMachine.actionMap = (blockchain: Blockchain) => ({
             await blockchain.database.restoreCurrentRound(block.data.height);
             await blockchain.transactionPool.buildWallets();
 
+            await blockchain.p2p.getMonitor().start();
+
             return blockchain.dispatch("STARTED");
         } catch (error) {
             logger.error(error.stack);

--- a/packages/core-interfaces/src/core-p2p/network-monitor.ts
+++ b/packages/core-interfaces/src/core-p2p/network-monitor.ts
@@ -28,6 +28,6 @@ export interface INetworkMonitor {
     broadcastBlock(block: Interfaces.IBlock): Promise<void>;
     broadcastTransactions(transactions: Interfaces.ITransaction[]): Promise<void>;
     getServer(): SocketCluster;
-    setServer(server: SocketCluster, options): void;
+    setServer(server: SocketCluster): void;
     stopServer(): void;
 }

--- a/packages/core-interfaces/src/core-p2p/network-monitor.ts
+++ b/packages/core-interfaces/src/core-p2p/network-monitor.ts
@@ -8,7 +8,7 @@ export interface INetworkStatus {
 }
 
 export interface INetworkMonitor {
-    start(options): Promise<INetworkMonitor>;
+    start(): Promise<void>;
     updateNetworkStatus(initialRun?: boolean): Promise<void>;
     cleansePeers({
         fast,
@@ -28,6 +28,6 @@ export interface INetworkMonitor {
     broadcastBlock(block: Interfaces.IBlock): Promise<void>;
     broadcastTransactions(transactions: Interfaces.ITransaction[]): Promise<void>;
     getServer(): SocketCluster;
-    setServer(server: SocketCluster): void;
+    setServer(server: SocketCluster, options): void;
     stopServer(): void;
 }

--- a/packages/core-p2p/src/network-monitor.ts
+++ b/packages/core-p2p/src/network-monitor.ts
@@ -47,7 +47,8 @@ export class NetworkMonitor implements P2P.INetworkMonitor {
         return this.server;
     }
 
-    public setServer(server: SocketCluster): void {
+    public setServer(server: SocketCluster, options): void {
+        this.config = options;
         this.server = server;
     }
 
@@ -59,11 +60,9 @@ export class NetworkMonitor implements P2P.INetworkMonitor {
         }
     }
 
-    public async start(options): Promise<this> {
-        this.config = options;
-
-        await this.checkDNSConnectivity(options.dns);
-        await this.checkNTPConnectivity(options.ntp);
+    public async start(): Promise<void> {
+        await this.checkDNSConnectivity(this.config.dns);
+        await this.checkNTPConnectivity(this.config.ntp);
 
         await this.populateSeedPeers();
 
@@ -78,8 +77,6 @@ export class NetworkMonitor implements P2P.INetworkMonitor {
         }
 
         this.initializing = false;
-
-        return this;
     }
 
     public async updateNetworkStatus(initialRun?: boolean): Promise<void> {

--- a/packages/core-p2p/src/network-monitor.ts
+++ b/packages/core-p2p/src/network-monitor.ts
@@ -33,11 +33,14 @@ export class NetworkMonitor implements P2P.INetworkMonitor {
         communicator,
         processor,
         storage,
+        options,
     }: {
         communicator: P2P.IPeerCommunicator;
         processor: P2P.IPeerProcessor;
         storage: P2P.IPeerStorage;
+        options;
     }) {
+        this.config = options;
         this.communicator = communicator;
         this.processor = processor;
         this.storage = storage;
@@ -47,8 +50,7 @@ export class NetworkMonitor implements P2P.INetworkMonitor {
         return this.server;
     }
 
-    public setServer(server: SocketCluster, options): void {
-        this.config = options;
+    public setServer(server: SocketCluster): void {
         this.server = server;
     }
 

--- a/packages/core-p2p/src/plugin.ts
+++ b/packages/core-p2p/src/plugin.ts
@@ -9,13 +9,13 @@ import { PeerService } from "./peer-service";
 import { PeerStorage } from "./peer-storage";
 import { startSocketServer } from "./socket-server";
 
-export const makePeerService = (): PeerService => {
+export const makePeerService = (options): PeerService => {
     const storage = new PeerStorage();
     const connector = new PeerConnector();
 
     const communicator = new PeerCommunicator(connector);
     const processor = new PeerProcessor({ storage, connector, communicator });
-    const monitor = new NetworkMonitor({ storage, processor, communicator });
+    const monitor = new NetworkMonitor({ storage, processor, communicator, options });
 
     return new PeerService({ storage, processor, connector, communicator, monitor });
 };
@@ -28,13 +28,13 @@ export const plugin: Container.IPluginDescriptor = {
     async register(container: Container.IContainer, options) {
         container.resolvePlugin<Logger.ILogger>("logger").info("Starting P2P Interface");
 
-        const service: P2P.IPeerService = makePeerService();
+        const service: P2P.IPeerService = makePeerService(options);
 
         // tslint:disable-next-line: no-unused-expression
         new EventListener(service);
 
         if (!process.env.DISABLE_P2P_SERVER) {
-            service.getMonitor().setServer(await startSocketServer(service, options), options);
+            service.getMonitor().setServer(await startSocketServer(service, options));
         }
 
         return service;

--- a/packages/core-p2p/src/plugin.ts
+++ b/packages/core-p2p/src/plugin.ts
@@ -34,10 +34,8 @@ export const plugin: Container.IPluginDescriptor = {
         new EventListener(service);
 
         if (!process.env.DISABLE_P2P_SERVER) {
-            service.getMonitor().setServer(await startSocketServer(service, options));
+            service.getMonitor().setServer(await startSocketServer(service, options), options);
         }
-
-        await service.getMonitor().start(options);
 
         return service;
     },

--- a/packages/core-p2p/src/schemas.ts
+++ b/packages/core-p2p/src/schemas.ts
@@ -7,7 +7,7 @@ export const requestSchemas = {
             required: ["ids"],
             additionalProperties: false,
             properties: {
-                ids: { type: "array", additionalItems: false, minItems: 1, items: { blockId: {} } },
+                ids: { type: "array", additionalItems: false, minItems: 1, maxItems: 10, items: { blockId: {} } },
             },
         },
         getBlocks: {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

This PR delays the peer discovery until after the state initialization is done to solve several issues where a relay could end up without peers.

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [X] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

## Does this PR release a new version?

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `develop` branch, _not_ the `master` branch
- [ ] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
