### PR TITLE
perf(core-database-postgres): speed up nonce checks at DB level

### DIFF
--- a/packages/core-database-postgres/src/migrations/20190905000000-change-set_row_nonce-to-use-max-nonce.sql
+++ b/packages/core-database-postgres/src/migrations/20190905000000-change-set_row_nonce-to-use-max-nonce.sql
@@ -1,0 +1,24 @@
+DROP TRIGGER transactions_set_nonce ON ${schema~}.transactions;
+
+DROP FUNCTION ${schema~}.set_row_nonce;
+
+CREATE FUNCTION ${schema~}.set_row_nonce() RETURNS TRIGGER
+AS
+$$
+BEGIN
+  SELECT COALESCE(MAX(nonce), 0) + 1 INTO NEW.nonce
+  FROM ${schema~}.transactions
+  WHERE sender_public_key = NEW.sender_public_key;
+
+  RETURN NEW;
+END;
+$$
+LANGUAGE PLPGSQL
+VOLATILE;
+
+CREATE TRIGGER transactions_set_nonce
+BEFORE INSERT
+ON ${schema~}.transactions
+FOR EACH ROW
+WHEN (NEW.version = 1)
+EXECUTE PROCEDURE ${schema~}.set_row_nonce();

--- a/packages/core-database-postgres/src/migrations/index.ts
+++ b/packages/core-database-postgres/src/migrations/index.ts
@@ -19,4 +19,5 @@ export const migrations = [
     loadQueryFile(__dirname, "./20190718000000-check_previous_block-add-schema.sql"),
     loadQueryFile(__dirname, "./20190803000000-add-type_group-column-to-transactions-table.sql"),
     loadQueryFile(__dirname, "./20190806000000-add-nonce-column-to-transactions-table.sql"),
+    loadQueryFile(__dirname, "./20190905000000-change-set_row_nonce-to-use-max-nonce.sql"),
 ];


### PR DESCRIPTION
Use `SELECT COALESCE(MAX(nonce), 0)` instead of `SELECT COUNT(*)` - they
produce the same result, but the former is much faster.

With this change a full block insert (with 500 transactions, so 1 + 500
INSERT queries) drops from about 4 seconds to about 0.4 seconds - the
same time it takes without the check constraint and the trigger on the
transactions table.

<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

A summary of what changes this PR introduces and why they were made.

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

## Does this PR release a new version?

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `develop` branch, _not_ the `master` branch
- [ ] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
