### PR TITLE
fix(core-api): return count of filtered peers

### DIFF
--- a/packages/core-api/src/handlers/peers/controller.ts
+++ b/packages/core-api/src/handlers/peers/controller.ts
@@ -13,7 +13,7 @@ export class PeersController extends Controller {
             ? result.filter(peer => peer.version === (request.query as any).version)
             : result;
 
-        const count = result.length;
+        const count: number = result.length;
 
         result = result.slice(0, +request.query.limit || 100);
 

--- a/packages/core-api/src/handlers/peers/controller.ts
+++ b/packages/core-api/src/handlers/peers/controller.ts
@@ -12,6 +12,9 @@ export class PeersController extends Controller {
         result = request.query.version
             ? result.filter(peer => peer.version === (request.query as any).version)
             : result;
+
+        const count = result.length;
+
         result = result.slice(0, +request.query.limit || 100);
 
         const orderBy: string = request.query.orderBy as string;
@@ -26,7 +29,7 @@ export class PeersController extends Controller {
             }
         }
 
-        return super.toPagination({ rows: result, count: allPeers.length }, "peer");
+        return super.toPagination({ rows: result, count }, "peer");
     }
 
     public async show(request: Hapi.Request, h: Hapi.ResponseToolkit) {

--- a/packages/core-api/src/handlers/peers/schema.ts
+++ b/packages/core-api/src/handlers/peers/schema.ts
@@ -6,8 +6,6 @@ export const index: object = {
         ...pagination,
         ...{
             ip: Joi.string().ip(),
-            status: Joi.string(),
-            port: Joi.number().port(),
             version: Joi.string(),
             orderBy: Joi.string(),
         },


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

The peer api currently returns the total count of all peers, instead of the count of the filtered peers, thus messing with the pagination.

It's worth noting that the schema for index currently accepts `ip`, `status`, and `port` as query params, yet filtering based on those values is not implemented.

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Does this PR release a new version?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch
- [x] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
