### PR TITLE
refactor(core-p2p): discover new peers sooner

### DIFF
--- a/__tests__/integration/core-p2p/network-monitor.test.ts
+++ b/__tests__/integration/core-p2p/network-monitor.test.ts
@@ -79,7 +79,7 @@ describe("NetworkMonitor", () => {
             // @ts-ignore
             monitor.config = { ignoreMinimumNetworkReach: true };
 
-            await monitor.discoverPeers();
+            await expect(monitor.discoverPeers(true)).resolves.toBeTrue();
 
             expect(validateAndAcceptPeer).toHaveBeenCalledTimes(1);
             expect(validateAndAcceptPeer).toHaveBeenCalledWith(getPeersPeerMock, { lessVerbose: true });

--- a/__tests__/unit/core-p2p/network-monitor.test.ts
+++ b/__tests__/unit/core-p2p/network-monitor.test.ts
@@ -76,11 +76,61 @@ describe("NetworkMonitor", () => {
             const validateAndAcceptPeer = jest.spyOn(processor, "validateAndAcceptPeer");
             const validatePeerIp = jest.spyOn(processor, "validatePeerIp").mockReturnValue(true);
 
-            await monitor.discoverPeers();
+            await expect(monitor.discoverPeers(true)).resolves.toBeTrue();
 
             expect(validateAndAcceptPeer).toHaveBeenCalledTimes(2);
             expect(validateAndAcceptPeer).toHaveBeenCalledWith({ ip: "1.1.1.1" }, { lessVerbose: true });
             expect(validateAndAcceptPeer).toHaveBeenCalledWith({ ip: "2.2.2.2" }, { lessVerbose: true });
+
+            validateAndAcceptPeer.mockReset();
+
+            await expect(monitor.discoverPeers()).resolves.toBeFalse();
+
+            expect(validateAndAcceptPeer).not.toHaveBeenCalled();
+
+            validatePeerIp.mockRestore();
+        });
+
+        it("should discover new peers when below minimum", async () => {
+            storage.setPeer(
+                createStubPeer({
+                    ip: "1.2.3.4",
+                    port: 4000,
+                }),
+            );
+            storage.setPeer(
+                createStubPeer({
+                    ip: "1.2.3.5",
+                    port: 4000,
+                }),
+            );
+
+            // @ts-ignore
+            monitor.config = { ignoreMinimumNetworkReach: true };
+
+            const validateAndAcceptPeer = jest.spyOn(processor, "validateAndAcceptPeer");
+            const validatePeerIp = jest.spyOn(processor, "validatePeerIp").mockReturnValue(true);
+
+            communicator.getPeers = jest.fn().mockReturnValue([{ ip: "1.1.1.1" }, { ip: "2.2.2.2" }]);
+
+            await expect(monitor.discoverPeers()).resolves.toBeFalse();
+
+            expect(validateAndAcceptPeer).not.toHaveBeenCalled();
+
+            const fakePeers = [];
+            for (let i = 0; i < 10; i++) {
+                fakePeers.push({ ip: `${i + 1}.${i + 1}.${i + 1}.${i + 1}` });
+            }
+
+            communicator.getPeers = jest.fn().mockReturnValue(fakePeers);
+
+            await expect(monitor.discoverPeers()).resolves.toBeTrue();
+
+            expect(validateAndAcceptPeer).toHaveBeenCalledTimes(10);
+
+            for (let i = 0; i < 10; i++) {
+                expect(validateAndAcceptPeer).toHaveBeenCalledWith(fakePeers[i], { lessVerbose: true });
+            }
 
             validatePeerIp.mockRestore();
         });

--- a/packages/core-interfaces/src/core-p2p/network-monitor.ts
+++ b/packages/core-interfaces/src/core-p2p/network-monitor.ts
@@ -19,7 +19,7 @@ export interface INetworkMonitor {
         forcePing?: boolean;
         peerCount?: number;
     }): Promise<void>;
-    discoverPeers(): Promise<void>;
+    discoverPeers(initialRun?: boolean): Promise<boolean>;
     getNetworkHeight(): number;
     getNetworkState(): Promise<INetworkState>;
     refreshPeersAfterFork(): Promise<void>;

--- a/packages/core-p2p/src/network-monitor.ts
+++ b/packages/core-p2p/src/network-monitor.ts
@@ -191,7 +191,7 @@ export class NetworkMonitor implements P2P.INetworkMonitor {
                 .reduce((acc, curr) => ({ ...acc, ...curr })),
         );
 
-        if (initialRun || ownPeers.length < theirPeers.length * 0.5) {
+        if (initialRun || !this.hasMinimumPeers() || ownPeers.length < theirPeers.length * 0.5) {
             await Promise.all(theirPeers.map(p => this.processor.validateAndAcceptPeer(p, { lessVerbose: true })));
             return true;
         }

--- a/packages/core-p2p/src/network-monitor.ts
+++ b/packages/core-p2p/src/network-monitor.ts
@@ -71,7 +71,7 @@ export class NetworkMonitor implements P2P.INetworkMonitor {
         if (this.config.skipDiscovery) {
             this.logger.warn("Skipped peer discovery because the relay is in skip-discovery mode.");
         } else {
-            await this.updateNetworkStatus(true);
+            await this.updateNetworkStatus();
 
             for (const [version, peers] of Object.entries(groupBy(this.storage.getPeers(), "version"))) {
                 this.logger.info(`Discovered ${pluralize("peer", peers.length, true)} with v${version}.`);
@@ -99,13 +99,12 @@ export class NetworkMonitor implements P2P.INetworkMonitor {
             return;
         }
 
-        if (initialRun || !this.hasMinimumPeers()) {
-            try {
-                await this.discoverPeers();
+        try {
+            if (await this.discoverPeers(initialRun)) {
                 await this.cleansePeers();
-            } catch (error) {
-                this.logger.error(`Network Status: ${error.message}`);
             }
+        } catch (error) {
+            this.logger.error(`Network Status: ${error.message}`);
         }
 
         let nextRunDelaySeconds = 600;
@@ -172,25 +171,34 @@ export class NetworkMonitor implements P2P.INetworkMonitor {
         }
     }
 
-    public async discoverPeers(): Promise<void> {
-        const queryAtLeastNPeers = 4;
-        let queriedPeers = 0;
+    public async discoverPeers(initialRun?: boolean): Promise<boolean> {
+        const ownPeers: P2P.IPeer[] = this.storage.getPeers();
+        const theirPeers: P2P.IPeer[] = Object.values(
+            (await Promise.all(
+                shuffle(this.storage.getPeers())
+                    .slice(0, 4)
+                    .map(async (peer: P2P.IPeer) => {
+                        try {
+                            const hisPeers = await this.communicator.getPeers(peer);
+                            return hisPeers || [];
+                        } catch (error) {
+                            this.logger.debug(`Failed to get peers from ${peer.ip}: ${error.message}`);
+                            return [];
+                        }
+                    }),
+            ))
+                .map(peers => peers.reduce((acc, curr) => ({ ...acc, ...{ [curr.ip]: curr } }), {}))
+                .reduce((acc, curr) => ({ ...acc, ...curr })),
+        );
 
-        const shuffledPeers = shuffle(this.storage.getPeers());
-
-        for (const peer of shuffledPeers) {
-            try {
-                const hisPeers = await this.communicator.getPeers(peer);
-                queriedPeers++;
-                await Promise.all(hisPeers.map(p => this.processor.validateAndAcceptPeer(p, { lessVerbose: true })));
-            } catch (error) {
-                // Just try with the next peer from shuffledPeers.
-            }
-
-            if (this.hasMinimumPeers() && queriedPeers >= queryAtLeastNPeers) {
-                return;
-            }
+        if (initialRun || ownPeers.length < theirPeers.length * 0.5) {
+            await Promise.all(
+                Object.values(theirPeers).map(p => this.processor.validateAndAcceptPeer(p, { lessVerbose: true })),
+            );
+            return true;
         }
+
+        return false;
     }
 
     public getNetworkHeight(): number {

--- a/packages/core-p2p/src/network-monitor.ts
+++ b/packages/core-p2p/src/network-monitor.ts
@@ -192,9 +192,7 @@ export class NetworkMonitor implements P2P.INetworkMonitor {
         );
 
         if (initialRun || ownPeers.length < theirPeers.length * 0.5) {
-            await Promise.all(
-                Object.values(theirPeers).map(p => this.processor.validateAndAcceptPeer(p, { lessVerbose: true })),
-            );
+            await Promise.all(theirPeers.map(p => this.processor.validateAndAcceptPeer(p, { lessVerbose: true })));
             return true;
         }
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

At the moment we only discover new peers when `hasMinimumPeers()` returns false. This is generally too low. This PR changes `discoverPeers` to also look for new peers when the own peer count is significantly lower than the peer count of other peers.

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [X] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

## Does this PR release a new version?

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `develop` branch, _not_ the `master` branch
- [ ] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
