### PR TITLE
chore(docker): Add Wallets API, remove PostgreSQL container port default mapping to localhost

### DIFF
--- a/docker/production/devnet/devnet.env
+++ b/docker/production/devnet/devnet.env
@@ -4,6 +4,8 @@
 MODE=relay
 NETWORK=devnet
 #Core variables
+CORE_LOG_LEVEL=info
+CORE_LOG_LEVEL_FILE=info
 CORE_DB_HOST=postgres-devnet
 CORE_DB_USERNAME=node
 CORE_DB_PASSWORD=password

--- a/docker/production/devnet/docker-compose-build.yml
+++ b/docker/production/devnet/docker-compose-build.yml
@@ -4,8 +4,6 @@ services:
     image: "postgres:alpine"
     container_name: postgres-devnet
     restart: always
-    ports:
-      - '127.0.0.1:5432:5432'
     volumes:
       - 'postgres:/var/lib/postgresql/data'
     networks:
@@ -27,6 +25,7 @@ services:
     ports:
      - "4002:4002"
      - "4003:4003"
+     - "4040:4040"
      - "127.0.0.1:4004:4004"
      - "127.0.0.1:4005:4005"
      - "127.0.0.1:8080:8080" 

--- a/docker/production/devnet/docker-compose.yml
+++ b/docker/production/devnet/docker-compose.yml
@@ -4,8 +4,6 @@ services:
     image: "postgres:alpine"
     container_name: postgres-devnet
     restart: always
-    ports:
-      - '127.0.0.1:5432:5432'
     volumes:
       - 'postgres:/var/lib/postgresql/data'
     networks:
@@ -22,6 +20,7 @@ services:
     ports:
      - "4002:4002"
      - "4003:4003"
+     - "4040:4040"
      - "127.0.0.1:4004:4004"
      - "127.0.0.1:4005:4005"
      - "127.0.0.1:8080:8080" 

--- a/docker/production/mainnet/docker-compose-build.yml
+++ b/docker/production/mainnet/docker-compose-build.yml
@@ -4,8 +4,6 @@ services:
     image: "postgres:alpine"
     container_name: postgres-mainnet
     restart: always
-    ports:
-      - '127.0.0.1:5432:5432'
     volumes:
       - 'postgres:/var/lib/postgresql/data'
     networks:
@@ -25,6 +23,7 @@ services:
     ports:
      - "4001:4001"
      - "4003:4003"
+     - "4040:4040"
      - "127.0.0.1:4004:4004"
      - "127.0.0.1:4005:4005"
      - "127.0.0.1:8080:8080" 

--- a/docker/production/mainnet/docker-compose.yml
+++ b/docker/production/mainnet/docker-compose.yml
@@ -4,8 +4,6 @@ services:
     image: "postgres:alpine"
     container_name: postgres-mainnet
     restart: always
-    ports:
-      - '127.0.0.1:5432:5432'
     volumes:
       - 'postgres:/var/lib/postgresql/data'
     networks:
@@ -22,6 +20,7 @@ services:
     ports:
      - "4001:4001"
      - "4003:4003"
+     - "4040:4040"
      - "127.0.0.1:4004:4004"
      - "127.0.0.1:4005:4005"
      - "127.0.0.1:8080:8080" 


### PR DESCRIPTION
Add Wallets API, remove PostgreSQL container port default mapping to localhost to avoid potential conflicts if the port is already occupied. Containers internal communication remains intact. User just losses the ability to access the database from the host.

## What kind of change does this PR introduce?

- [x] Refactor

## Does this PR introduce a breaking change?
-
 [x] No

## Does this PR release a new version?

- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch
