### PR TITLE
refactor(core-state): wallet model cleanup

### DIFF
--- a/__tests__/functional/transaction-forging/__support__/index.ts
+++ b/__tests__/functional/transaction-forging/__support__/index.ts
@@ -1,6 +1,7 @@
 import "jest-extended";
 
 import { Container, Database, State } from "@arkecosystem/core-interfaces";
+import { Wallets } from "@arkecosystem/core-state";
 import { Identities, Managers, Utils } from "@arkecosystem/crypto";
 import delay from "delay";
 import { secrets } from "../../../utils/config/testnet/delegates.json";
@@ -29,13 +30,16 @@ export const setUp = async (): Promise<void> => {
         await databaseService.reset();
         await databaseService.buildWallets();
         await databaseService.saveRound(
-            secrets.map(
-                secret =>
-                    ({
-                        round: 1,
-                        publicKey: Identities.PublicKey.fromPassphrase(secret),
-                        voteBalance: Utils.BigNumber.make("245098000000000"),
-                    } as State.IDelegateWallet),
+            secrets.map(secret =>
+                Object.assign(new Wallets.Wallet(Identities.Address.fromPassphrase(secret)), {
+                    publicKey: Identities.PublicKey.fromPassphrase(secret),
+                    attributes: {
+                        delegate: {
+                            voteBalance: Utils.BigNumber.make("245098000000000"),
+                            round: 1,
+                        },
+                    },
+                }),
             ),
         );
     } catch (error) {

--- a/__tests__/integration/core-api/__support__/setup.ts
+++ b/__tests__/integration/core-api/__support__/setup.ts
@@ -1,5 +1,6 @@
 import { app } from "@arkecosystem/core-container";
 import { Database, State } from "@arkecosystem/core-interfaces";
+import { Utils } from "@arkecosystem/crypto";
 import delay from "delay";
 import { defaults } from "../../../../packages/core-api/src/defaults";
 import { plugin } from "../../../../packages/core-api/src/plugin";
@@ -55,13 +56,13 @@ const calculateRanks = async () => {
     const databaseService = app.resolvePlugin<Database.IDatabaseService>("database");
 
     const delegateWallets = Object.values(databaseService.walletManager.allByUsername()).sort(
-        (a: State.IWallet, b: State.IWallet) => b.voteBalance.comparedTo(a.voteBalance),
+        (a: State.IWallet, b: State.IWallet) => b.getAttribute<Utils.BigNumber>("delegate.voteBalance").comparedTo(a.getAttribute<Utils.BigNumber>("delegate.voteBalance")),
     );
 
     // tslint:disable-next-line: ban
     sortBy(delegateWallets, "publicKey").forEach((delegate, i) => {
         const wallet = databaseService.walletManager.findByPublicKey(delegate.publicKey);
-        (wallet as any).rate = i + 1;
+        wallet.setAttribute("delegate.rank", i + 1);
 
         databaseService.walletManager.reindex(wallet);
     });

--- a/__tests__/integration/core-api/__support__/utils/generate-round.ts
+++ b/__tests__/integration/core-api/__support__/utils/generate-round.ts
@@ -1,9 +1,17 @@
+import { Wallets } from "@arkecosystem/core-state";
 import { Utils } from "@arkecosystem/crypto";
+import { Identities } from "@arkecosystem/crypto/src";
 
-export function generateRound(delegates, round) {
-    return delegates.map(delegate => ({
-        round,
-        publicKey: delegate,
-        voteBalance: Utils.BigNumber.make("245098000000000"),
-    }));
-}
+export const generateRound = (delegates, round) => {
+    return delegates.map(delegate =>
+        Object.assign(new Wallets.Wallet(Identities.Address.fromPublicKey(delegate)), {
+            attributes: {
+                delegate: {
+                    round,
+                    voteBalance: Utils.BigNumber.make("245098000000000"),
+                },
+            },
+            publicKey: delegate,
+        }),
+    );
+};

--- a/__tests__/integration/core-blockchain/blockchain.test.ts
+++ b/__tests__/integration/core-blockchain/blockchain.test.ts
@@ -184,12 +184,12 @@ describe("Blockchain", () => {
             // overwritten in afterEach
             // FIXME: wallet.lastBlock needs to be properly restored when reverting
             for (const forger of forgingDelegates) {
-                forger.unsetAttribute("delegate.lastBlock");
+                forger.forgetAttribute("delegate.lastBlock");
             }
 
             expect(forgingDelegates).toEqual(
                 (blockchain.database as any).forgingDelegates.map(forger => {
-                    forger.unsetAttribute("delegate.lastBlock");
+                    forger.forgetAttribute("delegate.lastBlock");
                     return forger;
                 }),
             );

--- a/__tests__/integration/core-blockchain/blockchain.test.ts
+++ b/__tests__/integration/core-blockchain/blockchain.test.ts
@@ -177,12 +177,12 @@ describe("Blockchain", () => {
             // overwritten in afterEach
             // FIXME: wallet.lastBlock needs to be properly restored when reverting
             for (const forger of forgingDelegates) {
-                forger.lastBlock = undefined;
+                forger.unsetAttribute("delegate.lastBlock");
             }
 
             expect(forgingDelegates).toEqual(
                 (blockchain.database as any).forgingDelegates.map(forger => {
-                    forger.lastBlock = undefined;
+                    forger.unsetAttribute("delegate.lastBlock");
                     return forger;
                 }),
             );
@@ -234,7 +234,7 @@ describe("Blockchain", () => {
                 reward: Utils.BigNumber.ZERO,
                 payloadLength: 32 * transactions.length,
                 payloadHash: Crypto.HashAlgorithms.sha256(transactionData.ids).toString("hex"),
-                transactions: transactions,
+                transactions,
             };
 
             return Blocks.BlockFactory.make(data, Identities.Keys.fromPassphrase(generatorKeys.secret));
@@ -248,7 +248,7 @@ describe("Blockchain", () => {
             const recipient = Identities.Address.fromPublicKey(keyPair.publicKey);
 
             let nextForger = await getNextForger();
-            const initialVoteBalance = nextForger.voteBalance;
+            const initialVoteBalance: Utils.BigNumber = nextForger.getAttribute("delegate.voteBalance");
 
             // First send funds to new voter wallet
             const forgerKeys = delegates.find(wallet => wallet.publicKey === nextForger.publicKey);
@@ -266,7 +266,7 @@ describe("Blockchain", () => {
             // New wallet received funds and vote balance of delegate has been reduced by the same amount,
             // since it forged it's own transaction the fees for the transaction have been recovered.
             expect(wallet.balance).toEqual(transfer.amount);
-            expect(walletForger.voteBalance).toEqual(initialVoteBalance.minus(transfer.amount));
+            expect(walletForger.getAttribute<Utils.BigNumber>("delegate.voteBalance")).toEqual(initialVoteBalance.minus(transfer.amount));
 
             // Now vote with newly created wallet for previous forger.
             const vote = TransactionFactory.vote(forgerKeys.publicKey)
@@ -283,11 +283,11 @@ describe("Blockchain", () => {
 
             // Wallet paid a fee of 1 and the vote has been placed.
             expect(wallet.balance).toEqual(Utils.BigNumber.make(124));
-            expect(wallet.vote).toEqual(forgerKeys.publicKey);
+            expect(wallet.getAttribute<string>("vote")).toEqual(forgerKeys.publicKey);
 
             // Vote balance of delegate now equals initial vote balance minus 1 for the vote fee
             // since it was forged by a different delegate.
-            expect(walletForger.voteBalance).toEqual(initialVoteBalance.minus(vote.fee));
+            expect(walletForger.getAttribute<Utils.BigNumber>("delegate.voteBalance")).toEqual(initialVoteBalance.minus(vote.fee));
 
             // Now unvote again
             const unvote = TransactionFactory.unvote(forgerKeys.publicKey)
@@ -304,17 +304,17 @@ describe("Blockchain", () => {
 
             // Wallet paid a fee of 1 and no longer voted a delegate
             expect(wallet.balance).toEqual(Utils.BigNumber.make(123));
-            expect(wallet.vote).toBeUndefined();
+            expect(wallet.hasVoted()).toBeFalse();
 
             // Vote balance of delegate now equals initial vote balance minus the amount sent to the voter wallet.
-            expect(walletForger.voteBalance).toEqual(initialVoteBalance.minus(transfer.amount));
+            expect(walletForger.getAttribute<Utils.BigNumber>("delegate.voteBalance")).toEqual(initialVoteBalance.minus(transfer.amount));
 
             // Now rewind 3 blocks back to the initial state
             await blockchain.removeBlocks(3);
 
             // Wallet is now a cold wallet and the initial vote balance has been restored.
             expect(wallet.balance).toEqual(Utils.BigNumber.ZERO);
-            expect(walletForger.voteBalance).toEqual(initialVoteBalance);
+            expect(walletForger.getAttribute<Utils.BigNumber>("delegate.voteBalance")).toEqual(initialVoteBalance);
         });
     });
 

--- a/__tests__/integration/core-blockchain/blockchain.test.ts
+++ b/__tests__/integration/core-blockchain/blockchain.test.ts
@@ -35,7 +35,14 @@ const resetToHeight1 = async () => {
         const generator = Identities.Address.fromPublicKey(genesisBlock.data.generatorPublicKey);
         const genesis = new Wallets.Wallet(generator);
         genesis.publicKey = genesisBlock.data.generatorPublicKey;
-        genesis.username = "genesis";
+        genesis.setAttribute("delegate", {
+            username: "genesis",
+            voteBalance: Utils.BigNumber.ZERO,
+            producedBlocks: Utils.BigNumber.ZERO,
+            forgedFees: Utils.BigNumber.ZERO,
+            forgedRewards: Utils.BigNumber.ZERO,
+        });
+
         blockchain.database.walletManager.reindex(genesis);
 
         blockchain.state.clear();
@@ -266,7 +273,9 @@ describe("Blockchain", () => {
             // New wallet received funds and vote balance of delegate has been reduced by the same amount,
             // since it forged it's own transaction the fees for the transaction have been recovered.
             expect(wallet.balance).toEqual(transfer.amount);
-            expect(walletForger.getAttribute<Utils.BigNumber>("delegate.voteBalance")).toEqual(initialVoteBalance.minus(transfer.amount));
+            expect(walletForger.getAttribute<Utils.BigNumber>("delegate.voteBalance")).toEqual(
+                initialVoteBalance.minus(transfer.amount),
+            );
 
             // Now vote with newly created wallet for previous forger.
             const vote = TransactionFactory.vote(forgerKeys.publicKey)
@@ -287,7 +296,9 @@ describe("Blockchain", () => {
 
             // Vote balance of delegate now equals initial vote balance minus 1 for the vote fee
             // since it was forged by a different delegate.
-            expect(walletForger.getAttribute<Utils.BigNumber>("delegate.voteBalance")).toEqual(initialVoteBalance.minus(vote.fee));
+            expect(walletForger.getAttribute<Utils.BigNumber>("delegate.voteBalance")).toEqual(
+                initialVoteBalance.minus(vote.fee),
+            );
 
             // Now unvote again
             const unvote = TransactionFactory.unvote(forgerKeys.publicKey)
@@ -307,7 +318,9 @@ describe("Blockchain", () => {
             expect(wallet.hasVoted()).toBeFalse();
 
             // Vote balance of delegate now equals initial vote balance minus the amount sent to the voter wallet.
-            expect(walletForger.getAttribute<Utils.BigNumber>("delegate.voteBalance")).toEqual(initialVoteBalance.minus(transfer.amount));
+            expect(walletForger.getAttribute<Utils.BigNumber>("delegate.voteBalance")).toEqual(
+                initialVoteBalance.minus(transfer.amount),
+            );
 
             // Now rewind 3 blocks back to the initial state
             await blockchain.removeBlocks(3);

--- a/__tests__/integration/core-transaction-pool/processor.test.ts
+++ b/__tests__/integration/core-transaction-pool/processor.test.ts
@@ -453,8 +453,8 @@ describe("Transaction Guard", () => {
             const wallet1 = transactionPool.walletManager.findByPublicKey(wallets[14].keys.publicKey);
             const wallet2 = transactionPool.walletManager.findByPublicKey(wallets[15].keys.publicKey);
 
-            expect(wallet1.username).toBe(undefined);
-            expect(wallet2.username).toBe(undefined);
+            expect(wallet1.isDelegate()).toBeFalse();
+            expect(wallet2.isDelegate()).toBeFalse();
         });
 
         it("should not validate a transaction if a second signature registration for the same wallet exists in the pool", async () => {

--- a/__tests__/unit/core-blockchain/mocks/database.ts
+++ b/__tests__/unit/core-blockchain/mocks/database.ts
@@ -2,7 +2,7 @@ export const database = {
     restoredDatabaseIntegrity: true,
 
     walletManager: {
-        findByPublicKey: pubKey => "username",
+        findByPublicKey: pubKey => ({ getAttribute: () => "username" }),
         revertBlock: () => undefined,
     },
 

--- a/__tests__/unit/core-database/database-service.test.ts
+++ b/__tests__/unit/core-database/database-service.test.ts
@@ -194,9 +194,9 @@ describe("Database Service", () => {
             for (const transaction of genesisBlock.transactions) {
                 if (transaction.type === TransactionTypes.DelegateRegistration) {
                     const wallet = walletManager.findByPublicKey(transaction.data.senderPublicKey);
-                    wallet.username = Transactions.TransactionFactory.fromBytes(
+                    wallet.setAttribute("delegate.username", Transactions.TransactionFactory.fromBytes(
                         transaction.serialized,
-                    ).data.asset.delegate.username;
+                    ).data.asset.delegate.username);
                     wallet.address = Identities.Address.fromPublicKey(transaction.data.senderPublicKey);
                     walletManager.reindex(wallet);
                 }
@@ -238,7 +238,7 @@ describe("Database Service", () => {
                     .build();
 
                 // Vote for delegate
-                walletManager.findByPublicKey(voterKeys.publicKey).vote = delegatesRound2[i].publicKey;
+                walletManager.findByPublicKey(voterKeys.publicKey).setAttribute("vote", delegatesRound2[i].publicKey);
 
                 const block = BlockFactory.make(
                     {
@@ -267,7 +267,7 @@ describe("Database Service", () => {
             const roundInfo2 = roundCalculator.calculateRound(initialHeight + 51);
             const delegatesRound3 = walletManager.loadActiveDelegateList(roundInfo2);
             for (let i = 0; i < delegatesRound3.length; i++) {
-                expect(delegatesRound3[i].rate).toBe(i + 1);
+                expect(delegatesRound3[i].getAttribute<number>("delegate.rank")).toBe(i + 1);
                 expect(delegatesRound3[i].publicKey).toBe(delegatesRound2[delegatesRound3.length - i - 1].publicKey);
             }
 
@@ -284,10 +284,10 @@ describe("Database Service", () => {
             });
 
             // Finally recalculate the round 2 list and compare against the original list
-            const restoredDelegatesRound2 = await (databaseService as any).calcPreviousActiveDelegates(roundInfo2);
+            const restoredDelegatesRound2: State.IWallet[] = await (databaseService as any).calcPreviousActiveDelegates(roundInfo2);
 
             for (let i = 0; i < restoredDelegatesRound2.length; i++) {
-                expect(restoredDelegatesRound2[i].rate).toBe(i + 1);
+                expect(restoredDelegatesRound2[i].getAttribute<number>("delegate.rank")).toBe(i + 1);
                 expect(restoredDelegatesRound2[i].publicKey).toBe(delegatesRound2[i].publicKey);
             }
 

--- a/__tests__/unit/core-database/repositories/delegates-business-repository.test.ts
+++ b/__tests__/unit/core-database/repositories/delegates-business-repository.test.ts
@@ -49,7 +49,7 @@ const generateWallets = (): Wallet[] => {
                     voteBalance: Utils.BigNumber.make(200),
                     rank: index + 1,
                 },
-            }
+            },
         });
     });
 };
@@ -88,8 +88,10 @@ describe("Delegate Repository", () => {
             const { rows } = repository.search({ forgedTotal: undefined });
 
             for (const delegate of rows) {
-                expect(delegate.hasOwnProperty("forgedTotal"));
-                expect(delegate.forgedTotal).toBe(delegateCalculator.calculateForgedTotal(delegate));
+                expect(delegate.hasAttribute("delegate.forgedTotal")).toBeTrue();
+                expect(delegate.getAttribute("delegate.forgedTotal")).toBe(
+                    delegateCalculator.calculateForgedTotal(delegate),
+                );
             }
         });
 
@@ -147,7 +149,7 @@ describe("Delegate Repository", () => {
 
                 expect(count).toBe(1);
                 expect(rows).toHaveLength(1);
-                expect(rows[0].username).toEqual(username);
+                expect(rows[0].getAttribute("delegate.username")).toEqual(username);
             });
 
             it("should search that username contains the string", () => {
@@ -167,7 +169,7 @@ describe("Delegate Repository", () => {
 
                     expect(count).toBe(1);
                     expect(rows).toHaveLength(1);
-                    expect(rows[0].username).toEqual(username);
+                    expect(rows[0].getAttribute("delegate.username")).toEqual(username);
                 });
             });
 
@@ -234,7 +236,7 @@ describe("Delegate Repository", () => {
                 expect(rows).toHaveLength(3);
 
                 for (const row of rows) {
-                    expect(usernames.includes(row.username)).toBeTrue();
+                    expect(usernames.includes(row.getAttribute("delegate.username"))).toBeTrue();
                 }
             });
 
@@ -248,7 +250,7 @@ describe("Delegate Repository", () => {
 
                     expect(count).toBe(1);
                     expect(rows).toHaveLength(1);
-                    expect(rows[0].username).toEqual(usernames[0]);
+                    expect(rows[0].getAttribute("delegate.username")).toEqual(usernames[0]);
                 });
             });
 
@@ -355,11 +357,13 @@ describe("Delegate Repository", () => {
             const wallets = generateWallets();
             walletManager.index(wallets);
 
-            const wallet = repository.findById(wallets[0][key]);
+            const id: string = key === "username" ? wallets[0].getAttribute("delegate.username") : wallets[0][key];
+
+            const wallet = repository.findById(id);
             expect(wallet).toBeObject();
             expect(wallet.address).toBe(wallets[0].address);
             expect(wallet.publicKey).toBe(wallets[0].publicKey);
-            expect(wallet.username).toBe(wallets[0].getAttribute("delegate.username"));
+            expect(wallet.getAttribute("delegate.username")).toBe(wallets[0].getAttribute("delegate.username"));
         };
 
         it("should be ok with an address", () => {

--- a/__tests__/unit/core-database/repositories/delegates-business-repository.test.ts
+++ b/__tests__/unit/core-database/repositories/delegates-business-repository.test.ts
@@ -38,16 +38,19 @@ const generateWallets = (): Wallet[] => {
         // @TODO: switch to unitnet
         const address: string = Address.fromPublicKey(transaction.data.senderPublicKey, 23);
 
-        return {
-            address,
-            publicKey: `publicKey-${address}`,
-            secondPublicKey: `secondPublicKey-${address}`,
-            vote: `vote-${address}`,
-            username: `username-${address}`,
+        return Object.assign(new Wallet(address), {
             balance: Utils.BigNumber.make(100),
-            voteBalance: Utils.BigNumber.make(200),
-            rate: index + 1,
-        } as Wallet;
+            publicKey: `publicKey-${address}`,
+            attributes: {
+                secondPublicKey: `secondPublicKey-${address}`,
+                vote: `vote-${address}`,
+                delegate: {
+                    username: `username-${address}`,
+                    voteBalance: Utils.BigNumber.make(200),
+                    rank: index + 1,
+                },
+            }
+        });
     });
 };
 
@@ -61,7 +64,7 @@ describe("Delegate Repository", () => {
 
         const wallets = [delegates[0], {}, delegates[1], { username: "" }, delegates[2], {}].map(delegate => {
             const wallet = new Wallet("");
-            return Object.assign(wallet, delegate);
+            return Object.assign(wallet, { attributes: { delegate } });
         });
 
         beforeEach(() => {
@@ -157,7 +160,7 @@ describe("Delegate Repository", () => {
             describe('when a username is "undefined"', () => {
                 it("should return it", () => {
                     // Index a wallet with username "undefined"
-                    walletManager.allByAddress()[0].username = "undefined";
+                    walletManager.allByAddress()[0].setAttribute("delegate", { username: "undefined" });
 
                     const username = "undefined";
                     const { count, rows } = repository.search({ username });
@@ -238,7 +241,7 @@ describe("Delegate Repository", () => {
             describe('when a username is "undefined"', () => {
                 it("should return it", () => {
                     // Index a wallet with username "undefined"
-                    walletManager.allByAddress()[0].username = "undefined";
+                    walletManager.allByAddress()[0].setAttribute("delegate", { username: "undefined" });
 
                     const usernames = ["undefined"];
                     const { count, rows } = repository.search({ usernames });
@@ -337,7 +340,7 @@ describe("Delegate Repository", () => {
             describe('when a username is "undefined"', () => {
                 it("should return all results", () => {
                     // Index a wallet with username "undefined"
-                    walletManager.allByAddress()[0].username = "undefined";
+                    walletManager.allByAddress()[0].setAttribute("delegate", { username: "undefined" });
 
                     const { count, rows } = repository.search({});
                     expect(count).toBe(52);
@@ -356,7 +359,7 @@ describe("Delegate Repository", () => {
             expect(wallet).toBeObject();
             expect(wallet.address).toBe(wallets[0].address);
             expect(wallet.publicKey).toBe(wallets[0].publicKey);
-            expect(wallet.username).toBe(wallets[0].username);
+            expect(wallet.username).toBe(wallets[0].getAttribute("delegate.username"));
         };
 
         it("should be ok with an address", () => {

--- a/__tests__/unit/core-database/repositories/wallets-business-repository.test.ts
+++ b/__tests__/unit/core-database/repositories/wallets-business-repository.test.ts
@@ -300,11 +300,12 @@ describe("Wallet Repository", () => {
             const wallets = generateFullWallets();
             walletManager.index(wallets);
 
-            const wallet = repository.findById(wallets[0][key]);
+            const id: string = key === "username" ? wallets[0].getAttribute("delegate.username") : wallets[0][key];
+            const wallet: State.IWallet = repository.findById(id);
             expect(wallet).toBeObject();
             expect(wallet.address).toBe(wallets[0].address);
             expect(wallet.publicKey).toBe(wallets[0].publicKey);
-            expect(wallet.username).toBe(wallets[0].getAttribute("delegate.username"));
+            expect(wallet.getAttribute("delegate.username")).toBe(wallets[0].getAttribute("delegate.username"));
         };
 
         it("should be ok with an address", () => {

--- a/__tests__/unit/core-state/wallets/temp-wallet-manager.test.ts
+++ b/__tests__/unit/core-state/wallets/temp-wallet-manager.test.ts
@@ -59,11 +59,11 @@ describe("TempWalletManager", () => {
     describe("findByUsername", () => {
         it("should return a copy", () => {
             const wallet = new Wallet(walletData1.address);
-            wallet.username = "test";
+            wallet.setAttribute("delegate", { username: "test" });
             walletManager.reindex(wallet);
 
             const tempWalletManager = walletManager.clone();
-            const tempWallet = tempWalletManager.findByUsername(wallet.username);
+            const tempWallet = tempWalletManager.findByUsername(wallet.getAttribute("delegate.username"));
             tempWallet.balance = Utils.BigNumber.ONE;
 
             expect(wallet.balance).not.toEqual(tempWallet.balance);
@@ -94,11 +94,11 @@ describe("TempWalletManager", () => {
     describe("hasByUsername", () => {
         it("should be ok", () => {
             const wallet = new Wallet(walletData1.address);
-            wallet.username = "test";
+            wallet.setAttribute("delegate", { username: "test" });
             walletManager.reindex(wallet);
 
             const tempWalletManager = walletManager.clone();
-            expect(tempWalletManager.hasByUsername(wallet.username)).toBeTrue();
+            expect(tempWalletManager.hasByUsername(wallet.getAttribute("delegate.username"))).toBeTrue();
         });
     });
 });

--- a/__tests__/unit/core-state/wallets/wallet-manager.test.ts
+++ b/__tests__/unit/core-state/wallets/wallet-manager.test.ts
@@ -197,9 +197,6 @@ describe("Wallet Manager", () => {
 
                 walletManager.reindex(sender);
                 walletManager.reindex(recipient);
-
-                // @ts-ignore
-                jest.spyOn(walletManager, "isDelegate").mockReturnValue(true);
             });
 
             it("should apply the transaction to the sender & recipient", async () => {
@@ -539,7 +536,7 @@ describe("Wallet Manager", () => {
 
             for (let i = 0; i < 5; i++) {
                 const delegate = delegates[i];
-                expect(delegate.rate).toEqual(i + 1);
+                expect(delegate.rank).toEqual(i + 1);
                 expect(delegate.voteBalance).toEqual(Utils.BigNumber.make((5 - i) * 1000 * SATOSHI));
             }
         });

--- a/__tests__/unit/core-state/wallets/wallet-manager.test.ts
+++ b/__tests__/unit/core-state/wallets/wallet-manager.test.ts
@@ -64,7 +64,7 @@ describe("Wallet Manager", () => {
         }
 
         beforeEach(() => {
-            delegateMock = { applyBlock: jest.fn(), publicKey: delegatePublicKey };
+            delegateMock = { applyBlock: jest.fn(), publicKey: delegatePublicKey, isDelegate: () => false };
             // @ts-ignore
             jest.spyOn(walletManager, "findByPublicKey").mockReturnValue(delegateMock);
             jest.spyOn(walletManager, "applyTransaction").mockImplementation();
@@ -185,8 +185,8 @@ describe("Wallet Manager", () => {
             ${"2nd sign"} | ${secondSign}  | ${Utils.BigNumber.ZERO}        | ${Utils.BigNumber.make(10 * SATOSHI)} | ${Utils.BigNumber.ONE}
             ${"vote"}     | ${vote}        | ${Utils.BigNumber.ZERO}        | ${Utils.BigNumber.make(5 * SATOSHI)}  | ${Utils.BigNumber.ONE}
         `("when the transaction is a $type", ({ type, transaction, amount, balanceSuccess, balanceFail }) => {
-            let sender;
-            let recipient;
+            let sender: State.IWallet;
+            let recipient: State.IWallet;
 
             beforeEach(() => {
                 sender = new Wallet(walletData1.address);
@@ -204,6 +204,10 @@ describe("Wallet Manager", () => {
 
                 expect(+sender.balance.toFixed()).toBe(+balanceSuccess);
                 expect(+recipient.balance.toFixed()).toBe(0);
+
+                if (type === "vote") {
+                    recipient.setAttribute("delegate", {});
+                }
 
                 await walletManager.applyTransaction(transaction);
 
@@ -258,10 +262,12 @@ describe("Wallet Manager", () => {
             const voterKeys = Identities.Keys.fromPassphrase("secret");
 
             const delegate = walletManager.findByPublicKey(delegateKeys.publicKey);
-            delegate.username = "unittest";
             delegate.balance = Utils.BigNumber.make(100_000_000);
-            delegate.vote = delegate.publicKey;
-            delegate.voteBalance = delegate.balance;
+            delegate.setAttribute("delegate", {
+                username: "unittest",
+                voteBalance: delegate.balance,
+            });
+            delegate.setAttribute("vote", delegate.publicKey);
             walletManager.reindex(delegate);
 
             const voter = walletManager.findByPublicKey(voterKeys.publicKey);
@@ -275,18 +281,17 @@ describe("Wallet Manager", () => {
                 .build();
 
             expect(delegate.balance).toEqual(Utils.BigNumber.make(100_000_000));
-            expect(delegate.voteBalance).toEqual(Utils.BigNumber.make(100_000_000));
+            expect(delegate.getAttribute<Utils.BigNumber>("delegate.voteBalance")).toEqual(Utils.BigNumber.make(100_000_000));
             expect(voter.balance).toEqual(Utils.BigNumber.make(100_000));
 
             walletManager.applyTransaction(voteTransaction);
 
             expect(voter.balance).toEqual(Utils.BigNumber.make(100_000).minus(voteTransaction.data.fee));
-            expect(delegate.voteBalance).toEqual(Utils.BigNumber.make(100_000_000).plus(voter.balance));
-
+            expect(delegate.getAttribute<Utils.BigNumber>("delegate.voteBalance")).toEqual(Utils.BigNumber.make(100_000_000).plus(voter.balance));
             walletManager.revertTransaction(voteTransaction);
 
             expect(voter.balance).toEqual(Utils.BigNumber.make(100_000));
-            expect(delegate.voteBalance).toEqual(Utils.BigNumber.make(100_000_000));
+            expect(delegate.getAttribute<Utils.BigNumber>("delegate.voteBalance")).toEqual(Utils.BigNumber.make(100_000_000));
         });
 
         it("should revert unvote transaction and correctly update vote balances", async () => {
@@ -294,10 +299,12 @@ describe("Wallet Manager", () => {
             const voterKeys = Identities.Keys.fromPassphrase("secret");
 
             const delegate = walletManager.findByPublicKey(delegateKeys.publicKey);
-            delegate.username = "unittest";
             delegate.balance = Utils.BigNumber.make(100_000_000);
-            delegate.vote = delegate.publicKey;
-            delegate.voteBalance = delegate.balance;
+            delegate.setAttribute("delegate", {
+                username: "unittest",
+                voteBalance: delegate.balance,
+            });
+            delegate.setAttribute("vote", delegate.publicKey);
             walletManager.reindex(delegate);
 
             const voter = walletManager.findByPublicKey(voterKeys.publicKey);
@@ -311,13 +318,13 @@ describe("Wallet Manager", () => {
                 .build();
 
             expect(delegate.balance).toEqual(Utils.BigNumber.make(100_000_000));
-            expect(delegate.voteBalance).toEqual(Utils.BigNumber.make(100_000_000));
+            expect(delegate.getAttribute<Utils.BigNumber>("delegate.voteBalance")).toEqual(Utils.BigNumber.make(100_000_000));
             expect(voter.balance).toEqual(Utils.BigNumber.make(100_000));
 
             walletManager.applyTransaction(voteTransaction);
 
             expect(voter.balance).toEqual(Utils.BigNumber.make(100_000).minus(voteTransaction.data.fee));
-            expect(delegate.voteBalance).toEqual(Utils.BigNumber.make(100_000_000).plus(voter.balance));
+            expect(delegate.getAttribute<Utils.BigNumber>("delegate.voteBalance")).toEqual(Utils.BigNumber.make(100_000_000).plus(voter.balance));
 
             const unvoteTransaction = Transactions.BuilderFactory.vote()
                 .votesAsset([`-${delegateKeys.publicKey}`])
@@ -333,12 +340,12 @@ describe("Wallet Manager", () => {
                     .minus(voteTransaction.data.fee)
                     .minus(unvoteTransaction.data.fee),
             );
-            expect(delegate.voteBalance).toEqual(Utils.BigNumber.make(100_000_000));
+            expect(delegate.getAttribute<Utils.BigNumber>("delegate.voteBalance")).toEqual(Utils.BigNumber.make(100_000_000));
 
             walletManager.revertTransaction(unvoteTransaction);
 
             expect(voter.balance).toEqual(Utils.BigNumber.make(100_000).minus(voteTransaction.data.fee));
-            expect(delegate.voteBalance).toEqual(Utils.BigNumber.make(100_000_000).plus(voter.balance));
+            expect(delegate.getAttribute<Utils.BigNumber>("delegate.voteBalance")).toEqual(Utils.BigNumber.make(100_000_000).plus(voter.balance));
         });
     });
 
@@ -364,10 +371,10 @@ describe("Wallet Manager", () => {
     describe("findByUsername", () => {
         it("should return it by username", () => {
             const wallet = new Wallet(walletData1.address);
-            wallet.username = "dummy-username";
+            wallet.setAttribute("delegate.username", "dummy-username");
 
             walletManager.reindex(wallet);
-            expect(walletManager.findByUsername(wallet.username).username).toBe(wallet.username);
+            expect(walletManager.findByUsername("dummy-username").getAttribute<string>("delegate.username")).toBe("dummy-username");
         });
     });
 
@@ -392,25 +399,25 @@ describe("Wallet Manager", () => {
 
         it("should not be removed if wallet.secondPublicKey is set", async () => {
             const wallet = new Wallet(walletData1.address);
-            wallet.secondPublicKey = "secondPublicKey";
+            wallet.setAttribute("secondPublicKey", "secondPublicKey");
 
-            expect(wallet.secondPublicKey).toBe("secondPublicKey");
+            expect(wallet.getAttribute<string>("secondPublicKey")).toBe("secondPublicKey");
             expect(walletManager.canBePurged(wallet)).toBeFalse();
         });
 
         it("should not be removed if wallet.multisignature is set", async () => {
             const wallet = new Wallet(walletData1.address);
-            wallet.multisignature = {} as Interfaces.IMultiSignatureAsset;
+            wallet.setAttribute("multiSignature", {});
 
-            expect(wallet.multisignature).toEqual({});
+            expect(wallet.getAttribute("multiSignature")).toEqual({});
             expect(walletManager.canBePurged(wallet)).toBeFalse();
         });
 
         it("should not be removed if wallet.username is set", async () => {
             const wallet = new Wallet(walletData1.address);
-            wallet.username = "username";
+            wallet.setAttribute("delegate.username", "username");
 
-            expect(wallet.username).toBe("username");
+            expect(wallet.getAttribute<string>("delegate.username")).toBe("username");
             expect(walletManager.canBePurged(wallet)).toBeFalse();
         });
     });
@@ -422,7 +429,7 @@ describe("Wallet Manager", () => {
             walletManager.reindex(wallet1);
 
             const wallet2 = new Wallet(walletData2.address);
-            wallet2.username = "username";
+            wallet2.setAttribute("delegate.username", "username");
 
             walletManager.reindex(wallet2);
 
@@ -434,11 +441,11 @@ describe("Wallet Manager", () => {
         it("should not be purged if wallet.secondPublicKey is set", async () => {
             const wallet1 = new Wallet(walletData1.address);
             wallet1.publicKey = "dummy-1-publicKey";
-            wallet1.secondPublicKey = "dummy-1-secondPublicKey";
+            wallet1.setAttribute("secondPublicKey", "dummy-1-secondPublicKey");
             walletManager.reindex(wallet1);
 
             const wallet2 = new Wallet(walletData2.address);
-            wallet2.username = "username";
+            wallet2.setAttribute("delegate.username", "username");
 
             walletManager.reindex(wallet2);
 
@@ -450,11 +457,11 @@ describe("Wallet Manager", () => {
         it("should not be purged if wallet.multisignature is set", async () => {
             const wallet1 = new Wallet(walletData1.address);
             wallet1.publicKey = "dummy-1-publicKey";
-            wallet1.multisignature = {} as Interfaces.IMultiSignatureAsset;
+            wallet1.setAttribute("multiSignature", {});
             walletManager.reindex(wallet1);
 
             const wallet2 = new Wallet(walletData2.address);
-            wallet2.username = "username";
+            wallet2.setAttribute("delegate.username", "username");
 
             walletManager.reindex(wallet2);
 
@@ -466,11 +473,11 @@ describe("Wallet Manager", () => {
         it("should not be purged if wallet.username is set", async () => {
             const wallet1 = new Wallet(walletData1.address);
             wallet1.publicKey = "dummy-1-publicKey";
-            wallet1.username = "dummy-1-username";
+            wallet1.setAttribute("delegate", {});
             walletManager.reindex(wallet1);
 
             const wallet2 = new Wallet(walletData2.address);
-            wallet2.username = "username";
+            wallet2.setAttribute("delegate", {});
 
             walletManager.reindex(wallet2);
 
@@ -486,15 +493,15 @@ describe("Wallet Manager", () => {
                 const delegateKey = i.toString().repeat(66);
                 const delegate = new Wallet(Address.fromPublicKey(delegateKey));
                 delegate.publicKey = delegateKey;
-                delegate.username = `delegate${i}`;
-                delegate.voteBalance = Utils.BigNumber.ZERO;
+                delegate.setAttribute("delegate.username", `delegate${i}`);
+                delegate.setAttribute("delegate.voteBalance", Utils.BigNumber.ZERO);
 
                 const voter = new Wallet(Address.fromPublicKey((i + 5).toString().repeat(66)));
                 voter.balance = Utils.BigNumber.make(i + 1)
                     .times(1000)
                     .times(SATOSHI);
                 voter.publicKey = `v${delegateKey}`;
-                voter.vote = delegateKey;
+                voter.setAttribute("vote", delegateKey);
 
                 walletManager.index([delegate, voter]);
             }
@@ -504,7 +511,7 @@ describe("Wallet Manager", () => {
             const delegates = walletManager.allByUsername();
             for (let i = 0; i < 5; i++) {
                 const delegate = delegates[4 - i];
-                expect(delegate.voteBalance).toEqual(
+                expect(delegate.getAttribute<Utils.BigNumber>("delegate.voteBalance")).toEqual(
                     Utils.BigNumber.make(5 - i)
                         .times(1000)
                         .times(SATOSHI),
@@ -519,13 +526,13 @@ describe("Wallet Manager", () => {
                 const delegateKey = i.toString().repeat(66);
                 const delegate = new Wallet(Identities.Address.fromPublicKey(delegateKey));
                 delegate.publicKey = delegateKey;
-                delegate.username = `delegate${i}`;
-                delegate.voteBalance = Utils.BigNumber.ZERO;
+                delegate.setAttribute("delegate.username", `delegate${i}`);
+                delegate.setAttribute("delegate.voteBalance", Utils.BigNumber.ZERO);
 
                 const voter = new Wallet(Identities.Address.fromPublicKey((i + 5).toString().repeat(66)));
                 voter.balance = Utils.BigNumber.make((i + 1) * 1000 * SATOSHI);
                 voter.publicKey = `v${delegateKey}`;
-                voter.vote = delegateKey;
+                voter.setAttribute("vote", delegateKey);
 
                 walletManager.index([delegate, voter]);
             }
@@ -536,8 +543,8 @@ describe("Wallet Manager", () => {
 
             for (let i = 0; i < 5; i++) {
                 const delegate = delegates[i];
-                expect(delegate.rank).toEqual(i + 1);
-                expect(delegate.voteBalance).toEqual(Utils.BigNumber.make((5 - i) * 1000 * SATOSHI));
+                expect(delegate.getAttribute<number>("delegate.rank")).toEqual(i + 1);
+                expect(delegate.getAttribute<Utils.BigNumber>("delegate.voteBalance")).toEqual(Utils.BigNumber.make((5 - i) * 1000 * SATOSHI));
             }
         });
     });

--- a/__tests__/unit/core-state/wallets/wallet.test.ts
+++ b/__tests__/unit/core-state/wallets/wallet.test.ts
@@ -3,6 +3,7 @@ import "jest-extended";
 import { State } from "@arkecosystem/core-interfaces";
 import { Constants, Enums, Interfaces, Managers, Utils } from "@arkecosystem/crypto";
 import { configManager } from "@arkecosystem/crypto/src/managers";
+import clonedeep from "lodash.clonedeep";
 import { Wallet } from "../../../../packages/core-state/src/wallets";
 import { TransactionFactory } from "../../../helpers/transaction-factory";
 
@@ -64,7 +65,7 @@ describe("Models - Wallet", () => {
 
         it("should not apply incorrect block", () => {
             block.generatorPublicKey = ("a" as any).repeat(66);
-            const originalWallet = Object.assign({}, testWallet);
+            const originalWallet = Object.assign(new Wallet(testWallet.address), testWallet);
             const delegate: State.IWalletDelegateAttributes = testWallet.getAttribute("delegate");
             const original: State.IWalletDelegateAttributes = originalWallet.getAttribute("delegate");
 
@@ -101,7 +102,7 @@ describe("Models - Wallet", () => {
 
         beforeEach(() => {
             testWallet = new Wallet(walletInit.address);
-            testWallet = Object.assign(testWallet, walletInit);
+            testWallet = clonedeep(Object.assign(testWallet, walletInit));
         });
 
         it("should revert block if generator public key matches the wallet public key", () => {
@@ -171,7 +172,7 @@ describe("Models - Wallet", () => {
 
         beforeEach(() => {
             testWallet = new Wallet(walletInit.address);
-            testWallet = Object.assign(testWallet, walletInit);
+            testWallet = clonedeep(Object.assign(testWallet, walletInit));
         });
 
         it("should return correct audit data for Transfer type", () => {

--- a/__tests__/unit/core-transaction-pool/connection.forging.test.ts
+++ b/__tests__/unit/core-transaction-pool/connection.forging.test.ts
@@ -55,11 +55,14 @@ describe("Connection", () => {
             const { publicKey } = delegates[i];
             const wallet = databaseWalletManager.findByPublicKey(publicKey);
             wallet.balance = Utils.BigNumber.make(100_000 * Constants.ARKTOSHI);
-            wallet.username = `delegate-${i + 1}`;
-            wallet.vote = publicKey;
+            wallet.setAttribute("delegate", {
+                username: `delegate-${i + 1}`,
+                voteBalance: Utils.BigNumber.ZERO,
+            });
+            wallet.setAttribute("vote", publicKey);
 
             if (i === 50) {
-                wallet.secondPublicKey = Identities.PublicKey.fromPassphrase("second secret");
+                wallet.setAttribute("secondPublicKey", Identities.PublicKey.fromPassphrase("second secret"));
             }
 
             databaseWalletManager.reindex(wallet);

--- a/__tests__/unit/core-transactions/handler.test.ts
+++ b/__tests__/unit/core-transactions/handler.test.ts
@@ -18,8 +18,8 @@ import {
     UnvoteMismatchError,
     VotedForResignedDelegateError,
     WalletAlreadyResignedError,
-    WalletUsernameEmptyError,
-    WalletUsernameNotEmptyError,
+    WalletIsAlreadyDelegateError,
+    WalletNotADelegateError,
 } from "../../../packages/core-transactions/src/errors";
 import { TransactionHandler } from "../../../packages/core-transactions/src/handlers/transaction";
 import { Handlers } from "../../../packages/core-transactions/src/index";
@@ -87,7 +87,7 @@ describe("General Tests", () => {
         });
 
         it("should be false if the wallet has a second public key but the transaction second signature does not match", () => {
-            senderWallet.secondPublicKey = "invalid-public-key";
+            senderWallet.setAttribute("secondPublicKey", "invalid-public-key");
             expect(() => handler.throwIfCannotBeApplied(instance, senderWallet, walletManager)).toThrow(
                 InvalidSecondSignatureError,
             );
@@ -208,7 +208,7 @@ describe("SecondSignatureRegistrationTransaction", () => {
         senderWallet = new Wallets.Wallet("AbfQq8iRSf9TFQRzQWo33dHYU7HFMS17Zd");
         senderWallet.balance = Utils.BigNumber.make("6453530000000");
         senderWallet.publicKey = "02def27da9336e7fbf63131b8d7e5c9f45b296235db035f1f4242c507398f0f21d";
-        senderWallet.secondPublicKey = undefined;
+        senderWallet.unsetAttribute("secondPublicKey");
 
         walletManager.reindex(senderWallet);
 
@@ -229,7 +229,7 @@ describe("SecondSignatureRegistrationTransaction", () => {
         });
 
         it("should throw if wallet already has a second signature", () => {
-            senderWallet.secondPublicKey = "03287bfebba4c7881a0509717e71b34b63f31e40021c321f89ae04f84be6d6ac37";
+            senderWallet.setAttribute("secondPublicKey", "03287bfebba4c7881a0509717e71b34b63f31e40021c321f89ae04f84be6d6ac37");
 
             expect(() => handler.throwIfCannotBeApplied(instance, senderWallet, walletManager)).toThrow(
                 SecondSignatureAlreadyRegisteredError,
@@ -250,7 +250,7 @@ describe("SecondSignatureRegistrationTransaction", () => {
             expect(() => handler.throwIfCannotBeApplied(instance, senderWallet, walletManager)).not.toThrow();
 
             handler.apply(instance, walletManager);
-            expect(senderWallet.secondPublicKey).toBe(
+            expect(senderWallet.getAttribute("secondPublicKey")).toBe(
                 "03287bfebba4c7881a0509717e71b34b63f31e40021c321f89ae04f84be6d6ac37",
             );
         });
@@ -259,7 +259,7 @@ describe("SecondSignatureRegistrationTransaction", () => {
             expect(() => handler.throwIfCannotBeApplied(instance, senderWallet, walletManager)).not.toThrow();
 
             handler.apply(instance, walletManager);
-            expect(senderWallet.secondPublicKey).toBe(
+            expect(senderWallet.getAttribute("secondPublicKey")).toBe(
                 "03287bfebba4c7881a0509717e71b34b63f31e40021c321f89ae04f84be6d6ac37",
             );
 
@@ -271,16 +271,16 @@ describe("SecondSignatureRegistrationTransaction", () => {
 
     describe("revert", () => {
         it("should be ok", () => {
-            expect(senderWallet.secondPublicKey).toBeUndefined();
+            expect(senderWallet.getAttribute("secondPublicKey")).toBeUndefined();
             expect(() => handler.throwIfCannotBeApplied(instance, senderWallet, walletManager)).not.toThrow();
 
             handler.apply(instance, walletManager);
-            expect(senderWallet.secondPublicKey).toBe(
+            expect(senderWallet.getAttribute("secondPublicKey")).toBe(
                 "03287bfebba4c7881a0509717e71b34b63f31e40021c321f89ae04f84be6d6ac37",
             );
 
             handler.revert(instance, walletManager);
-            expect(senderWallet.secondPublicKey).toBeUndefined();
+            expect(senderWallet.getAttribute("secondPublicKey")).toBeUndefined();
         });
     });
 });
@@ -302,16 +302,16 @@ describe("DelegateRegistrationTransaction", () => {
         });
 
         it("should throw if wallet already registered a username", () => {
-            senderWallet.username = "dummy";
+            senderWallet.setAttribute("delegate", { username: "dummy" });
 
             expect(() => handler.throwIfCannotBeApplied(instance, senderWallet, walletManager)).toThrow(
-                WalletUsernameNotEmptyError,
+                WalletIsAlreadyDelegateError,
             );
         });
 
         it("should throw if wallet has insufficient funds", () => {
             walletManager.forgetByUsername("dummy");
-            senderWallet.username = "";
+            senderWallet.unsetAttribute("delegate");
             senderWallet.balance = Utils.BigNumber.ZERO;
 
             expect(() => handler.throwIfCannotBeApplied(instance, senderWallet, walletManager)).toThrow(
@@ -323,7 +323,7 @@ describe("DelegateRegistrationTransaction", () => {
     describe("apply", () => {
         it("should set username", () => {
             handler.apply(instance, walletManager);
-            expect(senderWallet.username).toBe("dummy");
+            expect(senderWallet.getAttribute("delegate.username")).toBe("dummy");
         });
     });
 
@@ -334,22 +334,22 @@ describe("DelegateRegistrationTransaction", () => {
             handler.revert(instance, walletManager);
 
             expect(senderWallet.nonce.isZero()).toBeTrue();
-            expect(senderWallet.username).toBeUndefined();
+            expect(senderWallet.getAttribute("delegate.username")).toBeUndefined();
         });
     });
 });
 
 describe("VoteTransaction", () => {
-    let voteTransaction;
-    let unvoteTransaction;
-    let delegateWallet;
+    let voteTransaction: Interfaces.ITransactionData;
+    let unvoteTransaction: Interfaces.ITransactionData;
+    let delegateWallet: State.IWallet;
 
     beforeEach(() => {
-        senderWallet.vote = undefined;
+        senderWallet.unsetAttribute("vote");
 
         delegateWallet = new Wallets.Wallet("ARAibxGqLQJTo1bWMJfu5fCc88rdWWjqgv");
         delegateWallet.publicKey = "038082dad560a22ea003022015e3136b21ef1ffd9f2fd50049026cbe8e2258ca17";
-        delegateWallet.username = "test";
+        delegateWallet.setAttribute("delegate", { username: "test" });
 
         walletManager.reindex(senderWallet);
         walletManager.reindex(delegateWallet);
@@ -376,20 +376,20 @@ describe("VoteTransaction", () => {
         });
 
         it("should not throw if the unvote is valid and the wallet has voted", () => {
-            senderWallet.vote = "038082dad560a22ea003022015e3136b21ef1ffd9f2fd50049026cbe8e2258ca17";
+            senderWallet.setAttribute("vote", "038082dad560a22ea003022015e3136b21ef1ffd9f2fd50049026cbe8e2258ca17");
             instance = Transactions.TransactionFactory.fromData(unvoteTransaction);
             expect(() => handler.throwIfCannotBeApplied(instance, senderWallet, walletManager)).not.toThrow();
         });
 
         it("should throw if wallet has already voted", () => {
-            senderWallet.vote = "038082dad560a22ea003022015e3136b21ef1ffd9f2fd50049026cbe8e2258ca17";
+            senderWallet.setAttribute("vote", "038082dad560a22ea003022015e3136b21ef1ffd9f2fd50049026cbe8e2258ca17");
             expect(() => handler.throwIfCannotBeApplied(instance, senderWallet, walletManager)).toThrow(
                 AlreadyVotedError,
             );
         });
 
         it("should throw if the asset public key differs from the currently voted one", () => {
-            senderWallet.vote = "a310ad026647eed112d1a46145eed58b8c19c67c505a67f1199361a511ce7860c0";
+            senderWallet.setAttribute("vote", "a310ad026647eed112d1a46145eed58b8c19c67c505a67f1199361a511ce7860c0");
             instance = Transactions.TransactionFactory.fromData(unvoteTransaction);
             expect(() => handler.throwIfCannotBeApplied(instance, senderWallet, walletManager)).toThrow(
                 UnvoteMismatchError,
@@ -412,33 +412,33 @@ describe("VoteTransaction", () => {
     describe("apply", () => {
         describe("vote", () => {
             it("should be ok", () => {
-                expect(senderWallet.vote).toBeUndefined();
+                expect(senderWallet.getAttribute("vote")).toBeUndefined();
 
                 handler.apply(instance, walletManager);
-                expect(senderWallet.vote).not.toBeUndefined();
+                expect(senderWallet.getAttribute("vote")).not.toBeUndefined();
             });
 
             it("should not be ok", () => {
-                senderWallet.vote = "038082dad560a22ea003022015e3136b21ef1ffd9f2fd50049026cbe8e2258ca17";
+                senderWallet.setAttribute("vote", "038082dad560a22ea003022015e3136b21ef1ffd9f2fd50049026cbe8e2258ca17");
 
-                expect(senderWallet.vote).not.toBeUndefined();
+                expect(senderWallet.getAttribute("vote")).not.toBeUndefined();
 
                 expect(() => handler.apply(instance, walletManager)).toThrow(AlreadyVotedError);
 
-                expect(senderWallet.vote).not.toBeUndefined();
+                expect(senderWallet.getAttribute("vote")).not.toBeUndefined();
             });
         });
 
         describe("unvote", () => {
             it("should remove the vote from the wallet", () => {
-                senderWallet.vote = "038082dad560a22ea003022015e3136b21ef1ffd9f2fd50049026cbe8e2258ca17";
+                senderWallet.setAttribute("vote", "038082dad560a22ea003022015e3136b21ef1ffd9f2fd50049026cbe8e2258ca17");
 
-                expect(senderWallet.vote).not.toBeUndefined();
+                expect(senderWallet.getAttribute("vote")).not.toBeUndefined();
 
                 instance = Transactions.TransactionFactory.fromData(unvoteTransaction);
                 handler.apply(instance, walletManager);
 
-                expect(senderWallet.vote).toBeUndefined();
+                expect(senderWallet.getAttribute("vote")).toBeUndefined();
             });
         });
     });
@@ -446,15 +446,15 @@ describe("VoteTransaction", () => {
     describe("revert", () => {
         describe("vote", () => {
             it("should remove the vote from the wallet", () => {
-                senderWallet.vote = "038082dad560a22ea003022015e3136b21ef1ffd9f2fd50049026cbe8e2258ca17";
+                senderWallet.setAttribute("vote", "038082dad560a22ea003022015e3136b21ef1ffd9f2fd50049026cbe8e2258ca17");
                 senderWallet.nonce = Utils.BigNumber.make(1);
 
-                expect(senderWallet.vote).not.toBeUndefined();
+                expect(senderWallet.getAttribute("vote")).not.toBeUndefined();
 
                 handler.revert(instance, walletManager);
 
                 expect(senderWallet.nonce.isZero()).toBeTrue();
-                expect(senderWallet.vote).toBeUndefined();
+                expect(senderWallet.getAttribute("vote")).toBeUndefined();
             });
         });
 
@@ -462,13 +462,13 @@ describe("VoteTransaction", () => {
             it("should add the vote to the wallet", () => {
                 senderWallet.nonce = Utils.BigNumber.make(1);
 
-                expect(senderWallet.vote).toBeUndefined();
+                expect(senderWallet.getAttribute("vote")).toBeUndefined();
 
                 instance = Transactions.TransactionFactory.fromData(unvoteTransaction);
                 handler.revert(instance, walletManager);
 
                 expect(senderWallet.nonce.isZero()).toBeTrue();
-                expect(senderWallet.vote).toBe("038082dad560a22ea003022015e3136b21ef1ffd9f2fd50049026cbe8e2258ca17");
+                expect(senderWallet.getAttribute("vote")).toBe("038082dad560a22ea003022015e3136b21ef1ffd9f2fd50049026cbe8e2258ca17");
             });
         });
     });
@@ -494,12 +494,12 @@ describe("MultiSignatureRegistrationTransaction", () => {
     });
 
     describe("canApply", () => {
-        it("should not theow", () => {
+        it("should not throw", () => {
             expect(() => handler.throwIfCannotBeApplied(instance, senderWallet, walletManager)).not.toThrow();
         });
 
         it("should throw if the wallet already has multisignatures", () => {
-            recipientWallet.multisignature = instance.data.asset.multiSignature;
+            recipientWallet.setAttribute("multiSignature", instance.data.asset.multiSignature);
             expect(() => handler.throwIfCannotBeApplied(instance, senderWallet, walletManager)).toThrow(
                 MultiSignatureAlreadyRegisteredError,
             );
@@ -507,7 +507,7 @@ describe("MultiSignatureRegistrationTransaction", () => {
 
         it("should throw if failure to verify signatures", () => {
             senderWallet.verifySignatures = jest.fn(() => false);
-            delete senderWallet.multisignature;
+            senderWallet.unsetAttribute("multiSignature");
 
             expect(() => handler.throwIfCannotBeApplied(instance, senderWallet, walletManager)).toThrow(
                 InvalidMultiSignatureError,
@@ -522,7 +522,7 @@ describe("MultiSignatureRegistrationTransaction", () => {
         });
 
         it("should throw if the number of keys is less than minimum", () => {
-            delete senderWallet.multisignature;
+            senderWallet.unsetAttribute("multiSignature");
 
             senderWallet.verifySignatures = jest.fn(() => true);
             Transactions.Verifier.verifySecondSignature = jest.fn(() => true);
@@ -534,7 +534,7 @@ describe("MultiSignatureRegistrationTransaction", () => {
         });
 
         it("should throw if the number of keys does not equal the signature count", () => {
-            delete senderWallet.multisignature;
+            senderWallet.unsetAttribute("multiSignature");
 
             senderWallet.verifySignatures = jest.fn(() => true);
             Transactions.Verifier.verifySecondSignature = jest.fn(() => true);
@@ -546,7 +546,7 @@ describe("MultiSignatureRegistrationTransaction", () => {
         });
 
         it("should throw if wallet has insufficient funds", () => {
-            delete senderWallet.multisignature;
+            senderWallet.unsetAttribute("multiSignature");
             senderWallet.balance = Utils.BigNumber.ZERO;
 
             expect(() => handler.throwIfCannotBeApplied(instance, senderWallet, walletManager)).toThrow(
@@ -557,10 +557,10 @@ describe("MultiSignatureRegistrationTransaction", () => {
 
     describe("apply", () => {
         it("should be ok", () => {
-            recipientWallet.multisignature = undefined;
+            recipientWallet.unsetAttribute("multiSignature");
 
-            expect(senderWallet.multisignature).toBeUndefined();
-            expect(recipientWallet.multisignature).toBeUndefined();
+            expect(senderWallet.hasAttribute("multiSignature")).toBeFalse();
+            expect(recipientWallet.hasAttribute("multiSignature")).toBeFalse();
 
             expect(senderWallet.balance).toEqual(Utils.BigNumber.make(100390000000));
             expect(recipientWallet.balance).toEqual(Utils.BigNumber.ZERO);
@@ -570,8 +570,8 @@ describe("MultiSignatureRegistrationTransaction", () => {
             expect(senderWallet.balance).toEqual(Utils.BigNumber.make(98390000000));
             expect(recipientWallet.balance).toEqual(Utils.BigNumber.ZERO);
 
-            expect(senderWallet.multisignature).toBeUndefined();
-            expect(recipientWallet.multisignature).toEqual(transaction.asset.multiSignature);
+            expect(senderWallet.hasAttribute("multiSignature")).toBeFalse();
+            expect(recipientWallet.getAttribute("multiSignature")).toEqual(transaction.asset.multiSignature);
         });
     });
 
@@ -582,8 +582,8 @@ describe("MultiSignatureRegistrationTransaction", () => {
             handler.revert(instance, walletManager);
 
             expect(senderWallet.nonce.isZero()).toBeTrue();
-            expect(senderWallet.multisignature).toBeUndefined();
-            expect(recipientWallet.multisignature).toBeUndefined();
+            expect(senderWallet.hasMultiSignature()).toBeFalse();
+            expect(recipientWallet.hasMultiSignature()).toBeFalse();
         });
     });
 });
@@ -622,7 +622,7 @@ describe("Ipfs", () => {
 
             handler.apply(instance, walletManager);
 
-            expect(senderWallet.ipfsHashes[transaction.asset.ipfs]).toBeTrue();
+            expect(senderWallet.getAttribute<State.IWalletIpfsAttributes>("ipfs.hashes")[transaction.asset.ipfs]).toBeTrue();
             expect(senderWallet.balance).toEqual(balanceBefore.minus(transaction.fee));
         });
     });
@@ -636,11 +636,11 @@ describe("Ipfs", () => {
             handler.apply(instance, walletManager);
 
             expect(senderWallet.balance).toEqual(balanceBefore.minus(transaction.fee));
-            expect(senderWallet.ipfsHashes[transaction.asset.ipfs]).toBeTrue();
+            expect(senderWallet.getAttribute<State.IWalletIpfsAttributes>("ipfs.hashes")[transaction.asset.ipfs]).toBeTrue();
 
             handler.revert(instance, walletManager);
 
-            expect(senderWallet.ipfsHashes[transaction.asset.ipfs]).toBeUndefined();
+            expect(senderWallet.getAttribute("ipfs.hashes")[transaction.asset.ipfs]).toBeFalsy();
             expect(senderWallet.balance).toEqual(balanceBefore);
         });
     });
@@ -740,8 +740,8 @@ describe("DelegateResignationTransaction", () => {
             .withPassphrase("clay harbor enemy utility margin pretty hub comic piece aerobic umbrella acquire")
             .createOne();
 
-        senderWallet.username = "tiredDelegate";
-        delete senderWallet.resigned;
+        senderWallet.setAttribute("delegate", { username: "tiredDelegate" });
+        senderWallet.unsetAttribute("delegate.resigned");
 
         walletManager.reindex(senderWallet);
 
@@ -750,15 +750,15 @@ describe("DelegateResignationTransaction", () => {
     });
 
     describe("canApply", () => {
-        it("should not throw if wallet has registered username", () => {
-            senderWallet.username = "dummy";
+        it("should not throw if wallet is a delegate", () => {
+            senderWallet.setAttribute("delegate", {});
             expect(() => handler.throwIfCannotBeApplied(instance, senderWallet, walletManager)).not.toThrow();
         });
 
-        it("should throw if wallet has no registered username", () => {
-            senderWallet.username = undefined;
+        it("should throw if wallet is not a delegate", () => {
+            senderWallet.unsetAttribute("delegate");
             expect(() => handler.throwIfCannotBeApplied(instance, senderWallet, walletManager)).toThrow(
-                WalletUsernameEmptyError,
+                WalletNotADelegateError,
             );
         });
 
@@ -775,14 +775,14 @@ describe("DelegateResignationTransaction", () => {
             expect(() => handler.throwIfCannotBeApplied(instance, senderWallet, walletManager)).not.toThrow();
 
             handler.apply(instance, walletManager);
-            expect(senderWallet.resigned).toBeTrue();
+            expect(senderWallet.getAttribute<boolean>("delegate.resigned")).toBeTrue();
         });
 
         it("should fail when already resigned", () => {
             expect(() => handler.throwIfCannotBeApplied(instance, senderWallet, walletManager)).not.toThrow();
 
             handler.apply(instance, walletManager);
-            expect(senderWallet.resigned).toBeTrue();
+            expect(senderWallet.getAttribute<boolean>("delegate.resigned")).toBeTrue();
 
             expect(() => handler.throwIfCannotBeApplied(instance, senderWallet, walletManager)).toThrow(
                 WalletAlreadyResignedError,
@@ -790,10 +790,10 @@ describe("DelegateResignationTransaction", () => {
         });
 
         it("should fail when not a delegate", () => {
-            senderWallet.username = undefined;
+            senderWallet.unsetAttribute("delegate");
 
             expect(() => handler.throwIfCannotBeApplied(instance, senderWallet, walletManager)).toThrow(
-                WalletUsernameEmptyError,
+                WalletNotADelegateError,
             );
         });
 
@@ -801,7 +801,7 @@ describe("DelegateResignationTransaction", () => {
             expect(() => handler.throwIfCannotBeApplied(instance, senderWallet, walletManager)).not.toThrow();
 
             handler.apply(instance, walletManager);
-            expect(senderWallet.resigned).toBeTrue();
+            expect(senderWallet.getAttribute<boolean>("delegate.resigned")).toBeTrue();
 
             const vote = Transactions.TransactionFactory.fromData(voteTransaction);
             const voteHandler = Handlers.Registry.get(vote.type);
@@ -814,13 +814,13 @@ describe("DelegateResignationTransaction", () => {
 
     describe("revert", () => {
         it("should be ok", () => {
-            expect(senderWallet.resigned).toBeUndefined();
+            expect(senderWallet.hasAttribute("delegate.resigned")).toBeFalse();
             expect(() => handler.throwIfCannotBeApplied(instance, senderWallet, walletManager)).not.toThrow();
 
             handler.apply(instance, walletManager);
-            expect(senderWallet.resigned).toBeTrue();
+            expect(senderWallet.getAttribute<boolean>("delegate.resigned")).toBeTrue();
             handler.revert(instance, walletManager);
-            expect(senderWallet.resigned).toBeFalse();
+            expect(senderWallet.getAttribute<boolean>("delegate.resigned")).toBeFalsy();
         });
     });
 });

--- a/__tests__/unit/core-transactions/handler.test.ts
+++ b/__tests__/unit/core-transactions/handler.test.ts
@@ -208,7 +208,7 @@ describe("SecondSignatureRegistrationTransaction", () => {
         senderWallet = new Wallets.Wallet("AbfQq8iRSf9TFQRzQWo33dHYU7HFMS17Zd");
         senderWallet.balance = Utils.BigNumber.make("6453530000000");
         senderWallet.publicKey = "02def27da9336e7fbf63131b8d7e5c9f45b296235db035f1f4242c507398f0f21d";
-        senderWallet.unsetAttribute("secondPublicKey");
+        senderWallet.forgetAttribute("secondPublicKey");
 
         walletManager.reindex(senderWallet);
 
@@ -229,7 +229,10 @@ describe("SecondSignatureRegistrationTransaction", () => {
         });
 
         it("should throw if wallet already has a second signature", () => {
-            senderWallet.setAttribute("secondPublicKey", "03287bfebba4c7881a0509717e71b34b63f31e40021c321f89ae04f84be6d6ac37");
+            senderWallet.setAttribute(
+                "secondPublicKey",
+                "03287bfebba4c7881a0509717e71b34b63f31e40021c321f89ae04f84be6d6ac37",
+            );
 
             expect(() => handler.throwIfCannotBeApplied(instance, senderWallet, walletManager)).toThrow(
                 SecondSignatureAlreadyRegisteredError,
@@ -311,7 +314,7 @@ describe("DelegateRegistrationTransaction", () => {
 
         it("should throw if wallet has insufficient funds", () => {
             walletManager.forgetByUsername("dummy");
-            senderWallet.unsetAttribute("delegate");
+            senderWallet.forgetAttribute("delegate");
             senderWallet.balance = Utils.BigNumber.ZERO;
 
             expect(() => handler.throwIfCannotBeApplied(instance, senderWallet, walletManager)).toThrow(
@@ -345,7 +348,7 @@ describe("VoteTransaction", () => {
     let delegateWallet: State.IWallet;
 
     beforeEach(() => {
-        senderWallet.unsetAttribute("vote");
+        senderWallet.forgetAttribute("vote");
 
         delegateWallet = new Wallets.Wallet("ARAibxGqLQJTo1bWMJfu5fCc88rdWWjqgv");
         delegateWallet.publicKey = "038082dad560a22ea003022015e3136b21ef1ffd9f2fd50049026cbe8e2258ca17";
@@ -468,7 +471,9 @@ describe("VoteTransaction", () => {
                 handler.revert(instance, walletManager);
 
                 expect(senderWallet.nonce.isZero()).toBeTrue();
-                expect(senderWallet.getAttribute("vote")).toBe("038082dad560a22ea003022015e3136b21ef1ffd9f2fd50049026cbe8e2258ca17");
+                expect(senderWallet.getAttribute("vote")).toBe(
+                    "038082dad560a22ea003022015e3136b21ef1ffd9f2fd50049026cbe8e2258ca17",
+                );
             });
         });
     });
@@ -507,7 +512,7 @@ describe("MultiSignatureRegistrationTransaction", () => {
 
         it("should throw if failure to verify signatures", () => {
             senderWallet.verifySignatures = jest.fn(() => false);
-            senderWallet.unsetAttribute("multiSignature");
+            senderWallet.forgetAttribute("multiSignature");
 
             expect(() => handler.throwIfCannotBeApplied(instance, senderWallet, walletManager)).toThrow(
                 InvalidMultiSignatureError,
@@ -522,7 +527,7 @@ describe("MultiSignatureRegistrationTransaction", () => {
         });
 
         it("should throw if the number of keys is less than minimum", () => {
-            senderWallet.unsetAttribute("multiSignature");
+            senderWallet.forgetAttribute("multiSignature");
 
             senderWallet.verifySignatures = jest.fn(() => true);
             Transactions.Verifier.verifySecondSignature = jest.fn(() => true);
@@ -534,7 +539,7 @@ describe("MultiSignatureRegistrationTransaction", () => {
         });
 
         it("should throw if the number of keys does not equal the signature count", () => {
-            senderWallet.unsetAttribute("multiSignature");
+            senderWallet.forgetAttribute("multiSignature");
 
             senderWallet.verifySignatures = jest.fn(() => true);
             Transactions.Verifier.verifySecondSignature = jest.fn(() => true);
@@ -546,7 +551,7 @@ describe("MultiSignatureRegistrationTransaction", () => {
         });
 
         it("should throw if wallet has insufficient funds", () => {
-            senderWallet.unsetAttribute("multiSignature");
+            senderWallet.forgetAttribute("multiSignature");
             senderWallet.balance = Utils.BigNumber.ZERO;
 
             expect(() => handler.throwIfCannotBeApplied(instance, senderWallet, walletManager)).toThrow(
@@ -557,7 +562,7 @@ describe("MultiSignatureRegistrationTransaction", () => {
 
     describe("apply", () => {
         it("should be ok", () => {
-            recipientWallet.unsetAttribute("multiSignature");
+            recipientWallet.forgetAttribute("multiSignature");
 
             expect(senderWallet.hasAttribute("multiSignature")).toBeFalse();
             expect(recipientWallet.hasAttribute("multiSignature")).toBeFalse();
@@ -622,7 +627,9 @@ describe("Ipfs", () => {
 
             handler.apply(instance, walletManager);
 
-            expect(senderWallet.getAttribute<State.IWalletIpfsAttributes>("ipfs.hashes")[transaction.asset.ipfs]).toBeTrue();
+            expect(
+                senderWallet.getAttribute<State.IWalletIpfsAttributes>("ipfs.hashes")[transaction.asset.ipfs],
+            ).toBeTrue();
             expect(senderWallet.balance).toEqual(balanceBefore.minus(transaction.fee));
         });
     });
@@ -636,7 +643,9 @@ describe("Ipfs", () => {
             handler.apply(instance, walletManager);
 
             expect(senderWallet.balance).toEqual(balanceBefore.minus(transaction.fee));
-            expect(senderWallet.getAttribute<State.IWalletIpfsAttributes>("ipfs.hashes")[transaction.asset.ipfs]).toBeTrue();
+            expect(
+                senderWallet.getAttribute<State.IWalletIpfsAttributes>("ipfs.hashes")[transaction.asset.ipfs],
+            ).toBeTrue();
 
             handler.revert(instance, walletManager);
 
@@ -741,7 +750,7 @@ describe("DelegateResignationTransaction", () => {
             .createOne();
 
         senderWallet.setAttribute("delegate", { username: "tiredDelegate" });
-        senderWallet.unsetAttribute("delegate.resigned");
+        senderWallet.forgetAttribute("delegate.resigned");
 
         walletManager.reindex(senderWallet);
 
@@ -756,7 +765,7 @@ describe("DelegateResignationTransaction", () => {
         });
 
         it("should throw if wallet is not a delegate", () => {
-            senderWallet.unsetAttribute("delegate");
+            senderWallet.forgetAttribute("delegate");
             expect(() => handler.throwIfCannotBeApplied(instance, senderWallet, walletManager)).toThrow(
                 WalletNotADelegateError,
             );
@@ -790,7 +799,7 @@ describe("DelegateResignationTransaction", () => {
         });
 
         it("should fail when not a delegate", () => {
-            senderWallet.unsetAttribute("delegate");
+            senderWallet.forgetAttribute("delegate");
 
             expect(() => handler.throwIfCannotBeApplied(instance, senderWallet, walletManager)).toThrow(
                 WalletNotADelegateError,

--- a/__tests__/unit/core-utils/delegate-calculator.test.ts
+++ b/__tests__/unit/core-utils/delegate-calculator.test.ts
@@ -1,33 +1,39 @@
 import "jest-extended";
 import "./mocks/core-container-calculator";
 
+import { State } from "@arkecosystem/core-interfaces";
 import { Wallets } from "@arkecosystem/core-state";
 import { Utils } from "@arkecosystem/crypto";
 import { calculateApproval, calculateForgedTotal } from "../../../packages/core-utils/src/delegate-calculator";
 
 let delegate: Wallets.Wallet;
+let attributes: State.IWalletDelegateAttributes;
 
 beforeEach(() => {
+    attributes = {
+        producedBlocks: 0,
+    } as State.IWalletDelegateAttributes;
+
     delegate = new Wallets.Wallet("D61xc3yoBQDitwjqUspMPx1ooET6r1XLt7");
-    delegate.producedBlocks = 0;
+    delegate.setAttribute("delegate", attributes);
 });
 
 describe("Delegate Calculator", () => {
     describe("calculateApproval", () => {
         it("should calculate correctly with a height", () => {
-            delegate.voteBalance = Utils.BigNumber.make(10000 * 1e8);
+            attributes.voteBalance = Utils.BigNumber.make(10000 * 1e8);
 
             expect(calculateApproval(delegate, 1)).toBe(1);
         });
 
         it("should calculate correctly without a height", () => {
-            delegate.voteBalance = Utils.BigNumber.make(10000 * 1e8);
+            attributes.voteBalance = Utils.BigNumber.make(10000 * 1e8);
 
             expect(calculateApproval(delegate)).toBe(1);
         });
 
         it("should calculate correctly with 2 decimals", () => {
-            delegate.voteBalance = Utils.BigNumber.make(16500 * 1e8);
+            attributes.voteBalance = Utils.BigNumber.make(16500 * 1e8);
 
             expect(calculateApproval(delegate, 1)).toBe(1.65);
         });
@@ -35,8 +41,8 @@ describe("Delegate Calculator", () => {
 
     describe("calculateForgedTotal", () => {
         it("should calculate correctly", () => {
-            delegate.forgedFees = Utils.BigNumber.make(10);
-            delegate.forgedRewards = Utils.BigNumber.make(100);
+            attributes.forgedFees = Utils.BigNumber.make(10);
+            attributes.forgedRewards = Utils.BigNumber.make(100);
 
             expect(calculateForgedTotal(delegate)).toBe("110");
         });

--- a/packages/core-api/src/handlers/blocks/transformer.ts
+++ b/packages/core-api/src/handlers/blocks/transformer.ts
@@ -34,7 +34,7 @@ export const transformBlock = (model, transform) => {
             length: model.payloadLength,
         },
         generator: {
-            username: generator.username,
+            username: generator.getAttribute("delegate.username"),
             address: generator.address,
             publicKey: generator.publicKey,
         },

--- a/packages/core-api/src/handlers/delegates/transformer.ts
+++ b/packages/core-api/src/handlers/delegates/transformer.ts
@@ -1,27 +1,30 @@
+import { State } from "@arkecosystem/core-interfaces";
 import { delegateCalculator, formatTimestamp } from "@arkecosystem/core-utils";
 import { Utils } from "@arkecosystem/crypto";
 
-export const transformDelegate = delegate => {
+export const transformDelegate = (delegate: State.IWallet) => {
+    const attributes: State.IWalletDelegateAttributes = delegate.getAttribute("delegate");
+
     const data = {
-        username: delegate.username,
+        username: attributes.username,
         address: delegate.address,
         publicKey: delegate.publicKey,
-        votes: Utils.BigNumber.make(delegate.voteBalance).toFixed(),
-        rank: delegate.rate,
+        votes: Utils.BigNumber.make(attributes.voteBalance).toFixed(),
+        rank: attributes.rank,
         blocks: {
-            produced: delegate.producedBlocks,
+            produced: attributes.producedBlocks,
         },
         production: {
             approval: delegateCalculator.calculateApproval(delegate),
         },
         forged: {
-            fees: delegate.forgedFees.toFixed(),
-            rewards: delegate.forgedRewards.toFixed(),
+            fees: attributes.forgedFees.toFixed(),
+            rewards: attributes.forgedRewards.toFixed(),
             total: delegateCalculator.calculateForgedTotal(delegate),
         },
     };
 
-    const lastBlock = delegate.lastBlock;
+    const lastBlock = attributes.lastBlock;
 
     if (lastBlock) {
         // @ts-ignore

--- a/packages/core-api/src/handlers/wallets/transformer.ts
+++ b/packages/core-api/src/handlers/wallets/transformer.ts
@@ -1,15 +1,17 @@
 import { State } from "@arkecosystem/core-interfaces";
 import { Utils } from "@arkecosystem/crypto";
 
-export const transformWallet = (model: State.IWallet) => {
+export const transformWallet = (wallet: State.IWallet) => {
+    const username: string = wallet.getAttribute("delegate.username");
+
     return {
-        address: model.address,
-        publicKey: model.publicKey,
-        secondPublicKey: model.secondPublicKey,
-        nonce: model.nonce.toFixed(),
-        balance: Utils.BigNumber.make(model.balance).toFixed(),
-        username: model.username,
-        isDelegate: !!model.username,
-        vote: model.vote,
+        address: wallet.address,
+        publicKey: wallet.publicKey,
+        username,
+        nonce: wallet.nonce.toFixed(),
+        secondPublicKey: wallet.getAttribute("secondPublicKey"),
+        balance: +Utils.BigNumber.make(wallet.balance).toFixed(),
+        isDelegate: !!username,
+        vote: wallet.getAttribute("vote"),
     };
 };

--- a/packages/core-api/src/handlers/wallets/transformer.ts
+++ b/packages/core-api/src/handlers/wallets/transformer.ts
@@ -10,7 +10,7 @@ export const transformWallet = (wallet: State.IWallet) => {
         username,
         nonce: wallet.nonce.toFixed(),
         secondPublicKey: wallet.getAttribute("secondPublicKey"),
-        balance: +Utils.BigNumber.make(wallet.balance).toFixed(),
+        balance: Utils.BigNumber.make(wallet.balance).toFixed(),
         isDelegate: !!username,
         vote: wallet.getAttribute("vote"),
     };

--- a/packages/core-blockchain/src/processor/handlers/unchained-handler.ts
+++ b/packages/core-blockchain/src/processor/handlers/unchained-handler.ts
@@ -71,7 +71,7 @@ export class UnchainedHandler extends BlockHandler {
         switch (status) {
             case UnchainedBlockStatus.DoubleForging: {
                 const roundInfo: Shared.IRoundInfo = roundCalculator.calculateRound(this.block.data.height);
-                const delegates: State.IDelegateWallet[] = await app
+                const delegates: State.IWallet[] = await app
                     .resolvePlugin("database")
                     .getActiveDelegates(roundInfo);
 
@@ -123,7 +123,7 @@ export class UnchainedHandler extends BlockHandler {
 
             this.logger.debug(
                 `Blockchain is still not ready to accept block at height ${this.block.data.height.toLocaleString()} after ${
-                    BlockNotReadyCounter.maxAttempts
+                BlockNotReadyCounter.maxAttempts
                 } tries. Going to rollback. :warning:`,
             );
 

--- a/packages/core-blockchain/src/replay/memory-database-service.ts
+++ b/packages/core-blockchain/src/replay/memory-database-service.ts
@@ -12,8 +12,8 @@ export class MemoryDatabaseService extends DatabaseService {
         return;
     }
 
-    public async saveRound(activeDelegates: State.IDelegateWallet[]): Promise<void> {
-        this.logger.info(`Saving round ${activeDelegates[0].round.toLocaleString()}`);
+    public async saveRound(activeDelegates: State.IWallet[]): Promise<void> {
+        this.logger.info(`Saving round ${activeDelegates[0].getAttribute("delegate.round").toLocaleString()}`);
     }
 
     public async deleteRound(round: number): Promise<void> {

--- a/packages/core-blockchain/src/replay/replay-blockchain.ts
+++ b/packages/core-blockchain/src/replay/replay-blockchain.ts
@@ -117,11 +117,18 @@ export class ReplayBlockchain extends Blockchain {
             sender.balance = sender.balance.minus(transaction.data.amount).minus(transaction.data.fee);
 
             if (transaction.type === Enums.TransactionTypes.DelegateRegistration) {
-                sender.username = transaction.data.asset.delegate.username;
+                sender.setAttribute("delegate", {
+                    username: transaction.data.asset.delegate.username,
+                    voteBalance: Utils.BigNumber.ZERO,
+                    forgedFees: Utils.BigNumber.ZERO,
+                    forgedRewards: Utils.BigNumber.ZERO,
+                    producedBlocks: 0,
+                    round: 0,
+                });
                 this.walletManager.reindex(sender);
             } else if (transaction.type === Enums.TransactionTypes.Vote) {
                 const vote = transaction.data.asset.votes[0];
-                sender.vote = vote.slice(1);
+                sender.setAttribute("vote", vote.slice(1));
             }
         }
 
@@ -130,7 +137,7 @@ export class ReplayBlockchain extends Blockchain {
         this.state.setLastBlock(genesisBlock);
 
         const roundInfo: Shared.IRoundInfo = roundCalculator.calculateRound(1);
-        const delegates: State.IDelegateWallet[] = this.walletManager.loadActiveDelegateList(roundInfo);
+        const delegates: State.IWallet[] = this.walletManager.loadActiveDelegateList(roundInfo);
 
         (this.localDatabase as any).forgingDelegates = await this.localDatabase.getActiveDelegates(
             roundInfo,

--- a/packages/core-blockchain/src/utils/validate-generator.ts
+++ b/packages/core-blockchain/src/utils/validate-generator.ts
@@ -8,20 +8,24 @@ export const validateGenerator = async (block: Interfaces.IBlock): Promise<boole
     const logger: Logger.ILogger = app.resolvePlugin<Logger.ILogger>("logger");
 
     const roundInfo: Shared.IRoundInfo = roundCalculator.calculateRound(block.data.height);
-    const delegates: State.IDelegateWallet[] = await database.getActiveDelegates(roundInfo);
+    const delegates: State.IWallet[] = await database.getActiveDelegates(roundInfo);
     const slot: number = Crypto.Slots.getSlotNumber(block.data.timestamp);
-    const forgingDelegate: State.IDelegateWallet = delegates[slot % delegates.length];
+    const forgingDelegate: State.IWallet = delegates[slot % delegates.length];
 
-    const generatorUsername: string = database.walletManager.findByPublicKey(block.data.generatorPublicKey).username;
+    const generatorUsername: string = database.walletManager
+        .findByPublicKey(block.data.generatorPublicKey)
+        .getAttribute("delegate.username");
 
     if (!forgingDelegate) {
         logger.debug(
             `Could not decide if delegate ${generatorUsername} (${
-                block.data.generatorPublicKey
+            block.data.generatorPublicKey
             }) is allowed to forge block ${block.data.height.toLocaleString()}`,
         );
     } else if (forgingDelegate.publicKey !== block.data.generatorPublicKey) {
-        const forgingUsername = database.walletManager.findByPublicKey(forgingDelegate.publicKey).username;
+        const forgingUsername: string = database.walletManager
+            .findByPublicKey(forgingDelegate.publicKey)
+            .getAttribute("delegate.username");
 
         logger.warn(
             `Delegate ${generatorUsername} (${block.data.generatorPublicKey}) not allowed to forge, should be ${forgingUsername} (${forgingDelegate.publicKey})`,
@@ -32,7 +36,7 @@ export const validateGenerator = async (block: Interfaces.IBlock): Promise<boole
 
     logger.debug(
         `Delegate ${generatorUsername} (${
-            block.data.generatorPublicKey
+        block.data.generatorPublicKey
         }) allowed to forge block ${block.data.height.toLocaleString()}`,
     );
 

--- a/packages/core-database-postgres/src/models/round.ts
+++ b/packages/core-database-postgres/src/models/round.ts
@@ -12,8 +12,9 @@ export class Round extends Model {
         },
         {
             name: "balance",
-            prop: "voteBalance",
-            init: col => Utils.BigNumber.make(col.value).toFixed(),
+            init: col => {
+                return Utils.BigNumber.make(col.value).toFixed();
+            },
             supportedOperators: [
                 Database.SearchOperator.OP_EQ,
                 Database.SearchOperator.OP_LTE,

--- a/packages/core-database-postgres/src/repositories/rounds.ts
+++ b/packages/core-database-postgres/src/repositories/rounds.ts
@@ -1,4 +1,4 @@
-import { Database } from "@arkecosystem/core-interfaces";
+import { Database, State } from "@arkecosystem/core-interfaces";
 import { Round } from "../models";
 import { queries } from "../queries";
 import { Repository } from "./repository";
@@ -11,6 +11,22 @@ export class RoundsRepository extends Repository implements Database.IRoundsRepo
     public async delete(round: number, db?: any): Promise<void> {
         db = db || this.db;
         return db.none(queries.rounds.delete, { round });
+    }
+
+    public async insert(delegates: State.IWallet[]): Promise<void> {
+        const rounds: Array<Partial<Database.IRound>> = delegates.map(delegate => {
+            return {
+                publicKey: delegate.publicKey,
+                balance: delegate.getAttribute("delegate.voteBalance"),
+                round: delegate.getAttribute("delegate.round"),
+            };
+        });
+
+        await super.insert(rounds);
+    }
+
+    public async update(items: object | object[]): Promise<void> {
+        return;
     }
 
     public getModel(): Round {

--- a/packages/core-database-postgres/src/state-builder.ts
+++ b/packages/core-database-postgres/src/state-builder.ts
@@ -83,8 +83,9 @@ export class StateBuilder {
                 throw new Error("Non-genesis wallet with negative balance.");
             }
 
-            if (wallet.voteBalance.isLessThan(0)) {
-                this.logger.warn(`Wallet ${wallet.address} has a negative vote balance of '${wallet.voteBalance}'`);
+            const voteBalance: Utils.BigNumber = wallet.getAttribute("delegate.voteBalance");
+            if (voteBalance && voteBalance.isLessThan(0)) {
+                this.logger.warn(`Wallet ${wallet.address} has a negative vote balance of '${voteBalance}'`);
 
                 throw new Error("Wallet with negative vote balance.");
             }

--- a/packages/core-database/package.json
+++ b/packages/core-database/package.json
@@ -25,6 +25,7 @@
         "@arkecosystem/core-container": "^2.5.7",
         "@arkecosystem/core-event-emitter": "^2.5.7",
         "@arkecosystem/core-interfaces": "^2.5.7",
+        "@arkecosystem/core-state": "^2.5.7",
         "@arkecosystem/core-transactions": "^2.5.7",
         "@arkecosystem/core-utils": "^2.5.7",
         "@arkecosystem/crypto": "^2.5.7",

--- a/packages/core-database/src/database-service.ts
+++ b/packages/core-database/src/database-service.ts
@@ -1,10 +1,12 @@
 import { app } from "@arkecosystem/core-container";
 import { ApplicationEvents } from "@arkecosystem/core-event-emitter";
 import { Database, EventEmitter, Logger, Shared, State } from "@arkecosystem/core-interfaces";
+import { Wallets } from "@arkecosystem/core-state";
 import { Handlers } from "@arkecosystem/core-transactions";
 import { roundCalculator } from "@arkecosystem/core-utils";
 import { Blocks, Crypto, Identities, Interfaces, Managers, Transactions, Utils } from "@arkecosystem/crypto";
 import assert from "assert";
+import cloneDeep from "lodash.clonedeep";
 
 export class DatabaseService implements Database.IDatabaseService {
     public connection: Database.IConnection;
@@ -20,7 +22,7 @@ export class DatabaseService implements Database.IDatabaseService {
     public blocksInCurrentRound: Interfaces.IBlock[] = undefined;
     public stateStarted: boolean = false;
     public restoredDatabaseIntegrity: boolean = false;
-    public forgingDelegates: State.IDelegateWallet[] = undefined;
+    public forgingDelegates: State.IWallet[] = undefined;
     public cache: Map<any, any> = new Map();
 
     constructor(
@@ -98,7 +100,7 @@ export class DatabaseService implements Database.IDatabaseService {
                 nextHeight === 1 ||
                 !this.forgingDelegates ||
                 this.forgingDelegates.length === 0 ||
-                this.forgingDelegates[0].round !== round
+                this.forgingDelegates[0].getAttribute<number>("delegate.round") !== round
             ) {
                 this.logger.info(`Starting Round ${roundInfo.round.toLocaleString()}`);
 
@@ -107,10 +109,10 @@ export class DatabaseService implements Database.IDatabaseService {
                         this.updateDelegateStats(this.forgingDelegates);
                     }
 
-                    const delegates: State.IDelegateWallet[] = this.walletManager.loadActiveDelegateList(roundInfo);
+                    const delegates: State.IWallet[] = this.walletManager.loadActiveDelegateList(roundInfo);
 
-                    await this.saveRound(delegates);
                     await this.setForgingDelegatesOfRound(roundInfo, delegates);
+                    await this.saveRound(delegates);
 
                     this.blocksInCurrentRound.length = 0;
 
@@ -146,24 +148,41 @@ export class DatabaseService implements Database.IDatabaseService {
 
     public async getActiveDelegates(
         roundInfo: Shared.IRoundInfo,
-        delegates?: State.IDelegateWallet[],
-    ): Promise<State.IDelegateWallet[]> {
+        delegates?: State.IWallet[],
+    ): Promise<State.IWallet[]> {
         const { round } = roundInfo;
 
-        if (this.forgingDelegates && this.forgingDelegates.length && this.forgingDelegates[0].round === round) {
+        if (
+            this.forgingDelegates &&
+            this.forgingDelegates.length &&
+            this.forgingDelegates[0].getAttribute<number>("delegate.round") === round
+        ) {
             return this.forgingDelegates;
         }
 
         // When called during applyRound we already know the delegates, so we don't have to query the database.
         if (!delegates || delegates.length === 0) {
-            delegates = ((await this.connection.roundsRepository.findById(
-                round,
-            )) as unknown) as State.IDelegateWallet[];
+            delegates = (await this.connection.roundsRepository.findById(round)).map(({ round, publicKey, balance }) =>
+                Object.assign(new Wallets.Wallet(Identities.Address.fromPublicKey(publicKey)), {
+                    publicKey,
+                    attributes: {
+                        delegate: {
+                            voteBalance: Utils.BigNumber.make(balance),
+                            username: this.walletManager.findByPublicKey(publicKey).getAttribute("delegate.username"),
+                        },
+                    },
+                }),
+            );
+        }
+
+        for (const delegate of delegates) {
+            delegate.setAttribute("delegate.round", round);
         }
 
         const seedSource: string = round.toString();
         let currentSeed: Buffer = Crypto.HashAlgorithms.sha256(seedSource);
 
+        delegates = cloneDeep(delegates);
         for (let i = 0, delCount = delegates.length; i < delCount; i++) {
             for (let x = 0; x < 4 && i < delCount; i++, x++) {
                 const newIndex = currentSeed[x] % delCount;
@@ -174,13 +193,7 @@ export class DatabaseService implements Database.IDatabaseService {
             currentSeed = Crypto.HashAlgorithms.sha256(currentSeed);
         }
 
-        const forgingDelegates: State.IDelegateWallet[] = delegates.map(delegate => {
-            delegate.round = +delegate.round;
-            delegate.username = this.walletManager.findByPublicKey(delegate.publicKey).username;
-            return delegate;
-        });
-
-        return forgingDelegates;
+        return delegates;
     }
 
     public async getBlock(id: string): Promise<Interfaces.IBlock | undefined> {
@@ -430,15 +443,15 @@ export class DatabaseService implements Database.IDatabaseService {
         await this.connection.saveBlocks(blocks);
     }
 
-    public async saveRound(activeDelegates: State.IDelegateWallet[]): Promise<void> {
-        this.logger.info(`Saving round ${activeDelegates[0].round.toLocaleString()}`);
+    public async saveRound(activeDelegates: State.IWallet[]): Promise<void> {
+        this.logger.info(`Saving round ${activeDelegates[0].getAttribute("delegate.round").toLocaleString()}`);
 
         await this.connection.roundsRepository.insert(activeDelegates);
 
         this.emitter.emit(ApplicationEvents.RoundCreated, activeDelegates);
     }
 
-    public updateDelegateStats(delegates: State.IDelegateWallet[]): void {
+    public updateDelegateStats(delegates: State.IWallet[]): void {
         if (!delegates || !this.blocksInCurrentRound) {
             return;
         }
@@ -458,7 +471,11 @@ export class DatabaseService implements Database.IDatabaseService {
                 if (producedBlocks.length === 0) {
                     const wallet: State.IWallet = this.walletManager.findByPublicKey(delegate.publicKey);
 
-                    this.logger.debug(`Delegate ${wallet.username} (${wallet.publicKey}) just missed a block.`);
+                    this.logger.debug(
+                        `Delegate ${wallet.getAttribute("delegate.username")} (${
+                            wallet.publicKey
+                        }) just missed a block.`,
+                    );
 
                     this.emitter.emit(ApplicationEvents.ForgerMissing, {
                         delegate: wallet,
@@ -657,17 +674,14 @@ export class DatabaseService implements Database.IDatabaseService {
         await this.setForgingDelegatesOfRound(roundInfo, await this.calcPreviousActiveDelegates(roundInfo));
     }
 
-    private async setForgingDelegatesOfRound(
-        roundInfo: Shared.IRoundInfo,
-        delegates?: State.IDelegateWallet[],
-    ): Promise<void> {
+    private async setForgingDelegatesOfRound(roundInfo: Shared.IRoundInfo, delegates?: State.IWallet[]): Promise<void> {
         this.forgingDelegates = await this.getActiveDelegates(roundInfo, delegates);
     }
 
     private async calcPreviousActiveDelegates(
         roundInfo: Shared.IRoundInfo,
         blocks?: Interfaces.IBlock[],
-    ): Promise<State.IDelegateWallet[]> {
+    ): Promise<State.IWallet[]> {
         blocks = blocks || (await this.getBlocksForRound(roundInfo));
 
         const tempWalletManager = this.walletManager.clone();
@@ -686,14 +700,14 @@ export class DatabaseService implements Database.IDatabaseService {
             tempWalletManager.revertBlock(blocks[i]);
         }
 
-        // Now retrieve the active delegate list from the temporary wallet manager.
-        const delegates: State.IDelegateWallet[] = tempWalletManager.loadActiveDelegateList(roundInfo);
+        const delegates: State.IWallet[] = tempWalletManager.loadActiveDelegateList(roundInfo);
 
         for (const delegate of tempWalletManager.allByUsername()) {
-            this.walletManager.findByUsername(delegate.username).rate = delegate.rate;
+            const delegateWallet = this.walletManager.findByUsername(delegate.getAttribute("delegate.username"));
+            delegateWallet.setAttribute("delegate.rank", delegate.getAttribute("delegate.rank"));
         }
 
-        return delegates;
+        return delegates.map(delegate => this.walletManager.findByPublicKey(delegate.publicKey));
     }
 
     private emitTransactionEvents(transaction: Interfaces.ITransaction): void {

--- a/packages/core-database/src/database-service.ts
+++ b/packages/core-database/src/database-service.ts
@@ -707,7 +707,7 @@ export class DatabaseService implements Database.IDatabaseService {
             delegateWallet.setAttribute("delegate.rank", delegate.getAttribute("delegate.rank"));
         }
 
-        return delegates.map(delegate => this.walletManager.findByPublicKey(delegate.publicKey));
+        return delegates;
     }
 
     private emitTransactionEvents(transaction: Interfaces.ITransaction): void {

--- a/packages/core-database/src/repositories/delegates-business-repository.ts
+++ b/packages/core-database/src/repositories/delegates-business-repository.ts
@@ -37,6 +37,7 @@ export class DelegatesBusinessRepository implements Database.IDelegatesBusinessR
             forgedTotal: delegateCalculator.calculateForgedTotal,
         };
 
+        // TODO: fix attributes lookup
         if (hasSomeProperty(params, Object.keys(manipulators))) {
             delegates = delegates.map(delegate => {
                 for (const [prop, method] of Object.entries(manipulators)) {
@@ -49,7 +50,7 @@ export class DelegatesBusinessRepository implements Database.IDelegatesBusinessR
             });
         }
 
-        delegates = sortEntries(params, filterRows(delegates, params, query), ["rate", "asc"]);
+        delegates = sortEntries(params, filterRows(delegates, params, query), ["rank", "asc"]);
 
         return {
             rows: limitRows(delegates, params),
@@ -57,22 +58,21 @@ export class DelegatesBusinessRepository implements Database.IDelegatesBusinessR
         };
     }
 
-    // @TODO: simplify this
     public findById(id): State.IWallet {
-        return this.search().rows.find(a => a.address === id || a.publicKey === id || a.getAttribute("delegate.username") === id);
+        return this.databaseServiceProvider().walletManager.findById(id);
     }
 
     private applyOrder(params): [CallbackFunctionVariadicVoidReturn | string, string] {
         const assignOrder = (params, value) => (params.orderBy = value);
 
         if (!params.orderBy) {
-            return assignOrder(params, ["rate", "asc"]);
+            return assignOrder(params, ["rank", "asc"]);
         }
 
         const orderByMapped: string[] = params.orderBy.split(":").map(p => p.toLowerCase());
 
         if (orderByMapped.length !== 2 || ["desc", "asc"].includes(orderByMapped[1]) !== true) {
-            return assignOrder(params, ["rate", "asc"]);
+            return assignOrder(params, ["rank", "asc"]);
         }
 
         return assignOrder(params, [this.manipulateIteratee(orderByMapped[0]), orderByMapped[1]]);
@@ -85,7 +85,7 @@ export class DelegatesBusinessRepository implements Database.IDelegatesBusinessR
             case "forgedTotal":
                 return delegateCalculator.calculateForgedTotal;
             case "rank":
-                return "rate";
+                return "rate"; // TODO: is this still necessary?
             case "votes":
                 return "voteBalance";
             default:

--- a/packages/core-database/src/repositories/delegates-business-repository.ts
+++ b/packages/core-database/src/repositories/delegates-business-repository.ts
@@ -7,7 +7,7 @@ import { sortEntries } from "./utils/sort-entries";
 type CallbackFunctionVariadicVoidReturn = (...args: any[]) => void;
 
 export class DelegatesBusinessRepository implements Database.IDelegatesBusinessRepository {
-    public constructor(private readonly databaseServiceProvider: () => Database.IDatabaseService) {}
+    public constructor(private readonly databaseServiceProvider: () => Database.IDatabaseService) { }
 
     public search(params: Database.IParameters = {}): Database.IWalletsPaginated {
         // Prepare...
@@ -59,7 +59,7 @@ export class DelegatesBusinessRepository implements Database.IDelegatesBusinessR
 
     // @TODO: simplify this
     public findById(id): State.IWallet {
-        return this.search().rows.find(a => a.address === id || a.publicKey === id || a.username === id);
+        return this.search().rows.find(a => a.address === id || a.publicKey === id || a.getAttribute("delegate.username") === id);
     }
 
     private applyOrder(params): [CallbackFunctionVariadicVoidReturn | string, string] {

--- a/packages/core-database/src/repositories/delegates-business-repository.ts
+++ b/packages/core-database/src/repositories/delegates-business-repository.ts
@@ -42,7 +42,7 @@ export class DelegatesBusinessRepository implements Database.IDelegatesBusinessR
             delegates = delegates.map(delegate => {
                 for (const [prop, method] of Object.entries(manipulators)) {
                     if (params.hasOwnProperty(prop)) {
-                        delegate[prop] = method(delegate);
+                        delegate.setAttribute(`delegate.${prop}`, method(delegate));
                     }
                 }
 

--- a/packages/core-database/src/repositories/utils/filter-rows.ts
+++ b/packages/core-database/src/repositories/utils/filter-rows.ts
@@ -1,3 +1,5 @@
+import { State } from '@arkecosystem/core-interfaces';
+
 /**
  * Filter an Array of Objects based on the given parameters.
  * @param  {Array} rows
@@ -5,11 +7,28 @@
  * @param  {Object} filters
  * @return {Array}
  */
-export = <T>(rows: T[], params, filters) =>
-    rows.filter(item => {
+export = (rows: State.IWallet[], params, filters): State.IWallet[] => {
+    const get = (item: any, prop: string): any => {
+        for (const [key, value] of Object.entries(item)) {
+            if (key === prop) {
+                return value;
+            }
+
+            if (value && value.constructor.name === "Object") {
+                const result = get(value, prop);
+                if (result) {
+                    return result;
+                }
+            }
+        }
+
+        return undefined;
+    };
+
+    return rows.filter(item => {
         if (filters.hasOwnProperty("exact")) {
             for (const elem of filters.exact) {
-                if (params[elem] && item[elem] !== params[elem]) {
+                if (params[elem] && get(item, elem) !== params[elem]) {
                     return false;
                 }
             }
@@ -17,7 +36,7 @@ export = <T>(rows: T[], params, filters) =>
 
         if (filters.hasOwnProperty("like")) {
             for (const elem of filters.like) {
-                if (params[elem] && !item[elem].includes(params[elem])) {
+                if (params[elem] && !get(item, elem).includes(params[elem])) {
                     return false;
                 }
             }
@@ -32,7 +51,7 @@ export = <T>(rows: T[], params, filters) =>
                 if (
                     !params[elem].hasOwnProperty("from") &&
                     !params[elem].hasOwnProperty("to") &&
-                    item[elem] !== params[elem]
+                    get(item, elem) !== params[elem]
                 ) {
                     return false;
                 }
@@ -42,11 +61,11 @@ export = <T>(rows: T[], params, filters) =>
                     let isLessThan = true;
 
                     if (params[elem].hasOwnProperty("from")) {
-                        isMoreThan = item[elem] >= params[elem].from;
+                        isMoreThan = get(item, elem) >= params[elem].from;
                     }
 
                     if (params[elem].hasOwnProperty("to")) {
-                        isLessThan = item[elem] <= params[elem].to;
+                        isLessThan = get(item, elem) <= params[elem].to;
                     }
 
                     return isMoreThan && isLessThan;
@@ -57,7 +76,7 @@ export = <T>(rows: T[], params, filters) =>
         if (filters.hasOwnProperty("in")) {
             for (const elem of filters.in) {
                 if (params[elem] && Array.isArray(params[elem])) {
-                    return params[elem].indexOf(item[elem]) > -1;
+                    return params[elem].indexOf(get(item, elem)) > -1;
                 }
             }
         }
@@ -66,7 +85,7 @@ export = <T>(rows: T[], params, filters) =>
         // replaced by `vote`. This filter is kept here just in case
         if (filters.hasOwnProperty("any")) {
             for (const elem of filters.any) {
-                if (params[elem] && item[elem]) {
+                if (params[elem] && get(item, elem)) {
                     if (Array.isArray(params[elem])) {
                         if (item[elem].every(a => params[elem].indexOf(a) === -1)) {
                             return false;
@@ -80,3 +99,4 @@ export = <T>(rows: T[], params, filters) =>
 
         return true;
     });
+};

--- a/packages/core-database/src/repositories/utils/filter-rows.ts
+++ b/packages/core-database/src/repositories/utils/filter-rows.ts
@@ -1,4 +1,5 @@
-import { State } from '@arkecosystem/core-interfaces';
+import { State } from "@arkecosystem/core-interfaces";
+import { getProperty } from "./get-property";
 
 /**
  * Filter an Array of Objects based on the given parameters.
@@ -8,27 +9,10 @@ import { State } from '@arkecosystem/core-interfaces';
  * @return {Array}
  */
 export = (rows: State.IWallet[], params, filters): State.IWallet[] => {
-    const get = (item: any, prop: string): any => {
-        for (const [key, value] of Object.entries(item)) {
-            if (key === prop) {
-                return value;
-            }
-
-            if (value && value.constructor.name === "Object") {
-                const result = get(value, prop);
-                if (result) {
-                    return result;
-                }
-            }
-        }
-
-        return undefined;
-    };
-
     return rows.filter(item => {
         if (filters.hasOwnProperty("exact")) {
             for (const elem of filters.exact) {
-                if (params[elem] && get(item, elem) !== params[elem]) {
+                if (params[elem] && getProperty(item, elem) !== params[elem]) {
                     return false;
                 }
             }
@@ -36,7 +20,7 @@ export = (rows: State.IWallet[], params, filters): State.IWallet[] => {
 
         if (filters.hasOwnProperty("like")) {
             for (const elem of filters.like) {
-                if (params[elem] && !get(item, elem).includes(params[elem])) {
+                if (params[elem] && !getProperty(item, elem).includes(params[elem])) {
                     return false;
                 }
             }
@@ -51,7 +35,7 @@ export = (rows: State.IWallet[], params, filters): State.IWallet[] => {
                 if (
                     !params[elem].hasOwnProperty("from") &&
                     !params[elem].hasOwnProperty("to") &&
-                    get(item, elem) !== params[elem]
+                    getProperty(item, elem) !== params[elem]
                 ) {
                     return false;
                 }
@@ -61,11 +45,11 @@ export = (rows: State.IWallet[], params, filters): State.IWallet[] => {
                     let isLessThan = true;
 
                     if (params[elem].hasOwnProperty("from")) {
-                        isMoreThan = get(item, elem) >= params[elem].from;
+                        isMoreThan = getProperty(item, elem) >= params[elem].from;
                     }
 
                     if (params[elem].hasOwnProperty("to")) {
-                        isLessThan = get(item, elem) <= params[elem].to;
+                        isLessThan = getProperty(item, elem) <= params[elem].to;
                     }
 
                     return isMoreThan && isLessThan;
@@ -76,7 +60,7 @@ export = (rows: State.IWallet[], params, filters): State.IWallet[] => {
         if (filters.hasOwnProperty("in")) {
             for (const elem of filters.in) {
                 if (params[elem] && Array.isArray(params[elem])) {
-                    return params[elem].indexOf(get(item, elem)) > -1;
+                    return params[elem].indexOf(getProperty(item, elem)) > -1;
                 }
             }
         }
@@ -85,7 +69,7 @@ export = (rows: State.IWallet[], params, filters): State.IWallet[] => {
         // replaced by `vote`. This filter is kept here just in case
         if (filters.hasOwnProperty("any")) {
             for (const elem of filters.any) {
-                if (params[elem] && get(item, elem)) {
+                if (params[elem] && getProperty(item, elem)) {
                     if (Array.isArray(params[elem])) {
                         if (item[elem].every(a => params[elem].indexOf(a) === -1)) {
                             return false;

--- a/packages/core-database/src/repositories/utils/get-property.ts
+++ b/packages/core-database/src/repositories/utils/get-property.ts
@@ -1,0 +1,16 @@
+export const getProperty = (item: any, prop: string): any => {
+    for (const [key, value] of Object.entries(item)) {
+        if (key === prop) {
+            return value;
+        }
+
+        if (value && value.constructor.name === "Object") {
+            const result = getProperty(value, prop);
+            if (result !== undefined) {
+                return result;
+            }
+        }
+    }
+
+    return undefined;
+};

--- a/packages/core-database/src/repositories/utils/sort-entries.ts
+++ b/packages/core-database/src/repositories/utils/sort-entries.ts
@@ -1,12 +1,17 @@
-import { Database } from "@arkecosystem/core-interfaces";
+import { Database, State } from "@arkecosystem/core-interfaces";
+import { Utils } from "@arkecosystem/crypto";
 import { orderBy } from "@arkecosystem/utils";
+import { getProperty } from "./get-property";
 
-export const sortEntries = (params: Database.IParameters, entries: any[], defaultValue) => {
+export const sortEntries = (params: Database.IParameters, entries: State.IWallet[], defaultValue) => {
     const [iteratee, order] = params.orderBy ? params.orderBy : defaultValue;
 
     if (["balance", "voteBalance"].includes(iteratee)) {
-        return Object.values(entries).sort((a: any, b: any) => {
-            return order === "asc" ? a[iteratee].comparedTo(b[iteratee]) : b[iteratee].comparedTo(a[iteratee]);
+        return Object.values(entries).sort((a: State.IWallet, b: State.IWallet) => {
+            const iterateeA: Utils.BigNumber = getProperty(a, iteratee) || Utils.BigNumber.ZERO;
+            const iterateeB: Utils.BigNumber = getProperty(b, iteratee) || Utils.BigNumber.ZERO;
+
+            return order === "asc" ? iterateeA.comparedTo(iterateeB) : iterateeB.comparedTo(iterateeA);
         });
     }
 

--- a/packages/core-database/src/repositories/wallets-business-repository.ts
+++ b/packages/core-database/src/repositories/wallets-business-repository.ts
@@ -54,6 +54,7 @@ export class WalletsBusinessRepository implements Database.IWalletsBusinessRepos
         return this.search({ ...params, ...{ orderBy: "balance:desc" } });
     }
 
+    // TODO: check if order still works
     private applyOrder(params: Database.IParameters): void {
         const assignOrder = (params, value) => (params.orderBy = value);
 

--- a/packages/core-database/src/repositories/wallets-business-repository.ts
+++ b/packages/core-database/src/repositories/wallets-business-repository.ts
@@ -4,7 +4,7 @@ import limitRows from "./utils/limit-rows";
 import { sortEntries } from "./utils/sort-entries";
 
 export class WalletsBusinessRepository implements Database.IWalletsBusinessRepository {
-    public constructor(private readonly databaseServiceProvider: () => Database.IDatabaseService) {}
+    public constructor(private readonly databaseServiceProvider: () => Database.IDatabaseService) { }
 
     public search(params: Database.IParameters = {}): Database.IWalletsPaginated {
         const query: Record<string, string[]> = {

--- a/packages/core-forger/package.json
+++ b/packages/core-forger/package.json
@@ -25,6 +25,7 @@
         "@arkecosystem/core-event-emitter": "^2.5.7",
         "@arkecosystem/core-interfaces": "^2.5.7",
         "@arkecosystem/core-p2p": "^2.5.7",
+        "@arkecosystem/core-state": "^2.5.7",
         "@arkecosystem/core-utils": "^2.5.7",
         "@arkecosystem/crypto": "^2.5.7",
         "delay": "^4.3.0",

--- a/packages/core-forger/src/manager.ts
+++ b/packages/core-forger/src/manager.ts
@@ -2,6 +2,7 @@ import { app } from "@arkecosystem/core-container";
 import { ApplicationEvents } from "@arkecosystem/core-event-emitter";
 import { Logger, P2P } from "@arkecosystem/core-interfaces";
 import { NetworkStateStatus } from "@arkecosystem/core-p2p";
+import { Wallets } from "@arkecosystem/core-state";
 import { Blocks, Crypto, Interfaces, Managers, Transactions, Types } from "@arkecosystem/crypto";
 import isEmpty from "lodash.isempty";
 import uniq from "lodash.uniq";
@@ -251,10 +252,13 @@ export class ForgerManager {
     private async loadRound(): Promise<void> {
         this.round = await this.client.getRound();
 
-        this.usernames = this.round.delegates.reduce(
-            (acc, delegate) => Object.assign(acc, { [delegate.publicKey]: delegate.username }),
-            {},
-        );
+        this.usernames = this.round.delegates
+            .map(delegate => Object.assign(new Wallets.Wallet(delegate.address), delegate))
+            .reduce(
+                (acc, delegate) =>
+                    Object.assign(acc, { [delegate.publicKey]: delegate.getAttribute("delegate.username") }),
+                {},
+            );
 
         if (!this.initialized) {
             this.printLoadedDelegates();

--- a/packages/core-interfaces/src/core-database/database-service.ts
+++ b/packages/core-interfaces/src/core-database/database-service.ts
@@ -1,5 +1,5 @@
 import { Interfaces } from "@arkecosystem/crypto";
-import { IDelegateWallet, IWalletManager } from "../core-state/wallets";
+import { IWallet, IWalletManager } from "../core-state/wallets";
 import { EventEmitter, Logger } from "../index";
 import { IRoundInfo } from "../shared";
 import {
@@ -41,7 +41,7 @@ export interface IDatabaseService {
 
     verifyBlockchain(): Promise<boolean>;
 
-    getActiveDelegates(roundInfo: IRoundInfo, delegates?: IDelegateWallet[]): Promise<IDelegateWallet[]>;
+    getActiveDelegates(roundInfo: IRoundInfo, delegates?: IWallet[]): Promise<IWallet[]>;
 
     restoreCurrentRound(height: number): Promise<void>;
 
@@ -87,7 +87,7 @@ export interface IDatabaseService {
 
     getRecentBlockIds(): Promise<string[]>;
 
-    saveRound(activeDelegates: IDelegateWallet[]): Promise<void>;
+    saveRound(activeDelegates: IWallet[]): Promise<void>;
 
     deleteRound(round: number): Promise<void>;
 
@@ -101,7 +101,7 @@ export interface IDatabaseService {
 
     loadBlocksFromCurrentRound(): Promise<void>;
 
-    updateDelegateStats(delegates: IDelegateWallet[]): void;
+    updateDelegateStats(delegates: IWallet[]): void;
 
     applyRound(height: number): Promise<void>;
 

--- a/packages/core-interfaces/src/core-p2p/server.ts
+++ b/packages/core-interfaces/src/core-p2p/server.ts
@@ -1,5 +1,5 @@
 import { Interfaces } from "@arkecosystem/crypto";
-import { IDelegateWallet } from "../core-state";
+import { IWallet } from "../core-state";
 
 export interface IResponse<T> {
     data: T;
@@ -9,9 +9,9 @@ export interface ICurrentRound {
     current: number;
     reward: string;
     timestamp: number;
-    delegates: IDelegateWallet[];
-    currentForger: IDelegateWallet;
-    nextForger: IDelegateWallet;
+    delegates: IWallet[];
+    currentForger: IWallet;
+    nextForger: IWallet;
     lastBlock: Interfaces.IBlockData;
     canForge: boolean;
 }

--- a/packages/core-interfaces/src/core-state/wallets.ts
+++ b/packages/core-interfaces/src/core-state/wallets.ts
@@ -5,22 +5,8 @@ import { IRoundInfo } from "../shared";
 export interface IWallet {
     address: string;
     publicKey: string | undefined;
-    secondPublicKey: string | undefined;
     balance: Utils.BigNumber;
     nonce: Utils.BigNumber;
-    vote: string;
-    voted: boolean;
-    username: string | undefined;
-    resigned: boolean;
-    lastBlock: any;
-    voteBalance: Utils.BigNumber;
-    multisignature?: Interfaces.IMultiSignatureAsset;
-    ipfsHashes: { [ipfsHash: string]: boolean };
-    dirty: boolean;
-    producedBlocks: number;
-    forgedFees: Utils.BigNumber;
-    forgedRewards: Utils.BigNumber;
-    rate?: number;
 
     applyBlock(block: Interfaces.IBlockData): boolean;
     revertBlock(block: Interfaces.IBlockData): boolean;
@@ -28,13 +14,41 @@ export interface IWallet {
     auditApply(transaction: Interfaces.ITransactionData): any[];
     toString(): string;
 
+    hasAttribute(key: string): boolean;
+    getAttribute<T>(key: string, defaultValue?: T): T;
+    setAttribute(key: string, value: any);
+    unsetAttribute(key: string): void;
+
+    isDelegate(): boolean;
+    hasVoted(): boolean;
+    hasSecondSignature(): boolean;
+    hasMultiSignature(): boolean;
+
+    canBePurged(): boolean;
+
     verifySignatures(
         transaction: Interfaces.ITransactionData,
         multisignature?: Interfaces.IMultiSignatureAsset,
     ): boolean;
 }
 
-export type IDelegateWallet = IWallet & { rate: number; round: number };
+export interface IWalletDelegateAttributes {
+    username: string;
+    rank: number;
+    voteBalance: Utils.BigNumber;
+    forgedFees: Utils.BigNumber;
+    forgedRewards: Utils.BigNumber;
+    producedBlocks: number;
+    lastBlock: Interfaces.IBlockData;
+    round: number;
+    resigned: boolean;
+}
+
+export type IWalletMultiSignatureAttributes = Interfaces.IMultiSignatureAsset;
+
+export interface IWalletIpfsAttributes {
+    [hash: string]: boolean;
+}
 
 export interface IWalletManager {
     logger: Logger.ILogger;
@@ -65,21 +79,19 @@ export interface IWalletManager {
 
     clone(): IWalletManager;
 
-    loadActiveDelegateList(roundInfo: IRoundInfo): IDelegateWallet[];
+    loadActiveDelegateList(roundInfo: IRoundInfo): IWallet[];
 
     buildVoteBalances(): void;
 
     applyBlock(block: Interfaces.IBlock): void;
 
-    buildDelegateRanking(roundInfo?: Shared.IRoundInfo): IDelegateWallet[];
+    buildDelegateRanking(roundInfo?: Shared.IRoundInfo): IWallet[];
 
     revertBlock(block: Interfaces.IBlock): void;
 
     applyTransaction(transaction: Interfaces.ITransaction): void;
 
     revertTransaction(transaction: Interfaces.ITransaction): void;
-
-    isDelegate(publicKey: string): boolean;
 
     canBePurged(wallet: IWallet): boolean;
 

--- a/packages/core-interfaces/src/core-state/wallets.ts
+++ b/packages/core-interfaces/src/core-state/wallets.ts
@@ -17,7 +17,7 @@ export interface IWallet {
     hasAttribute(key: string): boolean;
     getAttribute<T = any>(key: string, defaultValue?: T): T;
     setAttribute<T = any>(key: string, value: T): void;
-    unsetAttribute(key: string): void;
+    forgetAttribute(key: string): void;
 
     isDelegate(): boolean;
     hasVoted(): boolean;

--- a/packages/core-interfaces/src/core-state/wallets.ts
+++ b/packages/core-interfaces/src/core-state/wallets.ts
@@ -34,14 +34,14 @@ export interface IWallet {
 
 export interface IWalletDelegateAttributes {
     username: string;
-    rank: number;
     voteBalance: Utils.BigNumber;
     forgedFees: Utils.BigNumber;
     forgedRewards: Utils.BigNumber;
     producedBlocks: number;
-    lastBlock: Interfaces.IBlockData;
-    round: number;
-    resigned: boolean;
+    rank?: number;
+    lastBlock?: Interfaces.IBlockData;
+    round?: number;
+    resigned?: boolean;
 }
 
 export type IWalletMultiSignatureAttributes = Interfaces.IMultiSignatureAsset;

--- a/packages/core-interfaces/src/core-state/wallets.ts
+++ b/packages/core-interfaces/src/core-state/wallets.ts
@@ -15,8 +15,8 @@ export interface IWallet {
     toString(): string;
 
     hasAttribute(key: string): boolean;
-    getAttribute<T>(key: string, defaultValue?: T): T;
-    setAttribute(key: string, value: any);
+    getAttribute<T = any>(key: string, defaultValue?: T): T;
+    setAttribute<T = any>(key: string, value: T): void;
     unsetAttribute(key: string): void;
 
     isDelegate(): boolean;

--- a/packages/core-p2p/src/peer-verifier.ts
+++ b/packages/core-p2p/src/peer-verifier.ts
@@ -7,12 +7,8 @@ import assert from "assert";
 import { inspect } from "util";
 import { Severity } from "./enums";
 
-interface IDelegateWallets {
-    [publicKey: string]: State.IDelegateWallet;
-}
-
 export class PeerVerificationResult implements P2P.IPeerVerificationResult {
-    public constructor(readonly myHeight: number, readonly hisHeight: number, readonly highestCommonHeight: number) {}
+    public constructor(readonly myHeight: number, readonly hisHeight: number, readonly highestCommonHeight: number) { }
 
     get forked(): boolean {
         return this.highestCommonHeight !== this.myHeight && this.highestCommonHeight !== this.hisHeight;
@@ -176,7 +172,7 @@ export class PeerVerifier {
             this.log(
                 Severity.DEBUG_EXTRA,
                 `peer's claimed chain is ${blocksAhead} block(s) higher than ` +
-                    `ours (our height ${ourHeight}, his claimed height ${claimedHeight})`,
+                `ours (our height ${ourHeight}, his claimed height ${claimedHeight})`,
             );
 
             return false;
@@ -188,8 +184,8 @@ export class PeerVerifier {
             blocks.length,
             1,
             `database.getBlocksByHeight([ ${claimedHeight} ]) returned ${blocks.length} results: ` +
-                this.anyToString(blocks) +
-                ` (our chain is at height ${ourHeight})`,
+            this.anyToString(blocks) +
+            ` (our chain is at height ${ourHeight})`,
         );
 
         const ourBlockAtHisHeight = blocks[0];
@@ -199,14 +195,14 @@ export class PeerVerifier {
                 this.log(
                     Severity.DEBUG_EXTRA,
                     `success: peer's latest block is the same as our latest ` +
-                        `block (height=${claimedHeight}, id=${claimedState.header.id}). Identical chains.`,
+                    `block (height=${claimedHeight}, id=${claimedState.header.id}). Identical chains.`,
                 );
             } else {
                 this.log(
                     Severity.DEBUG_EXTRA,
                     `success: peer's latest block ` +
-                        `(height=${claimedHeight}, id=${claimedState.header.id}) is part of our chain. ` +
-                        `Peer is ${ourHeight - claimedHeight} block(s) behind us.`,
+                    `(height=${claimedHeight}, id=${claimedState.header.id}) is part of our chain. ` +
+                    `Peer is ${ourHeight - claimedHeight} block(s) behind us.`,
                 );
             }
             return true;
@@ -215,9 +211,9 @@ export class PeerVerifier {
         this.log(
             Severity.DEBUG,
             `peer's latest block (height=${claimedHeight}, id=${claimedState.header.id}), is different than the ` +
-                `block at the same height in our chain (id=${ourBlockAtHisHeight.id}). Peer has ` +
-                (claimedHeight < ourHeight ? `a shorter and` : `an equal-height but`) +
-                ` different chain.`,
+            `block at the same height in our chain (id=${ourBlockAtHisHeight.id}). Peer has ` +
+            (claimedHeight < ourHeight ? `a shorter and` : `an equal-height but`) +
+            ` different chain.`,
         );
 
         return false;
@@ -286,7 +282,7 @@ export class PeerVerifier {
                 this.log(
                     Severity.DEBUG_EXTRA,
                     `failure: bogus reply from peer for common blocks ${ourBlocksPrint}: ` +
-                        `peer replied with block id ${highestCommon.id} which we did not ask for`,
+                    `peer replied with block id ${highestCommon.id} which we did not ask for`,
                 );
                 return undefined;
             }
@@ -295,9 +291,9 @@ export class PeerVerifier {
                 this.log(
                     Severity.DEBUG_EXTRA,
                     `failure: bogus reply from peer for common blocks ${ourBlocksPrint}: ` +
-                        `peer pretends to have block with id ${highestCommon.id} at height ` +
-                        `${highestCommon.height}, however a block with the same id is at ` +
-                        `different height ${probesHeightById[highestCommon.id]} in our chain`,
+                    `peer pretends to have block with id ${highestCommon.id} at height ` +
+                    `${highestCommon.height}, however a block with the same id is at ` +
+                    `different height ${probesHeightById[highestCommon.id]} in our chain`,
                 );
                 return undefined;
             }
@@ -368,7 +364,7 @@ export class PeerVerifier {
     /**
      * Get the delegates for the given round.
      */
-    private async getDelegatesByRound(roundInfo: Shared.IRoundInfo): Promise<IDelegateWallets> {
+    private async getDelegatesByRound(roundInfo: Shared.IRoundInfo): Promise<Record<string, State.IWallet>> {
         const { round, maxDelegates } = roundInfo;
 
         let delegates = await this.database.getActiveDelegates(roundInfo);
@@ -383,11 +379,11 @@ export class PeerVerifier {
                 delegates.length,
                 maxDelegates,
                 `Couldn't derive the list of delegates for round ${round}. The database ` +
-                    `returned empty list and the wallet manager returned ${this.anyToString(delegates)}.`,
+                `returned empty list and the wallet manager returned ${this.anyToString(delegates)}.`,
             );
         }
 
-        const delegatesByPublicKey = {} as IDelegateWallets;
+        const delegatesByPublicKey = {} as Record<string, State.IWallet>;
 
         for (const delegate of delegates) {
             delegatesByPublicKey[delegate.publicKey] = delegate;
@@ -439,7 +435,7 @@ export class PeerVerifier {
             this.log(
                 Severity.DEBUG_EXTRA,
                 `failure: could not get blocks starting from height ${height} ` +
-                    `from peer: unexpected response: ${this.anyToString(response)}`,
+                `from peer: unexpected response: ${this.anyToString(response)}`,
             );
             return false;
         }
@@ -462,7 +458,7 @@ export class PeerVerifier {
     private async verifyPeerBlock(
         blockData: Interfaces.IBlockData,
         expectedHeight: number,
-        delegatesByPublicKey: IDelegateWallets,
+        delegatesByPublicKey: Record<string, State.IWallet>,
     ): Promise<boolean> {
         if (PeerVerifier.verifiedBlocks.has(blockData.id)) {
             this.log(
@@ -506,8 +502,8 @@ export class PeerVerifier {
         this.log(
             Severity.DEBUG_EXTRA,
             `failure: block ${this.anyToString(blockData)} is not signed by any of the delegates ` +
-                `for the corresponding round: ` +
-                this.anyToString(Object.values(delegatesByPublicKey)),
+            `for the corresponding round: ` +
+            this.anyToString(Object.values(delegatesByPublicKey)),
         );
 
         return false;

--- a/packages/core-state/package.json
+++ b/packages/core-state/package.json
@@ -28,11 +28,13 @@
         "@arkecosystem/crypto": "^2.5.7",
         "immutable": "^4.0.0-rc.12",
         "lodash.clonedeep": "^4.5.0",
-        "pluralize": "^8.0.0"
+        "pluralize": "^8.0.0",
+        "dottie": "^2.0.1"
     },
     "devDependencies": {
         "@types/lodash.clonedeep": "^4.5.6",
-        "@types/pluralize": "^0.0.29"
+        "@types/pluralize": "^0.0.29",
+        "@types/dottie": "^2.0.3"
     },
     "engines": {
         "node": ">=10.x"

--- a/packages/core-state/src/wallets/wallet-manager.ts
+++ b/packages/core-state/src/wallets/wallet-manager.ts
@@ -111,8 +111,8 @@ export class WalletManager implements State.IWalletManager {
             this.byPublicKey[wallet.publicKey] = wallet;
         }
 
-        if (wallet.username) {
-            this.byUsername[wallet.username] = wallet;
+        if (wallet.isDelegate()) {
+            this.byUsername[wallet.getAttribute<string>("delegate.username")] = wallet;
         }
     }
 
@@ -120,28 +120,29 @@ export class WalletManager implements State.IWalletManager {
         return new TempWalletManager(this);
     }
 
-    public loadActiveDelegateList(roundInfo: Shared.IRoundInfo): State.IDelegateWallet[] {
+    public loadActiveDelegateList(roundInfo: Shared.IRoundInfo): State.IWallet[] {
         const delegates: State.IWallet[] = this.buildDelegateRanking(roundInfo);
         const { maxDelegates } = roundInfo;
 
         if (delegates.length < maxDelegates) {
             throw new Error(
                 `Expected to find ${maxDelegates} delegates but only found ${delegates.length}. ` +
-                    `This indicates an issue with the genesis block & delegates.`,
+                `This indicates an issue with the genesis block & delegates.`,
             );
         }
 
         this.logger.debug(`Loaded ${delegates.length} active ${pluralize("delegate", delegates.length)}`);
 
-        return delegates as State.IDelegateWallet[];
+        return delegates;
     }
 
     // Only called during integrity verification on boot.
     public buildVoteBalances(): void {
         for (const voter of Object.values(this.byPublicKey)) {
-            if (voter.vote) {
-                const delegate: State.IWallet = this.byPublicKey[voter.vote];
-                delegate.voteBalance = delegate.voteBalance.plus(voter.balance);
+            if (voter.hasVoted()) {
+                const delegate: State.IWallet = this.byPublicKey[voter.getAttribute<string>("vote")];
+                const voteBalance: Utils.BigNumber = delegate.getAttribute("delegate.voteBalance");
+                delegate.setAttribute("delegate.voteBalance", voteBalance.plus(voter.balance));
             }
         }
     }
@@ -187,10 +188,11 @@ export class WalletManager implements State.IWalletManager {
             // If the block has been applied to the delegate, the balance is increased
             // by reward + totalFee. In which case the vote balance of the
             // delegate's delegate has to be updated.
-            if (applied && delegate.vote) {
+            if (applied && delegate.hasVoted()) {
                 const increase: Utils.BigNumber = block.data.reward.plus(block.data.totalFee);
-                const votedDelegate: State.IWallet = this.findByPublicKey(delegate.vote);
-                votedDelegate.voteBalance = votedDelegate.voteBalance.plus(increase);
+                const votedDelegate: State.IWallet = this.byPublicKey[delegate.getAttribute<string>("vote")];
+                const voteBalance: Utils.BigNumber = votedDelegate.getAttribute("delegate.voteBalance");
+                votedDelegate.setAttribute("delegate.voteBalance", voteBalance.plus(increase));
             }
         } catch (error) {
             this.logger.error("Failed to apply all transactions in block - reverting previous transactions");
@@ -225,10 +227,11 @@ export class WalletManager implements State.IWalletManager {
             // If the block has been reverted, the balance is decreased
             // by reward + totalFee. In which case the vote balance of the
             // delegate's delegate has to be updated.
-            if (reverted && delegate.vote) {
+            if (reverted && delegate.hasVoted()) {
                 const decrease: Utils.BigNumber = block.data.reward.plus(block.data.totalFee);
-                const votedDelegate: State.IWallet = this.findByPublicKey(delegate.vote);
-                votedDelegate.voteBalance = votedDelegate.voteBalance.minus(decrease);
+                const votedDelegate: State.IWallet = this.byPublicKey[delegate.getAttribute<string>("vote")];
+                const voteBalance: Utils.BigNumber = votedDelegate.getAttribute("delegate.voteBalance");
+                votedDelegate.setAttribute("delegate.voteBalance", voteBalance.minus(decrease));
             }
         } catch (error) {
             this.logger.error(error.stack);
@@ -265,16 +268,8 @@ export class WalletManager implements State.IWalletManager {
         this.updateVoteBalances(sender, recipient, data, true);
     }
 
-    public isDelegate(publicKey: string): boolean {
-        if (!this.has(publicKey)) {
-            return false;
-        }
-
-        return !!this.findByPublicKey(publicKey).username;
-    }
-
     public canBePurged(wallet: State.IWallet): boolean {
-        return wallet.balance.isZero() && !wallet.secondPublicKey && !wallet.multisignature && !wallet.username;
+        return wallet.canBePurged();
     }
 
     /**
@@ -287,26 +282,23 @@ export class WalletManager implements State.IWalletManager {
         this.byUsername = {};
     }
 
-    public buildDelegateRanking(roundInfo?: Shared.IRoundInfo): State.IDelegateWallet[] {
-        const delegates: State.IWallet[] = this.allByUsername().filter((w: State.IWallet) => !w.resigned);
+    public buildDelegateRanking(roundInfo?: Shared.IRoundInfo): State.IWallet[] {
+        const delegates: State.IWallet[] = this.allByUsername().filter(
+            (wallet: State.IWallet) => !wallet.hasAttribute("delegate.resigned"),
+        );
 
-        const equalVotesMap = new Map();
         let delegateWallets = delegates
             .sort((a, b) => {
-                const diff = b.voteBalance.comparedTo(a.voteBalance);
+                const voteBalanceA: Utils.BigNumber = a.getAttribute("delegate.voteBalance");
+                const voteBalanceB: Utils.BigNumber = b.getAttribute("delegate.voteBalance");
 
+                const diff = voteBalanceB.comparedTo(voteBalanceA);
                 if (diff === 0) {
-                    if (!equalVotesMap.has(a.voteBalance.toFixed())) {
-                        equalVotesMap.set(a.voteBalance.toFixed(), new Set());
-                    }
-
-                    const set = equalVotesMap.get(a.voteBalance.toFixed());
-                    set.add(a);
-                    set.add(b);
-
                     if (a.publicKey === b.publicKey) {
                         throw new Error(
-                            `The balance and public key of both delegates are identical! Delegate "${a.username}" appears twice in the list.`,
+                            `The balance and public key of both delegates are identical! Delegate "${a.getAttribute(
+                                "delegate.username",
+                            )}" appears twice in the list.`,
                         );
                     }
 
@@ -315,28 +307,16 @@ export class WalletManager implements State.IWalletManager {
 
                 return diff;
             })
-            .map((delegate, i) => {
-                const rate = i + 1;
-                this.findByUsername(delegate.username).rate = rate;
-                return { round: roundInfo ? roundInfo.round : 0, ...delegate, rate };
-            });
+            .map(
+                (delegate, i): State.IWallet => {
+                    const rank = i + 1;
+                    delegate.setAttribute("delegate.rank", rank);
+                    return delegate;
+                },
+            );
 
         if (roundInfo) {
             delegateWallets = delegateWallets.slice(0, roundInfo.maxDelegates);
-
-            for (const [voteBalance, set] of equalVotesMap.entries()) {
-                const values: any[] = Array.from(set.values());
-                if (delegateWallets.includes(values[0])) {
-                    const mapped = values.map(v => `${v.username} (${v.publicKey})`);
-                    this.logger.warn(
-                        `Delegates ${JSON.stringify(
-                            mapped,
-                            undefined,
-                            4,
-                        )} have a matching vote balance of ${Utils.formatSatoshi(voteBalance)}`,
-                    );
-                }
-            }
         }
 
         return delegateWallets;
@@ -362,32 +342,49 @@ export class WalletManager implements State.IWalletManager {
         // TODO: multipayment?
         if (transaction.type !== Enums.TransactionTypes.Vote) {
             // Update vote balance of the sender's delegate
-            if (sender.vote) {
-                const delegate: State.IWallet = this.findByPublicKey(sender.vote);
+            if (sender.hasVoted()) {
+                const delegate: State.IWallet = this.findByPublicKey(sender.getAttribute("vote"));
                 const total: Utils.BigNumber = transaction.amount.plus(transaction.fee);
-                delegate.voteBalance = revert ? delegate.voteBalance.plus(total) : delegate.voteBalance.minus(total);
+
+                const voteBalance: Utils.BigNumber = delegate.getAttribute(
+                    "delegate.voteBalance",
+                    Utils.BigNumber.ZERO,
+                );
+                delegate.setAttribute(
+                    "delegate.voteBalance",
+                    revert ? voteBalance.plus(total) : voteBalance.minus(total),
+                );
             }
 
             // Update vote balance of recipient's delegate
-            if (recipient && recipient.vote) {
-                const delegate: State.IWallet = this.findByPublicKey(recipient.vote);
-                delegate.voteBalance = revert
-                    ? delegate.voteBalance.minus(transaction.amount)
-                    : delegate.voteBalance.plus(transaction.amount);
+            if (recipient && recipient.hasVoted()) {
+                const delegate: State.IWallet = this.findByPublicKey(recipient.getAttribute("vote"));
+                const voteBalance: Utils.BigNumber = delegate.getAttribute(
+                    "delegate.voteBalance",
+                    Utils.BigNumber.ZERO,
+                );
+
+                delegate.setAttribute(
+                    "delegate.voteBalance",
+                    revert ? voteBalance.minus(transaction.amount) : voteBalance.plus(transaction.amount),
+                );
             }
         } else {
             const vote: string = transaction.asset.votes[0];
             const delegate: State.IWallet = this.findByPublicKey(vote.substr(1));
+            let voteBalance: Utils.BigNumber = delegate.getAttribute("delegate.voteBalance", Utils.BigNumber.ZERO);
 
             if (vote.startsWith("+")) {
-                delegate.voteBalance = revert
-                    ? delegate.voteBalance.minus(sender.balance.minus(transaction.fee))
-                    : delegate.voteBalance.plus(sender.balance);
+                voteBalance = revert
+                    ? voteBalance.minus(sender.balance.minus(transaction.fee))
+                    : voteBalance.plus(sender.balance);
             } else {
-                delegate.voteBalance = revert
-                    ? delegate.voteBalance.plus(sender.balance)
-                    : delegate.voteBalance.minus(sender.balance.plus(transaction.fee));
+                voteBalance = revert
+                    ? voteBalance.plus(sender.balance)
+                    : voteBalance.minus(sender.balance.plus(transaction.fee));
             }
+
+            delegate.setAttribute("delegate.voteBalance", voteBalance);
         }
     }
 }

--- a/packages/core-state/src/wallets/wallet-manager.ts
+++ b/packages/core-state/src/wallets/wallet-manager.ts
@@ -127,7 +127,7 @@ export class WalletManager implements State.IWalletManager {
         if (delegates.length < maxDelegates) {
             throw new Error(
                 `Expected to find ${maxDelegates} delegates but only found ${delegates.length}. ` +
-                `This indicates an issue with the genesis block & delegates.`,
+                    `This indicates an issue with the genesis block & delegates.`,
             );
         }
 
@@ -317,6 +317,9 @@ export class WalletManager implements State.IWalletManager {
 
         if (roundInfo) {
             delegateWallets = delegateWallets.slice(0, roundInfo.maxDelegates);
+            for (const delegate of delegateWallets) {
+                delegate.setAttribute("delegate.round", roundInfo.round);
+            }
         }
 
         return delegateWallets;

--- a/packages/core-state/src/wallets/wallet.ts
+++ b/packages/core-state/src/wallets/wallet.ts
@@ -31,7 +31,7 @@ export class Wallet implements State.IWallet {
         dottie.set(this.attributes, key, value);
     }
 
-    public unsetAttribute(key: string): void {
+    public forgetAttribute(key: string): void {
         this.setAttribute(key, undefined);
     }
 

--- a/packages/core-state/src/wallets/wallet.ts
+++ b/packages/core-state/src/wallets/wallet.ts
@@ -1,44 +1,59 @@
 import { State } from "@arkecosystem/core-interfaces";
 import { Errors } from "@arkecosystem/core-transactions";
 import { Crypto, Enums, Identities, Interfaces, Transactions, Utils } from "@arkecosystem/crypto";
+import dottie from "dottie";
 
 export class Wallet implements State.IWallet {
     public address: string;
     public publicKey: string | undefined;
-    public secondPublicKey: string | undefined;
     public balance: Utils.BigNumber;
     public nonce: Utils.BigNumber;
-    public vote: string;
-    public voted: boolean;
-    public username: string | undefined;
-    public resigned: boolean;
-    public lastBlock: any;
-    public voteBalance: Utils.BigNumber;
-    public multisignature?: Interfaces.IMultiSignatureAsset;
-    public ipfsHashes: { [ipfsHash: string]: boolean };
-    public dirty: boolean;
-    public producedBlocks: number;
-    public forgedFees: Utils.BigNumber;
-    public forgedRewards: Utils.BigNumber;
-    public rate?: number;
+
+    private readonly attributes: Record<string, any>;
 
     constructor(address: string) {
         this.address = address;
-        this.publicKey = undefined;
-        this.secondPublicKey = undefined;
         this.balance = Utils.BigNumber.ZERO;
         this.nonce = Utils.BigNumber.ZERO;
-        this.vote = undefined;
-        this.voted = false;
-        this.username = undefined;
-        this.resigned = false;
-        this.lastBlock = undefined;
-        this.voteBalance = Utils.BigNumber.ZERO;
-        this.multisignature = undefined;
-        this.ipfsHashes = {};
-        this.producedBlocks = 0;
-        this.forgedFees = Utils.BigNumber.ZERO;
-        this.forgedRewards = Utils.BigNumber.ZERO;
+
+        this.attributes = {};
+    }
+
+    public hasAttribute(key: string): boolean {
+        return dottie.exists(this.attributes, key);
+    }
+
+    public getAttribute<T>(key: string, defaultValue?: T): T {
+        return dottie.get(this.attributes, key, defaultValue);
+    }
+
+    public setAttribute<T = any>(key: string, value: T): void {
+        dottie.set(this.attributes, key, value);
+    }
+
+    public unsetAttribute(key: string): void {
+        this.setAttribute(key, undefined);
+    }
+
+    public isDelegate(): boolean {
+        return !!this.getAttribute("delegate");
+    }
+
+    public hasVoted(): boolean {
+        return !!this.getAttribute("vote");
+    }
+
+    public hasSecondSignature(): boolean {
+        return !!this.getAttribute("secondPublicKey");
+    }
+
+    public hasMultiSignature(): boolean {
+        return !!this.getAttribute("multiSignature");
+    }
+
+    public canBePurged(): boolean {
+        const hasAttributes = Object.keys(this.attributes).length > 0;
+        return this.balance.isZero() && !hasAttributes;
     }
 
     public applyBlock(block: Interfaces.IBlockData): boolean {
@@ -48,11 +63,13 @@ export class Wallet implements State.IWallet {
         ) {
             this.balance = this.balance.plus(block.reward).plus(block.totalFee);
 
-            // update stats
-            this.producedBlocks++;
-            this.forgedFees = this.forgedFees.plus(block.totalFee);
-            this.forgedRewards = this.forgedRewards.plus(block.reward);
-            this.lastBlock = block;
+            const delegate: State.IWalletDelegateAttributes = this.getAttribute("delegate");
+
+            delegate.producedBlocks++;
+            delegate.forgedFees = delegate.forgedFees.plus(block.totalFee);
+            delegate.forgedRewards = delegate.forgedRewards.plus(block.reward);
+            delegate.lastBlock = block;
+
             return true;
         }
 
@@ -66,12 +83,15 @@ export class Wallet implements State.IWallet {
         ) {
             this.balance = this.balance.minus(block.reward).minus(block.totalFee);
 
-            this.forgedFees = this.forgedFees.minus(block.totalFee);
-            this.forgedRewards = this.forgedRewards.minus(block.reward);
-            this.producedBlocks--;
+            const delegate: State.IWalletDelegateAttributes = this.getAttribute("delegate");
+
+            delegate.forgedFees = delegate.forgedFees.minus(block.totalFee);
+            delegate.forgedRewards = delegate.forgedRewards.minus(block.reward);
+            delegate.producedBlocks--;
 
             // TODO: get it back from database?
-            this.lastBlock = undefined;
+            delegate.lastBlock = undefined;
+
             return true;
         }
 
@@ -82,7 +102,7 @@ export class Wallet implements State.IWallet {
         transaction: Interfaces.ITransactionData,
         multiSignature?: Interfaces.IMultiSignatureAsset,
     ): boolean {
-        multiSignature = multiSignature || this.multisignature;
+        multiSignature = multiSignature || this.getAttribute("multiSignature");
         if (!multiSignature) {
             throw new Errors.InvalidMultiSignatureError();
         }
@@ -122,9 +142,13 @@ export class Wallet implements State.IWallet {
     public auditApply(transaction: Interfaces.ITransactionData): any[] {
         const audit = [];
 
-        if (this.multisignature) {
+        const delegate: State.IWalletDelegateAttributes = this.getAttribute("delegate");
+        const secondPublicKey: string = this.getAttribute("secondPublicKey");
+        const multiSignature: State.IWalletMultiSignatureAttributes = this.getAttribute("multiSignature");
+
+        if (multiSignature) {
             audit.push({
-                Mutisignature: this.verifySignatures(transaction, this.multisignature),
+                Mutisignature: this.verifySignatures(transaction, multiSignature),
             });
         } else {
             audit.push({
@@ -134,12 +158,11 @@ export class Wallet implements State.IWallet {
                     .toFixed(),
             });
             audit.push({ "Signature validation": Transactions.Verifier.verifyHash(transaction) });
-            // TODO: this can blow up if 2nd phrase and other transactions are in the wrong order
-            if (this.secondPublicKey) {
+            if (secondPublicKey) {
                 audit.push({
                     "Second Signature Verification": Transactions.Verifier.verifySecondSignature(
                         transaction,
-                        this.secondPublicKey,
+                        secondPublicKey,
                     ),
                 });
             }
@@ -157,27 +180,27 @@ export class Wallet implements State.IWallet {
         }
 
         if (transaction.type === Enums.TransactionTypes.SecondSignature) {
-            audit.push({ "Second public key": this.secondPublicKey });
+            audit.push({ "Second public key": secondPublicKey });
         }
 
         if (transaction.type === Enums.TransactionTypes.DelegateRegistration) {
             const username = transaction.asset.delegate.username;
-            audit.push({ "Current username": this.username });
+            audit.push({ "Current username": delegate.username });
             audit.push({ "New username": username });
         }
 
         if (transaction.type === Enums.TransactionTypes.DelegateResignation) {
-            audit.push({ "Resigned delegate": this.username });
+            audit.push({ "Resigned delegate": delegate.username });
         }
 
         if (transaction.type === Enums.TransactionTypes.Vote) {
-            audit.push({ "Current vote": this.vote });
+            audit.push({ "Current vote": this.getAttribute("vote") });
             audit.push({ "New vote": transaction.asset.votes[0] });
         }
 
         if (transaction.type === Enums.TransactionTypes.MultiSignature) {
             const keysgroup = transaction.asset.multisignature.keysgroup;
-            audit.push({ "Multisignature not yet registered": !this.multisignature });
+            audit.push({ "Multisignature not yet registered": !multiSignature });
             audit.push({
                 "Multisignature enough keys": keysgroup.length >= transaction.asset.multiSignature.min,
             });

--- a/packages/core-transaction-pool/src/wallet-manager.ts
+++ b/packages/core-transaction-pool/src/wallet-manager.ts
@@ -3,6 +3,7 @@ import { Database, State } from "@arkecosystem/core-interfaces";
 import { Wallets } from "@arkecosystem/core-state";
 import { Handlers } from "@arkecosystem/core-transactions";
 import { Identities, Interfaces } from "@arkecosystem/crypto";
+import clonedeep from "lodash.clonedeep";
 
 export class WalletManager extends Wallets.WalletManager {
     private readonly databaseService: Database.IDatabaseService = app.resolvePlugin<Database.IDatabaseService>(
@@ -11,9 +12,7 @@ export class WalletManager extends Wallets.WalletManager {
 
     public findByAddress(address: string): State.IWallet {
         if (address && !this.byAddress[address]) {
-            this.reindex(
-                Object.assign(new Wallets.Wallet(address), this.databaseService.walletManager.findByAddress(address)),
-            );
+            this.reindex(clonedeep(this.databaseService.walletManager.findByAddress(address)));
         }
 
         return this.byAddress[address];
@@ -42,7 +41,11 @@ export class WalletManager extends Wallets.WalletManager {
 
         const sender: State.IWallet = this.findByPublicKey(senderPublicKey);
 
-        Handlers.Registry.get(transaction.type).throwIfCannotBeApplied(transaction, sender, this.databaseService.walletManager);
+        Handlers.Registry.get(transaction.type).throwIfCannotBeApplied(
+            transaction,
+            sender,
+            this.databaseService.walletManager,
+        );
     }
 
     public revertTransactionForSender(transaction: Interfaces.ITransaction): void {

--- a/packages/core-transactions/src/errors.ts
+++ b/packages/core-transactions/src/errors.ts
@@ -120,8 +120,8 @@ export class NotSupportedForMultiSignatureWalletError extends TransactionError {
 }
 
 export class AlreadyVotedError extends TransactionError {
-    constructor(transactionId: string) {
-        super(`Failed to apply transaction ${transactionId}, because the sender wallet has already voted.`);
+    constructor() {
+        super(`Failed to apply transaction, because the sender wallet has already voted.`);
     }
 }
 

--- a/packages/core-transactions/src/errors.ts
+++ b/packages/core-transactions/src/errors.ts
@@ -43,7 +43,7 @@ export class UnexpectedNonceError extends TransactionError {
         const action: string = reversal ? "revert" : "apply";
         super(
             `Cannot ${action} a transaction with nonce ${txNonce.toFixed()}: the ` +
-                `corresponding sender wallet has nonce ${walletNonce.toFixed()}.`,
+            `corresponding sender wallet has nonce ${walletNonce.toFixed()}.`,
         );
     }
 }
@@ -84,13 +84,13 @@ export class WalletAlreadyResignedError extends TransactionError {
     }
 }
 
-export class WalletUsernameEmptyError extends TransactionError {
+export class WalletNotADelegateError extends TransactionError {
     constructor() {
-        super(`Failed to apply transaction, because the username is empty.`);
+        super(`Failed to apply transaction, because the wallet is not a delegate.`);
     }
 }
 
-export class WalletUsernameNotEmptyError extends TransactionError {
+export class WalletIsAlreadyDelegateError extends TransactionError {
     constructor() {
         super(`Failed to apply transaction, because the wallet already has a registered username.`);
     }

--- a/packages/core-transactions/src/handlers/delegate-registration.ts
+++ b/packages/core-transactions/src/handlers/delegate-registration.ts
@@ -3,9 +3,9 @@ import { Database, EventEmitter, State, TransactionPool } from "@arkecosystem/co
 import { Enums, Interfaces, Transactions, Utils } from "@arkecosystem/crypto";
 import {
     NotSupportedForMultiSignatureWalletError,
+    WalletIsAlreadyDelegateError,
+    WalletNotADelegateError,
     WalletUsernameAlreadyRegisteredError,
-    WalletUsernameEmptyError,
-    WalletUsernameNotEmptyError,
 } from "../errors";
 import { TransactionHandler } from "./transaction";
 
@@ -71,11 +71,11 @@ export class DelegateRegistrationTransactionHandler extends TransactionHandler {
 
         const { username }: { username: string } = data.asset.delegate;
         if (!username) {
-            throw new WalletUsernameEmptyError();
+            throw new WalletNotADelegateError();
         }
 
         if (wallet.isDelegate()) {
-            throw new WalletUsernameNotEmptyError();
+            throw new WalletIsAlreadyDelegateError();
         }
 
         if (databaseWalletManager.findByUsername(username)) {

--- a/packages/core-transactions/src/handlers/delegate-registration.ts
+++ b/packages/core-transactions/src/handlers/delegate-registration.ts
@@ -150,7 +150,7 @@ export class DelegateRegistrationTransactionHandler extends TransactionHandler {
         const username: string = sender.getAttribute("delegate.username");
 
         walletManager.forgetByUsername(username);
-        sender.unsetAttribute("delegate");
+        sender.forgetAttribute("delegate");
     }
 
     // tslint:disable-next-line:no-empty

--- a/packages/core-transactions/src/handlers/delegate-registration.ts
+++ b/packages/core-transactions/src/handlers/delegate-registration.ts
@@ -23,20 +23,20 @@ export class DelegateRegistrationTransactionHandler extends TransactionHandler {
 
         for (const transaction of transactions) {
             const wallet = walletManager.findByPublicKey(transaction.senderPublicKey);
-            wallet.setAttribute("delegate", {
+            wallet.setAttribute<State.IWalletDelegateAttributes>("delegate", {
                 username: transaction.asset.delegate.username,
                 voteBalance: Utils.BigNumber.ZERO,
                 forgedFees: Utils.BigNumber.ZERO,
                 forgedRewards: Utils.BigNumber.ZERO,
                 producedBlocks: 0,
-                round: 0,
-            } as State.IWalletDelegateAttributes);
+                rank: 0,
+            });
 
             walletManager.reindex(wallet);
         }
 
         for (const block of forgedBlocks) {
-            const wallet = walletManager.findByPublicKey(block.generatorPublicKey);
+            const wallet: State.IWallet = walletManager.findByPublicKey(block.generatorPublicKey);
             const delegate: State.IWalletDelegateAttributes = wallet.getAttribute("delegate");
 
             // Genesis wallet is empty
@@ -131,7 +131,7 @@ export class DelegateRegistrationTransactionHandler extends TransactionHandler {
         super.applyToSender(transaction, walletManager);
 
         const sender: State.IWallet = walletManager.findByPublicKey(transaction.data.senderPublicKey);
-        sender.setAttribute("delegate", {
+        sender.setAttribute<State.IWalletDelegateAttributes>("delegate", {
             username: transaction.data.asset.delegate.username,
             voteBalance: Utils.BigNumber.ZERO,
             forgedFees: Utils.BigNumber.ZERO,
@@ -150,12 +150,12 @@ export class DelegateRegistrationTransactionHandler extends TransactionHandler {
         const username: string = sender.getAttribute("delegate.username");
 
         walletManager.forgetByUsername(username);
-        sender.unsetAttribute("delegate.username");
+        sender.unsetAttribute("delegate");
     }
 
     // tslint:disable-next-line:no-empty
-    public applyToRecipient(transaction: Interfaces.ITransaction, walletManager: State.IWalletManager): void { }
+    public applyToRecipient(transaction: Interfaces.ITransaction, walletManager: State.IWalletManager): void {}
 
     // tslint:disable-next-line:no-empty
-    public revertForRecipient(transaction: Interfaces.ITransaction, walletManager: State.IWalletManager): void { }
+    public revertForRecipient(transaction: Interfaces.ITransaction, walletManager: State.IWalletManager): void {}
 }

--- a/packages/core-transactions/src/handlers/delegate-resignation.ts
+++ b/packages/core-transactions/src/handlers/delegate-resignation.ts
@@ -64,12 +64,12 @@ export class DelegateResignationTransactionHandler extends TransactionHandler {
     public revertForSender(transaction: Interfaces.ITransaction, walletManager: State.IWalletManager): void {
         super.revertForSender(transaction, walletManager);
 
-        walletManager.findByPublicKey(transaction.data.senderPublicKey).unsetAttribute("delegate.resigned");
+        walletManager.findByPublicKey(transaction.data.senderPublicKey).forgetAttribute("delegate.resigned");
     }
 
     // tslint:disable-next-line:no-empty
-    public applyToRecipient(transaction: Interfaces.ITransaction, walletManager: State.IWalletManager): void { }
+    public applyToRecipient(transaction: Interfaces.ITransaction, walletManager: State.IWalletManager): void {}
 
     // tslint:disable-next-line:no-empty
-    public revertForRecipient(transaction: Interfaces.ITransaction, walletManager: State.IWalletManager): void { }
+    public revertForRecipient(transaction: Interfaces.ITransaction, walletManager: State.IWalletManager): void {}
 }

--- a/packages/core-transactions/src/handlers/delegate-resignation.ts
+++ b/packages/core-transactions/src/handlers/delegate-resignation.ts
@@ -13,7 +13,7 @@ export class DelegateResignationTransactionHandler extends TransactionHandler {
         const transactions = await connection.transactionsRepository.getAssetsByType(this.getConstructor().type);
 
         for (const transaction of transactions) {
-            walletManager.findByPublicKey(transaction.senderPublicKey).resigned = true;
+            walletManager.findByPublicKey(transaction.senderPublicKey).setAttribute("delegate.resigned", true);
         }
     }
 
@@ -22,11 +22,11 @@ export class DelegateResignationTransactionHandler extends TransactionHandler {
         wallet: State.IWallet,
         databaseWalletManager: State.IWalletManager,
     ): void {
-        if (!wallet.username) {
+        if (!wallet.isDelegate()) {
             throw new WalletUsernameEmptyError();
         }
 
-        if (wallet.resigned) {
+        if (wallet.hasAttribute("delegate.resigned")) {
             throw new WalletAlreadyResignedError();
         }
 
@@ -47,7 +47,7 @@ export class DelegateResignationTransactionHandler extends TransactionHandler {
             processor.pushError(
                 data,
                 "ERR_PENDING",
-                `Delegate resignation for "${wallet.username}" already in the pool`,
+                `Delegate resignation for "${wallet.getAttribute("delegate.username")}" already in the pool`,
             );
             return false;
         }
@@ -58,18 +58,18 @@ export class DelegateResignationTransactionHandler extends TransactionHandler {
     public applyToSender(transaction: Interfaces.ITransaction, walletManager: State.IWalletManager): void {
         super.applyToSender(transaction, walletManager);
 
-        walletManager.findByPublicKey(transaction.data.senderPublicKey).resigned = true;
+        walletManager.findByPublicKey(transaction.data.senderPublicKey).setAttribute("delegate.resigned", true);
     }
 
     public revertForSender(transaction: Interfaces.ITransaction, walletManager: State.IWalletManager): void {
         super.revertForSender(transaction, walletManager);
 
-        walletManager.findByPublicKey(transaction.data.senderPublicKey).resigned = false;
+        walletManager.findByPublicKey(transaction.data.senderPublicKey).unsetAttribute("delegate.resigned");
     }
 
     // tslint:disable-next-line:no-empty
-    public applyToRecipient(transaction: Interfaces.ITransaction, walletManager: State.IWalletManager): void {}
+    public applyToRecipient(transaction: Interfaces.ITransaction, walletManager: State.IWalletManager): void { }
 
     // tslint:disable-next-line:no-empty
-    public revertForRecipient(transaction: Interfaces.ITransaction, walletManager: State.IWalletManager): void {}
+    public revertForRecipient(transaction: Interfaces.ITransaction, walletManager: State.IWalletManager): void { }
 }

--- a/packages/core-transactions/src/handlers/delegate-resignation.ts
+++ b/packages/core-transactions/src/handlers/delegate-resignation.ts
@@ -1,7 +1,7 @@
 import { ApplicationEvents } from "@arkecosystem/core-event-emitter";
 import { Database, EventEmitter, State, TransactionPool } from "@arkecosystem/core-interfaces";
 import { Interfaces, Transactions } from "@arkecosystem/crypto";
-import { WalletAlreadyResignedError, WalletUsernameEmptyError } from "../errors";
+import { WalletAlreadyResignedError, WalletNotADelegateError } from "../errors";
 import { TransactionHandler } from "./transaction";
 
 export class DelegateResignationTransactionHandler extends TransactionHandler {
@@ -23,7 +23,7 @@ export class DelegateResignationTransactionHandler extends TransactionHandler {
         databaseWalletManager: State.IWalletManager,
     ): void {
         if (!wallet.isDelegate()) {
-            throw new WalletUsernameEmptyError();
+            throw new WalletNotADelegateError();
         }
 
         if (wallet.hasAttribute("delegate.resigned")) {

--- a/packages/core-transactions/src/handlers/ipfs.ts
+++ b/packages/core-transactions/src/handlers/ipfs.ts
@@ -42,7 +42,7 @@ export class IpfsTransactionHandler extends TransactionHandler {
         super.applyToSender(transaction, walletManager);
 
         const sender: State.IWallet = walletManager.findByPublicKey(transaction.data.senderPublicKey);
-        const ipfsHashes: State.IWalletIpfsAttributes = sender.getAttribute("ipfs.hashes");
+        const ipfsHashes: State.IWalletIpfsAttributes = sender.getAttribute("ipfs.hashes", {});
         ipfsHashes[transaction.data.asset.ipfs] = true;
 
         walletManager.reindex(sender);

--- a/packages/core-transactions/src/handlers/ipfs.ts
+++ b/packages/core-transactions/src/handlers/ipfs.ts
@@ -12,7 +12,8 @@ export class IpfsTransactionHandler extends TransactionHandler {
 
         for (const transaction of transactions) {
             const wallet = walletManager.findByPublicKey(transaction.senderPublicKey);
-            wallet.ipfsHashes[transaction.asset.ipfs] = true;
+            const ipfsHashes: State.IWalletIpfsAttributes = wallet.getAttribute("ipfs.hashes", {});
+            ipfsHashes[transaction.asset.ipfs] = true;
         }
     }
 
@@ -41,7 +42,8 @@ export class IpfsTransactionHandler extends TransactionHandler {
         super.applyToSender(transaction, walletManager);
 
         const sender: State.IWallet = walletManager.findByPublicKey(transaction.data.senderPublicKey);
-        sender.ipfsHashes[transaction.data.asset.ipfs] = true;
+        const ipfsHashes: State.IWalletIpfsAttributes = sender.getAttribute("ipfs.hashes");
+        ipfsHashes[transaction.data.asset.ipfs] = true;
 
         walletManager.reindex(sender);
     }
@@ -50,7 +52,8 @@ export class IpfsTransactionHandler extends TransactionHandler {
         super.revertForSender(transaction, walletManager);
 
         const sender: State.IWallet = walletManager.findByPublicKey(transaction.data.senderPublicKey);
-        delete sender.ipfsHashes[transaction.data.asset.ipfs];
+        const ipfsHashes: State.IWalletIpfsAttributes = sender.getAttribute("ipfs.hashes");
+        delete ipfsHashes[transaction.data.asset.ipfs];
 
         walletManager.reindex(sender);
     }

--- a/packages/core-transactions/src/handlers/ipfs.ts
+++ b/packages/core-transactions/src/handlers/ipfs.ts
@@ -12,7 +12,11 @@ export class IpfsTransactionHandler extends TransactionHandler {
 
         for (const transaction of transactions) {
             const wallet = walletManager.findByPublicKey(transaction.senderPublicKey);
-            const ipfsHashes: State.IWalletIpfsAttributes = wallet.getAttribute("ipfs.hashes", {});
+            if (!wallet.hasAttribute("ipfs")) {
+                wallet.setAttribute("ipfs", { hashes: {} });
+            }
+
+            const ipfsHashes: State.IWalletIpfsAttributes = wallet.getAttribute("ipfs.hashes");
             ipfsHashes[transaction.asset.ipfs] = true;
         }
     }
@@ -42,7 +46,11 @@ export class IpfsTransactionHandler extends TransactionHandler {
         super.applyToSender(transaction, walletManager);
 
         const sender: State.IWallet = walletManager.findByPublicKey(transaction.data.senderPublicKey);
-        const ipfsHashes: State.IWalletIpfsAttributes = sender.getAttribute("ipfs.hashes", {});
+        if (!sender.hasAttribute("ipfs")) {
+            sender.setAttribute("ipfs", { hashes: {} });
+        }
+
+        const ipfsHashes: State.IWalletIpfsAttributes = sender.getAttribute("ipfs.hashes");
         ipfsHashes[transaction.data.asset.ipfs] = true;
 
         walletManager.reindex(sender);
@@ -59,8 +67,8 @@ export class IpfsTransactionHandler extends TransactionHandler {
     }
 
     // tslint:disable-next-line:no-empty
-    public applyToRecipient(transaction: Interfaces.ITransaction, walletManager: State.IWalletManager): void {}
+    public applyToRecipient(transaction: Interfaces.ITransaction, walletManager: State.IWalletManager): void { }
 
     // tslint:disable-next-line:no-empty
-    public revertForRecipient(transaction: Interfaces.ITransaction, walletManager: State.IWalletManager): void {}
+    public revertForRecipient(transaction: Interfaces.ITransaction, walletManager: State.IWalletManager): void { }
 }

--- a/packages/core-transactions/src/handlers/multi-signature.ts
+++ b/packages/core-transactions/src/handlers/multi-signature.ts
@@ -82,9 +82,9 @@ export class MultiSignatureTransactionHandler extends TransactionHandler {
 
         // Create the multi sig wallet
         if (transaction.data.version >= 2) {
-            walletManager.findByAddress(
-                Identities.Address.fromMultiSignatureAsset(transaction.data.asset.multiSignature),
-            ).setAttribute("multiSignature", transaction.data.asset.multiSignature);
+            walletManager
+                .findByAddress(Identities.Address.fromMultiSignatureAsset(transaction.data.asset.multiSignature))
+                .setAttribute("multiSignature", transaction.data.asset.multiSignature);
         }
     }
 
@@ -113,7 +113,7 @@ export class MultiSignatureTransactionHandler extends TransactionHandler {
                 Identities.Address.fromMultiSignatureAsset(data.asset.multiSignature),
             );
 
-            recipientWallet.unsetAttribute("multiSignature");
+            recipientWallet.forgetAttribute("multiSignature");
         }
     }
 }

--- a/packages/core-transactions/src/handlers/multi-signature.ts
+++ b/packages/core-transactions/src/handlers/multi-signature.ts
@@ -17,15 +17,16 @@ export class MultiSignatureTransactionHandler extends TransactionHandler {
         const transactions = await connection.transactionsRepository.getAssetsByType(this.getConstructor().type);
 
         for (const transaction of transactions) {
-            const wallet = walletManager.findByPublicKey(transaction.senderPublicKey);
-            if (!wallet.multisignature) {
+            const wallet: State.IWallet = walletManager.findByPublicKey(transaction.senderPublicKey);
+            if (!wallet.hasMultiSignature()) {
+                let multiSignature: State.IWalletMultiSignatureAttributes;
                 if (transaction.version === 1) {
-                    wallet.multisignature = transaction.asset.multisignature || transaction.asset.multiSignatureLegacy;
-                } else if (transaction.version === 2) {
-                    wallet.multisignature = transaction.asset.multiSignature;
+                    multiSignature = transaction.asset.multisignature || transaction.asset.multiSignatureLegacy;
                 } else {
-                    throw new Error(`Invalid multi signature version ${transaction.version}`);
+                    multiSignature = transaction.asset.multiSignature;
                 }
+
+                wallet.setAttribute("multiSignature", multiSignature);
             }
         }
     }
@@ -50,10 +51,10 @@ export class MultiSignatureTransactionHandler extends TransactionHandler {
             throw new MultiSignatureKeyCountMismatchError();
         }
 
-        const multiSigAddress = Identities.Address.fromMultiSignatureAsset(data.asset.multiSignature);
+        const multiSigAddress: string = Identities.Address.fromMultiSignatureAsset(data.asset.multiSignature);
+        const recipientWallet: State.IWallet = databaseWalletManager.findByAddress(multiSigAddress);
 
-        const recipientWallet = databaseWalletManager.findByAddress(multiSigAddress);
-        if (recipientWallet.multisignature) {
+        if (recipientWallet.hasMultiSignature()) {
             throw new MultiSignatureAlreadyRegisteredError();
         }
 
@@ -83,7 +84,7 @@ export class MultiSignatureTransactionHandler extends TransactionHandler {
         if (transaction.data.version >= 2) {
             walletManager.findByAddress(
                 Identities.Address.fromMultiSignatureAsset(transaction.data.asset.multiSignature),
-            ).multisignature = transaction.data.asset.multiSignature;
+            ).setAttribute("multiSignature", transaction.data.asset.multiSignature);
         }
     }
 
@@ -97,9 +98,10 @@ export class MultiSignatureTransactionHandler extends TransactionHandler {
         const { data }: Interfaces.ITransaction = transaction;
 
         if (data.version >= 2) {
-            walletManager.findByAddress(
+            const recipientWallet: State.IWallet = walletManager.findByAddress(
                 Identities.Address.fromMultiSignatureAsset(data.asset.multiSignature),
-            ).multisignature = transaction.data.asset.multiSignature;
+            );
+            recipientWallet.setAttribute("multiSignature", transaction.data.asset.multiSignature);
         }
     }
 
@@ -107,9 +109,11 @@ export class MultiSignatureTransactionHandler extends TransactionHandler {
         const { data }: Interfaces.ITransaction = transaction;
 
         if (data.version >= 2) {
-            walletManager.findByAddress(
+            const recipientWallet: State.IWallet = walletManager.findByAddress(
                 Identities.Address.fromMultiSignatureAsset(data.asset.multiSignature),
-            ).multisignature = undefined;
+            );
+
+            recipientWallet.unsetAttribute("multiSignature");
         }
     }
 }

--- a/packages/core-transactions/src/handlers/second-signature.ts
+++ b/packages/core-transactions/src/handlers/second-signature.ts
@@ -13,7 +13,7 @@ export class SecondSignatureTransactionHandler extends TransactionHandler {
 
         for (const transaction of transactions) {
             const wallet = walletManager.findByPublicKey(transaction.senderPublicKey);
-            wallet.secondPublicKey = transaction.asset.signature.publicKey;
+            wallet.setAttribute("secondPublicKey", transaction.asset.signature.publicKey);
         }
     }
 
@@ -22,11 +22,11 @@ export class SecondSignatureTransactionHandler extends TransactionHandler {
         wallet: State.IWallet,
         databaseWalletManager: State.IWalletManager,
     ): void {
-        if (wallet.secondPublicKey) {
+        if (wallet.hasSecondSignature()) {
             throw new SecondSignatureAlreadyRegisteredError();
         }
 
-        if (databaseWalletManager.findByPublicKey(transaction.data.senderPublicKey).multisignature) {
+        if (databaseWalletManager.findByPublicKey(transaction.data.senderPublicKey).hasMultiSignature()) {
             throw new NotSupportedForMultiSignatureWalletError();
         }
 
@@ -48,19 +48,20 @@ export class SecondSignatureTransactionHandler extends TransactionHandler {
     public applyToSender(transaction: Interfaces.ITransaction, walletManager: State.IWalletManager): void {
         super.applyToSender(transaction, walletManager);
 
-        walletManager.findByPublicKey(transaction.data.senderPublicKey).secondPublicKey =
-            transaction.data.asset.signature.publicKey;
+        walletManager
+            .findByPublicKey(transaction.data.senderPublicKey)
+            .setAttribute("secondPublicKey", transaction.data.asset.signature.publicKey);
     }
 
     public revertForSender(transaction: Interfaces.ITransaction, walletManager: State.IWalletManager): void {
         super.revertForSender(transaction, walletManager);
 
-        walletManager.findByPublicKey(transaction.data.senderPublicKey).secondPublicKey = undefined;
+        walletManager.findByPublicKey(transaction.data.senderPublicKey).unsetAttribute("secondPublicKey");
     }
 
     // tslint:disable-next-line:no-empty
-    public applyToRecipient(transaction: Interfaces.ITransaction, walletManager: State.IWalletManager): void {}
+    public applyToRecipient(transaction: Interfaces.ITransaction, walletManager: State.IWalletManager): void { }
 
     // tslint:disable-next-line:no-empty
-    public revertForRecipient(transaction: Interfaces.ITransaction, walletManager: State.IWalletManager): void {}
+    public revertForRecipient(transaction: Interfaces.ITransaction, walletManager: State.IWalletManager): void { }
 }

--- a/packages/core-transactions/src/handlers/second-signature.ts
+++ b/packages/core-transactions/src/handlers/second-signature.ts
@@ -56,12 +56,12 @@ export class SecondSignatureTransactionHandler extends TransactionHandler {
     public revertForSender(transaction: Interfaces.ITransaction, walletManager: State.IWalletManager): void {
         super.revertForSender(transaction, walletManager);
 
-        walletManager.findByPublicKey(transaction.data.senderPublicKey).unsetAttribute("secondPublicKey");
+        walletManager.findByPublicKey(transaction.data.senderPublicKey).forgetAttribute("secondPublicKey");
     }
 
     // tslint:disable-next-line:no-empty
-    public applyToRecipient(transaction: Interfaces.ITransaction, walletManager: State.IWalletManager): void { }
+    public applyToRecipient(transaction: Interfaces.ITransaction, walletManager: State.IWalletManager): void {}
 
     // tslint:disable-next-line:no-empty
-    public revertForRecipient(transaction: Interfaces.ITransaction, walletManager: State.IWalletManager): void { }
+    public revertForRecipient(transaction: Interfaces.ITransaction, walletManager: State.IWalletManager): void {}
 }

--- a/packages/core-transactions/src/handlers/vote.ts
+++ b/packages/core-transactions/src/handlers/vote.ts
@@ -98,7 +98,7 @@ export class VoteTransactionHandler extends TransactionHandler {
         if (vote.startsWith("+")) {
             sender.setAttribute("vote", vote.slice(1));
         } else {
-            sender.unsetAttribute("vote");
+            sender.forgetAttribute("vote");
         }
     }
 
@@ -109,7 +109,7 @@ export class VoteTransactionHandler extends TransactionHandler {
         const vote: string = transaction.data.asset.votes[0];
 
         if (vote.startsWith("+")) {
-            sender.unsetAttribute("vote");
+            sender.forgetAttribute("vote");
         } else {
             sender.setAttribute("vote", vote.slice(1));
         }

--- a/packages/core-utils/src/delegate-calculator.ts
+++ b/packages/core-utils/src/delegate-calculator.ts
@@ -1,10 +1,10 @@
 import { app } from "@arkecosystem/core-container";
-import { Blockchain } from "@arkecosystem/core-interfaces";
+import { Blockchain, State } from "@arkecosystem/core-interfaces";
 import { Utils } from "@arkecosystem/crypto";
 
 const BignumMod = Utils.BigNumber.clone({ DECIMAL_PLACES: 2 });
 
-export const calculateApproval = (delegate, height?: number): number => {
+export const calculateApproval = (delegate: State.IWallet, height?: number): number => {
     const config = app.getConfig();
 
     if (!height) {
@@ -15,7 +15,7 @@ export const calculateApproval = (delegate, height?: number): number => {
     const totalSupply = new BignumMod(config.get("genesisBlock.totalAmount")).plus(
         (height - constants.height) * constants.reward,
     );
-    const voteBalance = new BignumMod(delegate.voteBalance);
+    const voteBalance = new BignumMod(delegate.getAttribute<Utils.BigNumber>("delegate.voteBalance"));
 
     return +voteBalance
         .times(100)
@@ -23,9 +23,10 @@ export const calculateApproval = (delegate, height?: number): number => {
         .toFixed(2);
 };
 
-export const calculateForgedTotal = (delegate): string => {
-    const forgedFees = Utils.BigNumber.make(delegate.forgedFees);
-    const forgedRewards = Utils.BigNumber.make(delegate.forgedRewards);
+export const calculateForgedTotal = (wallet: State.IWallet): string => {
+    const delegate: State.IWalletDelegateAttributes = wallet.getAttribute("delegate");
+    const forgedFees: Utils.BigNumber = Utils.BigNumber.make(delegate.forgedFees);
+    const forgedRewards: Utils.BigNumber = Utils.BigNumber.make(delegate.forgedRewards);
 
     return forgedFees.plus(forgedRewards).toFixed();
 };

--- a/packages/core-vote-report/src/handler.ts
+++ b/packages/core-vote-report/src/handler.ts
@@ -18,7 +18,10 @@ const formatDelegates = (
     return delegates.map((delegate: State.IWallet) => {
         const filteredVoters: State.IWallet[] = databaseService.walletManager
             .allByPublicKey()
-            .filter(wallet => wallet.vote === delegate.publicKey && wallet.balance.gt(0.1 * 1e8));
+            .filter(
+                wallet =>
+                    wallet.getAttribute<string>("vote") === delegate.publicKey && wallet.balance.gt(0.1 * 1e8),
+            );
 
         const approval: string = Number(delegateCalculator.calculateApproval(delegate, lastHeight)).toLocaleString(
             undefined,
@@ -28,11 +31,15 @@ const formatDelegates = (
             },
         );
 
-        const rank: string = delegate.rate.toLocaleString(undefined, {
+        const rank: string = delegate.getAttribute<number>("delegate.rank").toLocaleString(undefined, {
             minimumIntegerDigits: 2,
         });
 
-        const votes: string = delegate.voteBalance.div(1e8).toFixed(0);
+        const votes: string = Number(
+            delegate.getAttribute<Utils.BigNumber>("delegate.voteBalance").div(1e8),
+        ).toLocaleString(undefined, {
+            maximumFractionDigits: 0,
+        });
 
         const voterCount: string = filteredVoters.length.toLocaleString(undefined, {
             maximumFractionDigits: 0,
@@ -40,7 +47,7 @@ const formatDelegates = (
 
         return {
             rank,
-            username: delegate.username.padEnd(25),
+            username: delegate.getAttribute<string>("delegate.username").padEnd(25),
             approval: approval.padEnd(4),
             votes: votes.padStart(10),
             voterCount: voterCount.padStart(5),
@@ -60,10 +67,10 @@ export const handler = (request, h) => {
     const allByUsername: State.IWallet[] = databaseService.walletManager
         .allByUsername()
         .map((delegate, index) => {
-            delegate.rate = delegate.rate || index + 1;
+            delegate.setAttribute("delegate.rank", delegate.getAttribute("delegate.rank") || index + 1);
             return delegate;
         })
-        .sort((a, b) => a.rate - b.rate);
+        .sort((a, b) => a.getAttribute<number>("delegate.rank") - b.getAttribute<number>("delegate.rank"));
 
     const active: State.IWallet[] = allByUsername.slice(0, maxDelegates);
     const standby: State.IWallet[] = allByUsername.slice(
@@ -73,7 +80,7 @@ export const handler = (request, h) => {
 
     const voters: State.IWallet[] = databaseService.walletManager
         .allByPublicKey()
-        .filter(wallet => wallet.vote && (wallet.balance as Utils.BigNumber).gt(0.1 * 1e8));
+        .filter(wallet => wallet.hasVoted() && (wallet.balance as Utils.BigNumber).gt(0.1 * 1e8));
 
     const totalVotes: Utils.BigNumber = voters
         .map(wallet => wallet.balance)

--- a/packages/crypto/src/interfaces/transactions.ts
+++ b/packages/crypto/src/interfaces/transactions.ts
@@ -30,7 +30,6 @@ export interface ITransactionAsset {
     };
     delegate?: {
         username: string;
-        publicKey?: string;
     };
     votes?: string[];
     multiSignatureLegacy?: IMultiSignatureLegacyAsset;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2716,6 +2716,10 @@
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/@types/depcheck/-/depcheck-0.8.0.tgz#5c33f80c4d4ce6aa576c9ac09d326084d5c0884d"
   integrity sha512-kpGVvWeWWhfZ8SPW+OWYmLfrHVCZtIcOzKaGJHUk4WcheY6UgxUb5xU+3aVymZEvQ7z9MuWmzaKibF8YwxR0Xg==
+"@types/dottie@^2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@types/dottie/-/dottie-2.0.3.tgz#71725fceafe2df8f1e07d6bb7436524af530b376"
+  integrity sha512-XtN0M6lKMCYiDLnLXB4FSbEr5vgrpNEA24jhjnvhqobIYYDqyahTJrDblLqJ8bz1eG+Vm6BE0yqtsr88prEjww==
 
 "@types/events@*":
   version "3.0.0"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

This PR cleans up the wallet model and moves almost all of the existing wallet properties into a private `attributes` object.

Whenever the wallet model had to be extended we'd introduce a new property. This bloated the entire class with no clear semantic structure. With more and more transaction types coming up. this becomes even more of an issue.

The new approach to interface with (custom) wallet data is by using the following set of functions:

```typescript
    hasAttribute(key: string): boolean;
    getAttribute<T = any>(key: string, defaultValue?: T): T;
    setAttribute<T = any>(key: string, value: T): void;
    forgetAttribute(key: string): void;
```

Internally it is using `dottie` to support access based on a property path.

This PR is quite pervasive and will break at least all existing custom transactions and #2773.

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [X] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [X] Yes
- [ ] No

## Does this PR release a new version?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `develop` branch, _not_ the `master` branch
- [x] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
