### PR TITLE
feat(core-p2p): change minimum version via milestone

### DIFF
--- a/__tests__/integration/core-p2p/__support__/mock-socket-server/manager.ts
+++ b/__tests__/integration/core-p2p/__support__/mock-socket-server/manager.ts
@@ -53,6 +53,7 @@ export class MockSocketManager {
     }
 
     public stopServer() {
+        this.clientSocket.destroy();
         return this.serverProcess.kill();
     }
 }

--- a/__tests__/integration/core-p2p/mocks/core-container.ts
+++ b/__tests__/integration/core-p2p/mocks/core-container.ts
@@ -1,4 +1,5 @@
 import { Managers } from "@arkecosystem/crypto";
+import { EventEmitter } from "../../../../packages/core-event-emitter/src/emitter";
 import * as plugins from "../../../utils/config/testnet/plugins.js";
 import { blocks2to100 } from "../../../utils/fixtures";
 import { delegates } from "../../../utils/fixtures/testnet/delegates";
@@ -6,6 +7,8 @@ import { genesisBlock } from "../../../utils/fixtures/unitnet/block-model";
 import { defaults } from "./p2p-options";
 
 Managers.configManager.setFromPreset("unitnet");
+
+export const eventEmitter = new EventEmitter();
 
 jest.mock("@arkecosystem/core-container", () => {
     return {
@@ -68,9 +71,7 @@ jest.mock("@arkecosystem/core-container", () => {
                 }
 
                 if (name === "event-emitter") {
-                    return {
-                        emit: jest.fn(),
-                    };
+                    return eventEmitter;
                 }
 
                 if (name === "blockchain") {

--- a/__tests__/integration/core-p2p/peer-processor.test.ts
+++ b/__tests__/integration/core-p2p/peer-processor.test.ts
@@ -1,0 +1,63 @@
+import "jest-extended";
+
+import "./mocks/core-container";
+
+import { P2P } from "@arkecosystem/core-interfaces";
+import { Managers } from "@arkecosystem/crypto";
+import { createPeerService, createStubPeer } from "../../helpers/peers";
+import { MockSocketManager } from "./__support__/mock-socket-server/manager";
+import { eventEmitter } from "./mocks/core-container";
+
+let socketManager: MockSocketManager;
+
+let storage: P2P.IPeerStorage;
+
+beforeAll(async () => {
+    socketManager = new MockSocketManager();
+    await socketManager.init();
+});
+
+afterAll(async () => {
+    socketManager.stopServer();
+});
+
+beforeEach(() => {
+    ({ storage } = createPeerService());
+});
+
+afterEach(() => socketManager.resetAllMocks());
+
+describe("PeerProcessor", () => {
+    describe("milestone change", () => {
+        it("should remove peers with an invalid version", async () => {
+            jest.spyOn(Managers.configManager, "getMilestone").mockReturnValue({
+                p2p: {
+                    minimumVersions: ["^3.0"],
+                },
+            });
+
+            for (let i = 0; i < 5; i++) {
+                storage.setPeer(createStubPeer({ ip: `127.0.0.${i + 1}`, port: 4009, version: "2.5.0" }));
+            }
+
+            storage.setPeer(createStubPeer({ ip: `127.0.0.30`, port: 4009, version: "3.0.0" }));
+
+            expect(storage.getPeers()).toHaveLength(6);
+            eventEmitter.emit("internal.milestone.changed");
+            expect(storage.getPeers()).toHaveLength(1);
+            eventEmitter.emit("internal.milestone.changed");
+            expect(storage.getPeers()).toHaveLength(1);
+
+            jest.spyOn(Managers.configManager, "getMilestone").mockReturnValue({
+                p2p: {
+                    minimumVersions: ["^4.0"],
+                },
+            });
+
+            eventEmitter.emit("internal.milestone.changed");
+            expect(storage.getPeers()).toBeEmpty();
+
+            jest.restoreAllMocks();
+        });
+    });
+});

--- a/__tests__/integration/core-p2p/socket-server/peer.test.ts
+++ b/__tests__/integration/core-p2p/socket-server/peer.test.ts
@@ -71,8 +71,9 @@ describe("Peer socket endpoint", () => {
             expect(data.state.height).toBe(1);
         });
 
-        describe("postBlock", async () => {
+        describe("postBlock", () => {
             it("should postBlock successfully", async () => {
+                await delay(1000);
                 const { data } = await emit("p2p.peer.postBlock", {
                     data: { block: Blocks.BlockFactory.fromData(genesisBlock).toJson() },
                     headers,
@@ -81,9 +82,8 @@ describe("Peer socket endpoint", () => {
                 expect(data).toEqual({});
             });
 
-            await delay(1000);
-
             it("should throw validation error when sending wrong data", async () => {
+                await delay(1000);
                 await expect(
                     emit("p2p.peer.postBlock", {
                         data: {},

--- a/__tests__/unit/core-p2p/mocks/event-emitter.ts
+++ b/__tests__/unit/core-p2p/mocks/event-emitter.ts
@@ -1,3 +1,4 @@
 export const eventEmitter = {
     emit: jest.fn(),
+    on: jest.fn(),
 };

--- a/packages/core-p2p/src/peer-processor.ts
+++ b/packages/core-p2p/src/peer-processor.ts
@@ -4,7 +4,7 @@ import { app } from "@arkecosystem/core-container";
 import { ApplicationEvents } from "@arkecosystem/core-event-emitter";
 import { EventEmitter, Logger, P2P } from "@arkecosystem/core-interfaces";
 import { Peer } from "./peer";
-import { isValidPeer, isWhitelisted } from "./utils";
+import { isValidPeer, isValidVersion, isWhitelisted } from "./utils";
 
 export class PeerProcessor implements P2P.IPeerProcessor {
     public server: any;
@@ -29,6 +29,10 @@ export class PeerProcessor implements P2P.IPeerProcessor {
         this.communicator = communicator;
         this.connector = connector;
         this.storage = storage;
+
+        this.emitter.on("internal.milestone.changed", () => {
+            this.updatePeersAfterMilestoneChange();
+        });
     }
 
     public async validateAndAcceptPeer(peer: P2P.IPeer, options: P2P.IAcceptNewPeerOptions = {}): Promise<void> {
@@ -67,6 +71,16 @@ export class PeerProcessor implements P2P.IPeerProcessor {
         }
 
         return true;
+    }
+
+    private updatePeersAfterMilestoneChange(): void {
+        const peers: P2P.IPeer[] = this.storage.getPeers();
+        for (const peer of peers) {
+            if (!isValidVersion(peer)) {
+                this.connector.disconnect(peer);
+                this.storage.forgetPeer(peer);
+            }
+        }
     }
 
     private async acceptNewPeer(peer, options: P2P.IAcceptNewPeerOptions = {}): Promise<void> {

--- a/packages/core-p2p/src/utils/is-valid-version.ts
+++ b/packages/core-p2p/src/utils/is-valid-version.ts
@@ -10,8 +10,9 @@ export const isValidVersion = (peer: P2P.IPeer): boolean => {
 
     let minimumVersions: string[];
     const milestones: Record<string, any> = Managers.configManager.getMilestone();
-    if (milestones.p2p && milestones.p2p.minimumVersions && milestones.p2p.minimumVersions.length > 0) {
-        minimumVersions = milestones.p2p.minimumVersions;
+    const { p2p } = milestones;
+    if (p2p && Array.isArray(p2p.minimumVersions) && p2p.minimumVersions.length > 0) {
+        minimumVersions = p2p.minimumVersions;
     } else {
         minimumVersions = app.resolveOptions("p2p").minimumVersions;
     }

--- a/packages/core-p2p/src/utils/is-valid-version.ts
+++ b/packages/core-p2p/src/utils/is-valid-version.ts
@@ -1,5 +1,6 @@
 import { app } from "@arkecosystem/core-container";
 import { P2P } from "@arkecosystem/core-interfaces";
+import { Managers } from "@arkecosystem/crypto";
 import semver from "semver";
 
 export const isValidVersion = (peer: P2P.IPeer): boolean => {
@@ -7,7 +8,13 @@ export const isValidVersion = (peer: P2P.IPeer): boolean => {
         return false;
     }
 
-    return app
-        .resolveOptions("p2p")
-        .minimumVersions.some((minimumVersion: string) => semver.satisfies(peer.version, minimumVersion));
+    let minimumVersions: string[];
+    const milestones: Record<string, any> = Managers.configManager.getMilestone();
+    if (milestones.p2p && milestones.p2p.minimumVersions && milestones.p2p.minimumVersions.length > 0) {
+        minimumVersions = milestones.p2p.minimumVersions;
+    } else {
+        minimumVersions = app.resolveOptions("p2p").minimumVersions;
+    }
+
+    return minimumVersions.some((minimumVersion: string) => semver.satisfies(peer.version, minimumVersion));
 };


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

Allows changing the accepted minimum versions via milestone.

For example this would cause all peers below `3.0` to be dropped once reaching the milestone:
```
{
    "height": 10000000,
    "p2p": {
        "minimumVersions": ["^3.0"]
    }
}
```

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [ ] Bugfix
- [X] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

## Does this PR release a new version?

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `develop` branch, _not_ the `master` branch
- [ ] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
