### PR TITLE
fix(core-snapshots): do not restore genesis block with wrong id

### DIFF
--- a/packages/core-snapshots/src/transport/index.ts
+++ b/packages/core-snapshots/src/transport/index.ts
@@ -7,6 +7,7 @@ import zlib from "zlib";
 
 import { app } from "@arkecosystem/core-container";
 import { EventEmitter, Logger } from "@arkecosystem/core-interfaces";
+import { Managers } from "@arkecosystem/crypto";
 
 import * as utils from "../utils";
 import { Codec } from "./codec";
@@ -86,6 +87,10 @@ export const importTable = async (table, options) => {
     // @ts-ignore
     for await (const record of readStream) {
         counter++;
+
+        if (table === "blocks" && record.height === 1) {
+            record.id = Managers.configManager.get("genesisBlock").id;
+        }
 
         if (!verifyData(table, record, prevData, options.verifySignatures)) {
             app.forceExit(`Error verifying data. Payload ${JSON.stringify(record, undefined, 2)}`);

--- a/packages/core-snapshots/src/transport/verification.ts
+++ b/packages/core-snapshots/src/transport/verification.ts
@@ -1,20 +1,12 @@
 import { app } from "@arkecosystem/core-container";
 import { Logger } from "@arkecosystem/core-interfaces";
-import { Blocks, Crypto, Managers, Transactions } from "@arkecosystem/crypto";
+import { Blocks, Crypto, Transactions } from "@arkecosystem/crypto";
 import { camelizeKeys } from "xcase";
 
 export const verifyData = (context, data, prevData, verifySignatures) => {
     if (context === "blocks") {
         const isBlockChained = () => {
             if (!prevData) {
-                return true;
-            }
-            // genesis payload different as block.serialize stores
-            // block.previous_block with 00000 instead of undefined
-            // it fails on height 2 - chain check
-            // TODO: check to improve ser/deser for genesis
-            const genesisBlock = Managers.configManager.get("genesisBlock");
-            if (data.height === 2 && data.previous_block === genesisBlock.id) {
                 return true;
             }
 


### PR DESCRIPTION
For some reason the hardcoded id of the genesis block in
packages/crypto/src/networks/*/genesisBlock.json is different than the
one that would be calculated by the crypto package (block
serialize/deserialize).

Because the id as in genesisBlock.json is already in previous_block of
the subsequent block (at height 2), we must use the hardcoded id instead
of the one derived by the crypto package.

<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

A summary of what changes this PR introduces and why they were made.

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

## Does this PR release a new version?

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `develop` branch, _not_ the `master` branch
- [ ] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
