### PR TITLE
fix(crypto): use `anyOf` for transactions schema

### DIFF
--- a/packages/crypto/src/validation/index.ts
+++ b/packages/crypto/src/validation/index.ts
@@ -98,7 +98,7 @@ export class Validator {
             $id: "transactions",
             type: "array",
             additionalItems: false,
-            items: { oneOf: [...this.transactionSchemas].map(schema => ({ $ref: `${schema}Signed` })) },
+            items: { anyOf: [...this.transactionSchemas].map(schema => ({ $ref: `${schema}Signed` })) },
         });
         this.ajv.addSchema(schemas.block);
     }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

`anyOf` looks for the first matching schema and exits early. `oneOf` always matches against each schema and will error when there's more than 1 match. This is not only slower but also sporadically causing issues when a transaction payload matches against multiple schemas.

Resolves #2888 

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

## Does this PR release a new version?

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `develop` branch, _not_ the `master` branch
- [ ] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
