### PR TITLE
fix(core-blockchain): revert accepted blocks when saveBlocks fails

### DIFF
--- a/__tests__/integration/core-database-postgres/connection.test.ts
+++ b/__tests__/integration/core-database-postgres/connection.test.ts
@@ -15,6 +15,7 @@ beforeAll(async () => {
 
     databaseService = app.resolvePlugin<Database.IDatabaseService>("database");
 
+    await databaseService.deleteBlocks([genesisBlock]);
     await databaseService.saveBlock(BlockFactory.fromData(genesisBlock));
 });
 

--- a/__tests__/unit/core-blockchain/blockchain.test.ts
+++ b/__tests__/unit/core-blockchain/blockchain.test.ts
@@ -2,6 +2,7 @@
 import "./mocks/";
 import { container } from "./mocks/container";
 
+import * as Utils from "@arkecosystem/core-utils";
 import { Blocks, Crypto, Interfaces } from "@arkecosystem/crypto";
 import delay from "delay";
 import { Blockchain } from "../../../packages/core-blockchain/src/blockchain";
@@ -147,7 +148,6 @@ describe("Blockchain", () => {
             const mockCallback = jest.fn(() => true);
             blockchain.state.blockchain = {};
             jest.spyOn(database, "saveBlocks").mockRejectedValueOnce(new Error("oops saveBlocks"));
-            jest.spyOn(database, "getLastBlock").mockRejectedValueOnce(new Error("oops getLastBlock"));
             jest.spyOn(blockchain, "removeTopBlocks").mockReturnValueOnce(undefined);
 
             await blockchain.processBlocks([BlockFactory.fromData(blocks2to100[2])], mockCallback);
@@ -158,6 +158,7 @@ describe("Blockchain", () => {
 
         it("should broadcast a block if (Crypto.Slots.getSlotNumber() * blocktime <= block.data.timestamp)", async () => {
             blockchain.state.started = true;
+            jest.spyOn(Utils, "isBlockChained").mockReturnValueOnce(true);
 
             const mockCallback = jest.fn(() => true);
             const lastBlock = blockchain.getLastBlock();

--- a/__tests__/unit/core-blockchain/mocks/database.ts
+++ b/__tests__/unit/core-blockchain/mocks/database.ts
@@ -3,6 +3,7 @@ export const database = {
 
     walletManager: {
         findByPublicKey: pubKey => "username",
+        revertBlock: () => undefined,
     },
 
     buildWallets: () => undefined,
@@ -21,4 +22,5 @@ export const database = {
     revertBlock: () => undefined,
     applyBlock: () => undefined,
     getForgedTransactionsIds: () => [],
+    loadBlocksFromCurrentRound: () => undefined,
 };

--- a/packages/core-blockchain/src/blockchain.ts
+++ b/packages/core-blockchain/src/blockchain.ts
@@ -12,6 +12,7 @@ import {
 } from "@arkecosystem/core-interfaces";
 import { Blocks, Crypto, Interfaces, Managers } from "@arkecosystem/crypto";
 
+import { isBlockChained, roundCalculator } from "@arkecosystem/core-utils";
 import async from "async";
 import delay from "delay";
 import pluralize from "pluralize";
@@ -385,6 +386,11 @@ export class Blockchain implements blockchain.IBlockchain {
     public async processBlocks(blocks: Interfaces.IBlock[], callback): Promise<Interfaces.IBlock[]> {
         const acceptedBlocks: Interfaces.IBlock[] = [];
         let lastProcessResult: BlockProcessorResult;
+
+        if (blocks[0] && !isBlockChained(this.getLastBlock().data, blocks[0].data)) {
+            return callback();
+        }
+
         for (const block of blocks) {
             lastProcessResult = await this.blockProcessor.process(block);
 
@@ -398,23 +404,33 @@ export class Blockchain implements blockchain.IBlockchain {
         if (acceptedBlocks.length > 0) {
             try {
                 await this.database.saveBlocks(acceptedBlocks);
-            } catch (exceptionSaveBlocks) {
-                logger.error(
-                    `Could not save ${acceptedBlocks.length} blocks to database : ${exceptionSaveBlocks.stack}`,
+            } catch (error) {
+                logger.error(`Could not save ${acceptedBlocks.length} blocks to database : ${error.stack}`);
+
+                this.clearQueue();
+
+                // Rounds are saved while blocks are being processed and may now be out of sync with the last
+                // block that was written into the database.
+
+                const lastBlock: Interfaces.IBlock = await this.database.getLastBlock();
+                const lastHeight: number = lastBlock.data.height;
+                const deleteRoundsAfter: number = roundCalculator.calculateRound(lastHeight).round;
+
+                logger.info(
+                    `Reverting ${pluralize("block", acceptedBlocks.length, true)} back to last height: ${lastHeight}`,
                 );
 
-                const resetToHeight = async height => {
-                    try {
-                        return await this.removeTopBlocks((await this.database.getLastBlock()).data.height - height);
-                    } catch (e) {
-                        logger.error(`Could not remove top blocks from database : ${e.stack}`);
+                for (const block of acceptedBlocks.reverse()) {
+                    this.database.walletManager.revertBlock(block);
+                }
 
-                        return resetToHeight(height); // keep trying, we can't do anything while this fails
-                    }
-                };
-                await resetToHeight(acceptedBlocks[0].data.height - 1);
+                this.state.setLastBlock(lastBlock);
+                this.resetLastDownloadedBlock();
 
-                return this.processBlocks(blocks, callback); // keep trying, we can't do anything while this fails
+                await this.database.deleteRound(deleteRoundsAfter + 1);
+                await this.database.loadBlocksFromCurrentRound();
+
+                return callback();
             }
         }
 

--- a/packages/core-database-postgres/src/postgres-connection.ts
+++ b/packages/core-database-postgres/src/postgres-connection.ts
@@ -123,11 +123,11 @@ export class PostgresConnection implements Database.IConnection {
                 const { nextRound } = roundCalculator.calculateRound(blocks[blocks.length - 1].height);
                 const blockIds: string[] = blocks.map(block => block.id);
 
-                return [
+                return t.batch([
                     this.transactionsRepository.deleteByBlockId(blockIds, t),
                     this.blocksRepository.delete(blockIds, t),
                     this.roundsRepository.delete(nextRound, t),
-                ];
+                ]);
             });
         } catch (error) {
             this.logger.error(error.message);
@@ -163,7 +163,7 @@ export class PostgresConnection implements Database.IConnection {
                     queries.push(this.transactionsRepository.insert(transactionInserts, t));
                 }
 
-                return queries;
+                return t.batch(queries);
             });
         } catch (err) {
             this.logger.error(err.message);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->
When `saveBlocks` fails, we have to revert the accepted blocks. It would also pretty much loop indefinitely and keep trying to process the same blocks over and over again. Instead of removing the top blocks, now all accepted blocks are reverted, all queued blocks dropped and the state machine gets to decide when to process blocks again.

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

## Does this PR release a new version?

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `develop` branch, _not_ the `master` branch
- [ ] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
