### PR TITLE
fix(core-database-postgres): correct estimate if less than limit rows

### DIFF
--- a/packages/core-database-postgres/src/repositories/repository.ts
+++ b/packages/core-database-postgres/src/repositories/repository.ts
@@ -76,7 +76,7 @@ export abstract class Repository implements Database.IRepository {
         const rows = await this.findMany(selectQuery);
 
         if (rows.length < paginate.limit) {
-            return { rows, count: paginate.limit + rows.length };
+            return { rows, count: paginate.offset + rows.length };
         }
 
         // Get the last rows=... from something that looks like (1 column, few rows):


### PR DESCRIPTION
For example, if the request is contains offset=100, limit=10 and we
get 3 rows from the database, then we know that the total rows matching
the query are 103: 100 (skipped due to offset) + 3 (returned rows).

<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

A summary of what changes this PR introduces and why they were made.

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

## Does this PR release a new version?

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `develop` branch, _not_ the `master` branch
- [ ] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
