### PR TITLE
refactor(core-forger): increase timeout, check time left in slot

### DIFF
--- a/__tests__/unit/core-forger/manager.test.ts
+++ b/__tests__/unit/core-forger/manager.test.ts
@@ -4,7 +4,7 @@ import "./mocks/core-container";
 
 import { ApplicationEvents } from "@arkecosystem/core-event-emitter";
 import { NetworkState, NetworkStateStatus } from "@arkecosystem/core-p2p";
-import { Transactions } from "@arkecosystem/crypto";
+import { Crypto, Transactions } from "@arkecosystem/crypto";
 import { defaults } from "../../../packages/core-forger/src/defaults";
 import { Delegate } from "../../../packages/core-forger/src/delegate";
 import { ForgerManager } from "../../../packages/core-forger/src/manager";
@@ -24,6 +24,7 @@ afterAll(async () => {
 });
 
 beforeEach(() => {
+    jest.restoreAllMocks();
     defaults.hosts = [{ hostname: "127.0.0.1", port: 4000 }];
     forgeManager = new ForgerManager(defaults);
 });
@@ -51,6 +52,8 @@ describe("Forger Manager", () => {
                 reward: 2 * 1e8,
             };
 
+            jest.spyOn(Crypto.Slots, "getTimeInMsUntilNextSlot").mockReturnValueOnce(2000);
+
             await forgeManager.forgeNewBlock(del, round, {
                 lastBlockId: round.lastBlock.id,
                 nodeHeight: round.lastBlock.height,
@@ -70,6 +73,48 @@ describe("Forger Manager", () => {
                 ApplicationEvents.TransactionForged,
                 expect.any(Object),
             );
+        });
+
+        it("should not forge a block when not enough time left", async () => {
+            // NOTE: make sure we have valid transactions from an existing wallet
+            const transactions = TransactionFactory.transfer()
+                .withNetwork("testnet")
+                .withPassphrase("clay harbor enemy utility margin pretty hub comic piece aerobic umbrella acquire")
+                .build();
+
+            // @ts-ignore
+            forgeManager.client.getTransactions.mockReturnValue({
+                transactions: transactions.map(tx => tx.serialized.toString("hex")),
+            });
+
+            forgeManager.usernames = [];
+
+            const del = new Delegate("a secret", testnet.network);
+            const round = {
+                lastBlock: { id: sampleBlock.data.id, height: sampleBlock.data.height },
+                timestamp: 1,
+                reward: 2 * 1e8,
+            };
+
+            jest.spyOn(Crypto.Slots, "getTimeInMsUntilNextSlot").mockReturnValueOnce(2000);
+
+            await forgeManager.forgeNewBlock(del, round, {
+                lastBlockId: round.lastBlock.id,
+                nodeHeight: round.lastBlock.height,
+            });
+
+            expect(forgeManager.client.broadcastBlock).toHaveBeenCalled();
+
+            jest.resetAllMocks();
+
+            jest.spyOn(Crypto.Slots, "getTimeInMsUntilNextSlot").mockReturnValueOnce(1000);
+
+            await forgeManager.forgeNewBlock(del, round, {
+                lastBlockId: round.lastBlock.id,
+                nodeHeight: round.lastBlock.height,
+            });
+
+            expect(forgeManager.client.broadcastBlock).not.toHaveBeenCalled();
         });
     });
 

--- a/packages/core-forger/src/client.ts
+++ b/packages/core-forger/src/client.ts
@@ -125,7 +125,7 @@ export class Client {
         throw new HostNoResponseError(this.hosts.map(host => host.hostname).join());
     }
 
-    private async emit<T = object>(event: string, data: Record<string, any> = {}, timeout: number = 2000): Promise<T> {
+    private async emit<T = object>(event: string, data: Record<string, any> = {}, timeout: number = 4000): Promise<T> {
         try {
             const response: P2P.IResponse<T> = await socketEmit(
                 this.host.hostname,

--- a/packages/core-forger/src/manager.ts
+++ b/packages/core-forger/src/manager.ts
@@ -153,18 +153,28 @@ export class ForgerManager {
             reward: round.reward,
         });
 
-        this.logger.info(
-            `Forged new block ${block.data.id} by delegate ${this.usernames[delegate.publicKey]} (${
-                delegate.publicKey
-            })`,
-        );
+        const minimumMs: number = 2000;
+        const timeLeftInMs: number = Crypto.Slots.getTimeInMsUntilNextSlot();
+        if (timeLeftInMs >= minimumMs) {
+            this.logger.info(
+                `Forged new block ${block.data.id} by delegate ${this.usernames[delegate.publicKey]} (${
+                    delegate.publicKey
+                })`,
+            );
 
-        await this.client.broadcastBlock(block.toJson());
+            await this.client.broadcastBlock(block.toJson());
 
-        this.client.emitEvent(ApplicationEvents.BlockForged, block.data);
+            this.client.emitEvent(ApplicationEvents.BlockForged, block.data);
 
-        for (const transaction of transactions) {
-            this.client.emitEvent(ApplicationEvents.TransactionForged, transaction);
+            for (const transaction of transactions) {
+                this.client.emitEvent(ApplicationEvents.TransactionForged, transaction);
+            }
+        } else {
+            this.logger.warn(
+                `Failed to forge new block by delegate ${this.usernames[delegate.publicKey]} (${
+                    delegate.publicKey
+                }, because there were less than ${minimumMs}ms left`,
+            );
         }
     }
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->
Increase request timeout and prevent blocks from getting forged when the current slot has less than 2 seconds left.

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [X] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

## Does this PR release a new version?

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `develop` branch, _not_ the `master` branch
- [ ] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
