### PR TITLE
feat(core-p2p): use compression on the p2p level

### DIFF
--- a/packages/core-p2p/src/peer-connector.ts
+++ b/packages/core-p2p/src/peer-connector.ts
@@ -27,6 +27,7 @@ export class PeerConnector implements P2P.IPeerConnector {
             port: peer.port,
             hostname: peer.ip,
             ackTimeout: Math.max(app.resolveOptions("p2p").getBlocksTimeout, app.resolveOptions("p2p").verifyTimeout),
+            perMessageDeflate: true,
         });
 
         this.connections.set(peer.ip, connection);

--- a/packages/core-p2p/src/socket-server/index.ts
+++ b/packages/core-p2p/src/socket-server/index.ts
@@ -26,6 +26,7 @@ export const startSocketServer = async (service: P2P.IPeerService, config: Recor
             // See https://github.com/SocketCluster/socketcluster/issues/506 about
             // details on how pingTimeout works.
             pingTimeout: Math.max(app.resolveOptions("p2p").getBlocksTimeout, app.resolveOptions("p2p").verifyTimeout),
+            perMessageDeflate: true,
         },
         ...config.server,
     });


### PR DESCRIPTION
* Traffic volume is reduced 21 times (!)
* As expected, only small messages appear in clear text (uncompressed)
  now in tcpdump(1) output. Messages smaller than 1024 bytes are not
  compressed
* Compression is used according to the following:
  server perMessageDeflate=true,    client perMessageDeflate=true:    yes
  server perMessageDeflate=true,    client perMessageDeflate not set: yes
  server perMessageDeflate not set, client perMessageDeflate=true:    no
  server perMessageDeflate not set, client perMessageDeflate not set: no

<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

A summary of what changes this PR introduces and why they were made.

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

## Does this PR release a new version?

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `develop` branch, _not_ the `master` branch
- [ ] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
