### PR TITLE
fix(core-transactions): reject delegate resignation if not enough inactive delegates

### DIFF
--- a/__tests__/functional/transaction-forging/delegate-resignation.test.ts
+++ b/__tests__/functional/transaction-forging/delegate-resignation.test.ts
@@ -1,5 +1,5 @@
 import { app } from "@arkecosystem/core-container";
-import { Database, State } from "@arkecosystem/core-interfaces";
+import { Database } from "@arkecosystem/core-interfaces";
 import { Identities } from "@arkecosystem/crypto";
 import { generateMnemonic } from "bip39";
 import { TransactionFactory } from "../../helpers/transaction-factory";

--- a/__tests__/functional/transaction-forging/delegate-resignation.test.ts
+++ b/__tests__/functional/transaction-forging/delegate-resignation.test.ts
@@ -1,3 +1,5 @@
+import { app } from "@arkecosystem/core-container";
+import { Database, State } from "@arkecosystem/core-interfaces";
 import { Identities } from "@arkecosystem/crypto";
 import { generateMnemonic } from "bip39";
 import { TransactionFactory } from "../../helpers/transaction-factory";
@@ -105,6 +107,49 @@ describe("Transaction Forging - Delegate Resignation", () => {
             await expect(transactionsResign2).toBeRejected();
             await support.snoozeForBlock(1);
             await expect(transactionsResign2.id).not.toBeForged();
+        });
+
+        it("should broadcast, reject and not forge it if not enough delegates", async () => {
+            // Prepare a fresh wallet for the tests
+            const passphrase = generateMnemonic();
+
+            // Initial Funds
+            const initialFunds = TransactionFactory.transfer(Identities.Address.fromPassphrase(passphrase), 100 * 1e8)
+                .withPassphrase(genesisPassphrase)
+                .createOne();
+
+            await expect(initialFunds).toBeAccepted();
+            await support.snoozeForBlock(1);
+            await expect(initialFunds.id).toBeForged();
+
+            // Register a delegate
+            const transactionsRegister = TransactionFactory.delegateRegistration()
+                .withPassphrase(passphrase)
+                .createOne();
+
+            await expect(transactionsRegister).toBeAccepted();
+            await support.snoozeForBlock(1);
+            await expect(transactionsRegister.id).toBeForged();
+
+            const walletManager = app.resolvePlugin<Database.IDatabaseService>("database").walletManager;
+
+            const takenDelegates = walletManager.allByUsername().slice(0, 50);
+            for (const delegate of takenDelegates) {
+                walletManager.forgetByUsername(delegate.getAttribute("delegate.username"));
+            }
+
+            // Resign a delegate
+            const transactionsResign = TransactionFactory.delegateResignation()
+                .withPassphrase(passphrase)
+                .createOne();
+
+            await expect(transactionsResign).toBeRejected();
+            await support.snoozeForBlock(1);
+            await expect(transactionsResign.id).not.toBeForged();
+
+            for (const delegate of takenDelegates) {
+                walletManager.reindex(delegate);
+            }
         });
     });
 

--- a/packages/core-transactions/src/errors.ts
+++ b/packages/core-transactions/src/errors.ts
@@ -156,6 +156,12 @@ export class VotedForResignedDelegateError extends TransactionError {
     }
 }
 
+export class NotEnoughDelegatesError extends TransactionError {
+    constructor() {
+        super(`Failed to apply transaction, because not enough delegates to allow resignation.`);
+    }
+}
+
 export class MultiSignatureAlreadyRegisteredError extends TransactionError {
     constructor() {
         super(`Failed to apply transaction, because multi signature is already enabled.`);

--- a/packages/core-transactions/src/handlers/delegate-resignation.ts
+++ b/packages/core-transactions/src/handlers/delegate-resignation.ts
@@ -1,7 +1,7 @@
 import { ApplicationEvents } from "@arkecosystem/core-event-emitter";
 import { Database, EventEmitter, State, TransactionPool } from "@arkecosystem/core-interfaces";
 import { Interfaces, Managers, Transactions } from "@arkecosystem/crypto";
-import { WalletAlreadyResignedError, WalletNotADelegateError } from "../errors";
+import { NotEnoughDelegatesError, WalletAlreadyResignedError, WalletNotADelegateError } from "../errors";
 import { DelegateRegistrationTransactionHandler } from "./delegate-registration";
 import { TransactionHandler, TransactionHandlerConstructor } from "./transaction";
 
@@ -41,6 +41,24 @@ export class DelegateResignationTransactionHandler extends TransactionHandler {
 
         if (wallet.hasAttribute("delegate.resigned")) {
             throw new WalletAlreadyResignedError();
+        }
+
+        const delegates: ReadonlyArray<State.IWallet> = databaseWalletManager.allByUsername();
+        let requiredDelegates: number = Managers.configManager.getMilestone().activeDelegates + 1;
+        for (const delegate of delegates) {
+            if (requiredDelegates === 0) {
+                break;
+            }
+
+            if (delegate.getAttribute("delegate.resigned")) {
+                continue;
+            }
+
+            requiredDelegates--;
+        }
+
+        if (requiredDelegates > 0) {
+            throw new NotEnoughDelegatesError();
         }
 
         return super.throwIfCannotBeApplied(transaction, wallet, databaseWalletManager);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

Core assumes to always have at least `activeDelegates` (i.e. 51) delegates so we mustn't allow dropping below that number if there are no other delegates to fill that spot.

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

## Does this PR release a new version?

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `develop` branch, _not_ the `master` branch
- [ ] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
