### PR TITLE
refactor(core): run GC earlier on potatos

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -67,7 +67,7 @@
         "@oclif/plugin-help": "^2.2.0",
         "@oclif/plugin-not-found": "^1.2.2",
         "@oclif/plugin-plugins": "^1.7.8",
-        "@typeskrift/foreman": "^0.2.0",
+        "@typeskrift/foreman": "^0.2.1",
         "bip39": "^3.0.2",
         "bytebuffer": "^5.0.1",
         "chalk": "^2.4.2",

--- a/packages/core/src/shared/start.ts
+++ b/packages/core/src/shared/start.ts
@@ -50,7 +50,7 @@ export abstract class AbstractStartCommand extends BaseCommand {
                             NODE_ENV: "production",
                             CORE_ENV: flags.env,
                         },
-                        node_args: potato ? "--max_old_space_size=500" : undefined,
+                        node_args: potato ? { max_old_space_size: 500 } : undefined,
                     },
                 },
                 flagsProcess,

--- a/packages/core/src/shared/start.ts
+++ b/packages/core/src/shared/start.ts
@@ -1,6 +1,6 @@
 import cli from "cli-ux";
 
-import { freemem } from "os";
+import { freemem, totalmem } from "os";
 import { BaseCommand } from "../commands/command";
 import { processManager } from "../process-manager";
 import { CommandFlags, ProcessOptions } from "../types";
@@ -17,7 +17,7 @@ export abstract class AbstractStartCommand extends BaseCommand {
     protected abstract async runProcess(flags: CommandFlags): Promise<void>;
 
     protected async runWithPm2(options: ProcessOptions, flags: CommandFlags) {
-        const processName = options.name;
+        const processName: string = options.name;
 
         try {
             if (processManager.has(processName)) {
@@ -38,8 +38,9 @@ export abstract class AbstractStartCommand extends BaseCommand {
 
             flagsProcess.name = processName;
 
-            const mem = freemem() / Math.pow(1024, 3);
-            const potato = mem < 1;
+            const totalMemGb: number = totalmem() / Math.pow(1024, 3);
+            const freeMemGb: number = freemem() / Math.pow(1024, 3);
+            const potato: boolean = totalMemGb < 2 || freeMemGb < 1.5;
 
             processManager.start(
                 {

--- a/packages/core/src/shared/start.ts
+++ b/packages/core/src/shared/start.ts
@@ -1,5 +1,6 @@
 import cli from "cli-ux";
 
+import { freemem } from "os";
 import { BaseCommand } from "../commands/command";
 import { processManager } from "../process-manager";
 import { CommandFlags, ProcessOptions } from "../types";
@@ -37,14 +38,18 @@ export abstract class AbstractStartCommand extends BaseCommand {
 
             flagsProcess.name = processName;
 
+            const mem = freemem() / Math.pow(1024, 3);
+            const potato = mem < 1;
+
             processManager.start(
                 {
                     ...options,
                     ...{
                         env: {
-                            NODE_ENV: 'production',
+                            NODE_ENV: "production",
                             CORE_ENV: flags.env,
                         },
+                        node_args: potato ? "--max_old_space_size=500" : undefined,
                     },
                 },
                 flagsProcess,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

Potatos (<=2GB RAM) tend to run OOM during sync from 0 because Node.js tries to use up to 1.5GB before the GC kicks in by default.

By lowering the `max_old_space_size` to `500` on nodes with little RAM they actually manage to sync without running OOM. 

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [X] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

## Does this PR release a new version?

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `develop` branch, _not_ the `master` branch
- [ ] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
