### PR TITLE
fix(core-p2p): avoid iterating on non-iterable peerBlocks

### DIFF
--- a/packages/core-p2p/src/peer-communicator.ts
+++ b/packages/core-p2p/src/peer-communicator.ts
@@ -161,6 +161,7 @@ export class PeerCommunicator implements P2P.IPeerCommunicator {
             this.logger.debug(
                 `Peer ${peer.ip} did not return any blocks via height ${fromBlockHeight.toLocaleString()}.`,
             );
+            return [];
         }
 
         // To stay backward compatible, don't assume peers respond with serialized transactions just yet.


### PR DESCRIPTION
If peerBlocks is falsy, then "for (const block of peerBlocks) {"
would throw an exception that peerBlocks is not iterable.

<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

A summary of what changes this PR introduces and why they were made.

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

## Does this PR release a new version?

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `develop` branch, _not_ the `master` branch
- [ ] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
