### PR TITLE
refactor: increase transaction type size

### DIFF
--- a/__tests__/integration/core-tester-cli/commands/send/htlc-claim.test.ts
+++ b/__tests__/integration/core-tester-cli/commands/send/htlc-claim.test.ts
@@ -43,7 +43,7 @@ describe("Commands - Htlc claim", () => {
         expect(httpie.post).toHaveBeenCalledTimes(3);
 
         expectedTransactions
-            .filter(tx => tx.type === Enums.TransactionTypes.HtlcClaim)
+            .filter(tx => tx.type === Enums.TransactionType.HtlcClaim)
             .map(tx => {
                 expect(tx.fee).toEqual(arkToSatoshi(opts.htlcClaimFee));
                 expect(tx.asset.claim.unlockSecret).toEqual(
@@ -67,7 +67,7 @@ describe("Commands - Htlc claim", () => {
         expect(httpie.post).toHaveBeenCalledTimes(3);
 
         expectedTransactions
-            .filter(tx => tx.type === Enums.TransactionTypes.HtlcClaim)
+            .filter(tx => tx.type === Enums.TransactionType.HtlcClaim)
             .map(tx => {
                 expect(tx.fee).toEqual(arkToSatoshi(0.1));
                 expect(tx.asset.claim.unlockSecret).toEqual(

--- a/__tests__/integration/core-tester-cli/commands/send/htlc-lock.test.ts
+++ b/__tests__/integration/core-tester-cli/commands/send/htlc-lock.test.ts
@@ -43,7 +43,7 @@ describe("Commands - Htlc lock", () => {
         expect(httpie.post).toHaveBeenCalledTimes(2);
 
         expectedTransactions
-            .filter(tx => tx.type === Enums.TransactionTypes.HtlcLock)
+            .filter(tx => tx.type === Enums.TransactionType.HtlcLock)
             .map(tx => {
                 expect(tx.fee).toEqual(arkToSatoshi(opts.htlcLockFee));
                 expect(tx.asset.lock.secretHash).toEqual(
@@ -68,7 +68,7 @@ describe("Commands - Htlc lock", () => {
         expect(httpie.post).toHaveBeenCalledTimes(2);
 
         expectedTransactions
-            .filter(tx => tx.type === Enums.TransactionTypes.HtlcLock)
+            .filter(tx => tx.type === Enums.TransactionType.HtlcLock)
             .map(tx => {
                 expect(tx.fee).toEqual(arkToSatoshi(0.1));
                 expect(tx.asset.lock.secretHash).toEqual(

--- a/__tests__/integration/core-tester-cli/commands/send/htlc-refund.test.ts
+++ b/__tests__/integration/core-tester-cli/commands/send/htlc-refund.test.ts
@@ -43,7 +43,7 @@ describe("Commands - Htlc refund", () => {
         expect(httpie.post).toHaveBeenCalledTimes(3);
 
         expectedTransactions
-            .filter(tx => tx.type === Enums.TransactionTypes.HtlcRefund)
+            .filter(tx => tx.type === Enums.TransactionType.HtlcRefund)
             .map(tx => {
                 expect(tx.fee).toEqual(arkToSatoshi(opts.htlcRefundFee));
                 expect(tx.asset.refund.lockTransactionId).toBeDefined();
@@ -64,7 +64,7 @@ describe("Commands - Htlc refund", () => {
         expect(httpie.post).toHaveBeenCalledTimes(3);
 
         expectedTransactions
-            .filter(tx => tx.type === Enums.TransactionTypes.HtlcRefund)
+            .filter(tx => tx.type === Enums.TransactionType.HtlcRefund)
             .map(tx => {
                 expect(tx.fee).toEqual(arkToSatoshi(0.1));
                 expect(tx.asset.refund.lockTransactionId).toBeDefined();

--- a/__tests__/integration/core-transaction-pool/processor.test.ts
+++ b/__tests__/integration/core-transaction-pool/processor.test.ts
@@ -1047,7 +1047,7 @@ describe("Transaction Guard", () => {
     //         const tx = {
     //             id: "1",
     //             network: 23,
-    //             type: Enums.TransactionTypes.Transfer,
+    //             type: Enums.TransactionType.Transfer,
     //             senderPublicKey: "023ee98f453661a1cb765fd60df95b4efb1e110660ffb88ae31c2368a70f1f7359",
     //             recipientId: "DEJHR83JFmGpXYkJiaqn7wPGztwjheLAmY",
     //         };
@@ -1075,7 +1075,7 @@ describe("Transaction Guard", () => {
 
     //         const tx = {
     //             id: "1",
-    //             type: Enums.TransactionTypes.Transfer,
+    //             type: Enums.TransactionType.Transfer,
     //             senderPublicKey: "023ee98f453661a1cb765fd60df95b4efb1e110660ffb88ae31c2368a70f1f7359",
     //             recipientId: "DEJHR83JFmGpXYkJiaqn7wPGztwjheLAmY",
     //         };
@@ -1223,7 +1223,7 @@ describe("Transaction Guard", () => {
     //                     type: "ERR_PENDING",
     //                     message:
     //                         `Sender ${tx.data.senderPublicKey} already has a transaction of type ` +
-    //                         `'${Enums.TransactionTypes[tx.type]}' in the pool`,
+    //                         `'${Enums.TransactionType[tx.type]}' in the pool`,
     //                 },
     //             ]);
     //         }
@@ -1241,10 +1241,10 @@ describe("Transaction Guard", () => {
     //             .build()[0];
 
     //         for (const transactionType of [
-    //             Enums.TransactionTypes.MultiSignature,
-    //             Enums.TransactionTypes.Ipfs,
-    //             Enums.TransactionTypes.MultiPayment,
-    //             Enums.TransactionTypes.DelegateResignation,
+    //             Enums.TransactionType.MultiSignature,
+    //             Enums.TransactionType.Ipfs,
+    //             Enums.TransactionType.MultiPayment,
+    //             Enums.TransactionType.DelegateResignation,
     //             99,
     //         ]) {
     //             baseTransaction.data.type = transactionType;
@@ -1257,7 +1257,7 @@ describe("Transaction Guard", () => {
     //                 {
     //                     type: "ERR_UNSUPPORTED",
     //                     message: `Invalidating transaction of unsupported type '${
-    //                         Enums.TransactionTypes[transactionType]
+    //                         Enums.TransactionType[transactionType]
     //                     }'`,
     //                 },
     //             ]);

--- a/__tests__/unit/core-database/database-service.test.ts
+++ b/__tests__/unit/core-database/database-service.test.ts
@@ -15,7 +15,7 @@ import { stateStorageStub } from "./__fixtures__/state-storage-stub";
 
 const { BlockFactory } = Blocks;
 const { SATOSHI } = Constants;
-const { TransactionTypes } = Enums;
+const { TransactionType } = Enums;
 
 let connection: Database.IConnection;
 let databaseService: DatabaseService;
@@ -192,7 +192,7 @@ describe("Database Service", () => {
 
             // Create delegates
             for (const transaction of genesisBlock.transactions) {
-                if (transaction.type === TransactionTypes.DelegateRegistration) {
+                if (transaction.type === TransactionType.DelegateRegistration) {
                     const wallet = walletManager.findByPublicKey(transaction.data.senderPublicKey);
                     wallet.setAttribute("delegate", {
                         voteBalance: Utils.BigNumber.ONE,
@@ -217,7 +217,7 @@ describe("Database Service", () => {
             const delegatesRound2 = walletManager.loadActiveDelegateList(roundInfo1);
 
             // Prepare sender wallet
-            const transactionHandler = Handlers.Registry.get(TransactionTypes.Transfer);
+            const transactionHandler = Handlers.Registry.get(TransactionType.Transfer);
             const originalApply = transactionHandler.throwIfCannotBeApplied;
             transactionHandler.throwIfCannotBeApplied = jest.fn();
 

--- a/__tests__/unit/core-database/repositories/transactions-business-repository.test.ts
+++ b/__tests__/unit/core-database/repositories/transactions-business-repository.test.ts
@@ -324,7 +324,7 @@ describe("Transactions Business Repository", () => {
                         {
                             field: "type",
                             operator: expect.anything(),
-                            value: Enums.TransactionTypes.Vote,
+                            value: Enums.TransactionType.Vote,
                         },
                     ]),
                 }),
@@ -438,7 +438,7 @@ describe("Transactions Business Repository", () => {
                 count: 0,
             }));
 
-            await transactionsBusinessRepository.findAllByType(Enums.TransactionTypes.Transfer);
+            await transactionsBusinessRepository.findAllByType(Enums.TransactionType.Transfer);
 
             expect(databaseService.connection.transactionsRepository.search).toHaveBeenCalledWith(
                 expect.objectContaining({
@@ -446,7 +446,7 @@ describe("Transactions Business Repository", () => {
                         {
                             field: "type",
                             operator: expect.anything(),
-                            value: Enums.TransactionTypes.Transfer,
+                            value: Enums.TransactionType.Transfer,
                         },
                     ],
                 }),
@@ -507,7 +507,7 @@ describe("Transactions Business Repository", () => {
                 count: 0,
             }));
 
-            await transactionsBusinessRepository.findByTypeAndId(Enums.TransactionTypes.Transfer, "id");
+            await transactionsBusinessRepository.findByTypeAndId(Enums.TransactionType.Transfer, "id");
 
             expect(databaseService.connection.transactionsRepository.search).toHaveBeenCalledWith(
                 expect.objectContaining({
@@ -515,7 +515,7 @@ describe("Transactions Business Repository", () => {
                         {
                             field: "type",
                             operator: expect.anything(),
-                            value: Enums.TransactionTypes.Transfer,
+                            value: Enums.TransactionType.Transfer,
                         },
                         {
                             field: "id",

--- a/__tests__/unit/core-jest-matchers/transactions/types/delegate-registration.test.ts
+++ b/__tests__/unit/core-jest-matchers/transactions/types/delegate-registration.test.ts
@@ -1,12 +1,12 @@
 import "../../../../../packages/core-jest-matchers/src/transactions/types/delegate-registration";
 
 import { Enums } from "@arkecosystem/crypto";
-const { TransactionTypes } = Enums;
+const { TransactionType } = Enums;
 
 describe(".toBeDelegateRegistrationType", () => {
     test("passes when given a delegate transaction", () => {
         expect({
-            type: TransactionTypes.DelegateRegistration,
+            type: TransactionType.DelegateRegistration,
         }).toBeDelegateRegistrationType();
     });
 

--- a/__tests__/unit/core-jest-matchers/transactions/types/delegate-resignation.test.ts
+++ b/__tests__/unit/core-jest-matchers/transactions/types/delegate-resignation.test.ts
@@ -1,12 +1,12 @@
 import "../../../../../packages/core-jest-matchers/src/transactions/types/delegate-resignation";
 
 import { Enums } from "@arkecosystem/crypto";
-const { TransactionTypes } = Enums;
+const { TransactionType } = Enums;
 
 describe(".toBeDelegateResignationType", () => {
     test("passes when given a valid transaction", () => {
         expect({
-            type: TransactionTypes.DelegateResignation,
+            type: TransactionType.DelegateResignation,
         }).toBeDelegateResignationType();
     });
 

--- a/__tests__/unit/core-jest-matchers/transactions/types/ipfs.test.ts
+++ b/__tests__/unit/core-jest-matchers/transactions/types/ipfs.test.ts
@@ -1,11 +1,11 @@
 import "../../../../../packages/core-jest-matchers/src/transactions/types/ipfs";
 
 import { Enums } from "@arkecosystem/crypto";
-const { TransactionTypes } = Enums;
+const { TransactionType } = Enums;
 
 describe(".toBeIpfsType", () => {
     test("passes when given a valid transaction", () => {
-        expect({ type: TransactionTypes.Ipfs }).toBeIpfsType();
+        expect({ type: TransactionType.Ipfs }).toBeIpfsType();
     });
 
     test("fails when given an invalid transaction", () => {

--- a/__tests__/unit/core-jest-matchers/transactions/types/multi-payment.test.ts
+++ b/__tests__/unit/core-jest-matchers/transactions/types/multi-payment.test.ts
@@ -1,11 +1,11 @@
 import "../../../../../packages/core-jest-matchers/src/transactions/types/multi-payment";
 
 import { Enums } from "@arkecosystem/crypto";
-const { TransactionTypes } = Enums;
+const { TransactionType } = Enums;
 
 describe(".toBeMultiPaymentType", () => {
     test("passes when given a valid transaction", () => {
-        expect({ type: TransactionTypes.MultiPayment }).toBeMultiPaymentType();
+        expect({ type: TransactionType.MultiPayment }).toBeMultiPaymentType();
     });
 
     test("fails when given an invalid transaction", () => {

--- a/__tests__/unit/core-jest-matchers/transactions/types/multi-signature.test.ts
+++ b/__tests__/unit/core-jest-matchers/transactions/types/multi-signature.test.ts
@@ -1,12 +1,12 @@
 import "../../../../../packages/core-jest-matchers/src/transactions/types/multi-signature";
 
 import { Enums } from "@arkecosystem/crypto";
-const { TransactionTypes } = Enums;
+const { TransactionType } = Enums;
 
 describe(".toBeMultiSignatureType", () => {
     test("passes when given a valid transaction", () => {
         expect({
-            type: TransactionTypes.MultiSignature,
+            type: TransactionType.MultiSignature,
         }).toBeMultiSignatureType();
     });
 

--- a/__tests__/unit/core-jest-matchers/transactions/types/second-signature.test.ts
+++ b/__tests__/unit/core-jest-matchers/transactions/types/second-signature.test.ts
@@ -1,12 +1,12 @@
 import "../../../../../packages/core-jest-matchers/src/transactions/types/second-signature";
 
 import { Enums } from "@arkecosystem/crypto";
-const { TransactionTypes } = Enums;
+const { TransactionType } = Enums;
 
 describe(".toBeSecondSignatureType", () => {
     test("passes when given a valid transaction", () => {
         expect({
-            type: TransactionTypes.SecondSignature,
+            type: TransactionType.SecondSignature,
         }).toBeSecondSignatureType();
     });
 

--- a/__tests__/unit/core-jest-matchers/transactions/types/transfer.test.ts
+++ b/__tests__/unit/core-jest-matchers/transactions/types/transfer.test.ts
@@ -1,11 +1,11 @@
 import "../../../../../packages/core-jest-matchers/src/transactions/types/transfer";
 
 import { Enums } from "@arkecosystem/crypto";
-const { TransactionTypes } = Enums;
+const { TransactionType } = Enums;
 
 describe(".toBeTransferType", () => {
     test("passes when given a valid transaction", () => {
-        expect({ type: TransactionTypes.Transfer }).toBeTransferType();
+        expect({ type: TransactionType.Transfer }).toBeTransferType();
     });
 
     test("fails when given an invalid transaction", () => {

--- a/__tests__/unit/core-jest-matchers/transactions/types/vote.test.ts
+++ b/__tests__/unit/core-jest-matchers/transactions/types/vote.test.ts
@@ -1,11 +1,11 @@
 import "../../../../../packages/core-jest-matchers/src/transactions/types/vote";
 
 import { Enums } from "@arkecosystem/crypto";
-const { TransactionTypes } = Enums;
+const { TransactionType } = Enums;
 
 describe(".toBeVoteType", () => {
     test("passes when given a valid transaction", () => {
-        expect({ type: TransactionTypes.Vote }).toBeVoteType();
+        expect({ type: TransactionType.Vote }).toBeVoteType();
     });
 
     test("fails when given an invalid transaction", () => {

--- a/__tests__/unit/core-state/wallets/wallet.test.ts
+++ b/__tests__/unit/core-state/wallets/wallet.test.ts
@@ -8,7 +8,7 @@ import { Wallet } from "../../../../packages/core-state/src/wallets";
 import { TransactionFactory } from "../../../helpers/transaction-factory";
 
 const { SATOSHI } = Constants;
-const { TransactionTypes } = Enums;
+const { TransactionType } = Enums;
 
 describe("Models - Wallet", () => {
     beforeEach(() => Managers.configManager.setFromPreset("devnet"));
@@ -266,7 +266,7 @@ describe("Models - Wallet", () => {
                     min: 2,
                 },
             };
-            const transaction = generateTransactionType(TransactionTypes.MultiSignature, 2, asset);
+            const transaction = generateTransactionType(TransactionType.MultiSignature, 2, asset);
             transaction.version = 2;
             transaction.signatures = [];
             const audit = testWallet.auditApply(transaction);
@@ -284,7 +284,7 @@ describe("Models - Wallet", () => {
         });
 
         it("should return correct audit data for ipfs type", () => {
-            const transaction = generateTransactionType(TransactionTypes.Ipfs);
+            const transaction = generateTransactionType(TransactionType.Ipfs);
             const audit = testWallet.auditApply(transaction);
 
             expect(audit).toEqual([
@@ -300,7 +300,7 @@ describe("Models - Wallet", () => {
             const asset = {
                 payments: [{ amount: Utils.BigNumber.make(10) }, { amount: Utils.BigNumber.make(20) }],
             };
-            const transaction = generateTransactionType(TransactionTypes.MultiPayment, 1, asset);
+            const transaction = generateTransactionType(TransactionType.MultiPayment, 1, asset);
             const audit = testWallet.auditApply(transaction);
 
             expect(audit).toEqual([
@@ -313,7 +313,7 @@ describe("Models - Wallet", () => {
         });
 
         it("should return correct audit data for delegate resignation type", () => {
-            const transaction = generateTransactionType(TransactionTypes.DelegateResignation);
+            const transaction = generateTransactionType(TransactionType.DelegateResignation);
             const audit = testWallet.auditApply(transaction);
 
             expect(audit).toEqual([

--- a/__tests__/unit/core-transaction-pool/__stubs__/connection.ts
+++ b/__tests__/unit/core-transaction-pool/__stubs__/connection.ts
@@ -121,7 +121,7 @@ export class Connection implements TransactionPool.IConnection {
         return;
     }
 
-    public senderHasTransactionsOfType(senderPublicKey: string, transactionType: Enums.TransactionTypes): boolean {
+    public senderHasTransactionsOfType(senderPublicKey: string, transactionType: Enums.TransactionType): boolean {
         return true;
     }
 }

--- a/__tests__/unit/core-transaction-pool/connection.test.ts
+++ b/__tests__/unit/core-transaction-pool/connection.test.ts
@@ -34,7 +34,7 @@ import { database as databaseService } from "./mocks/database";
 
 const { BlockFactory } = Blocks;
 const { SATOSHI } = Constants;
-const { TransactionTypes } = Enums;
+const { TransactionType } = Enums;
 
 const delegatesSecrets = delegates.map(d => d.secret);
 
@@ -659,7 +659,7 @@ describe("Connection", () => {
     describe("acceptChainedBlock", () => {
         let mockWallet;
         beforeEach(() => {
-            const transactionHandler = Handlers.Registry.get(TransactionTypes.Transfer);
+            const transactionHandler = Handlers.Registry.get(TransactionType.Transfer);
             jest.spyOn(transactionHandler, "throwIfCannotBeApplied").mockReturnValue();
 
             mockWallet = new Wallets.Wallet(block2.transactions[0].recipientId);
@@ -705,7 +705,7 @@ describe("Connection", () => {
         });
 
         it("should forget sender if throwIfApplyingFails() failed for a transaction in the chained block", () => {
-            const transactionHandler = Handlers.Registry.get(TransactionTypes.Transfer);
+            const transactionHandler = Handlers.Registry.get(TransactionType.Transfer);
             jest.spyOn(transactionHandler, "throwIfCannotBeApplied").mockImplementation(() => {
                 throw new Error("test error");
             });
@@ -743,7 +743,7 @@ describe("Connection", () => {
         findByPublicKeyWallet.publicKey = "02778aa3d5b332965ea2a5ef6ac479ce2478535bc681a098dff1d683ff6eccc417";
 
         beforeEach(() => {
-            const transactionHandler = Handlers.Registry.get(TransactionTypes.Transfer);
+            const transactionHandler = Handlers.Registry.get(TransactionType.Transfer);
             throwIfCannotBeApplied = jest.spyOn(transactionHandler, "throwIfCannotBeApplied").mockReturnValue();
             applyToSender = jest.spyOn(transactionHandler, "applyToSender").mockReturnValue();
 
@@ -793,7 +793,7 @@ describe("Connection", () => {
         });
 
         it("should not apply transaction to wallet if throwIfCannotBeApplied() failed", async () => {
-            const transactionHandler = Handlers.Registry.get(TransactionTypes.Transfer);
+            const transactionHandler = Handlers.Registry.get(TransactionType.Transfer);
             throwIfCannotBeApplied = jest.spyOn(transactionHandler, "throwIfCannotBeApplied").mockImplementation(() => {
                 throw new Error("throw from test");
             });
@@ -818,14 +818,14 @@ describe("Connection", () => {
         it("should be false for non-existent sender", () => {
             addTransactions([mockData.dummy1]);
 
-            expect(connection.senderHasTransactionsOfType("nonexistent", TransactionTypes.Vote)).toBeFalse();
+            expect(connection.senderHasTransactionsOfType("nonexistent", TransactionType.Vote)).toBeFalse();
         });
 
         it("should be false for existent sender with no votes", () => {
             addTransactions([mockData.dummy1]);
 
             expect(
-                connection.senderHasTransactionsOfType(mockData.dummy1.data.senderPublicKey, TransactionTypes.Vote),
+                connection.senderHasTransactionsOfType(mockData.dummy1.data.senderPublicKey, TransactionType.Vote),
             ).toBeFalse();
         });
 
@@ -834,7 +834,7 @@ describe("Connection", () => {
 
             const voteTx = Transactions.TransactionFactory.fromData(cloneDeep(tx.data));
             voteTx.data.id = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
-            voteTx.data.type = TransactionTypes.Vote;
+            voteTx.data.type = TransactionType.Vote;
             voteTx.data.amount = Utils.BigNumber.ZERO;
             voteTx.data.asset = { votes: [`+${tx.data.senderPublicKey}`] };
 
@@ -842,7 +842,7 @@ describe("Connection", () => {
 
             addTransactions(transactions);
 
-            expect(connection.senderHasTransactionsOfType(tx.data.senderPublicKey, TransactionTypes.Vote)).toBeTrue();
+            expect(connection.senderHasTransactionsOfType(tx.data.senderPublicKey, TransactionType.Vote)).toBeTrue();
         });
     });
 

--- a/__tests__/unit/crypto/enums.test.ts
+++ b/__tests__/unit/crypto/enums.test.ts
@@ -3,39 +3,39 @@ import * as enums from "../../../packages/crypto/src/enums";
 
 describe("Constants", () => {
     it("transaction types are defined", () => {
-        expect(enums.TransactionTypes).toBeDefined();
+        expect(enums.TransactionType).toBeDefined();
 
-        expect(enums.TransactionTypes.Transfer).toBeDefined();
-        expect(enums.TransactionTypes.Transfer).toBe(0);
+        expect(enums.TransactionType.Transfer).toBeDefined();
+        expect(enums.TransactionType.Transfer).toBe(0);
 
-        expect(enums.TransactionTypes.SecondSignature).toBeDefined();
-        expect(enums.TransactionTypes.SecondSignature).toBe(1);
+        expect(enums.TransactionType.SecondSignature).toBeDefined();
+        expect(enums.TransactionType.SecondSignature).toBe(1);
 
-        expect(enums.TransactionTypes.DelegateRegistration).toBeDefined();
-        expect(enums.TransactionTypes.DelegateRegistration).toBe(2);
+        expect(enums.TransactionType.DelegateRegistration).toBeDefined();
+        expect(enums.TransactionType.DelegateRegistration).toBe(2);
 
-        expect(enums.TransactionTypes.Vote).toBeDefined();
-        expect(enums.TransactionTypes.Vote).toBe(3);
+        expect(enums.TransactionType.Vote).toBeDefined();
+        expect(enums.TransactionType.Vote).toBe(3);
 
-        expect(enums.TransactionTypes.MultiSignature).toBeDefined();
-        expect(enums.TransactionTypes.MultiSignature).toBe(4);
+        expect(enums.TransactionType.MultiSignature).toBeDefined();
+        expect(enums.TransactionType.MultiSignature).toBe(4);
 
-        expect(enums.TransactionTypes.Ipfs).toBeDefined();
-        expect(enums.TransactionTypes.Ipfs).toBe(5);
+        expect(enums.TransactionType.Ipfs).toBeDefined();
+        expect(enums.TransactionType.Ipfs).toBe(5);
 
-        expect(enums.TransactionTypes.MultiPayment).toBeDefined();
-        expect(enums.TransactionTypes.MultiPayment).toBe(6);
+        expect(enums.TransactionType.MultiPayment).toBeDefined();
+        expect(enums.TransactionType.MultiPayment).toBe(6);
 
-        expect(enums.TransactionTypes.DelegateResignation).toBeDefined();
-        expect(enums.TransactionTypes.DelegateResignation).toBe(7);
+        expect(enums.TransactionType.DelegateResignation).toBeDefined();
+        expect(enums.TransactionType.DelegateResignation).toBe(7);
 
-        expect(enums.TransactionTypes.HtlcLock).toBeDefined();
-        expect(enums.TransactionTypes.HtlcLock).toBe(8);
+        expect(enums.TransactionType.HtlcLock).toBeDefined();
+        expect(enums.TransactionType.HtlcLock).toBe(8);
 
-        expect(enums.TransactionTypes.HtlcClaim).toBeDefined();
-        expect(enums.TransactionTypes.HtlcClaim).toBe(9);
+        expect(enums.TransactionType.HtlcClaim).toBeDefined();
+        expect(enums.TransactionType.HtlcClaim).toBe(9);
 
-        expect(enums.TransactionTypes.HtlcRefund).toBeDefined();
-        expect(enums.TransactionTypes.HtlcRefund).toBe(10);
+        expect(enums.TransactionType.HtlcRefund).toBeDefined();
+        expect(enums.TransactionType.HtlcRefund).toBe(10);
     });
 });

--- a/__tests__/unit/crypto/transactions/builders/transactions/delegate-registration.test.ts
+++ b/__tests__/unit/crypto/transactions/builders/transactions/delegate-registration.test.ts
@@ -1,6 +1,6 @@
 import "jest-extended";
 
-import { TransactionTypes } from "../../../../../../packages/crypto/src/enums";
+import { TransactionType } from "../../../../../../packages/crypto/src/enums";
 import { DelegateRegistrationTransaction, Utils } from "../../../../../../packages/crypto/src/transactions";
 import { BuilderFactory } from "../../../../../../packages/crypto/src/transactions/builders";
 import { DelegateRegistrationBuilder } from "../../../../../../packages/crypto/src/transactions/builders/transactions/delegate-registration";
@@ -38,7 +38,7 @@ describe("Delegate Registration Transaction", () => {
         });
 
         it("should have its specific properties", () => {
-            expect(builder).toHaveProperty("data.type", TransactionTypes.DelegateRegistration);
+            expect(builder).toHaveProperty("data.type", TransactionType.DelegateRegistration);
             expect(builder).toHaveProperty("data.amount", BigNumber.ZERO);
             expect(builder).toHaveProperty("data.fee", DelegateRegistrationTransaction.staticFee());
             expect(builder).toHaveProperty("data.recipientId", undefined);

--- a/__tests__/unit/crypto/transactions/builders/transactions/delegate-resignation.test.ts
+++ b/__tests__/unit/crypto/transactions/builders/transactions/delegate-resignation.test.ts
@@ -1,6 +1,6 @@
 import "jest-extended";
 
-import { TransactionTypes } from "../../../../../../packages/crypto/src/enums";
+import { TransactionType } from "../../../../../../packages/crypto/src/enums";
 import { configManager } from "../../../../../../packages/crypto/src/managers";
 import { DelegateResignationTransaction } from "../../../../../../packages/crypto/src/transactions/";
 import { BuilderFactory } from "../../../../../../packages/crypto/src/transactions/builders";
@@ -34,7 +34,7 @@ describe("Delegate Resignation Transaction", () => {
 
     describe("properties", () => {
         it("should have its specific properties", () => {
-            expect(builder).toHaveProperty("data.type", TransactionTypes.DelegateResignation);
+            expect(builder).toHaveProperty("data.type", TransactionType.DelegateResignation);
             expect(builder).toHaveProperty("data.amount", BigNumber.ZERO);
             expect(builder).toHaveProperty("data.fee", DelegateResignationTransaction.staticFee());
             expect(builder).toHaveProperty("data.senderPublicKey", undefined);

--- a/__tests__/unit/crypto/transactions/builders/transactions/htlc-claim.test.ts
+++ b/__tests__/unit/crypto/transactions/builders/transactions/htlc-claim.test.ts
@@ -1,6 +1,6 @@
 import "jest-extended";
 
-import { TransactionTypes } from "../../../../../../packages/crypto/src/enums";
+import { TransactionType } from "../../../../../../packages/crypto/src/enums";
 import { BuilderFactory } from "../../../../../../packages/crypto/src/transactions";
 import { HtlcClaimBuilder } from "../../../../../../packages/crypto/src/transactions/builders/transactions/htlc-claim";
 import { HtlcClaimTransaction } from "../../../../../../packages/crypto/src/transactions/types/htlc-claim";
@@ -17,7 +17,7 @@ describe("Htlc claim Transaction", () => {
     transactionBuilder(() => builder);
 
     it("should have its specific properties", () => {
-        expect(builder).toHaveProperty("data.type", TransactionTypes.HtlcClaim);
+        expect(builder).toHaveProperty("data.type", TransactionType.HtlcClaim);
         expect(builder).toHaveProperty("data.fee", HtlcClaimTransaction.staticFee());
         expect(builder).toHaveProperty("data.amount", BigNumber.make(0));
         expect(builder).toHaveProperty("data.asset", {});

--- a/__tests__/unit/crypto/transactions/builders/transactions/htlc-lock.test.ts
+++ b/__tests__/unit/crypto/transactions/builders/transactions/htlc-lock.test.ts
@@ -1,6 +1,6 @@
 import "jest-extended";
 
-import { TransactionTypes } from "../../../../../../packages/crypto/src/enums";
+import { TransactionType } from "../../../../../../packages/crypto/src/enums";
 import { BuilderFactory } from "../../../../../../packages/crypto/src/transactions";
 import { HtlcLockBuilder } from "../../../../../../packages/crypto/src/transactions/builders/transactions/htlc-lock";
 import { HtlcLockExpirationType } from "../../../../../../packages/crypto/src/transactions/types/enums";
@@ -19,7 +19,7 @@ describe("Htlc lock Transaction", () => {
     transactionBuilder(() => builder);
 
     it("should have its specific properties", () => {
-        expect(builder).toHaveProperty("data.type", TransactionTypes.HtlcLock);
+        expect(builder).toHaveProperty("data.type", TransactionType.HtlcLock);
         expect(builder).toHaveProperty("data.fee", HtlcLockTransaction.staticFee());
         expect(builder).toHaveProperty("data.asset", {});
     });

--- a/__tests__/unit/crypto/transactions/builders/transactions/htlc-refund.test.ts
+++ b/__tests__/unit/crypto/transactions/builders/transactions/htlc-refund.test.ts
@@ -1,6 +1,6 @@
 import "jest-extended";
 
-import { TransactionTypes } from "../../../../../../packages/crypto/src/enums";
+import { TransactionType } from "../../../../../../packages/crypto/src/enums";
 import { BuilderFactory } from "../../../../../../packages/crypto/src/transactions";
 import { HtlcRefundBuilder } from "../../../../../../packages/crypto/src/transactions/builders/transactions/htlc-refund";
 import { HtlcRefundTransaction } from "../../../../../../packages/crypto/src/transactions/types/htlc-refund";
@@ -17,7 +17,7 @@ describe("Htlc refund Transaction", () => {
     transactionBuilder(() => builder);
 
     it("should have its specific properties", () => {
-        expect(builder).toHaveProperty("data.type", TransactionTypes.HtlcRefund);
+        expect(builder).toHaveProperty("data.type", TransactionType.HtlcRefund);
         expect(builder).toHaveProperty("data.fee", HtlcRefundTransaction.staticFee());
         expect(builder).toHaveProperty("data.amount", BigNumber.make(0));
         expect(builder).toHaveProperty("data.asset", {});

--- a/__tests__/unit/crypto/transactions/builders/transactions/ipfs.test.ts
+++ b/__tests__/unit/crypto/transactions/builders/transactions/ipfs.test.ts
@@ -1,7 +1,7 @@
 import "jest-extended";
 
 import { Utils } from "@arkecosystem/crypto";
-import { TransactionTypes } from "../../../../../../packages/crypto/src/enums";
+import { TransactionType } from "../../../../../../packages/crypto/src/enums";
 import { BuilderFactory, IpfsTransaction } from "../../../../../../packages/crypto/src/transactions";
 import { IPFSBuilder } from "../../../../../../packages/crypto/src/transactions/builders/transactions/ipfs";
 import { transactionBuilder } from "./__shared__/transaction-builder";
@@ -16,7 +16,7 @@ describe("IPFS Transaction", () => {
     transactionBuilder(() => builder);
 
     it("should have its specific properties", () => {
-        expect(builder).toHaveProperty("data.type", TransactionTypes.Ipfs);
+        expect(builder).toHaveProperty("data.type", TransactionType.Ipfs);
         expect(builder).toHaveProperty("data.fee", IpfsTransaction.staticFee());
         expect(builder).toHaveProperty("data.amount", Utils.BigNumber.make(0));
         expect(builder).toHaveProperty("data.asset", {});

--- a/__tests__/unit/crypto/transactions/builders/transactions/multi-payment.test.ts
+++ b/__tests__/unit/crypto/transactions/builders/transactions/multi-payment.test.ts
@@ -1,6 +1,6 @@
 import "jest-extended";
 
-import { TransactionTypes } from "../../../../../../packages/crypto/src/enums";
+import { TransactionType } from "../../../../../../packages/crypto/src/enums";
 import { MaximumPaymentCountExceededError } from "../../../../../../packages/crypto/src/errors";
 import { BuilderFactory, MultiPaymentTransaction } from "../../../../../../packages/crypto/src/transactions";
 import { MultiPaymentBuilder } from "../../../../../../packages/crypto/src/transactions/builders/transactions/multi-payment";
@@ -17,7 +17,7 @@ describe("Multi Payment Transaction", () => {
     transactionBuilder(() => builder);
 
     it("should have its specific properties", () => {
-        expect(builder).toHaveProperty("data.type", TransactionTypes.MultiPayment);
+        expect(builder).toHaveProperty("data.type", TransactionType.MultiPayment);
         expect(builder).toHaveProperty("data.fee", MultiPaymentTransaction.staticFee());
         expect(builder).toHaveProperty("data.asset.payments", []);
         expect(builder).toHaveProperty("data.vendorFieldHex", undefined);

--- a/__tests__/unit/crypto/transactions/builders/transactions/multi-signature.test.ts
+++ b/__tests__/unit/crypto/transactions/builders/transactions/multi-signature.test.ts
@@ -4,7 +4,7 @@ import { configManager } from "../../../../../../packages/crypto/src/managers";
 
 configManager.setFromPreset("testnet");
 
-import { TransactionTypes } from "../../../../../../packages/crypto/src/enums";
+import { TransactionType } from "../../../../../../packages/crypto/src/enums";
 import { TransactionVersionError } from "../../../../../../packages/crypto/src/errors";
 import {
     BuilderFactory,
@@ -63,7 +63,7 @@ describe("Multi Signature Transaction", () => {
     transactionBuilder(() => builder);
 
     it("should have its specific properties", () => {
-        expect(builder).toHaveProperty("data.type", TransactionTypes.MultiSignature);
+        expect(builder).toHaveProperty("data.type", TransactionType.MultiSignature);
         expect(builder).toHaveProperty("data.version", 0x02);
         expect(builder).toHaveProperty("data.fee", Utils.BigNumber.make(0));
         expect(builder).toHaveProperty("data.amount", Utils.BigNumber.make(0));
@@ -111,9 +111,9 @@ describe("Multi Signature Transaction", () => {
                 .multiSign("secret 3", 2);
 
             expect(actual.data.signatures).toEqual([
-                "003c736a01ad8a240c41cf9e9f6b863b21c3514c49068d93105ee5d00083e0d66bf333ab2fcda5b90fffa8969ccb2fe1233a29eca31a90f9d809e33dec169c7698",
-                "0112d150d02cbdf29309dd578683659d6a90666aaff950a4a4c2837815727d4b3d1eaaab24f4f1e6e57b845ff7b74b37eecd72dc85829a6652ccddf26b4c9e4a39",
-                "0211b1c08bc30ef7aed19c61ec36bddedf336bb58935789a89430eb15028226ee3cc93db436a7896f3315d8da94f4d2d1b1cc6c1a03934b7c60502c33add0d0a7a",
+                "009fe6ca3b83a9a5e693fecb2b184900c5135a8c07e704c473b2f19117630f840428416f583f1a24ff371ba7e6fbca9a7fb796226ef9ef6542f44ed911951ac88d",
+                "0116779a98b2009b35d4003dda7628e46365f1a52068489bfbd80594770967a3949f76bc09e204eddd7d460e1e519b826c53dc6e2c9573096326dbc495050cf292",
+                "02687bd0f4a91be39daf648a5b1e1af5ffa4a3d4319b2e38b1fc2dc206db03f542f3b26c4803e0b4c8a53ddfb6cf4533b512d71ae869d4e4ccba989c4a4222396b",
             ]);
             expect(actual.data.signatures.length).toBe(3);
         });

--- a/__tests__/unit/crypto/transactions/builders/transactions/second-signature.test.ts
+++ b/__tests__/unit/crypto/transactions/builders/transactions/second-signature.test.ts
@@ -5,7 +5,7 @@ import { configManager } from "../../../../../../packages/crypto/src/managers";
 configManager.setFromPreset("testnet");
 
 import { Utils } from "@arkecosystem/crypto";
-import { TransactionTypes } from "../../../../../../packages/crypto/src/enums";
+import { TransactionType } from "../../../../../../packages/crypto/src/enums";
 import { Keys } from "../../../../../../packages/crypto/src/identities";
 import {
     BuilderFactory,
@@ -34,7 +34,7 @@ describe("Second Signature Transaction", () => {
     transactionBuilder(() => builder);
 
     it("should have its specific properties", () => {
-        expect(builder).toHaveProperty("data.type", TransactionTypes.SecondSignature);
+        expect(builder).toHaveProperty("data.type", TransactionType.SecondSignature);
         expect(builder).toHaveProperty("data.fee", SecondSignatureRegistrationTransaction.staticFee());
         expect(builder).toHaveProperty("data.amount", Utils.BigNumber.make(0));
         expect(builder).toHaveProperty("data.recipientId", undefined);

--- a/__tests__/unit/crypto/transactions/builders/transactions/transfer.test.ts
+++ b/__tests__/unit/crypto/transactions/builders/transactions/transfer.test.ts
@@ -5,7 +5,7 @@ import { configManager } from "../../../../../../packages/crypto/src/managers";
 configManager.setFromPreset("testnet");
 
 import { Utils } from "@arkecosystem/crypto";
-import { TransactionTypes } from "../../../../../../packages/crypto/src/enums";
+import { TransactionType } from "../../../../../../packages/crypto/src/enums";
 import { Keys, WIF } from "../../../../../../packages/crypto/src/identities";
 import { devnet } from "../../../../../../packages/crypto/src/networks";
 import { BuilderFactory, TransferTransaction } from "../../../../../../packages/crypto/src/transactions";
@@ -96,7 +96,7 @@ describe("Transfer Transaction", () => {
     transactionBuilder(() => builder);
 
     it("should have its specific properties", () => {
-        expect(builder).toHaveProperty("data.type", TransactionTypes.Transfer);
+        expect(builder).toHaveProperty("data.type", TransactionType.Transfer);
         expect(builder).toHaveProperty("data.fee", TransferTransaction.staticFee());
         expect(builder).toHaveProperty("data.amount", Utils.BigNumber.make(0));
         expect(builder).toHaveProperty("data.recipientId", undefined);

--- a/__tests__/unit/crypto/transactions/builders/transactions/vote.test.ts
+++ b/__tests__/unit/crypto/transactions/builders/transactions/vote.test.ts
@@ -4,7 +4,7 @@ import { configManager } from "../../../../../../packages/crypto/src/managers";
 
 configManager.setFromPreset("testnet");
 
-import { TransactionTypes } from "../../../../../../packages/crypto/src/enums";
+import { TransactionType } from "../../../../../../packages/crypto/src/enums";
 import { Keys } from "../../../../../../packages/crypto/src/identities";
 import { BuilderFactory, VoteTransaction } from "../../../../../../packages/crypto/src/transactions";
 import { VoteBuilder } from "../../../../../../packages/crypto/src/transactions/builders/transactions/vote";
@@ -43,7 +43,7 @@ describe("Vote Transaction", () => {
     transactionBuilder(() => builder);
 
     it("should have its specific properties", () => {
-        expect(builder).toHaveProperty("data.type", TransactionTypes.Vote);
+        expect(builder).toHaveProperty("data.type", TransactionType.Vote);
         expect(builder).toHaveProperty("data.fee", VoteTransaction.staticFee());
         expect(builder).toHaveProperty("data.amount", Utils.BigNumber.make(0));
         expect(builder).toHaveProperty("data.recipientId", undefined);

--- a/__tests__/unit/crypto/transactions/factory.test.ts
+++ b/__tests__/unit/crypto/transactions/factory.test.ts
@@ -80,6 +80,7 @@ describe("TransactionFactory", () => {
 
             const transaction = TransactionFactory.fromBytesUnsafe(bytes, id);
             expect(transaction).toBeInstanceOf(Transaction);
+            delete transactionDataJSON.typeGroup;
             expect(transaction.toJson()).toEqual(transactionDataJSON);
         });
     });

--- a/__tests__/unit/crypto/transactions/schemas.test.ts
+++ b/__tests__/unit/crypto/transactions/schemas.test.ts
@@ -1,6 +1,6 @@
 import { Utils } from "@arkecosystem/crypto";
 import { ARKTOSHI } from "../../../../packages/crypto/src/constants";
-import { TransactionTypes } from "../../../../packages/crypto/src/enums";
+import { TransactionType } from "../../../../packages/crypto/src/enums";
 import { PublicKey } from "../../../../packages/crypto/src/identities";
 import { IMultiSignatureAsset } from "../../../../packages/crypto/src/interfaces";
 import { configManager } from "../../../../packages/crypto/src/managers";
@@ -21,7 +21,7 @@ describe("Transfer Transaction", () => {
     const amount = 10 * ARKTOSHI;
 
     beforeAll(() => {
-        transactionSchema = TransactionTypeFactory.get(TransactionTypes.Transfer).getSchema();
+        transactionSchema = TransactionTypeFactory.get(TransactionType.Transfer).getSchema();
     });
 
     beforeEach(() => {
@@ -243,7 +243,7 @@ describe("Transfer Transaction", () => {
 
 describe("Second Signature Transaction", () => {
     beforeAll(() => {
-        transactionSchema = TransactionTypeFactory.get(TransactionTypes.SecondSignature).getSchema();
+        transactionSchema = TransactionTypeFactory.get(TransactionType.SecondSignature).getSchema();
     });
 
     beforeEach(() => {
@@ -314,7 +314,7 @@ describe("Second Signature Transaction", () => {
 
 describe("Delegate Registration Transaction", () => {
     beforeAll(() => {
-        transactionSchema = TransactionTypeFactory.get(TransactionTypes.DelegateRegistration).getSchema();
+        transactionSchema = TransactionTypeFactory.get(TransactionType.DelegateRegistration).getSchema();
     });
 
     beforeEach(() => {
@@ -407,7 +407,7 @@ describe("Vote Transaction", () => {
     ];
 
     beforeAll(() => {
-        transactionSchema = TransactionTypeFactory.get(TransactionTypes.Vote).getSchema();
+        transactionSchema = TransactionTypeFactory.get(TransactionType.Vote).getSchema();
     });
 
     beforeEach(() => {
@@ -504,7 +504,7 @@ describe("Multi Signature Registration Transaction", () => {
     let multiSignatureAsset: IMultiSignatureAsset;
 
     beforeAll(() => {
-        transactionSchema = TransactionTypeFactory.get(TransactionTypes.MultiSignature).getSchema();
+        transactionSchema = TransactionTypeFactory.get(TransactionType.MultiSignature).getSchema();
     });
 
     beforeEach(() => {
@@ -705,7 +705,7 @@ describe("Multi Payment Transaction", () => {
     let multiPayment = BuilderFactory.multiPayment();
 
     beforeAll(() => {
-        transactionSchema = TransactionTypeFactory.get(TransactionTypes.MultiPayment).getSchema();
+        transactionSchema = TransactionTypeFactory.get(TransactionType.MultiPayment).getSchema();
     });
 
     beforeEach(() => {
@@ -776,7 +776,7 @@ describe("HTLC Lock Transaction", () => {
     };
 
     beforeAll(() => {
-        transactionSchema = TransactionTypeFactory.get(TransactionTypes.HtlcLock).getSchema();
+        transactionSchema = TransactionTypeFactory.get(TransactionType.HtlcLock).getSchema();
     });
 
     beforeEach(() => {
@@ -888,7 +888,7 @@ describe("HTLC Claim Transaction", () => {
     };
 
     beforeAll(() => {
-        transactionSchema = TransactionTypeFactory.get(TransactionTypes.HtlcClaim).getSchema();
+        transactionSchema = TransactionTypeFactory.get(TransactionType.HtlcClaim).getSchema();
     });
 
     beforeEach(() => {
@@ -984,7 +984,7 @@ describe("HTLC Refund Transaction", () => {
     };
 
     beforeAll(() => {
-        transactionSchema = TransactionTypeFactory.get(TransactionTypes.HtlcRefund).getSchema();
+        transactionSchema = TransactionTypeFactory.get(TransactionType.HtlcRefund).getSchema();
     });
 
     beforeEach(() => {

--- a/__tests__/unit/crypto/transactions/utils.test.ts
+++ b/__tests__/unit/crypto/transactions/utils.test.ts
@@ -131,6 +131,7 @@ describe("Transaction", () => {
                     }
 
                     if (transaction.data.version === 1) {
+                        delete transaction.data.typeGroup;
                         delete transaction.data.nonce;
                     }
 

--- a/__tests__/unit/crypto/validation/keywords.test.ts
+++ b/__tests__/unit/crypto/validation/keywords.test.ts
@@ -1,7 +1,7 @@
 import "jest-extended";
 
 import { Managers, Utils, Validation } from "../../../../packages/crypto";
-import { TransactionTypes } from "../../../../packages/crypto/src/enums";
+import { TransactionType } from "../../../../packages/crypto/src/enums";
 
 const ajv = Validation.validator.getInstance();
 
@@ -45,11 +45,11 @@ describe("keyword network", () => {
 
 describe("keyword transactionType", () => {
     it("should be ok", () => {
-        const schema = { transactionType: TransactionTypes.Transfer };
+        const schema = { transactionType: TransactionType.Transfer };
         const validate = ajv.compile(schema);
 
         expect(validate(0)).toBeTrue();
-        expect(validate(TransactionTypes.Vote)).toBeFalse();
+        expect(validate(TransactionType.Vote)).toBeFalse();
         expect(validate(-1)).toBeFalse();
         expect(validate("")).toBeFalse();
         expect(validate("0")).toBeFalse();

--- a/deprecated/core-graphql/src/repositories/transactions.ts
+++ b/deprecated/core-graphql/src/repositories/transactions.ts
@@ -3,7 +3,7 @@ import { dato } from "@faustbrian/dato";
 import { Repository } from "./repository";
 import { buildFilterQuery } from "./utils/filter-query";
 
-const { TransactionTypes } = constants;
+const { TransactionType } = constants;
 
 class TransactionsRepository extends Repository {
     /**
@@ -26,7 +26,7 @@ class TransactionsRepository extends Repository {
         }
 
         if (parameters.type) {
-            parameters.type = TransactionTypes[parameters.type];
+            parameters.type = TransactionType[parameters.type];
         }
 
         const applyConditions = queries => {
@@ -159,7 +159,7 @@ class TransactionsRepository extends Repository {
      */
     public async allVotesBySender(senderPublicKey, parameters = {}) {
         return this.findAll({
-            ...{ senderPublicKey, type: TransactionTypes.Vote },
+            ...{ senderPublicKey, type: TransactionType.Vote },
             ...parameters,
         });
     }

--- a/packages/core-api/src/handlers/transactions/controller.ts
+++ b/packages/core-api/src/handlers/transactions/controller.ts
@@ -107,12 +107,12 @@ export class TransactionsController extends Controller {
 
     public async types(request: Hapi.Request, h: Hapi.ResponseToolkit) {
         try {
-            // Remove reverse mapping from TransactionTypes enum.
-            const { TransactionTypes } = Enums;
-            const data = Object.assign({}, TransactionTypes);
+            // Remove reverse mapping from TransactionType enum.
+            const { TransactionType } = Enums;
+            const data = Object.assign({}, TransactionType);
 
             // tslint:disable-next-line: ban
-            Object.values(TransactionTypes)
+            Object.values(TransactionType)
                 .filter(value => typeof value === "string")
                 .map((type: string) => data[type])
                 .forEach((key: string) => delete data[key]);

--- a/packages/core-api/src/handlers/votes/methods.ts
+++ b/packages/core-api/src/handlers/votes/methods.ts
@@ -5,13 +5,13 @@ import Boom from "@hapi/boom";
 import { ServerCache } from "../../services";
 import { paginate, respondWithResource, toPagination } from "../utils";
 
-const { TransactionTypes } = Enums;
+const { TransactionType } = Enums;
 
 const databaseService = app.resolvePlugin<Database.IDatabaseService>("database");
 const transactionsRepository = databaseService.transactionsBusinessRepository;
 
 const index = async request => {
-    const transactions = await transactionsRepository.findAllByType(TransactionTypes.Vote, {
+    const transactions = await transactionsRepository.findAllByType(TransactionType.Vote, {
         ...request.query,
         ...paginate(request),
     });
@@ -20,7 +20,7 @@ const index = async request => {
 };
 
 const show = async request => {
-    const transaction = await transactionsRepository.findByTypeAndId(TransactionTypes.Vote, request.params.id);
+    const transaction = await transactionsRepository.findByTypeAndId(TransactionType.Vote, request.params.id);
 
     if (!transaction) {
         return Boom.notFound("Vote not found");

--- a/packages/core-blockchain/src/processor/block-processor.ts
+++ b/packages/core-blockchain/src/processor/block-processor.ts
@@ -62,7 +62,10 @@ export class BlockProcessor {
     private verifyBlock(block: Interfaces.IBlock): boolean {
         if (block.verification.containsMultiSignatures) {
             for (const transaction of block.transactions) {
-                const handler: Handlers.TransactionHandler = Handlers.Registry.get(transaction.type);
+                const handler: Handlers.TransactionHandler = Handlers.Registry.get(
+                    transaction.type,
+                    transaction.typeGroup,
+                );
                 handler.verify(transaction, this.blockchain.database.walletManager);
             }
 

--- a/packages/core-blockchain/src/replay/replay-blockchain.ts
+++ b/packages/core-blockchain/src/replay/replay-blockchain.ts
@@ -106,7 +106,7 @@ export class ReplayBlockchain extends Blockchain {
 
         const { transactions }: Interfaces.IBlock = genesisBlock;
         for (const transaction of transactions) {
-            if (transaction.type === Enums.TransactionTypes.Transfer) {
+            if (transaction.type === Enums.TransactionType.Transfer) {
                 const recipient: State.IWallet = this.walletManager.findByAddress(transaction.data.recipientId);
                 recipient.balance = new Utils.BigNumber(transaction.data.amount);
             }
@@ -116,7 +116,7 @@ export class ReplayBlockchain extends Blockchain {
             const sender: State.IWallet = this.walletManager.findByPublicKey(transaction.data.senderPublicKey);
             sender.balance = sender.balance.minus(transaction.data.amount).minus(transaction.data.fee);
 
-            if (transaction.type === Enums.TransactionTypes.DelegateRegistration) {
+            if (transaction.type === Enums.TransactionType.DelegateRegistration) {
                 sender.setAttribute("delegate", {
                     username: transaction.data.asset.delegate.username,
                     voteBalance: Utils.BigNumber.ZERO,
@@ -126,7 +126,7 @@ export class ReplayBlockchain extends Blockchain {
                     round: 0,
                 });
                 this.walletManager.reindex(sender);
-            } else if (transaction.type === Enums.TransactionTypes.Vote) {
+            } else if (transaction.type === Enums.TransactionType.Vote) {
                 const vote = transaction.data.asset.votes[0];
                 sender.setAttribute("vote", vote.slice(1));
             }

--- a/packages/core-database-postgres/src/migrations/20190803000000-add-type_group-column-to-transactions-table.sql
+++ b/packages/core-database-postgres/src/migrations/20190803000000-add-type_group-column-to-transactions-table.sql
@@ -1,0 +1,2 @@
+ALTER TABLE transactions DROP COLUMN IF EXISTS type_group;
+ALTER TABLE transactions ADD COLUMN type_group INTEGER NOT NULL DEFAULT 1;

--- a/packages/core-database-postgres/src/migrations/index.ts
+++ b/packages/core-database-postgres/src/migrations/index.ts
@@ -17,4 +17,5 @@ export const migrations = [
     loadQueryFile(__dirname, "./20190619000000-drop-id-column-from-rounds-table.sql"),
     loadQueryFile(__dirname, "./20190626000000-enforce-chained-blocks.sql"),
     loadQueryFile(__dirname, "./20190718000000-check_previous_block-add-schema.sql"),
+    loadQueryFile(__dirname, "./20190803000000-add-type_group-column-to-transactions-table.sql"),
 ];

--- a/packages/core-database-postgres/src/models/transaction.ts
+++ b/packages/core-database-postgres/src/models/transaction.ts
@@ -46,6 +46,11 @@ export class Transaction extends Model {
             supportedOperators: [Database.SearchOperator.OP_EQ, Database.SearchOperator.OP_IN],
         },
         {
+            name: "type_group",
+            prop: "typeGroup",
+            supportedOperators: [Database.SearchOperator.OP_EQ, Database.SearchOperator.OP_IN],
+        },
+        {
             name: "vendor_field_hex",
             prop: "vendorFieldHex",
             supportedOperators: [Database.SearchOperator.OP_LIKE],

--- a/packages/core-database-postgres/src/repositories/transactions.ts
+++ b/packages/core-database-postgres/src/repositories/transactions.ts
@@ -119,7 +119,7 @@ export class TransactionsRepository extends Repository implements Database.ITran
         return this.db.manyOrNone(queries.transactions.latestByBlocks, { ids });
     }
 
-    public async getAssetsByType(type: Enums.TransactionTypes | number): Promise<any> {
+    public async getAssetsByType(type: Enums.TransactionType | number): Promise<any> {
         return this.db.manyOrNone(queries.stateBuilder.assetsByType, { type });
     }
 

--- a/packages/core-database/src/database-service.ts
+++ b/packages/core-database/src/database-service.ts
@@ -554,7 +554,10 @@ export class DatabaseService implements Database.IDatabaseService {
         const senderId: string = Identities.Address.fromPublicKey(transaction.data.senderPublicKey);
 
         const sender: State.IWallet = this.walletManager.findByAddress(senderId);
-        const transactionHandler: Handlers.TransactionHandler = Handlers.Registry.get(transaction.type);
+        const transactionHandler: Handlers.TransactionHandler = Handlers.Registry.get(
+            transaction.type,
+            transaction.typeGroup,
+        );
 
         if (!sender.publicKey) {
             sender.publicKey = transaction.data.senderPublicKey;
@@ -713,7 +716,7 @@ export class DatabaseService implements Database.IDatabaseService {
     private emitTransactionEvents(transaction: Interfaces.ITransaction): void {
         this.emitter.emit(ApplicationEvents.TransactionApplied, transaction.data);
 
-        Handlers.Registry.get(transaction.type).emitEvents(transaction, this.emitter);
+        Handlers.Registry.get(transaction.type, transaction.typeGroup).emitEvents(transaction, this.emitter);
     }
 
     private registerListeners(): void {

--- a/packages/core-database/src/repositories/transactions-business-repository.ts
+++ b/packages/core-database/src/repositories/transactions-business-repository.ts
@@ -27,7 +27,7 @@ export class TransactionsBusinessRepository implements Database.ITransactionsBus
         parameters: Database.IParameters = {},
     ): Promise<Database.ITransactionsPaginated> {
         return this.search({
-            ...{ senderPublicKey, type: Enums.TransactionTypes.Vote },
+            ...{ senderPublicKey, type: Enums.TransactionType.Vote },
             ...parameters,
         });
     }
@@ -105,7 +105,7 @@ export class TransactionsBusinessRepository implements Database.ITransactionsBus
         );
     }
 
-    public async getAssetsByType(type: Enums.TransactionTypes | number): Promise<any> {
+    public async getAssetsByType(type: Enums.TransactionType | number): Promise<any> {
         return this.databaseServiceProvider().connection.transactionsRepository.getAssetsByType(type);
     }
 

--- a/packages/core-interfaces/src/core-database/business-repository/transactions-business-repository.ts
+++ b/packages/core-interfaces/src/core-database/business-repository/transactions-business-repository.ts
@@ -26,7 +26,7 @@ export interface ITransactionsBusinessRepository {
 
     findByTypeAndId(type: number, id: string): Promise<Interfaces.ITransactionData>;
 
-    getAssetsByType(type: Enums.TransactionTypes | number): Promise<any>;
+    getAssetsByType(type: Enums.TransactionType | number): Promise<any>;
 
     getReceivedTransactions(): Promise<any>;
 

--- a/packages/core-interfaces/src/core-database/database-repository/transactions-repository.ts
+++ b/packages/core-interfaces/src/core-database/database-repository/transactions-repository.ts
@@ -35,7 +35,7 @@ export interface ITransactionsRepository extends IRepository {
         }>
     >;
 
-    getAssetsByType(type: Enums.TransactionTypes | number): Promise<any>;
+    getAssetsByType(type: Enums.TransactionType | number): Promise<any>;
 
     getReceivedTransactions(): Promise<any>;
 

--- a/packages/core-interfaces/src/core-transaction-pool/connection.ts
+++ b/packages/core-interfaces/src/core-transaction-pool/connection.ts
@@ -37,5 +37,5 @@ export interface IConnection {
     removeTransactionById(id: string, senderPublicKey?: string): void;
     removeTransactionsById(ids: string[]): void;
     removeTransactionsForSender(senderPublicKey: string): void;
-    senderHasTransactionsOfType(senderPublicKey: string, transactionType: Enums.TransactionTypes): boolean;
+    senderHasTransactionsOfType(senderPublicKey: string, transactionType: Enums.TransactionType): boolean;
 }

--- a/packages/core-jest-matchers/src/transactions/types/delegate-registration.ts
+++ b/packages/core-jest-matchers/src/transactions/types/delegate-registration.ts
@@ -1,6 +1,6 @@
 import { Enums } from "@arkecosystem/crypto";
 
-const { DelegateRegistration } = Enums.TransactionTypes;
+const { DelegateRegistration } = Enums.TransactionType;
 
 export {};
 

--- a/packages/core-jest-matchers/src/transactions/types/delegate-resignation.ts
+++ b/packages/core-jest-matchers/src/transactions/types/delegate-resignation.ts
@@ -1,5 +1,5 @@
 import { Enums } from "@arkecosystem/crypto";
-const { DelegateResignation } = Enums.TransactionTypes;
+const { DelegateResignation } = Enums.TransactionType;
 
 export {};
 

--- a/packages/core-jest-matchers/src/transactions/types/ipfs.ts
+++ b/packages/core-jest-matchers/src/transactions/types/ipfs.ts
@@ -1,6 +1,6 @@
 import { Enums } from "@arkecosystem/crypto";
 
-const { Ipfs } = Enums.TransactionTypes;
+const { Ipfs } = Enums.TransactionType;
 
 export {};
 

--- a/packages/core-jest-matchers/src/transactions/types/multi-payment.ts
+++ b/packages/core-jest-matchers/src/transactions/types/multi-payment.ts
@@ -1,6 +1,6 @@
 import { Enums } from "@arkecosystem/crypto";
 
-const { MultiPayment } = Enums.TransactionTypes;
+const { MultiPayment } = Enums.TransactionType;
 
 export {};
 

--- a/packages/core-jest-matchers/src/transactions/types/multi-signature.ts
+++ b/packages/core-jest-matchers/src/transactions/types/multi-signature.ts
@@ -1,6 +1,6 @@
 import { Enums } from "@arkecosystem/crypto";
 
-const { MultiSignature } = Enums.TransactionTypes;
+const { MultiSignature } = Enums.TransactionType;
 
 export {};
 

--- a/packages/core-jest-matchers/src/transactions/types/second-signature.ts
+++ b/packages/core-jest-matchers/src/transactions/types/second-signature.ts
@@ -1,6 +1,6 @@
 import { Enums } from "@arkecosystem/crypto";
 
-const { SecondSignature } = Enums.TransactionTypes;
+const { SecondSignature } = Enums.TransactionType;
 
 export {};
 

--- a/packages/core-jest-matchers/src/transactions/types/transfer.ts
+++ b/packages/core-jest-matchers/src/transactions/types/transfer.ts
@@ -1,6 +1,6 @@
 import { Enums } from "@arkecosystem/crypto";
 
-const { Transfer } = Enums.TransactionTypes;
+const { Transfer } = Enums.TransactionType;
 
 export {};
 

--- a/packages/core-jest-matchers/src/transactions/types/vote.ts
+++ b/packages/core-jest-matchers/src/transactions/types/vote.ts
@@ -1,6 +1,6 @@
 import { Enums } from "@arkecosystem/crypto";
 
-const { Vote } = Enums.TransactionTypes;
+const { Vote } = Enums.TransactionType;
 
 export {};
 

--- a/packages/core-state/src/wallets/wallet.ts
+++ b/packages/core-state/src/wallets/wallet.ts
@@ -176,30 +176,30 @@ export class Wallet implements State.IWallet {
             });
         }
 
-        if (transaction.type === Enums.TransactionTypes.Transfer) {
+        if (transaction.type === Enums.TransactionType.Transfer) {
             audit.push({ Transfer: true });
         }
 
-        if (transaction.type === Enums.TransactionTypes.SecondSignature) {
+        if (transaction.type === Enums.TransactionType.SecondSignature) {
             audit.push({ "Second public key": secondPublicKey });
         }
 
-        if (transaction.type === Enums.TransactionTypes.DelegateRegistration) {
+        if (transaction.type === Enums.TransactionType.DelegateRegistration) {
             const username = transaction.asset.delegate.username;
             audit.push({ "Current username": delegate.username });
             audit.push({ "New username": username });
         }
 
-        if (transaction.type === Enums.TransactionTypes.DelegateResignation) {
+        if (transaction.type === Enums.TransactionType.DelegateResignation) {
             audit.push({ "Resigned delegate": delegate.username });
         }
 
-        if (transaction.type === Enums.TransactionTypes.Vote) {
+        if (transaction.type === Enums.TransactionType.Vote) {
             audit.push({ "Current vote": this.getAttribute("vote") });
             audit.push({ "New vote": transaction.asset.votes[0] });
         }
 
-        if (transaction.type === Enums.TransactionTypes.MultiSignature) {
+        if (transaction.type === Enums.TransactionType.MultiSignature) {
             const keysgroup = transaction.asset.multisignature.keysgroup;
             audit.push({ "Multisignature not yet registered": !multiSignature });
             audit.push({
@@ -213,16 +213,16 @@ export class Wallet implements State.IWallet {
             });
         }
 
-        if (transaction.type === Enums.TransactionTypes.Ipfs) {
+        if (transaction.type === Enums.TransactionType.Ipfs) {
             audit.push({ IPFS: true });
         }
 
-        if (transaction.type === Enums.TransactionTypes.MultiPayment) {
+        if (transaction.type === Enums.TransactionType.MultiPayment) {
             const amount = transaction.asset.payments.reduce((a, p) => a.plus(p.amount), Utils.BigNumber.ZERO);
             audit.push({ "Multipayment remaining amount": amount });
         }
 
-        if (!Object.values(Enums.TransactionTypes).includes(transaction.type)) {
+        if (!Object.values(Enums.TransactionType).includes(transaction.type)) {
             audit.push({ "Unknown Type": true });
         }
 

--- a/packages/core-transaction-pool/src/connection.ts
+++ b/packages/core-transaction-pool/src/connection.ts
@@ -205,7 +205,10 @@ export class Connection implements TransactionPool.IConnection {
             const { data }: Interfaces.ITransaction = transaction;
             const exists: boolean = this.has(data.id);
             const senderPublicKey: string = data.senderPublicKey;
-            const transactionHandler: Handlers.TransactionHandler = Handlers.Registry.get(transaction.type);
+            const transactionHandler: Handlers.TransactionHandler = Handlers.Registry.get(
+                transaction.type,
+                transaction.typeGroup,
+            );
 
             const senderWallet: State.IWallet = this.walletManager.hasByPublicKey(senderPublicKey)
                 ? this.walletManager.findByPublicKey(senderPublicKey)
@@ -288,7 +291,10 @@ export class Connection implements TransactionPool.IConnection {
 
             // TODO: rework error handling
             try {
-                const transactionHandler: Handlers.TransactionHandler = Handlers.Registry.get(transaction.type);
+                const transactionHandler: Handlers.TransactionHandler = Handlers.Registry.get(
+                    transaction.type,
+                    transaction.typeGroup,
+                );
                 transactionHandler.throwIfCannotBeApplied(
                     transaction,
                     senderWallet,
@@ -317,7 +323,7 @@ export class Connection implements TransactionPool.IConnection {
         this.purgeTransactions(ApplicationEvents.TransactionPoolRemoved, this.memory.getInvalid());
     }
 
-    public senderHasTransactionsOfType(senderPublicKey: string, transactionType: Enums.TransactionTypes): boolean {
+    public senderHasTransactionsOfType(senderPublicKey: string, transactionType: Enums.TransactionType): boolean {
         this.purgeExpired();
 
         for (const transaction of this.memory.getBySender(senderPublicKey)) {
@@ -423,7 +429,7 @@ export class Connection implements TransactionPool.IConnection {
 
         try {
             this.walletManager.throwIfCannotBeApplied(transaction);
-            Handlers.Registry.get(transaction.type).applyToSender(transaction, this.walletManager);
+            Handlers.Registry.get(transaction.type, transaction.typeGroup).applyToSender(transaction, this.walletManager);
         } catch (error) {
             this.logger.error(error.message);
 
@@ -469,7 +475,10 @@ export class Connection implements TransactionPool.IConnection {
 
                 const { sender, recipient } = this.getSenderAndRecipient(transaction, localWalletManager);
 
-                const handler: Handlers.TransactionHandler = Handlers.Registry.get(transaction.type);
+                const handler: Handlers.TransactionHandler = Handlers.Registry.get(
+                    transaction.type,
+                    transaction.typeGroup,
+                );
                 handler.throwIfCannotBeApplied(transaction, sender, databaseWalletManager);
 
                 handler.applyToSender(transaction, localWalletManager);
@@ -508,12 +517,12 @@ export class Connection implements TransactionPool.IConnection {
         }
 
         // HACK: need tx agonistic way for wallets which are modified by transaction
-        if (transaction.type === Enums.TransactionTypes.Vote) {
+        if (transaction.type === Enums.TransactionType.Vote) {
             const vote = transaction.data.asset.votes[0].slice(1);
             if (!localWalletManager.hasByPublicKey(vote)) {
                 localWalletManager.reindex(clonedeep(databaseWalletManager.findByPublicKey(vote)));
             }
-        } else if (transaction.type === Enums.TransactionTypes.HtlcClaim) {
+        } else if (transaction.type === Enums.TransactionType.HtlcClaim) {
             const lockId = transaction.data.asset.claim.lockTransactionId;
             if (!localWalletManager.hasByIndex(State.WalletIndexes.Locks, lockId)) {
                 localWalletManager.reindex(

--- a/packages/core-transaction-pool/src/dynamic-fee.ts
+++ b/packages/core-transaction-pool/src/dynamic-fee.ts
@@ -15,7 +15,7 @@ export const dynamicFeeMatcher = (transaction: Interfaces.ITransaction): IDynami
     let enterPool: boolean;
 
     if (dynamicFees.enabled) {
-        const handler: Handlers.TransactionHandler = Handlers.Registry.get(transaction.type);
+        const handler: Handlers.TransactionHandler = Handlers.Registry.get(transaction.type, transaction.typeGroup);
         const addonBytes: number = app.resolveOptions("transaction-pool").dynamicFees.addonBytes[transaction.key];
         const minFeeBroadcast: Utils.BigNumber = handler.dynamicFee(
             transaction,

--- a/packages/core-transaction-pool/src/wallet-manager.ts
+++ b/packages/core-transaction-pool/src/wallet-manager.ts
@@ -41,7 +41,7 @@ export class WalletManager extends Wallets.WalletManager {
 
         const sender: State.IWallet = this.findByPublicKey(senderPublicKey);
 
-        Handlers.Registry.get(transaction.type).throwIfCannotBeApplied(
+        Handlers.Registry.get(transaction.type, transaction.typeGroup).throwIfCannotBeApplied(
             transaction,
             sender,
             this.databaseService.walletManager,
@@ -49,6 +49,6 @@ export class WalletManager extends Wallets.WalletManager {
     }
 
     public async revertTransactionForSender(transaction: Interfaces.ITransaction): Promise<void> {
-        return Handlers.Registry.get(transaction.type).revertForSender(transaction, this);
+        return Handlers.Registry.get(transaction.type, transaction.typeGroup).revertForSender(transaction, this);
     }
 }

--- a/packages/core-transactions/src/errors.ts
+++ b/packages/core-transactions/src/errors.ts
@@ -27,7 +27,7 @@ export class NotImplementedError extends TransactionError {
 }
 
 export class InvalidTransactionTypeError extends TransactionError {
-    constructor(type: number) {
+    constructor(type: string) {
         super(`Transaction type ${type} does not exist.`);
     }
 }

--- a/packages/core-transactions/src/handlers/delegate-registration.ts
+++ b/packages/core-transactions/src/handlers/delegate-registration.ts
@@ -9,7 +9,7 @@ import {
 } from "../errors";
 import { TransactionHandler, TransactionHandlerConstructor } from "./transaction";
 
-const { TransactionTypes } = Enums;
+const { TransactionType } = Enums;
 
 export class DelegateRegistrationTransactionHandler extends TransactionHandler {
     public getConstructor(): Transactions.TransactionConstructor {
@@ -109,7 +109,7 @@ export class DelegateRegistrationTransactionHandler extends TransactionHandler {
         const { username }: { username: string } = data.asset.delegate;
         const delegateRegistrationsSameNameInPayload = processor
             .getTransactions()
-            .filter(tx => tx.type === TransactionTypes.DelegateRegistration && tx.asset.delegate.username === username);
+            .filter(tx => tx.type === TransactionType.DelegateRegistration && tx.asset.delegate.username === username);
 
         if (delegateRegistrationsSameNameInPayload.length > 1) {
             processor.pushError(
@@ -121,7 +121,7 @@ export class DelegateRegistrationTransactionHandler extends TransactionHandler {
         }
 
         const delegateRegistrationsInPool: Interfaces.ITransactionData[] = Array.from(
-            pool.getTransactionsByType(TransactionTypes.DelegateRegistration),
+            pool.getTransactionsByType(TransactionType.DelegateRegistration),
         ).map((memTx: Interfaces.ITransaction) => memTx.data);
 
         const containsDelegateRegistrationForSameNameInPool: boolean = delegateRegistrationsInPool.some(

--- a/packages/core-transactions/src/handlers/htlc-claim.ts
+++ b/packages/core-transactions/src/handlers/htlc-claim.ts
@@ -107,7 +107,7 @@ export class HtlcClaimTransactionHandler extends TransactionHandler {
             if (!sender.verifySignatures(data, sender.getAttribute("multiSignature"))) {
                 throw new InvalidMultiSignatureError();
             }
-        } else if (transaction.type !== Enums.TransactionTypes.MultiSignature && transaction.data.signatures) {
+        } else if (transaction.type !== Enums.TransactionType.MultiSignature && transaction.data.signatures) {
             throw new UnexpectedMultiSignatureError();
         }
 

--- a/packages/core-transactions/src/handlers/htlc-refund.ts
+++ b/packages/core-transactions/src/handlers/htlc-refund.ts
@@ -105,7 +105,7 @@ export class HtlcRefundTransactionHandler extends TransactionHandler {
             if (!sender.verifySignatures(data, sender.getAttribute("multiSignature"))) {
                 throw new InvalidMultiSignatureError();
             }
-        } else if (transaction.type !== Enums.TransactionTypes.MultiSignature && transaction.data.signatures) {
+        } else if (transaction.type !== Enums.TransactionType.MultiSignature && transaction.data.signatures) {
             throw new UnexpectedMultiSignatureError();
         }
 

--- a/packages/core-transactions/src/handlers/transaction.ts
+++ b/packages/core-transactions/src/handlers/transaction.ts
@@ -117,7 +117,7 @@ export abstract class TransactionHandler implements ITransactionHandler {
             if (!dbSender.verifySignatures(data, dbSender.getAttribute("multiSignature"))) {
                 throw new InvalidMultiSignatureError();
             }
-        } else if (transaction.type !== Enums.TransactionTypes.MultiSignature && transaction.data.signatures) {
+        } else if (transaction.type !== Enums.TransactionType.MultiSignature && transaction.data.signatures) {
             throw new UnexpectedMultiSignatureError();
         }
     }
@@ -197,7 +197,7 @@ export abstract class TransactionHandler implements ITransactionHandler {
         processor.pushError(
             data,
             "ERR_UNSUPPORTED",
-            `Invalidating transaction of unsupported type '${Enums.TransactionTypes[data.type]}'`,
+            `Invalidating transaction of unsupported type '${Enums.TransactionType[data.type]}'`,
         );
 
         return false;
@@ -214,7 +214,7 @@ export abstract class TransactionHandler implements ITransactionHandler {
             processor.pushError(
                 data,
                 "ERR_PENDING",
-                `Sender ${senderPublicKey} already has a transaction of type '${Enums.TransactionTypes[type]}' in the pool`,
+                `Sender ${senderPublicKey} already has a transaction of type '${Enums.TransactionType[type]}' in the pool`,
             );
 
             return true;

--- a/packages/crypto/src/enums.ts
+++ b/packages/crypto/src/enums.ts
@@ -1,4 +1,4 @@
-export enum TransactionTypes {
+export enum TransactionType {
     Transfer = 0,
     SecondSignature = 1,
     DelegateRegistration = 2,
@@ -10,4 +10,12 @@ export enum TransactionTypes {
     HtlcLock = 8,
     HtlcClaim = 9,
     HtlcRefund = 10,
+}
+
+export enum TransactionTypeGroup {
+    Test = 0,
+    Core = 1,
+
+    // Everything above is available to anyone
+    Reserved = 1000,
 }

--- a/packages/crypto/src/errors.ts
+++ b/packages/crypto/src/errors.ts
@@ -91,7 +91,7 @@ export class TransactionVersionError extends CryptoError {
 }
 
 export class UnkownTransactionError extends CryptoError {
-    constructor(given: number) {
+    constructor(given: string) {
         super(`Transaction type ${given} is not registered.`);
     }
 }
@@ -102,9 +102,9 @@ export class TransactionAlreadyRegisteredError extends CryptoError {
     }
 }
 
-export class TransactionTypeInvalidRangeError extends CryptoError {
-    constructor(given: number) {
-        super(`Custom transaction type must be in the range 100-255 (${given}).`);
+export class CoreTransactionTypeGroupImmutableError extends CryptoError {
+    constructor() {
+        super(`The Core transaction type group is immutable.`);
     }
 }
 

--- a/packages/crypto/src/interfaces/transactions.ts
+++ b/packages/crypto/src/interfaces/transactions.ts
@@ -1,11 +1,11 @@
 import { ErrorObject } from "ajv";
-import { TransactionTypes } from "../enums";
 import { HtlcLockExpirationType } from "../transactions/types/enums";
 import { BigNumber } from "../utils";
 
 export interface ITransaction {
     readonly id: string;
-    readonly type: TransactionTypes;
+    readonly typeGroup: number;
+    readonly type: number;
     readonly verified: boolean;
     readonly key: string;
     readonly staticFee: BigNumber;
@@ -49,7 +49,8 @@ export interface ITransactionData {
     version?: number;
     network?: number;
 
-    type: TransactionTypes;
+    typeGroup?: number;
+    type: number;
     timestamp: number;
     nonce?: BigNumber;
     senderPublicKey: string;
@@ -78,7 +79,9 @@ export interface ITransactionJson {
     version?: number;
     network?: number;
 
-    type: TransactionTypes;
+    typeGroup?: number;
+    type: number;
+
     timestamp?: number;
     nonce?: string;
     senderPublicKey: string;

--- a/packages/crypto/src/transactions/builders/transactions/delegate-registration.ts
+++ b/packages/crypto/src/transactions/builders/transactions/delegate-registration.ts
@@ -1,4 +1,3 @@
-import { TransactionTypes } from "../../../enums";
 import { ITransactionAsset, ITransactionData } from "../../../interfaces";
 import { BigNumber } from "../../../utils";
 import { DelegateRegistrationTransaction } from "../../types";
@@ -8,7 +7,8 @@ export class DelegateRegistrationBuilder extends TransactionBuilder<DelegateRegi
     constructor() {
         super();
 
-        this.data.type = TransactionTypes.DelegateRegistration;
+        this.data.type = DelegateRegistrationTransaction.type;
+        this.data.typeGroup = DelegateRegistrationTransaction.typeGroup;
         this.data.fee = DelegateRegistrationTransaction.staticFee();
         this.data.amount = BigNumber.ZERO;
         this.data.recipientId = undefined;

--- a/packages/crypto/src/transactions/builders/transactions/delegate-resignation.ts
+++ b/packages/crypto/src/transactions/builders/transactions/delegate-resignation.ts
@@ -1,4 +1,3 @@
-import { TransactionTypes } from "../../../enums";
 import { ITransactionData } from "../../../interfaces";
 import { BigNumber } from "../../../utils";
 import { DelegateResignationTransaction } from "../../types";
@@ -8,7 +7,8 @@ export class DelegateResignationBuilder extends TransactionBuilder<DelegateResig
     constructor() {
         super();
 
-        this.data.type = TransactionTypes.DelegateResignation;
+        this.data.type = DelegateResignationTransaction.type;
+        this.data.typeGroup = DelegateResignationTransaction.typeGroup;
         this.data.version = 2;
         this.data.fee = DelegateResignationTransaction.staticFee();
         this.data.amount = BigNumber.ZERO;

--- a/packages/crypto/src/transactions/builders/transactions/htlc-claim.ts
+++ b/packages/crypto/src/transactions/builders/transactions/htlc-claim.ts
@@ -1,4 +1,3 @@
-import { TransactionTypes } from "../../../enums";
 import { IHtlcClaimAsset, ITransactionData } from "../../../interfaces";
 import { BigNumber } from "../../../utils";
 import { HtlcClaimTransaction } from "../../types";
@@ -8,7 +7,8 @@ export class HtlcClaimBuilder extends TransactionBuilder<HtlcClaimBuilder> {
     constructor() {
         super();
 
-        this.data.type = TransactionTypes.HtlcClaim;
+        this.data.type = HtlcClaimTransaction.type;
+        this.data.typeGroup = HtlcClaimTransaction.typeGroup;
         this.data.fee = HtlcClaimTransaction.staticFee();
         this.data.amount = BigNumber.ZERO;
         this.data.asset = {};

--- a/packages/crypto/src/transactions/builders/transactions/htlc-lock.ts
+++ b/packages/crypto/src/transactions/builders/transactions/htlc-lock.ts
@@ -1,4 +1,3 @@
-import { TransactionTypes } from "../../../enums";
 import { IHtlcLockAsset, ITransactionData } from "../../../interfaces";
 import { BigNumber } from "../../../utils";
 import { HtlcLockTransaction } from "../../types";
@@ -8,7 +7,8 @@ export class HtlcLockBuilder extends TransactionBuilder<HtlcLockBuilder> {
     constructor() {
         super();
 
-        this.data.type = TransactionTypes.HtlcLock;
+        this.data.type = HtlcLockTransaction.type;
+        this.data.typeGroup = HtlcLockTransaction.typeGroup;
         this.data.recipientId = undefined;
         this.data.amount = BigNumber.ZERO;
         this.data.fee = HtlcLockTransaction.staticFee();

--- a/packages/crypto/src/transactions/builders/transactions/htlc-refund.ts
+++ b/packages/crypto/src/transactions/builders/transactions/htlc-refund.ts
@@ -1,4 +1,3 @@
-import { TransactionTypes } from "../../../enums";
 import { IHtlcRefundAsset, ITransactionData } from "../../../interfaces";
 import { BigNumber } from "../../../utils";
 import { HtlcRefundTransaction } from "../../types";
@@ -8,7 +7,8 @@ export class HtlcRefundBuilder extends TransactionBuilder<HtlcRefundBuilder> {
     constructor() {
         super();
 
-        this.data.type = TransactionTypes.HtlcRefund;
+        this.data.type = HtlcRefundTransaction.type;
+        this.data.typeGroup = HtlcRefundTransaction.typeGroup;
         this.data.fee = HtlcRefundTransaction.staticFee();
         this.data.amount = BigNumber.ZERO;
         this.data.asset = {};

--- a/packages/crypto/src/transactions/builders/transactions/ipfs.ts
+++ b/packages/crypto/src/transactions/builders/transactions/ipfs.ts
@@ -1,4 +1,3 @@
-import { TransactionTypes } from "../../../enums";
 import { ITransactionData } from "../../../interfaces";
 import { BigNumber } from "../../../utils";
 import { IpfsTransaction } from "../../types";
@@ -8,7 +7,8 @@ export class IPFSBuilder extends TransactionBuilder<IPFSBuilder> {
     constructor() {
         super();
 
-        this.data.type = TransactionTypes.Ipfs;
+        this.data.type = IpfsTransaction.type;
+        this.data.typeGroup = IpfsTransaction.typeGroup;
         this.data.fee = IpfsTransaction.staticFee();
         this.data.amount = BigNumber.ZERO;
         this.data.asset = {};

--- a/packages/crypto/src/transactions/builders/transactions/multi-payment.ts
+++ b/packages/crypto/src/transactions/builders/transactions/multi-payment.ts
@@ -1,4 +1,3 @@
-import { TransactionTypes } from "../../../enums";
 import { MaximumPaymentCountExceededError } from "../../../errors";
 import { ITransactionData } from "../../../interfaces";
 import { BigNumber } from "../../../utils";
@@ -9,7 +8,8 @@ export class MultiPaymentBuilder extends TransactionBuilder<MultiPaymentBuilder>
     constructor() {
         super();
 
-        this.data.type = TransactionTypes.MultiPayment;
+        this.data.type = MultiPaymentTransaction.type;
+        this.data.typeGroup = MultiPaymentTransaction.typeGroup;
         this.data.fee = MultiPaymentTransaction.staticFee();
         this.data.vendorFieldHex = undefined;
         this.data.asset = {

--- a/packages/crypto/src/transactions/builders/transactions/multi-signature.ts
+++ b/packages/crypto/src/transactions/builders/transactions/multi-signature.ts
@@ -1,4 +1,3 @@
-import { TransactionTypes } from "../../../enums";
 import { IMultiSignatureAsset, ITransactionData } from "../../../interfaces";
 import { BigNumber } from "../../../utils";
 import { MultiSignatureRegistrationTransaction } from "../../types";
@@ -8,7 +7,8 @@ export class MultiSignatureBuilder extends TransactionBuilder<MultiSignatureBuil
     constructor() {
         super();
 
-        this.data.type = TransactionTypes.MultiSignature;
+        this.data.type = MultiSignatureRegistrationTransaction.type;
+        this.data.typeGroup = MultiSignatureRegistrationTransaction.typeGroup;
         this.data.version = 2;
         this.data.fee = BigNumber.ZERO;
         this.data.amount = BigNumber.ZERO;

--- a/packages/crypto/src/transactions/builders/transactions/second-signature.ts
+++ b/packages/crypto/src/transactions/builders/transactions/second-signature.ts
@@ -1,4 +1,3 @@
-import { TransactionTypes } from "../../../enums";
 import { Keys } from "../../../identities";
 import { ITransactionAsset, ITransactionData } from "../../../interfaces";
 import { BigNumber } from "../../../utils";
@@ -9,7 +8,8 @@ export class SecondSignatureBuilder extends TransactionBuilder<SecondSignatureBu
     constructor() {
         super();
 
-        this.data.type = TransactionTypes.SecondSignature;
+        this.data.type = SecondSignatureRegistrationTransaction.type;
+        this.data.typeGroup = SecondSignatureRegistrationTransaction.typeGroup;
         this.data.fee = SecondSignatureRegistrationTransaction.staticFee();
         this.data.amount = BigNumber.ZERO;
         this.data.recipientId = undefined;

--- a/packages/crypto/src/transactions/builders/transactions/transaction.ts
+++ b/packages/crypto/src/transactions/builders/transactions/transaction.ts
@@ -1,5 +1,6 @@
 import { TransactionFactory, Utils } from "../..";
 import { Slots } from "../../../crypto";
+import { TransactionTypeGroup } from "../../../enums";
 import { MissingTransactionSignatureError } from "../../../errors";
 import { Address, Keys } from "../../../identities";
 import { IKeyPair, ITransaction, ITransactionData } from "../../../interfaces";
@@ -18,6 +19,7 @@ export abstract class TransactionBuilder<TBuilder extends TransactionBuilder<TBu
         this.data = {
             id: undefined,
             timestamp: Slots.getTime(),
+            typeGroup: TransactionTypeGroup.Test,
             nonce: BigNumber.ZERO,
             version: configManager.getMilestone().aip11 ? 0x02 : 0x01,
         } as ITransactionData;
@@ -29,6 +31,12 @@ export abstract class TransactionBuilder<TBuilder extends TransactionBuilder<TBu
 
     public version(version: number): TBuilder {
         this.data.version = version;
+
+        return this.instance();
+    }
+
+    public typeGroup(typeGroup: number): TBuilder {
+        this.data.typeGroup = typeGroup;
 
         return this.instance();
     }
@@ -162,6 +170,7 @@ export abstract class TransactionBuilder<TBuilder extends TransactionBuilder<TBu
         if (this.data.version === 1) {
             struct.timestamp = this.data.timestamp;
         } else {
+            struct.typeGroup = this.data.typeGroup;
             struct.nonce = this.data.nonce;
         }
 

--- a/packages/crypto/src/transactions/builders/transactions/transfer.ts
+++ b/packages/crypto/src/transactions/builders/transactions/transfer.ts
@@ -1,4 +1,3 @@
-import { TransactionTypes } from "../../../enums";
 import { ITransactionData } from "../../../interfaces";
 import { BigNumber } from "../../../utils";
 import { TransferTransaction } from "../../types";
@@ -8,7 +7,8 @@ export class TransferBuilder extends TransactionBuilder<TransferBuilder> {
     constructor() {
         super();
 
-        this.data.type = TransactionTypes.Transfer;
+        this.data.type = TransferTransaction.type;
+        this.data.typeGroup = TransferTransaction.typeGroup;
         this.data.fee = TransferTransaction.staticFee();
         this.data.amount = BigNumber.ZERO;
         this.data.recipientId = undefined;

--- a/packages/crypto/src/transactions/builders/transactions/vote.ts
+++ b/packages/crypto/src/transactions/builders/transactions/vote.ts
@@ -1,4 +1,3 @@
-import { TransactionTypes } from "../../../enums";
 import { ITransactionData } from "../../../interfaces";
 import { BigNumber } from "../../../utils";
 import { VoteTransaction } from "../../types";
@@ -8,7 +7,8 @@ export class VoteBuilder extends TransactionBuilder<VoteBuilder> {
     constructor() {
         super();
 
-        this.data.type = TransactionTypes.Vote;
+        this.data.type = VoteTransaction.type;
+        this.data.typeGroup = VoteTransaction.typeGroup;
         this.data.fee = VoteTransaction.staticFee();
         this.data.amount = BigNumber.ZERO;
         this.data.recipientId = undefined;

--- a/packages/crypto/src/transactions/deserializer.ts
+++ b/packages/crypto/src/transactions/deserializer.ts
@@ -1,5 +1,5 @@
 import ByteBuffer from "bytebuffer";
-import { TransactionTypes } from "../enums";
+import { TransactionType, TransactionTypeGroup } from "../enums";
 import { MalformedTransactionBytesError, TransactionVersionError } from "../errors";
 import { Address } from "../identities";
 import { ITransaction, ITransactionData } from "../interfaces";
@@ -25,7 +25,9 @@ class Deserializer {
 
         if (data.version === 1) {
             this.applyV1Compatibility(data);
-        } else if (!configManager.getMilestone().aip11) {
+        } else if (data.version === 2 && configManager.getMilestone().aip11) {
+            //
+        } else {
             throw new TransactionVersionError(data.version);
         }
 
@@ -43,6 +45,7 @@ class Deserializer {
             transaction.type = buf.readUint8();
             transaction.timestamp = buf.readUint32();
         } else {
+            transaction.typeGroup = buf.readUint32();
             transaction.type = buf.readUint16();
             transaction.nonce = BigNumber.make(buf.readUint64().toString());
         }
@@ -151,10 +154,11 @@ class Deserializer {
     // tslint:disable-next-line:member-ordering
     public applyV1Compatibility(transaction: ITransactionData): void {
         transaction.secondSignature = transaction.secondSignature || transaction.signSignature;
+        transaction.typeGroup = TransactionTypeGroup.Core;
 
-        if (transaction.type === TransactionTypes.Vote) {
+        if (transaction.type === TransactionType.Vote) {
             transaction.recipientId = Address.fromPublicKey(transaction.senderPublicKey, transaction.network);
-        } else if (transaction.type === TransactionTypes.MultiSignature) {
+        } else if (transaction.type === TransactionType.MultiSignature) {
             transaction.asset.multiSignatureLegacy.keysgroup = transaction.asset.multiSignatureLegacy.keysgroup.map(k =>
                 k.startsWith("+") ? k : `+${k}`,
             );

--- a/packages/crypto/src/transactions/deserializer.ts
+++ b/packages/crypto/src/transactions/deserializer.ts
@@ -25,9 +25,7 @@ class Deserializer {
 
         if (data.version === 1) {
             this.applyV1Compatibility(data);
-        } else if (data.version === 2 && configManager.getMilestone().aip11) {
-            // TODO
-        } else {
+        } else if (!configManager.getMilestone().aip11) {
             throw new TransactionVersionError(data.version);
         }
 
@@ -40,11 +38,12 @@ class Deserializer {
         buf.skip(1); // Skip 0xFF marker
         transaction.version = buf.readUint8();
         transaction.network = buf.readUint8();
-        transaction.type = buf.readUint8();
 
         if (transaction.version === 1) {
+            transaction.type = buf.readUint8();
             transaction.timestamp = buf.readUint32();
         } else {
+            transaction.type = buf.readUint16();
             transaction.nonce = BigNumber.make(buf.readUint64().toString());
         }
 

--- a/packages/crypto/src/transactions/types/delegate-registration.ts
+++ b/packages/crypto/src/transactions/types/delegate-registration.ts
@@ -1,12 +1,13 @@
 import ByteBuffer from "bytebuffer";
-import { TransactionTypes } from "../../enums";
+import { TransactionType, TransactionTypeGroup } from "../../enums";
 import { ISerializeOptions } from "../../interfaces";
 import { BigNumber } from "../../utils/bignum";
 import * as schemas from "./schemas";
 import { Transaction } from "./transaction";
 
 export class DelegateRegistrationTransaction extends Transaction {
-    public static type: TransactionTypes = TransactionTypes.DelegateRegistration;
+    public static typeGroup: number = TransactionTypeGroup.Core;
+    public static type: number = TransactionType.DelegateRegistration;
     public static key: string = "delegateRegistration";
 
     public static getSchema(): schemas.TransactionSchema {

--- a/packages/crypto/src/transactions/types/delegate-resignation.ts
+++ b/packages/crypto/src/transactions/types/delegate-resignation.ts
@@ -1,12 +1,13 @@
 import ByteBuffer from "bytebuffer";
-import { TransactionTypes } from "../../enums";
+import { TransactionType, TransactionTypeGroup } from "../../enums";
 import { ISerializeOptions } from "../../interfaces";
 import { BigNumber } from "../../utils/bignum";
 import * as schemas from "./schemas";
 import { Transaction } from "./transaction";
 
 export class DelegateResignationTransaction extends Transaction {
-    public static type: TransactionTypes = TransactionTypes.DelegateResignation;
+    public static typeGroup: number = TransactionTypeGroup.Core;
+    public static type: number = TransactionType.DelegateResignation;
     public static key: string = "delegateResignation";
 
     public static getSchema(): schemas.TransactionSchema {

--- a/packages/crypto/src/transactions/types/factory.ts
+++ b/packages/crypto/src/transactions/types/factory.ts
@@ -1,28 +1,29 @@
 import { TransactionConstructor } from "..";
-import { TransactionTypes } from "../../enums";
 import { UnkownTransactionError } from "../../errors";
 import { ITransaction, ITransactionData } from "../../interfaces";
+import { InternalTransactionType } from "./internal-transaction-type";
 
 export class TransactionTypeFactory {
-    public static initialize(coreTypes: Map<TransactionTypes, TransactionConstructor>) {
-        this.transactionTypes = coreTypes;
+    public static initialize(transactionTypes: Map<InternalTransactionType, TransactionConstructor>) {
+        this.transactionTypes = transactionTypes;
     }
 
     public static create(data: ITransactionData): ITransaction {
-        const instance: ITransaction = new (this.get(data.type) as any)() as ITransaction;
+        const instance: ITransaction = new (this.get(data.type, data.typeGroup) as any)() as ITransaction;
         instance.data = data;
         instance.data.version = data.version || 1;
 
         return instance;
     }
 
-    public static get(type: TransactionTypes | number): TransactionConstructor {
-        if (this.transactionTypes.has(type)) {
-            return this.transactionTypes.get(type);
+    public static get(type: number, typeGroup?: number): TransactionConstructor {
+        const internalType: InternalTransactionType = InternalTransactionType.from(type, typeGroup);
+        if (this.transactionTypes.has(internalType)) {
+            return this.transactionTypes.get(internalType);
         }
 
-        throw new UnkownTransactionError(type);
+        throw new UnkownTransactionError(internalType.toString());
     }
 
-    private static transactionTypes: Map<TransactionTypes, TransactionConstructor>;
+    private static transactionTypes: Map<InternalTransactionType, TransactionConstructor>;
 }

--- a/packages/crypto/src/transactions/types/htlc-claim.ts
+++ b/packages/crypto/src/transactions/types/htlc-claim.ts
@@ -1,12 +1,13 @@
 import ByteBuffer from "bytebuffer";
-import { TransactionTypes } from "../../enums";
+import { TransactionType, TransactionTypeGroup } from "../../enums";
 import { ISerializeOptions } from "../../interfaces";
 import { BigNumber } from "../../utils/bignum";
 import * as schemas from "./schemas";
 import { Transaction } from "./transaction";
 
 export class HtlcClaimTransaction extends Transaction {
-    public static type: TransactionTypes = TransactionTypes.HtlcClaim;
+    public static typeGroup: number = TransactionTypeGroup.Core;
+    public static type: number = TransactionType.HtlcClaim;
     public static key: string = "htlcClaim";
 
     public static getSchema(): schemas.TransactionSchema {

--- a/packages/crypto/src/transactions/types/htlc-lock.ts
+++ b/packages/crypto/src/transactions/types/htlc-lock.ts
@@ -1,5 +1,5 @@
 import ByteBuffer from "bytebuffer";
-import { TransactionTypes } from "../../enums";
+import { TransactionType, TransactionTypeGroup } from "../../enums";
 import { ISerializeOptions } from "../../interfaces";
 import { Base58 } from "../../utils/base58";
 import { BigNumber } from "../../utils/bignum";
@@ -7,7 +7,8 @@ import * as schemas from "./schemas";
 import { Transaction } from "./transaction";
 
 export class HtlcLockTransaction extends Transaction {
-    public static type: TransactionTypes = TransactionTypes.HtlcLock;
+    public static typeGroup: number = TransactionTypeGroup.Core;
+    public static type: number = TransactionType.HtlcLock;
     public static key: string = "htlcLock";
 
     public static getSchema(): schemas.TransactionSchema {

--- a/packages/crypto/src/transactions/types/htlc-refund.ts
+++ b/packages/crypto/src/transactions/types/htlc-refund.ts
@@ -1,12 +1,13 @@
 import ByteBuffer from "bytebuffer";
-import { TransactionTypes } from "../../enums";
+import { TransactionType, TransactionTypeGroup } from "../../enums";
 import { ISerializeOptions } from "../../interfaces";
 import { BigNumber } from "../../utils/bignum";
 import * as schemas from "./schemas";
 import { Transaction } from "./transaction";
 
 export class HtlcRefundTransaction extends Transaction {
-    public static type: TransactionTypes = TransactionTypes.HtlcRefund;
+    public static typeGroup: number = TransactionTypeGroup.Core;
+    public static type: number = TransactionType.HtlcRefund;
     public static key: string = "htlcRefund";
 
     public static getSchema(): schemas.TransactionSchema {

--- a/packages/crypto/src/transactions/types/index.ts
+++ b/packages/crypto/src/transactions/types/index.ts
@@ -11,6 +11,7 @@ export * from "./htlc-lock";
 export * from "./htlc-claim";
 export * from "./htlc-refund";
 export * from "./factory";
+export * from "./internal-transaction-type";
 
 import * as schemas from "./schemas";
 

--- a/packages/crypto/src/transactions/types/internal-transaction-type.ts
+++ b/packages/crypto/src/transactions/types/internal-transaction-type.ts
@@ -1,0 +1,27 @@
+import { TransactionTypeGroup } from "../../enums";
+
+export class InternalTransactionType {
+    public static from(type: number, typeGroup?: number): InternalTransactionType {
+        if (typeGroup === undefined) {
+            typeGroup = TransactionTypeGroup.Core;
+        }
+
+        const compositeType: string = `${typeGroup}-${type}`;
+        if (!this.types.has(compositeType)) {
+            this.types.set(compositeType, new InternalTransactionType(type, typeGroup));
+        }
+
+        return this.types.get(compositeType);
+    }
+
+    private static types: Map<string, InternalTransactionType> = new Map();
+
+    private compositeType: string;
+    private constructor(public readonly type: number, public readonly typeGroup: number) {
+        this.compositeType = `${typeGroup}-${type}`;
+    }
+
+    public toString(): string {
+        return this.compositeType;
+    }
+}

--- a/packages/crypto/src/transactions/types/ipfs.ts
+++ b/packages/crypto/src/transactions/types/ipfs.ts
@@ -1,13 +1,14 @@
 import { base58 } from "bstring";
 import ByteBuffer from "bytebuffer";
-import { TransactionTypes } from "../../enums";
+import { TransactionType, TransactionTypeGroup } from "../../enums";
 import { ISerializeOptions } from "../../interfaces";
 import { BigNumber } from "../../utils/bignum";
 import * as schemas from "./schemas";
 import { Transaction } from "./transaction";
 
 export class IpfsTransaction extends Transaction {
-    public static type: TransactionTypes = TransactionTypes.Ipfs;
+    public static typeGroup: number = TransactionTypeGroup.Core;
+    public static type: number = TransactionType.Ipfs;
     public static key: string = "ipfs";
 
     public static getSchema(): schemas.TransactionSchema {

--- a/packages/crypto/src/transactions/types/multi-payment.ts
+++ b/packages/crypto/src/transactions/types/multi-payment.ts
@@ -1,5 +1,5 @@
 import ByteBuffer from "bytebuffer";
-import { TransactionTypes } from "../../enums";
+import { TransactionType, TransactionTypeGroup } from "../../enums";
 import { IMultiPaymentItem, ISerializeOptions } from "../../interfaces";
 import { Base58 } from "../../utils/base58";
 import { BigNumber } from "../../utils/bignum";
@@ -7,7 +7,8 @@ import * as schemas from "./schemas";
 import { Transaction } from "./transaction";
 
 export class MultiPaymentTransaction extends Transaction {
-    public static type: TransactionTypes = TransactionTypes.MultiPayment;
+    public static typeGroup: number = TransactionTypeGroup.Core;
+    public static type: number = TransactionType.MultiPayment;
     public static key: string = "multiPayment";
 
     public static getSchema(): schemas.TransactionSchema {

--- a/packages/crypto/src/transactions/types/multi-signature.ts
+++ b/packages/crypto/src/transactions/types/multi-signature.ts
@@ -1,5 +1,5 @@
 import ByteBuffer from "bytebuffer";
-import { TransactionTypes } from "../../enums";
+import { TransactionType, TransactionTypeGroup } from "../../enums";
 import {
     IMultiSignatureAsset,
     IMultiSignatureLegacyAsset,
@@ -11,7 +11,8 @@ import * as schemas from "./schemas";
 import { Transaction } from "./transaction";
 
 export class MultiSignatureRegistrationTransaction extends Transaction {
-    public static type: TransactionTypes = TransactionTypes.MultiSignature;
+    public static typeGroup: number = TransactionTypeGroup.Core;
+    public static type: number = TransactionType.MultiSignature;
     public static key: string = "multiSignature";
 
     public static getSchema(): schemas.TransactionSchema {

--- a/packages/crypto/src/transactions/types/schemas.ts
+++ b/packages/crypto/src/transactions/types/schemas.ts
@@ -1,5 +1,5 @@
 import deepmerge = require("deepmerge");
-import { TransactionTypes } from "../../enums";
+import { TransactionType } from "../../enums";
 
 const signedTransaction = {
     anyOf: [
@@ -25,6 +25,7 @@ export const transactionBaseSchema = {
         network: { $ref: "networkByte" },
         timestamp: { type: "integer", minimum: 0 },
         nonce: { bignumber: { minimum: 0 } },
+        typeGroup: { type: "integer", minimum: 0 },
         amount: { bignumber: { minimum: 1, bypassGenesis: true } },
         fee: { bignumber: { minimum: 1, bypassGenesis: true } },
         senderPublicKey: { $ref: "publicKey" },
@@ -63,7 +64,7 @@ export const transfer = extend(transactionBaseSchema, {
     $id: "transfer",
     required: ["recipientId"],
     properties: {
-        type: { transactionType: TransactionTypes.Transfer },
+        type: { transactionType: TransactionType.Transfer },
         vendorField: { anyOf: [{ type: "null" }, { type: "string", format: "vendorField" }] },
         vendorFieldHex: { anyOf: [{ type: "null" }, { type: "string", format: "vendorFieldHex" }] },
         recipientId: { $ref: "address" },
@@ -75,7 +76,7 @@ export const secondSignature = extend(transactionBaseSchema, {
     $id: "secondSignature",
     required: ["asset"],
     properties: {
-        type: { transactionType: TransactionTypes.SecondSignature },
+        type: { transactionType: TransactionType.SecondSignature },
         amount: { bignumber: { minimum: 0, maximum: 0 } },
         secondSignature: { type: "null" },
         asset: {
@@ -100,7 +101,7 @@ export const delegateRegistration = extend(transactionBaseSchema, {
     $id: "delegateRegistration",
     required: ["asset"],
     properties: {
-        type: { transactionType: TransactionTypes.DelegateRegistration },
+        type: { transactionType: TransactionType.DelegateRegistration },
         amount: { bignumber: { minimum: 0, maximum: 0 } },
         asset: {
             type: "object",
@@ -122,7 +123,7 @@ export const vote = extend(transactionBaseSchema, {
     $id: "vote",
     required: ["asset"],
     properties: {
-        type: { transactionType: TransactionTypes.Vote },
+        type: { transactionType: TransactionType.Vote },
         amount: { bignumber: { minimum: 0, maximum: 0 } },
         recipientId: { $ref: "address" },
         asset: {
@@ -145,7 +146,7 @@ export const multiSignature = extend(transactionBaseSchema, {
     $id: "multiSignature",
     required: ["asset", "signatures"],
     properties: {
-        type: { transactionType: TransactionTypes.MultiSignature },
+        type: { transactionType: TransactionType.MultiSignature },
         amount: { bignumber: { minimum: 0, maximum: 0 } },
         asset: {
             type: "object",
@@ -185,7 +186,7 @@ export const multiSignature = extend(transactionBaseSchema, {
 export const ipfs = extend(transactionBaseSchema, {
     $id: "ipfs",
     properties: {
-        type: { transactionType: TransactionTypes.Ipfs },
+        type: { transactionType: TransactionType.Ipfs },
         amount: { bignumber: { minimum: 0, maximum: 0 } },
         asset: {
             type: "object",
@@ -203,7 +204,7 @@ export const ipfs = extend(transactionBaseSchema, {
 export const htlcLock = extend(transactionBaseSchema, {
     $id: "htlcLock",
     properties: {
-        type: { transactionType: TransactionTypes.HtlcLock },
+        type: { transactionType: TransactionType.HtlcLock },
         amount: { bignumber: { minimum: 1 } },
         recipientId: { $ref: "address" },
         asset: {
@@ -233,7 +234,7 @@ export const htlcLock = extend(transactionBaseSchema, {
 export const htlcClaim = extend(transactionBaseSchema, {
     $id: "htlcClaim",
     properties: {
-        type: { transactionType: TransactionTypes.HtlcClaim },
+        type: { transactionType: TransactionType.HtlcClaim },
         amount: { bignumber: { minimum: 0, maximum: 0 } },
         fee: { bignumber: { minimum: 0, maximum: 0 } },
         asset: {
@@ -256,7 +257,7 @@ export const htlcClaim = extend(transactionBaseSchema, {
 export const htlcRefund = extend(transactionBaseSchema, {
     $id: "htlcRefund",
     properties: {
-        type: { transactionType: TransactionTypes.HtlcRefund },
+        type: { transactionType: TransactionType.HtlcRefund },
         amount: { bignumber: { minimum: 0, maximum: 0 } },
         fee: { bignumber: { minimum: 0, maximum: 0 } },
         asset: {
@@ -278,7 +279,7 @@ export const htlcRefund = extend(transactionBaseSchema, {
 export const multiPayment = extend(transactionBaseSchema, {
     $id: "multiPayment",
     properties: {
-        type: { transactionType: TransactionTypes.MultiPayment },
+        type: { transactionType: TransactionType.MultiPayment },
         amount: { bignumber: { minimum: 0, maximum: 0 } },
         asset: {
             type: "object",
@@ -307,7 +308,7 @@ export const multiPayment = extend(transactionBaseSchema, {
 export const delegateResignation = extend(transactionBaseSchema, {
     $id: "delegateResignation",
     properties: {
-        type: { transactionType: TransactionTypes.DelegateResignation },
+        type: { transactionType: TransactionType.DelegateResignation },
         amount: { bignumber: { minimum: 0, maximum: 0 } },
     },
 });

--- a/packages/crypto/src/transactions/types/second-signature.ts
+++ b/packages/crypto/src/transactions/types/second-signature.ts
@@ -1,12 +1,13 @@
 import ByteBuffer from "bytebuffer";
-import { TransactionTypes } from "../../enums";
+import { TransactionType, TransactionTypeGroup } from "../../enums";
 import { ISerializeOptions } from "../../interfaces";
 import { BigNumber } from "../../utils/bignum";
 import * as schemas from "./schemas";
 import { Transaction } from "./transaction";
 
 export class SecondSignatureRegistrationTransaction extends Transaction {
-    public static type: TransactionTypes = TransactionTypes.SecondSignature;
+    public static typeGroup: number = TransactionTypeGroup.Core;
+    public static type: number = TransactionType.SecondSignature;
     public static key: string = "secondSignature";
 
     public static getSchema(): schemas.TransactionSchema {

--- a/packages/crypto/src/transactions/types/transaction.ts
+++ b/packages/crypto/src/transactions/types/transaction.ts
@@ -1,4 +1,4 @@
-import { TransactionTypes } from "../../enums";
+import { TransactionTypeGroup } from "../../enums";
 import { NotImplementedError } from "../../errors";
 import { ISchemaValidationResult, ITransaction, ITransactionData, ITransactionJson } from "../../interfaces";
 import { configManager } from "../../managers/config";
@@ -11,8 +11,12 @@ export abstract class Transaction implements ITransaction {
         return this.data.id;
     }
 
-    public get type(): TransactionTypes {
+    public get type(): number {
         return this.data.type;
+    }
+
+    public get typeGroup(): number {
+        return this.data.typeGroup;
     }
 
     public get verified(): boolean {
@@ -27,7 +31,8 @@ export abstract class Transaction implements ITransaction {
         return (this as any).__proto__.constructor.staticFee({ data: this.data });
     }
 
-    public static type: TransactionTypes = undefined;
+    public static type: number = undefined;
+    public static typeGroup: number = undefined;
     public static key: string = undefined;
 
     public static getSchema(): TransactionSchema {
@@ -71,6 +76,10 @@ export abstract class Transaction implements ITransaction {
 
     public toJson(): ITransactionJson {
         const data: ITransactionJson = JSON.parse(JSON.stringify(this.data));
+
+        if (data.typeGroup === TransactionTypeGroup.Core) {
+            delete data.typeGroup;
+        }
 
         if (data.version === 1) {
             delete data.nonce;

--- a/packages/crypto/src/transactions/types/transfer.ts
+++ b/packages/crypto/src/transactions/types/transfer.ts
@@ -1,5 +1,5 @@
 import ByteBuffer from "bytebuffer";
-import { TransactionTypes } from "../../enums";
+import { TransactionType, TransactionTypeGroup } from "../../enums";
 import { ISerializeOptions } from "../../interfaces";
 import { Base58 } from "../../utils/base58";
 import { BigNumber } from "../../utils/bignum";
@@ -7,7 +7,8 @@ import * as schemas from "./schemas";
 import { Transaction } from "./transaction";
 
 export class TransferTransaction extends Transaction {
-    public static type: TransactionTypes = TransactionTypes.Transfer;
+    public static typeGroup: number = TransactionTypeGroup.Core;
+    public static type: number = TransactionType.Transfer;
     public static key: string = "transfer";
 
     public static getSchema(): schemas.TransactionSchema {

--- a/packages/crypto/src/transactions/types/vote.ts
+++ b/packages/crypto/src/transactions/types/vote.ts
@@ -1,12 +1,13 @@
 import ByteBuffer from "bytebuffer";
-import { TransactionTypes } from "../../enums";
+import { TransactionType, TransactionTypeGroup } from "../../enums";
 import { ISerializeOptions } from "../../interfaces";
 import { BigNumber } from "../../utils/bignum";
 import * as schemas from "./schemas";
 import { Transaction } from "./transaction";
 
 export class VoteTransaction extends Transaction {
-    public static type: TransactionTypes = TransactionTypes.Vote;
+    public static typeGroup: number = TransactionTypeGroup.Core;
+    public static type: number = TransactionType.Vote;
     public static key: string = "vote";
 
     public static getSchema(): schemas.TransactionSchema {

--- a/packages/crypto/src/transactions/verifier.ts
+++ b/packages/crypto/src/transactions/verifier.ts
@@ -46,7 +46,7 @@ export class Verifier {
     }
 
     public static verifySchema(data: ITransactionData, strict: boolean = true): ISchemaValidationResult {
-        const { $id } = TransactionTypeFactory.get(data.type).getSchema();
+        const { $id } = TransactionTypeFactory.get(data.type, data.typeGroup).getSchema();
         return validator.validate(strict ? `${$id}Strict` : `${$id}`, data);
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3909,13 +3909,13 @@ bs-logger@0.x:
   dependencies:
     fast-json-stable-stringify "2.x"
 
-bs58@^4.0.0:
+bs58@^4.0.0, bs58@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/bs58/-/bs58-4.0.1.tgz#be161e76c354f6f788ae4071f63f34e8c4f0a42a"
   dependencies:
     base-x "^3.0.2"
 
-bs58check@<3.0.0, bs58check@^2.1.1:
+bs58check@<3.0.0, bs58check@^2.1.1, bs58check@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/bs58check/-/bs58check-2.1.2.tgz#53b018291228d82a5aa08e7d796fdafda54aebfc"
   dependencies:
@@ -7918,6 +7918,11 @@ lodash.assign@^4.2.0:
 lodash.assignin@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.assignin/-/lodash.assignin-4.2.0.tgz#ba8df5fb841eb0a3e8044232b0e263a8dc6a28a2"
+
+lodash.camelcase@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
+  integrity sha1-soqmKIorn8ZRA1x3EfZathkDMaY=
 
 lodash.chunk@^4.2.0:
   version "4.2.0"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

Increases the transaction type from 1 byte to 2 bytes and adds a new `typeGroup` property which is used to group transaction types logically together. This minimizes the risk of collisions between custom transaction types and allows them to start numbering at 0.

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [X] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

## Does this PR release a new version?

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `develop` branch, _not_ the `master` branch
- [ ] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
