### PR TITLE
fix(core-p2p): stricter schema on peer replies, disconnect on invalid requests

### DIFF
--- a/__tests__/integration/core-p2p/peer-communicator.test.ts
+++ b/__tests__/integration/core-p2p/peer-communicator.test.ts
@@ -4,6 +4,7 @@ import "./mocks/core-container";
 
 import { P2P } from "@arkecosystem/core-interfaces";
 import { Transactions } from "@arkecosystem/crypto";
+import { getPeerConfig } from '../../../packages/core-p2p/src/socket-server/utils/get-peer-config';
 import { createPeerService, createStubPeer } from "../../helpers/peers";
 import { TransactionFactory } from "../../helpers/transaction-factory";
 import { genesisBlock } from "../../utils/config/unitnet/genesisBlock";
@@ -16,6 +17,19 @@ let socketManager: MockSocketManager;
 
 let storage: P2P.IPeerStorage;
 let communicator: P2P.IPeerCommunicator;
+
+const blockHeader = {
+    height: 1,
+    id: "123456",
+    timestamp: 0,
+    totalAmount: "0",
+    totalFee: "0",
+    reward: "0",
+    // tslint:disable-next-line: no-null-keyword
+    previousBlock: null,
+    generatorPublicKey: "03b47f6b6719c76bad46a302d9cff7be9b1c2b2a20602a0d880f139b5b8901f068",
+    blockSignature: "304402202fe5de5697fa25d3d3c0cb24617ac02ddfb1c915ee9194a89f8392f948c6076402200d07c5244642fe36afa53fb2d048735f1adfa623e8fa4760487e5f72e17d253b"
+}
 
 beforeAll(async () => {
     socketManager = new MockSocketManager();
@@ -97,12 +111,9 @@ describe("PeerCommunicator", () => {
                     height: 1,
                     forgingAllowed: true,
                     currentSlot: 1,
-                    header: {
-                        height: 1,
-                        id: "123456",
-                    },
+                    header: Object.assign({}, blockHeader),
                 },
-                config: { plugins: {} },
+                config: getPeerConfig(),
             };
 
             await socketManager.addMock("getStatus", mockStatus);
@@ -110,6 +121,9 @@ describe("PeerCommunicator", () => {
             process.env.CORE_SKIP_PEER_STATE_VERIFICATION = "true";
 
             const status = await communicator.ping(stubPeer, 1000);
+            status.header.totalAmount = status.header.totalAmount.toFixed();
+            status.header.totalFee = status.header.totalFee.toFixed();
+            status.header.reward = status.header.reward.toFixed();
 
             expect(status).toEqual(mockStatus.state);
         });
@@ -130,12 +144,9 @@ describe("PeerCommunicator", () => {
                     height: 1,
                     forgingAllowed: true,
                     currentSlot: 1,
-                    header: {
-                        height: 1,
-                        id: "123456",
-                    },
+                    header: Object.assign({}, blockHeader),
                 },
-                config: { plugins: {} },
+                config: getPeerConfig(),
             });
 
             stubPeer.lastPinged = undefined;

--- a/__tests__/unit/core-p2p/mocks/core-container.ts
+++ b/__tests__/unit/core-p2p/mocks/core-container.ts
@@ -24,6 +24,16 @@ jest.mock("@arkecosystem/core-container", () => {
                                 return [{ ip: "1.2.3.4", port: 4000 }];
                             case "blacklist":
                                 return [];
+                            case "network.pubKeyHash":
+                                return 23;
+                            case "network.name":
+                                return "unit";
+                            case "network.client.explorer":
+                                return "unit";
+                            case "network.client.token":
+                                return "T";
+                            case "network.client.symbol":
+                                return "T";
                         }
 
                         return undefined;

--- a/__tests__/unit/core-p2p/socket-server/utils/validate.test.ts
+++ b/__tests__/unit/core-p2p/socket-server/utils/validate.test.ts
@@ -1,0 +1,98 @@
+import "../../mocks/core-container";
+
+import { Crypto } from "@arkecosystem/crypto";
+import { replySchemas } from "../../../../../packages/core-p2p/src/schemas";
+import { validate } from "../../../../../packages/core-p2p/src/socket-server/utils/validate";
+import {
+    getStatus,
+} from "../../../../../packages/core-p2p/src/socket-server/versions/peer";
+
+describe("Peer reply validation", () => {
+
+    describe("getStatus", () => {
+        beforeAll(() => {
+            Crypto.Slots.isForgingAllowed = jest.fn().mockReturnValue(true);
+            Crypto.Slots.getSlotNumber = jest.fn().mockReturnValue(3);
+
+        });
+
+        it("should be valid", async () => {
+            const schema = replySchemas['p2p.peer.getStatus'];
+            const result = await getStatus();
+
+            expect(() => validate(schema, result)).not.toThrowError();
+
+            (result.state as any).header = {}
+            expect(() => validate(schema, result)).not.toThrowError();
+
+            (result.state as any).header = { id: 1 }
+            expect(() => validate(schema, result)).toThrowError();
+        });
+
+        it("should strip invalid properties", async () => {
+            const schema = replySchemas['p2p.peer.getStatus'];
+            const result = await getStatus();
+
+            (result.config as any).plugins = {
+                "@arkecosystem/core-api": {
+                    "enabled": true,
+                    "port": 4003,
+                    "x": 1,
+                },
+                "@arkecosystem/core-exchange-json-rpc": {
+                    "enabled": false,
+                    "port": 8080,
+                },
+                "@arkecosystem/core-webhooks": {
+                    "enabled": false,
+                    "port": 4004,
+                },
+            };
+
+            expect(() => validate(schema, result)).not.toThrowError();
+            expect(result.config.plugins["@arkecosystem/core-api"]).not.toHaveProperty("x");
+
+            result.config.plugins = {
+                "aa": {
+                    "enabled": true,
+                    "port": 4002,
+                },
+                "@arkecosystem/core-api-core-exchange-json-rpc-core-exchange-json-rpc": {
+                    "enabled": true,
+                    "port": 4003,
+                },
+                "@arkecosystem/core-exchange-json-rpc": {
+                    "enabled": false,
+                    "port": 8080,
+                },
+                "@arkecosystem/core-webhooks": {
+                    "enabled": false,
+                    "port": 4004,
+                },
+            };
+
+            expect(() => validate(schema, result)).not.toThrowError();
+            expect(result).not.toHaveProperty("aa");
+            expect(result).not.toHaveProperty("@arkecosystem/core-api-core-exchange-json-rpc-core-exchange-json-rpc");
+        });
+
+        it("should fail with too many properties", async () => {
+            const schema = replySchemas['p2p.peer.getStatus'];
+            const result = await getStatus();
+
+            result.config.plugins = {};
+            for (let i = 0; i < 32; i++) {
+                result.config.plugins[`@arkecosystem/core-api-${i}`] = {
+                    "enabled": true,
+                    "port": 4003,
+                };
+            }
+
+            expect(() => validate(schema, result)).not.toThrowError();
+
+            result.config.plugins["too-many"] = { "enabled": true, "port": 1234 };
+
+            expect(() => validate(schema, result)).toThrowError();
+        });
+    });
+});

--- a/packages/core-p2p/src/schemas.ts
+++ b/packages/core-p2p/src/schemas.ts
@@ -60,6 +60,7 @@ export const requestSchemas = {
 export const replySchemas = {
     "p2p.peer.getBlocks": {
         type: "array",
+        maxItems: 400,
         items: {
             $ref: "blockHeader",
         },
@@ -91,6 +92,7 @@ export const replySchemas = {
     },
     "p2p.peer.getPeers": {
         type: "array",
+        maxItems: 2000,
         items: {
             type: "object",
             properties: {
@@ -112,36 +114,124 @@ export const replySchemas = {
     },
     "p2p.peer.getStatus": {
         type: "object",
-        required: ["state"],
+        required: ["state", "config"],
         additionalProperties: false,
         properties: {
-            state: { type: "object" },
-            config: { type: "object" },
+            state: {
+                type: "object",
+                required: ["height", "forgingAllowed", "currentSlot", "header"],
+                properties: {
+                    height: {
+                        type: "integer",
+                        minimum: 1
+                    },
+                    forgingAllowed: {
+                        type: "boolean"
+                    },
+                    currentSlot: {
+                        type: "integer",
+                        minimum: 1
+                    },
+                    header: {
+                        anyOf: [
+                            {
+                                $ref: "blockHeader",
+                            },
+                            {
+                                type: "object",
+                                minProperties: 0,
+                                maxProperties: 0,
+                            }
+                        ],
+                    }
+                },
+            },
+            config: {
+                type: "object",
+                required: ["version", "network", "plugins"],
+                additionalProperties: false,
+                properties: {
+                    version: {
+                        type: "string",
+                        minLength: 5,
+                        maxLength: 24,
+                    },
+                    network: {
+                        type: "object",
+                        required: ["name", "nethash", "explorer", "token"],
+                        additionalProperties: false,
+                        properties: {
+                            name: {
+                                type: "string",
+                                minLength: 1,
+                                maxLength: 20,
+                            },
+                            version: {
+                                type: "integer",
+                                minimum: 0,
+                                maximum: 255,
+                            },
+                            nethash: {
+                                allOf: [
+                                    {
+                                        $ref: "hex"
+                                    },
+                                    {
+                                        minLength: 64,
+                                        maxLength: 64
+                                    }
+                                ],
+                            },
+                            explorer: {
+                                type: "string",
+                                minLength: 0,
+                                maxLength: 128,
+                            },
+                            token: {
+                                type: "object",
+                                required: ["name", "symbol"],
+                                additionalProperties: false,
+                                properties: {
+                                    name: {
+                                        type: "string",
+                                        minLength: 1,
+                                        maxLength: 8,
+                                    },
+                                    symbol: {
+                                        type: "string",
+                                        minLength: 1,
+                                        maxLength: 3,
+                                    },
+                                },
+                            },
+                        },
+                    },
+                    plugins: {
+                        type: "object",
+                        maxProperties: 32,
+                        minProperties: 1,
+                        additionalProperties: false,
+                        patternProperties: {
+                            "^.{4,64}$": {
+                                type: "object",
+                                required: ["port", "enabled"],
+                                additionalProperties: false,
+                                properties: {
+                                    port: {
+                                        type: "integer",
+                                        minimum: 0,
+                                        maximum: 65535,
+                                    },
+                                    enabled: {
+                                        type: "boolean",
+                                    }
+                                }
+                            },
+                        }
+                    },
+                },
+            },
         },
-        // @TODO: adjust schema to match { state, config }
-        // type: "object",
-        // properties: {
-        //     header: {
-        //         type: "object",
-        //         properties: {
-        //             height: {
-        //                 type: "integer",
-        //                 minimum: 1,
-        //             },
-        //             id: {
-        //                 type: "string",
-        //                 maxLength: 64,
-        //                 pattern: "[0-9a-fA-F]+", // hexadecimal
-        //             },
-        //         },
-        //         required: ["height", "id"],
-        //     },
-        //     height: {
-        //         type: "integer",
-        //         minimum: 1,
-        //     },
-        // },
-        // required: ["header", "height"],
     },
     "p2p.peer.postBlock": {
         type: "object",

--- a/packages/core-p2p/src/socket-server/worker.ts
+++ b/packages/core-p2p/src/socket-server/worker.ts
@@ -99,10 +99,16 @@ export class Worker extends SCWorker {
         }
 
         try {
+            if (req.event.length > 128) {
+                req.socket.disconnect(4413, "Payload Too Large");
+                return;
+            }
+
             const [prefix, version] = req.event.split(".");
 
             if (prefix !== "p2p") {
-                return next(this.createError(SocketErrors.WrongEndpoint, `Wrong endpoint: ${req.event}`));
+                req.socket.disconnect(4404, "Not Found");
+                return;
             }
 
             // Check that blockchain, tx-pool and p2p are ready
@@ -132,6 +138,9 @@ export class Worker extends SCWorker {
                     data: { ip: req.socket.remoteAddress },
                     headers: req.data.headers,
                 });
+            } else {
+                req.socket.disconnect(4400, "Bad Request");
+                return;
             }
 
             // some handlers need this remoteAddress info


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->
Make the peer reply schemas more strict and disconnect on invalid request instead of returning an error.

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

## Does this PR release a new version?

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `develop` branch, _not_ the `master` branch
- [ ] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
