### PR TITLE
fix(core-api): return data directly if cache is disabled

### DIFF
--- a/packages/core-api/src/handlers/utils.ts
+++ b/packages/core-api/src/handlers/utils.ts
@@ -1,3 +1,4 @@
+import { app } from "@arkecosystem/core-container";
 import Boom from "@hapi/boom";
 import Hapi from "@hapi/hapi";
 import { transformerService } from "../services/transformer";
@@ -30,6 +31,10 @@ export const respondWithCollection = (data, transformer, transform: boolean = tr
 };
 
 export const respondWithCache = (data, h): any => {
+    if (!app.resolveOptions("api").cache.enabled) {
+        return data;
+    }
+
     const { value, cached } = data;
     const lastModified = cached ? new Date(cached.stored) : new Date();
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

If the cache is disabled the `respondWithCache` will run into issues because it assumes the data it received is a cache object that was created by hapi. Return early if the cache is disabled to avoid this behaviour.

```
Debug: internal, implementation, error
    TypeError: Cannot read property 'isBoom' of undefined
    at Object.exports.respondWithCache (/Users/dev/Code/core/packages/core-api/dist/handlers/utils.js:35:15)
    at WalletsController.respondWithCache (/Users/dev/Code/core/packages/core-api/dist/handlers/shared/controller.js:18:24)
    at WalletsController.transactions (/Users/dev/Code/core/packages/core-api/dist/handlers/wallets/controller.js:23:22)
```

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Does this PR release a new version?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `develop` branch, _not_ the `master` branch
- [x] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
