### PR TITLE
refactor(core-database-postgres): exit on unexpected error

### DIFF
--- a/packages/core-database-postgres/src/postgres-connection.ts
+++ b/packages/core-database-postgres/src/postgres-connection.ts
@@ -71,6 +71,9 @@ export class PostgresConnection implements Database.IConnection {
         const pgp: pgPromise.IMain = pgPromise({
             ...this.options.initialization,
             ...{
+                error: async (error, context) => {
+                    app.forceExit("Unexpected database error. Shutting down to prevent further damage.", error);
+                },
                 receive(data) {
                     camelizeColumns(pgp, data);
                 },

--- a/packages/core-database-postgres/src/postgres-connection.ts
+++ b/packages/core-database-postgres/src/postgres-connection.ts
@@ -72,6 +72,10 @@ export class PostgresConnection implements Database.IConnection {
             ...this.options.initialization,
             ...{
                 error: async (error, context) => {
+                    if (process.env.NODE_ENV === "test") {
+                        return;
+                    }
+
                     app.forceExit("Unexpected database error. Shutting down to prevent further damage.", error);
                 },
                 receive(data) {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

Core doesn't really recover on it's own when the database throws an error (i.e. try a db restart while Core is running). It pretty much rekts Core. While it would be nice to handle it more gracefully, this PR enables Core to at least to recover from it by exiting the process so pm2 can restart it.

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [X] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

## Does this PR release a new version?

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `develop` branch, _not_ the `master` branch
- [ ] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
