### PR TITLE
fix(core-database-postgres): drop check_previous_block with arguments

### DIFF
--- a/packages/core-database-postgres/src/migrations/20190626000000-enforce-chained-blocks.sql
+++ b/packages/core-database-postgres/src/migrations/20190626000000-enforce-chained-blocks.sql
@@ -1,6 +1,10 @@
 ALTER TABLE blocks DROP CONSTRAINT IF EXISTS "chained_blocks";
 
-DROP FUNCTION IF EXISTS check_previous_block;
+DROP FUNCTION IF EXISTS check_previous_block(
+  id_arg VARCHAR(64),
+  previous_block_arg VARCHAR(64),
+  height_arg INTEGER
+);
 
 CREATE FUNCTION check_previous_block(
   id_arg VARCHAR(64),


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

@adrian69 was experiencing some issues with PG9.5 that didn't occur on PG10.5 so changed the drop command to also take the function specific arguments into account.

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Does this PR release a new version?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch
- [x] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
