### PR TITLE
fix: try harder to return the requested number of transactions

### DIFF
--- a/__tests__/unit/core-transaction-pool/connection.forging.test.ts
+++ b/__tests__/unit/core-transaction-pool/connection.forging.test.ts
@@ -543,5 +543,17 @@ describe("Connection", () => {
 
             await expectForgingTransactions(transactions, 4);
         });
+
+        it("should remove all invalid transactions from the transaction pool", async () => {
+            const transactions = TransactionFactory.transfer().build(151);
+            for (let i = 0; i < transactions.length - 1; i++) {
+                transactions[i].serialized = customSerialize(transactions[i].data, {
+                    signature: (b: ByteBuffer) => {
+                        b.writeByte(0x01);
+                    },
+                });
+            }
+            await expectForgingTransactions(transactions, 1);
+        });
     });
 });

--- a/packages/core-transaction-pool/src/connection.ts
+++ b/packages/core-transaction-pool/src/connection.ts
@@ -337,14 +337,17 @@ export class Connection implements TransactionPool.IConnection {
         const removeInvalid = async (transactions: Interfaces.ITransaction[]): Promise<Interfaces.ITransaction[]> => {
             const valid = await this.validateTransactions(transactions);
             return transactions.filter(transaction => valid.includes(transaction.serialized.toString("hex")));
-        }
+        };
 
         let i = 0;
-        for (const transaction of this.memory.allSortedByFee()) {
+        const allTransactions: Interfaces.ITransaction[] = [...this.memory.allSortedByFee()];
+        for (const transaction of allTransactions) {
             if (data.length === size) {
                 data = await removeInvalid(data);
                 if (data.length === size) {
                     return data;
+                } else {
+                    transactionBytes = 0; // TODO: get rid of `maxBytes`
                 }
             }
 


### PR DESCRIPTION
Before this patch we would take the top "size" transactions, filter away
some of them and return the result, possibly returning less than the
requested "size" even if there could be legit transactions in the pool
that could be returned, up to "size".

Change the code to keep iterating until we have collected "size" valid
transactions, or the end of the pool is reached.

<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

A summary of what changes this PR introduces and why they were made.

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

## Does this PR release a new version?

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `develop` branch, _not_ the `master` branch
- [ ] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
