### PR TITLE
perf(core-database-postgres): faster count method

### DIFF
--- a/packages/core-database-postgres/src/repositories/blocks.ts
+++ b/packages/core-database-postgres/src/repositories/blocks.ts
@@ -8,7 +8,7 @@ export class BlocksRepository extends Repository implements Database.IBlocksRepo
     public async search(params: Database.ISearchParameters): Promise<{ rows: Interfaces.IBlockData[]; count: number }> {
         // TODO: we're selecting all the columns right now. Add support for choosing specific columns, when it proves useful.
         const selectQuery = this.query.select().from(this.query);
-        const selectQueryCount = this.query.select(this.query.count().as("cnt")).from(this.query);
+        const selectQueryCount = this.query.select(this.query.id).from(this.query);
         // Blocks repo atm, doesn't search using any custom parameters
         const parameterList = params.parameters.filter(o => o.operator !== Database.SearchOperator.OP_CUSTOM);
 
@@ -20,11 +20,11 @@ export class BlocksRepository extends Repository implements Database.IBlocksRepo
             } while (!first.operator && parameterList.length);
 
             if (first) {
-                for (const query of [ selectQuery, selectQueryCount ]) {
+                for (const query of [selectQuery, selectQueryCount]) {
                     query.where(this.query[this.propToColumnName(first.field)][first.operator](first.value));
                 }
                 for (const param of parameterList) {
-                    for (const query of [ selectQuery, selectQueryCount ]) {
+                    for (const query of [selectQuery, selectQueryCount]) {
                         query.and(this.query[this.propToColumnName(param.field)][param.operator](param.value));
                     }
                 }

--- a/packages/core-database-postgres/src/repositories/repository.ts
+++ b/packages/core-database-postgres/src/repositories/repository.ts
@@ -53,7 +53,7 @@ export abstract class Repository implements Database.IRepository {
         selectQueryCount: Query<any>,
         paginate?: Database.ISearchPaginate,
         orderBy?: Database.ISearchOrderBy[],
-    ): Promise<{ rows: T; count: number, countIsEstimate: boolean }> {
+    ): Promise<{ rows: T; count: number; countIsEstimate: boolean }> {
         if (!!orderBy) {
             for (const o of orderBy) {
                 const column = this.query.columns.find(column => column.prop.toLowerCase() === o.field);
@@ -103,8 +103,8 @@ export abstract class Repository implements Database.IRepository {
             return { rows, count: Math.max(count, rows.length), countIsEstimate: true };
         }
 
-        const countRow = await this.find(selectQueryCount);
+        const { count } = await this.db.one(`SELECT COUNT(*) FROM (${selectQueryCount.toString()}) AS count;`);
 
-        return { rows, count: Number(countRow.cnt), countIsEstimate: false };
+        return { rows, count: Number(count), countIsEstimate: false };
     }
 }

--- a/packages/core-database-postgres/src/repositories/transactions.ts
+++ b/packages/core-database-postgres/src/repositories/transactions.ts
@@ -17,7 +17,7 @@ export class TransactionsRepository extends Repository implements Database.ITran
         }
 
         const selectQuery = this.query.select().from(this.query);
-        const selectQueryCount = this.query.select(this.query.count().as("cnt")).from(this.query);
+        const selectQueryCount = this.query.select(this.query.id).from(this.query);
         const params = parameters.parameters;
 
         if (params.length) {
@@ -168,7 +168,7 @@ export class TransactionsRepository extends Repository implements Database.ITran
         orderBy?: Database.ISearchOrderBy[],
     ): Promise<Database.ITransactionsPaginated> {
         const selectQuery = this.query.select();
-        const selectQueryCount = this.query.select(this.query.count().as("cnt"));
+        const selectQueryCount = this.query.select(this.query.id);
 
         for (const query of [selectQuery, selectQueryCount]) {
             query


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

Use a faster query that performs better against larger datasets like on mainnet while the benefit on devnet is still visible but a lot smaller as the database is 1/3 the size. _This is obviously not a permanent solution but a nice little improvement for now._

**EXPLAIN ANALYZE SELECT COUNT(id) FROM blocks;**
```
 Finalize Aggregate  (cost=298772.77..298772.78 rows=1 width=8) (actual time=2079.334..2079.334 rows=1 loops=1)
   ->  Gather  (cost=298772.55..298772.76 rows=2 width=8) (actual time=2079.232..2087.596 rows=3 loops=1)
         Workers Planned: 2
         Workers Launched: 2
         ->  Partial Aggregate  (cost=297772.55..297772.56 rows=1 width=8) (actual time=2074.550..2074.550 rows=1 loops=3)
               ->  Parallel Index Only Scan using blocks_pkey on blocks  (cost=0.56..288371.32 rows=3760492 width=24) (actual time=0.068..1678.611 rows=3009111 loops=3)
                     Heap Fetches: 311
 Planning time: 0.149 ms
 Execution time: 2087.720 ms
(9 rows)
```

**EXPLAIN ANALYZE SELECT COUNT(*) FROM (SELECT id FROM blocks) AS count;**
```
 Finalize Aggregate  (cost=192153.71..192153.72 rows=1 width=8) (actual time=1095.040..1095.041 rows=1 loops=1)
   ->  Gather  (cost=192153.49..192153.70 rows=2 width=8) (actual time=1094.962..1101.561 rows=3 loops=1)
         Workers Planned: 2
         Workers Launched: 2
         ->  Partial Aggregate  (cost=191153.49..191153.50 rows=1 width=8) (actual time=1086.913..1086.914 rows=1 loops=3)
               ->  Parallel Index Only Scan using blocks_timestamp_key on blocks  (cost=0.43..181752.26 rows=3760492 width=0) (actual time=0.085..719.661 rows=3009114 loops=3)
                     Heap Fetches: 366
 Planning time: 0.135 ms
 Execution time: 1101.631 ms
(9 rows)
```

Tested on a 4 CPU / 16 GB RAM / 160GB NVME server so results will vary between servers.

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactor
- [x] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Does this PR release a new version?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `develop` branch, _not_ the `master` branch
- [x] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
