### PR TITLE
fix(core-database-postgres): prefix table names with schema

### DIFF
--- a/packages/core-database-postgres/src/migrations/20190718000000-check_previous_block-add-schema.sql
+++ b/packages/core-database-postgres/src/migrations/20190718000000-check_previous_block-add-schema.sql
@@ -1,0 +1,47 @@
+ALTER TABLE blocks DROP CONSTRAINT IF EXISTS "chained_blocks";
+
+DROP FUNCTION IF EXISTS check_previous_block(
+  id_arg VARCHAR(64),
+  previous_block_arg VARCHAR(64),
+  height_arg INTEGER
+);
+
+CREATE FUNCTION check_previous_block(
+  id_arg VARCHAR(64),
+  previous_block_arg VARCHAR(64),
+  height_arg INTEGER
+) RETURNS BOOLEAN
+AS
+$$
+DECLARE
+  block_id_at_height_minus1 VARCHAR(64);
+  previous_block_height INTEGER;
+  fail_reason TEXT;
+BEGIN
+  IF height_arg = 1 THEN
+    RETURN TRUE;
+  END IF;
+
+  SELECT id INTO block_id_at_height_minus1 FROM ${schema~}.blocks WHERE height = height_arg - 1;
+
+  IF previous_block_arg = block_id_at_height_minus1 THEN
+    RETURN TRUE;
+  END IF;
+
+  SELECT height INTO previous_block_height FROM ${schema~}.blocks WHERE id = previous_block_arg;
+
+  IF previous_block_height IS NULL THEN
+    fail_reason := 'a block with id "' || previous_block_arg || '" does not exist';
+  ELSE
+    fail_reason := 'a block with id "' || previous_block_arg || '" exists but at an unexpected height ' ||
+      previous_block_height || ' instead of ' || height_arg - 1;
+  END IF;
+
+  RAISE 'Cannot insert new block (id="%", height=%, previous_block="%") because %',
+    id_arg, height_arg, previous_block_arg, fail_reason;
+END;
+$$
+LANGUAGE PLPGSQL
+VOLATILE;
+
+ALTER TABLE blocks ADD CONSTRAINT "chained_blocks" CHECK (check_previous_block(id, previous_block, height));

--- a/packages/core-database-postgres/src/migrations/index.ts
+++ b/packages/core-database-postgres/src/migrations/index.ts
@@ -16,4 +16,5 @@ export const migrations = [
     loadQueryFile(__dirname, "./20190606000000-add-block-id-foreign-key-on-transactions.sql"),
     loadQueryFile(__dirname, "./20190619000000-drop-id-column-from-rounds-table.sql"),
     loadQueryFile(__dirname, "./20190626000000-enforce-chained-blocks.sql"),
+    loadQueryFile(__dirname, "./20190718000000-check_previous_block-add-schema.sql"),
 ];


### PR DESCRIPTION
Without "public." prefix, accessing the table just by name - "blocks"
causes pg_dump dumps to fail during load with:

  pg_restore: [archiver (db)] COPY failed for table "blocks": ERROR:  relation "blocks" does not exist

<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

A summary of what changes this PR introduces and why they were made.

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

## Does this PR release a new version?

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `develop` branch, _not_ the `master` branch
- [ ] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
