### PR TITLE
refactor(core-p2p): block when rate limit exceeded

### DIFF
--- a/__tests__/integration/core-p2p/socket-server/peer.test.ts
+++ b/__tests__/integration/core-p2p/socket-server/peer.test.ts
@@ -129,14 +129,14 @@ describe("Peer socket endpoint", () => {
     describe("Socket errors", () => {
         it("should accept the request when below rate limit", async () => {
             await delay(1000);
-            for (let i = 0; i < 18; i++) {
+            for (let i = 0; i < 1; i++) {
                 const { data } = await emit("p2p.peer.getStatus", {
                     headers,
                 });
                 expect(data.state.height).toBeNumber();
             }
             await delay(1100);
-            for (let i = 0; i < 10; i++) {
+            for (let i = 0; i < 1; i++) {
                 const { data } = await emit("p2p.peer.getStatus", {
                     headers,
                 });
@@ -146,7 +146,7 @@ describe("Peer socket endpoint", () => {
 
         it("should cancel the request when exceeding rate limit", async () => {
             await delay(1000);
-            for (let i = 0; i < 100; i++) {
+            for (let i = 0; i < 1; i++) {
                 const { data } = await emit("p2p.peer.getStatus", {
                     headers,
                 });

--- a/__tests__/integration/core-p2p/socket-server/peer.test.ts
+++ b/__tests__/integration/core-p2p/socket-server/peer.test.ts
@@ -129,14 +129,14 @@ describe("Peer socket endpoint", () => {
     describe("Socket errors", () => {
         it("should accept the request when below rate limit", async () => {
             await delay(1000);
-            for (let i = 0; i < 1; i++) {
+            for (let i = 0; i < 2; i++) {
                 const { data } = await emit("p2p.peer.getStatus", {
                     headers,
                 });
                 expect(data.state.height).toBeNumber();
             }
             await delay(1100);
-            for (let i = 0; i < 1; i++) {
+            for (let i = 0; i < 2; i++) {
                 const { data } = await emit("p2p.peer.getStatus", {
                     headers,
                 });
@@ -146,7 +146,7 @@ describe("Peer socket endpoint", () => {
 
         it("should cancel the request when exceeding rate limit", async () => {
             await delay(1000);
-            for (let i = 0; i < 1; i++) {
+            for (let i = 0; i < 2; i++) {
                 const { data } = await emit("p2p.peer.getStatus", {
                     headers,
                 });

--- a/__tests__/unit/core-p2p/socket-server/versions/peer/index.test.ts
+++ b/__tests__/unit/core-p2p/socket-server/versions/peer/index.test.ts
@@ -4,8 +4,8 @@ import { blockchain } from "../../../mocks/blockchain";
 import { database } from "../../../mocks/database";
 
 import { Crypto } from "@arkecosystem/crypto";
+import { acceptNewPeer } from "../../../../../../packages/core-p2p/src/socket-server/versions/internal";
 import {
-    acceptNewPeer,
     getBlocks,
     getCommonBlocks,
     getPeers,

--- a/packages/core-p2p/src/enums.ts
+++ b/packages/core-p2p/src/enums.ts
@@ -30,4 +30,5 @@ export enum SocketErrors {
     Unknown = "CoreUnknownError",
     Validation = "CoreValidationError",
     RateLimitExceeded = "CoreRateLimitExceededError",
+    Forbidden = "CoreForbiddenError",
 }

--- a/packages/core-p2p/src/socket-server/versions/internal.ts
+++ b/packages/core-p2p/src/socket-server/versions/internal.ts
@@ -3,6 +3,10 @@ import { Blockchain, Database, EventEmitter, Logger, P2P, TransactionPool } from
 import { roundCalculator } from "@arkecosystem/core-utils";
 import { Crypto } from "@arkecosystem/crypto";
 
+export const acceptNewPeer = async ({ service, req }: { service: P2P.IPeerService; req }): Promise<void> => {
+    await service.getProcessor().validateAndAcceptPeer({ ip: req.data.ip });
+};
+
 export const emitEvent = ({ req }): void => {
     app.resolvePlugin<EventEmitter.EventEmitter>("event-emitter").emit(req.data.event, req.data.body);
 };

--- a/packages/core-p2p/src/socket-server/versions/peer.ts
+++ b/packages/core-p2p/src/socket-server/versions/peer.ts
@@ -10,10 +10,6 @@ import { InvalidTransactionsError, UnchainedBlockError } from "../errors";
 import { getPeerConfig } from "../utils/get-peer-config";
 import { mapAddr } from "../utils/map-addr";
 
-export const acceptNewPeer = async ({ service, req }: { service: P2P.IPeerService; req }): Promise<void> => {
-    await service.getProcessor().validateAndAcceptPeer({ ip: req.data.ip });
-};
-
 export const getPeers = ({ service }: { service: P2P.IPeerService }): P2P.IPeerBroadcast[] => {
     return service
         .getStorage()

--- a/packages/core-p2p/src/socket-server/worker.ts
+++ b/packages/core-p2p/src/socket-server/worker.ts
@@ -120,7 +120,7 @@ export class Worker extends SCWorker {
                     );
                 }
             } else if (version === "peer") {
-                this.sendToMasterAsync("p2p.peer.acceptNewPeer", {
+                this.sendToMasterAsync("p2p.internal.acceptNewPeer", {
                     data: { ip: req.socket.remoteAddress },
                     headers: req.data.headers,
                 });

--- a/packages/core-p2p/src/socket-server/worker.ts
+++ b/packages/core-p2p/src/socket-server/worker.ts
@@ -39,6 +39,14 @@ export class Worker extends SCWorker {
                         endpoint: "p2p.peer.getBlocks",
                     },
                     {
+                        rateLimit: 1,
+                        endpoint: "p2p.peer.getPeers",
+                    },
+                    {
+                        rateLimit: 2,
+                        endpoint: "p2p.peer.getStatus",
+                    },
+                    {
                         rateLimit: 5,
                         endpoint: "p2p.peer.getCommonBlocks",
                     },

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -29,7 +29,6 @@
         "@hapi/joi": "^15.0.3",
         "ajv": "^6.10.0",
         "ajv-keywords": "^3.4.0",
-        "ajv-merge-patch": "^4.1.0",
         "bcrypto": "^3.1.11",
         "bignumber.js": "^8.1.1",
         "bip32": "^2.0.3",


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

When a node exceeds the global rate limit it is now blocked for 60 seconds and the connection is closed.

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [X] Bugfix
- [X] Feature
- [X] Refactor
- [X] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

## Does this PR release a new version?

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `develop` branch, _not_ the `master` branch
- [ ] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
