### PR TITLE
fix: previous round order calculation

### DIFF
--- a/__tests__/unit/core-database/database-service.test.ts
+++ b/__tests__/unit/core-database/database-service.test.ts
@@ -227,18 +227,20 @@ describe("Database Service", () => {
             // reverse the current delegate order.
             const blocksInRound = [];
             for (let i = 0; i < 51; i++) {
+                const voterKeys = Identities.Keys.fromPassphrase(`voter-${i}`);
+
                 const transfer = Transactions.BuilderFactory.transfer()
                     .amount(
                         Utils.BigNumber.make(i + 1)
                             .times(SATOSHI)
                             .toFixed(),
                     )
-                    .recipientId(delegatesRound2[i].address)
+                    .recipientId(Identities.Address.fromPublicKey(voterKeys.publicKey))
                     .sign(keys.passphrase)
                     .build();
 
-                // Vote for itself
-                walletManager.findByPublicKey(delegatesRound2[i].publicKey).vote = delegatesRound2[i].publicKey;
+                // Vote for delegate
+                walletManager.findByPublicKey(voterKeys.publicKey).vote = delegatesRound2[i].publicKey;
 
                 const block = BlockFactory.make(
                     {

--- a/__tests__/unit/core-state/wallets/temp-wallet-manager.test.ts
+++ b/__tests__/unit/core-state/wallets/temp-wallet-manager.test.ts
@@ -1,0 +1,104 @@
+/* tslint:disable:max-line-length no-empty */
+import "../../core-database/mocks/core-container";
+
+import { State } from "@arkecosystem/core-interfaces";
+import { Utils } from "@arkecosystem/crypto";
+import { Wallet, WalletManager } from "../../../../packages/core-state/src/wallets";
+import wallets from "../__fixtures__/wallets.json";
+
+const walletData1 = wallets[0];
+
+let walletManager: State.IWalletManager;
+
+beforeEach(() => {
+    walletManager = new WalletManager();
+});
+
+describe("TempWalletManager", () => {
+    describe("reindex", () => {
+        it("should not affect the original", () => {
+            const wallet = new Wallet(walletData1.address);
+            walletManager.reindex(wallet);
+
+            const tempWalletManager = walletManager.clone();
+            tempWalletManager.reindex(wallet);
+
+            expect(walletManager.findByAddress(wallet.address)).not.toBe(
+                tempWalletManager.findByAddress(wallet.address),
+            );
+        });
+    });
+
+    describe("findByAddress", () => {
+        it("should return a copy", () => {
+            const wallet = new Wallet(walletData1.address);
+            walletManager.reindex(wallet);
+
+            const tempWalletManager = walletManager.clone();
+            const tempWallet = tempWalletManager.findByAddress(wallet.address);
+            tempWallet.balance = Utils.BigNumber.ONE;
+
+            expect(wallet.balance).not.toEqual(tempWallet.balance);
+        });
+    });
+
+    describe("findByPublickey", () => {
+        it("should return a copy", () => {
+            const wallet = new Wallet(walletData1.address);
+            wallet.publicKey = walletData1.publicKey;
+            walletManager.reindex(wallet);
+
+            const tempWalletManager = walletManager.clone();
+            const tempWallet = tempWalletManager.findByPublicKey(wallet.publicKey);
+            tempWallet.balance = Utils.BigNumber.ONE;
+
+            expect(wallet.balance).not.toEqual(tempWallet.balance);
+        });
+    });
+
+    describe("findByUsername", () => {
+        it("should return a copy", () => {
+            const wallet = new Wallet(walletData1.address);
+            wallet.username = "test";
+            walletManager.reindex(wallet);
+
+            const tempWalletManager = walletManager.clone();
+            const tempWallet = tempWalletManager.findByUsername(wallet.username);
+            tempWallet.balance = Utils.BigNumber.ONE;
+
+            expect(wallet.balance).not.toEqual(tempWallet.balance);
+        });
+    });
+
+    describe("hasByAddress", () => {
+        it("should be ok", () => {
+            const wallet = new Wallet(walletData1.address);
+            walletManager.reindex(wallet);
+
+            const tempWalletManager = walletManager.clone();
+            expect(tempWalletManager.hasByAddress(wallet.address)).toBeTrue();
+        });
+    });
+
+    describe("hasByPublicKey", () => {
+        it("should be ok", () => {
+            const wallet = new Wallet(walletData1.address);
+            wallet.publicKey = walletData1.publicKey;
+            walletManager.reindex(wallet);
+
+            const tempWalletManager = walletManager.clone();
+            expect(tempWalletManager.hasByPublicKey(wallet.publicKey)).toBeTrue();
+        });
+    });
+
+    describe("hasByUsername", () => {
+        it("should be ok", () => {
+            const wallet = new Wallet(walletData1.address);
+            wallet.username = "test";
+            walletManager.reindex(wallet);
+
+            const tempWalletManager = walletManager.clone();
+            expect(tempWalletManager.hasByUsername(wallet.username)).toBeTrue();
+        });
+    });
+});

--- a/packages/core-blockchain/src/state-machine.ts
+++ b/packages/core-blockchain/src/state-machine.ts
@@ -161,6 +161,7 @@ blockchainMachine.actionMap = (blockchain: Blockchain) => ({
                 await blockchain.database.buildWallets();
                 await blockchain.database.applyRound(block.data.height);
                 await blockchain.transactionPool.buildWallets();
+                await blockchain.p2p.getMonitor().start();
 
                 return blockchain.dispatch("STARTED");
             }
@@ -170,6 +171,7 @@ blockchainMachine.actionMap = (blockchain: Blockchain) => ({
 
                 stateStorage.setLastBlock(BlockFactory.fromJson(config.get("genesisBlock")));
                 await blockchain.database.buildWallets();
+                await blockchain.p2p.getMonitor().start();
 
                 return blockchain.dispatch("STARTED");
             }

--- a/packages/core-database/src/database-service.ts
+++ b/packages/core-database/src/database-service.ts
@@ -655,7 +655,7 @@ export class DatabaseService implements Database.IDatabaseService {
     ): Promise<State.IDelegateWallet[]> {
         blocks = blocks || (await this.getBlocksForRound(roundInfo));
 
-        const tempWalletManager = this.walletManager.cloneDelegateWallets();
+        const tempWalletManager = this.walletManager.clone();
 
         // Revert all blocks in reverse order
         const index: number = blocks.length - 1;

--- a/packages/core-interfaces/src/core-state/wallets.ts
+++ b/packages/core-interfaces/src/core-state/wallets.ts
@@ -58,7 +58,7 @@ export interface IWalletManager {
 
     reindex(wallet: IWallet): void;
 
-    cloneDelegateWallets(): IWalletManager;
+    clone(): IWalletManager;
 
     loadActiveDelegateList(roundInfo: IRoundInfo): IDelegateWallet[];
 
@@ -83,12 +83,6 @@ export interface IWalletManager {
     forgetByPublicKey(publicKey: string): void;
 
     forgetByUsername(username: string): void;
-
-    setByAddress(address: string, wallet: IWallet): void;
-
-    setByPublicKey(publicKey: string, wallet: IWallet): void;
-
-    setByUsername(username: string, wallet: IWallet): void;
 
     hasByAddress(address: string): boolean;
 

--- a/packages/core-state/src/wallets/index.ts
+++ b/packages/core-state/src/wallets/index.ts
@@ -1,2 +1,3 @@
+export * from "./temp-wallet-manager";
 export * from "./wallet-manager";
 export * from "./wallet";

--- a/packages/core-state/src/wallets/temp-wallet-manager.ts
+++ b/packages/core-state/src/wallets/temp-wallet-manager.ts
@@ -1,0 +1,51 @@
+import { State } from "@arkecosystem/core-interfaces";
+import cloneDeep from "lodash.clonedeep";
+import { WalletManager } from "./wallet-manager";
+
+export class TempWalletManager extends WalletManager {
+    public constructor(private walletManager: State.IWalletManager) {
+        super();
+
+        this.index(this.walletManager.allByUsername());
+    }
+
+    public reindex(wallet: State.IWallet): void {
+        super.reindex(cloneDeep(wallet));
+    }
+
+    public findByAddress(address: string): State.IWallet {
+        if (!this.byAddress[address]) {
+            this.byAddress[address] = cloneDeep(this.walletManager.findByAddress(address));
+        }
+
+        return this.byAddress[address];
+    }
+
+    public findByPublicKey(publicKey: string): State.IWallet {
+        if (!this.byPublicKey[publicKey]) {
+            this.byPublicKey[publicKey] = cloneDeep(this.walletManager.findByPublicKey(publicKey));
+        }
+
+        return this.byPublicKey[publicKey];
+    }
+
+    public findByUsername(username: string): State.IWallet {
+        if (!this.byUsername[username]) {
+            this.byUsername[username] = cloneDeep(this.walletManager.findByUsername(username));
+        }
+
+        return this.byUsername[username];
+    }
+
+    public hasByAddress(address: string): boolean {
+        return this.walletManager.hasByAddress(address);
+    }
+
+    public hasByPublicKey(publicKey: string): boolean {
+        return this.walletManager.hasByPublicKey(publicKey);
+    }
+
+    public hasByUsername(username: string): boolean {
+        return this.walletManager.hasByUsername(username);
+    }
+}

--- a/packages/core-state/src/wallets/wallet-manager.ts
+++ b/packages/core-state/src/wallets/wallet-manager.ts
@@ -2,8 +2,8 @@ import { app } from "@arkecosystem/core-container";
 import { Logger, Shared, State } from "@arkecosystem/core-interfaces";
 import { Handlers } from "@arkecosystem/core-transactions";
 import { Enums, Identities, Interfaces, Utils } from "@arkecosystem/crypto";
-import cloneDeep from "lodash.clonedeep";
 import pluralize from "pluralize";
+import { TempWalletManager } from "./temp-wallet-manager";
 import { Wallet } from "./wallet";
 
 export class WalletManager implements State.IWalletManager {
@@ -56,24 +56,6 @@ export class WalletManager implements State.IWalletManager {
         return this.byUsername[username];
     }
 
-    public setByAddress(address: string, wallet: Wallet): void {
-        if (address && wallet) {
-            this.byAddress[address] = wallet;
-        }
-    }
-
-    public setByPublicKey(publicKey: string, wallet: Wallet): void {
-        if (publicKey && wallet) {
-            this.byPublicKey[publicKey] = wallet;
-        }
-    }
-
-    public setByUsername(username: string, wallet: Wallet): void {
-        if (username && wallet) {
-            this.byUsername[username] = wallet;
-        }
-    }
-
     public has(addressOrPublicKey: string): boolean {
         return this.hasByAddress(addressOrPublicKey) || this.hasByPublicKey(addressOrPublicKey);
     }
@@ -122,10 +104,8 @@ export class WalletManager implements State.IWalletManager {
         }
     }
 
-    public cloneDelegateWallets(): WalletManager {
-        const walletManager: WalletManager = new WalletManager();
-        walletManager.index(cloneDeep(this.allByUsername()));
-        return walletManager;
+    public clone(): WalletManager {
+        return new TempWalletManager(this);
     }
 
     public loadActiveDelegateList(roundInfo: Shared.IRoundInfo): State.IDelegateWallet[] {
@@ -166,9 +146,8 @@ export class WalletManager implements State.IWalletManager {
     public applyBlock(block: Interfaces.IBlock): void {
         const generatorPublicKey: string = block.data.generatorPublicKey;
 
-        let delegate: State.IWallet = this.byPublicKey[block.data.generatorPublicKey];
-
-        if (!delegate) {
+        let delegate: State.IWallet;
+        if (!this.has(generatorPublicKey)) {
             const generator: string = Identities.Address.fromPublicKey(generatorPublicKey);
 
             if (block.data.height === 1) {
@@ -177,14 +156,10 @@ export class WalletManager implements State.IWalletManager {
 
                 this.reindex(delegate);
             } else {
-                this.logger.debug(`Delegate by address: ${this.byAddress[generator]}`);
-
-                if (this.byAddress[generator]) {
-                    this.logger.info("This look like a bug, please report");
-                }
-
-                throw new Error(`Could not find delegate with publicKey ${generatorPublicKey}`);
+                app.forceExit(`Failed to lookup generator '${generatorPublicKey}' of block '${block.data.id}'.`);
             }
+        } else {
+            delegate = this.findByPublicKey(block.data.generatorPublicKey);
         }
 
         const appliedTransactions: Interfaces.ITransaction[] = [];
@@ -202,7 +177,7 @@ export class WalletManager implements State.IWalletManager {
             // delegate's delegate has to be updated.
             if (applied && delegate.vote) {
                 const increase: Utils.BigNumber = block.data.reward.plus(block.data.totalFee);
-                const votedDelegate: State.IWallet = this.byPublicKey[delegate.vote];
+                const votedDelegate: State.IWallet = this.findByPublicKey(delegate.vote);
                 votedDelegate.voteBalance = votedDelegate.voteBalance.plus(increase);
             }
         } catch (error) {
@@ -218,12 +193,11 @@ export class WalletManager implements State.IWalletManager {
     }
 
     public revertBlock(block: Interfaces.IBlock): void {
-        const delegate: State.IWallet = this.byPublicKey[block.data.generatorPublicKey];
-
-        if (!delegate) {
+        if (!this.has(block.data.generatorPublicKey)) {
             app.forceExit(`Failed to lookup generator '${block.data.generatorPublicKey}' of block '${block.data.id}'.`);
         }
 
+        const delegate: State.IWallet = this.findByPublicKey(block.data.generatorPublicKey);
         const revertedTransactions: Interfaces.ITransaction[] = [];
 
         try {
@@ -241,7 +215,7 @@ export class WalletManager implements State.IWalletManager {
             // delegate's delegate has to be updated.
             if (reverted && delegate.vote) {
                 const decrease: Utils.BigNumber = block.data.reward.plus(block.data.totalFee);
-                const votedDelegate: State.IWallet = this.byPublicKey[delegate.vote];
+                const votedDelegate: State.IWallet = this.findByPublicKey(delegate.vote);
                 votedDelegate.voteBalance = votedDelegate.voteBalance.minus(decrease);
             }
         } catch (error) {
@@ -287,7 +261,7 @@ export class WalletManager implements State.IWalletManager {
 
         const transactionHandler: Handlers.TransactionHandler = Handlers.Registry.get(transaction.type);
         const sender: State.IWallet = this.findByPublicKey(data.senderPublicKey);
-        const recipient: State.IWallet = this.byAddress[data.recipientId];
+        const recipient: State.IWallet = this.findByAddress(data.recipientId);
 
         transactionHandler.revert(transaction, this);
 
@@ -296,13 +270,11 @@ export class WalletManager implements State.IWalletManager {
     }
 
     public isDelegate(publicKey: string): boolean {
-        const delegateWallet: State.IWallet = this.byPublicKey[publicKey];
-
-        if (delegateWallet && delegateWallet.username) {
-            return this.hasByUsername(delegateWallet.username);
+        if (!this.has(publicKey)) {
+            return false;
         }
 
-        return false;
+        return !!this.findByPublicKey(publicKey).username;
     }
 
     public canBePurged(wallet: State.IWallet): boolean {
@@ -351,7 +323,7 @@ export class WalletManager implements State.IWalletManager {
             })
             .map((delegate, i) => {
                 const rate = i + 1;
-                this.byUsername[delegate.username].rate = rate;
+                this.findByUsername(delegate.username).rate = rate;
                 return { round: roundInfo ? roundInfo.round : 0, ...delegate, rate };
             });
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

The function `calcPreviousActiveDelegates` that is called on node start and after a rollback is using a
temporary wallet manager to restore the vote balances from the beginning of the current round. Then based on these numbers the active delegate order is derived.

Now, there is one problem that manifests when the blocks that are reverted affect the vote balances in a way that the ranking changes and it is not caused by a delegate but a voter other than a delegate. In other words the temporary wallet manager only knows about the delegate wallets and thus can't revert the vote balances accurately when other non-delegate wallets are in play as their actual balances are unknown.

This PR fixes this by giving the temporary wallet manager access to all wallets.

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

## Does this PR release a new version?

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `develop` branch, _not_ the `master` branch
- [ ] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
