### PR TITLE
refactor(core-transaction-pool): clear cached transaction ids after accepting block

### DIFF
--- a/__tests__/integration/core-p2p/mocks/core-container.ts
+++ b/__tests__/integration/core-p2p/mocks/core-container.ts
@@ -114,7 +114,7 @@ jest.mock("@arkecosystem/core-container", () => {
                             getLastBlocks: () => [genesisBlock],
                             getLastHeight: () => genesisBlock.data.height,
                             cacheTransactions: jest.fn().mockImplementation(txs => ({ notAdded: txs, added: [] })),
-                            removeCachedTransactionIds: jest.fn().mockReturnValue(undefined),
+                            clearCachedTransactionIds: jest.fn().mockReturnValue(undefined),
                         }),
                     };
                 }

--- a/__tests__/unit/core-blockchain/stubs/state-storage.ts
+++ b/__tests__/unit/core-blockchain/stubs/state-storage.ts
@@ -21,9 +21,9 @@ export class StateStoreStub implements State.IStateStore {
         return undefined;
     }
 
-    public clear(): void {}
+    public clear(): void { }
 
-    public clearWakeUpTimeout(): void {}
+    public clearWakeUpTimeout(): void { }
 
     public getCachedTransactionIds(): string[] {
         return [];
@@ -76,9 +76,9 @@ export class StateStoreStub implements State.IStateStore {
         };
     }
 
-    public removeCachedTransactionIds(transactionIds: string[]): void {}
+    public clearCachedTransactionIds(): void { }
 
-    public reset(): void {}
+    public reset(): void { }
 
     public setLastBlock(block: Blocks.Block): void {
         this.lastDownloadedBlock = block.data;

--- a/__tests__/unit/core-database/__fixtures__/state-storage-stub.ts
+++ b/__tests__/unit/core-database/__fixtures__/state-storage-stub.ts
@@ -21,9 +21,9 @@ export class StateStoreStub implements State.IStateStore {
         return undefined;
     }
 
-    public clear(): void {}
+    public clear(): void { }
 
-    public clearWakeUpTimeout(): void {}
+    public clearWakeUpTimeout(): void { }
 
     public getCachedTransactionIds(): string[] {
         return [];
@@ -65,13 +65,13 @@ export class StateStoreStub implements State.IStateStore {
         return false;
     }
 
-    public pushPingBlock(block: Interfaces.IBlockData): void {}
+    public pushPingBlock(block: Interfaces.IBlockData): void { }
 
-    public removeCachedTransactionIds(transactionIds: string[]): void {}
+    public clearCachedTransactionIds(): void { }
 
-    public reset(): void {}
+    public reset(): void { }
 
-    public setLastBlock(block: Blocks.Block): void {}
+    public setLastBlock(block: Blocks.Block): void { }
 }
 
 export const stateStorageStub = new StateStoreStub();

--- a/__tests__/unit/core-state/__fixtures__/state-storage-stub.ts
+++ b/__tests__/unit/core-state/__fixtures__/state-storage-stub.ts
@@ -20,9 +20,9 @@ export class StateStorageStub implements State.IStateStorage {
         return undefined;
     }
 
-    public clear(): void {}
+    public clear(): void { }
 
-    public clearWakeUpTimeout(): void {}
+    public clearWakeUpTimeout(): void { }
 
     public getCachedTransactionIds(): string[] {
         return [];
@@ -56,13 +56,13 @@ export class StateStorageStub implements State.IStateStorage {
         return false;
     }
 
-    public pushPingBlock(block: Interfaces.IBlockData): void {}
+    public pushPingBlock(block: Interfaces.IBlockData): void { }
 
-    public removeCachedTransactionIds(transactionIds: string[]): void {}
+    public clearCachedTransactionIds(): void { }
 
-    public reset(): void {}
+    public reset(): void { }
 
-    public setLastBlock(block: Blocks.Block): void {}
+    public setLastBlock(block: Blocks.Block): void { }
 }
 
 export const stateStorageStub = new StateStorageStub();

--- a/__tests__/unit/core-state/stores/state.test.ts
+++ b/__tests__/unit/core-state/stores/state.test.ts
@@ -249,7 +249,7 @@ describe("State Storage", () => {
         });
     });
 
-    describe("removeCachedTransactionIds", () => {
+    describe("clearCachedTransactionIds", () => {
         it("should remove cached transaction ids", () => {
             const transactions = [];
             for (let i = 0; i < 10; i++) {
@@ -262,7 +262,7 @@ describe("State Storage", () => {
             });
 
             expect(stateStorage.getCachedTransactionIds()).toHaveLength(10);
-            stateStorage.removeCachedTransactionIds(transactions.map(tx => tx.id));
+            stateStorage.clearCachedTransactionIds();
             expect(stateStorage.getCachedTransactionIds()).toHaveLength(0);
         });
     });

--- a/__tests__/unit/core-transaction-pool/mocks/state.ts
+++ b/__tests__/unit/core-transaction-pool/mocks/state.ts
@@ -3,6 +3,6 @@ export const state = {
         cacheTransactions: () => undefined,
         getLastBlock: () => ({ data: { height: 0 } }),
         getLastHeight: () => 1,
-        removeCachedTransactionIds: () => undefined,
+        clearCachedTransactionIds: () => undefined,
     }),
 };

--- a/packages/core-interfaces/src/core-state/state-store.ts
+++ b/packages/core-interfaces/src/core-state/state-store.ts
@@ -84,9 +84,9 @@ export interface IStateStore {
     ): { [key in "added" | "notAdded"]: Interfaces.ITransactionData[] };
 
     /**
-     * Remove the given transaction ids from the cache.
+     * Drop all cached transaction ids.
      */
-    removeCachedTransactionIds(transactionIds: string[]): void;
+    clearCachedTransactionIds(): void;
 
     /**
      * Get cached transaction ids.

--- a/packages/core-state/src/stores/state.ts
+++ b/packages/core-state/src/stores/state.ts
@@ -197,10 +197,10 @@ export class StateStore implements State.IStateStore {
     }
 
     /**
-     * Remove the given transaction ids from the cache.
+     * Drop all cached transaction ids.
      */
-    public removeCachedTransactionIds(transactionIds: string[]): void {
-        this.cachedTransactionIds = this.cachedTransactionIds.subtract(transactionIds);
+    public clearCachedTransactionIds(): void {
+        this.cachedTransactionIds = this.cachedTransactionIds.clear();
     }
 
     /**

--- a/packages/core-transaction-pool/src/connection.ts
+++ b/packages/core-transaction-pool/src/connection.ts
@@ -175,7 +175,7 @@ export class Connection implements TransactionPool.IConnection {
             if (!this.loggedAllowedSenders.includes(senderPublicKey)) {
                 this.logger.debug(
                     `Transaction pool: allowing sender public key ${senderPublicKey} ` +
-                        `(listed in options.allowedSenders), thus skipping throttling.`,
+                    `(listed in options.allowedSenders), thus skipping throttling.`,
                 );
 
                 this.loggedAllowedSenders.push(senderPublicKey);
@@ -246,7 +246,7 @@ export class Connection implements TransactionPool.IConnection {
 
                     this.logger.error(
                         `Cannot apply transaction ${transaction.id} when trying to accept ` +
-                            `block ${block.data.id}: ${error.message}`,
+                        `block ${block.data.id}: ${error.message}`,
                     );
 
                     continue;
@@ -269,9 +269,10 @@ export class Connection implements TransactionPool.IConnection {
             delegateWallet.balance = delegateWallet.balance.plus(block.data.reward.plus(block.data.totalFee));
         }
 
+
         app.resolvePlugin<State.IStateService>("state")
             .getStore()
-            .removeCachedTransactionIds(block.transactions.map(tx => tx.id));
+            .clearCachedTransactionIds();
     }
 
     public async buildWallets(): Promise<void> {
@@ -281,7 +282,7 @@ export class Connection implements TransactionPool.IConnection {
 
         app.resolvePlugin<State.IStateService>("state")
             .getStore()
-            .removeCachedTransactionIds(transactionIds);
+            .clearCachedTransactionIds();
 
         for (const transactionId of transactionIds) {
             const transaction: Interfaces.ITransaction = await this.getTransaction(transactionId);
@@ -409,7 +410,7 @@ export class Connection implements TransactionPool.IConnection {
         if (await this.has(transaction.id)) {
             this.logger.debug(
                 "Transaction pool: ignoring attempt to add a transaction that is already " +
-                    `in the pool, id: ${transaction.id}`,
+                `in the pool, id: ${transaction.id}`,
             );
 
             return { transaction, type: "ERR_ALREADY_IN_POOL", message: "Already in pool" };

--- a/packages/core-transaction-pool/src/processor.ts
+++ b/packages/core-transaction-pool/src/processor.ts
@@ -19,7 +19,7 @@ export class Processor implements TransactionPool.IProcessor {
     private readonly invalid: Map<string, Interfaces.ITransactionData> = new Map();
     private readonly errors: { [key: string]: TransactionPool.ITransactionErrorResponse[] } = {};
 
-    constructor(private readonly pool: TransactionPool.IConnection, private readonly walletManager: WalletManager) {}
+    constructor(private readonly pool: TransactionPool.IConnection, private readonly walletManager: WalletManager) { }
 
     public async validate(transactions: Interfaces.ITransactionData[]): Promise<TransactionPool.IProcessorResult> {
         this.cacheTransactions(transactions);
@@ -30,10 +30,6 @@ export class Processor implements TransactionPool.IProcessor {
             await this.removeForgedTransactions();
 
             await this.addTransactionsToPool();
-
-            app.resolvePlugin<State.IStateService>("state")
-                .getStore()
-                .removeCachedTransactionIds([...new Set([...this.accept.keys(), ...Object.keys(this.errors)])]);
 
             this.printStats();
         }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

Because of nonces, #2879 changed how the transaction pool processor removes cached transaction ids. They are now removed too early which effectively renders the cache useless. But with nonces it is not trivially possible to generate a different id anymore (without changing the payload) and thus if rejected once (e.g. sent too early or whatever) it will likely be rejected again for quite some time.

The only purpose of the id caching is to "debounce" the transaction broadcasts that happen between peers in the network. Without it, the processor would end up processing the same transactions multiple times, because the endpoint is hit multiple times with the same payload in a short timeframe.

This PR changes it so that the cache is cleared whenever a block is accepted instead. While that solution is still far from perfect, so is the transaction endpoint.

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [X] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

## Does this PR release a new version?

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `develop` branch, _not_ the `master` branch
- [ ] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
