### PR TITLE
fix(core-blockchain): always attempt to download blocks after start

### DIFF
--- a/packages/core-blockchain/src/blockchain.ts
+++ b/packages/core-blockchain/src/blockchain.ts
@@ -498,7 +498,7 @@ export class Blockchain implements blockchain.IBlockchain {
      * Get the last downloaded block of the blockchain.
      */
     public getLastDownloadedBlock(): Interfaces.IBlockData {
-        return this.state.lastDownloadedBlock;
+        return this.state.lastDownloadedBlock || this.getLastBlock().data;
     }
 
     /**

--- a/packages/core-blockchain/src/state-machine.ts
+++ b/packages/core-blockchain/src/state-machine.ts
@@ -75,7 +75,7 @@ blockchainMachine.actionMap = (blockchain: Blockchain) => ({
             }
         }
 
-        if (blockchain.isSynced(stateStorage.lastDownloadedBlock)) {
+        if (stateStorage.lastDownloadedBlock && blockchain.isSynced(stateStorage.lastDownloadedBlock)) {
             stateStorage.noBlockCounter = 0;
             stateStorage.p2pUpdateCounter = 0;
 
@@ -152,7 +152,6 @@ blockchainMachine.actionMap = (blockchain: Blockchain) => ({
              *  state machine data init      *
              ******************************* */
             stateStorage.setLastBlock(block);
-            stateStorage.lastDownloadedBlock = block.data;
 
             // Delete all rounds from the future due to shutdown before processBlocks finished writing the blocks.
             const roundInfo = roundCalculator.calculateRound(block.data.height);
@@ -208,7 +207,7 @@ blockchainMachine.actionMap = (blockchain: Blockchain) => ({
         }
 
         // Could have changed since entering this function, e.g. due to a rollback.
-        if (lastDownloadedBlock.id !== stateStorage.lastDownloadedBlock.id) {
+        if (stateStorage.lastDownloadedBlock && lastDownloadedBlock.id !== stateStorage.lastDownloadedBlock.id) {
             return;
         }
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

When a node is restarted and the last block is less than `blockTime * 3` old it thinks it is already synced and thus won't download new blocks and often miss the "train". It will take at least a minute until the wake up happens to sync and catch up to height to start receiving blocks.

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

## Does this PR release a new version?

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `develop` branch, _not_ the `master` branch
- [ ] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
