### PR TITLE
fix(core-blockchain): remove too early check for a chained block

### DIFF
--- a/packages/core-blockchain/src/blockchain.ts
+++ b/packages/core-blockchain/src/blockchain.ts
@@ -12,7 +12,7 @@ import {
 } from "@arkecosystem/core-interfaces";
 import { Blocks, Crypto, Interfaces, Managers } from "@arkecosystem/crypto";
 
-import { isBlockChained, roundCalculator } from "@arkecosystem/core-utils";
+import { roundCalculator } from "@arkecosystem/core-utils";
 import async from "async";
 import delay from "delay";
 import pluralize from "pluralize";
@@ -383,11 +383,6 @@ export class Blockchain implements blockchain.IBlockchain {
     public async processBlocks(blocks: Interfaces.IBlock[], callback): Promise<Interfaces.IBlock[]> {
         const acceptedBlocks: Interfaces.IBlock[] = [];
         let lastProcessResult: BlockProcessorResult;
-
-        if (blocks[0] && !isBlockChained(this.getLastBlock().data, blocks[0].data)) {
-            this.clearQueue(); // Discard remaining blocks as it won't go anywhere anyway.
-            return callback();
-        }
 
         for (const block of blocks) {
             lastProcessResult = await this.blockProcessor.process(block);


### PR DESCRIPTION
In processBlocks() we would check whether the first downloaded block is
chained and if not then we would return from processBlocks(). However,
if that happens it leads to an "infinite" loop of downloading blocks,
not applying any of them until the nodejs process runs out of memory to
store all the blocks it has downloaded. A block that would cause this is
(on devnet): height=1199883, id=5174570296595098048.

Remove this early check. Later all blocks (not only the first one) are
verified whether chained or not.

<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

A summary of what changes this PR introduces and why they were made.

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

## Does this PR release a new version?

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `develop` branch, _not_ the `master` branch
- [ ] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
