### PR TITLE
fix(crypto): use 2 bytes to store number of payments

### DIFF
--- a/__tests__/unit/crypto/transactions/builders/transactions/multi-payment.test.ts
+++ b/__tests__/unit/crypto/transactions/builders/transactions/multi-payment.test.ts
@@ -54,7 +54,7 @@ describe("Multi Payment Transaction", () => {
         });
 
         it("should throw if we want to add more payments than max authorized", () => {
-            builder.data.asset.payments = new Array(2258);
+            builder.data.asset.payments = new Array(500);
 
             expect(() => builder.addPayment("address", "2")).toThrow(MaximumPaymentCountExceededError);
         });

--- a/__tests__/unit/crypto/transactions/deserializer.test.ts
+++ b/__tests__/unit/crypto/transactions/deserializer.test.ts
@@ -1,7 +1,7 @@
 import "jest-extended";
 
 import ByteBuffer from "bytebuffer";
-import { Enums, Utils } from "../../../../packages/crypto/src";
+import { Enums, Errors, Utils } from "../../../../packages/crypto/src";
 import { Hash } from "../../../../packages/crypto/src/crypto";
 import {
     MalformedTransactionBytesError,
@@ -332,6 +332,24 @@ describe("Transaction serializer / deserializer", () => {
             configManager.getMilestone().aip11 = true;
             expect(multiPayment.verify()).toBeTrue();
         });
+
+        it("should fail if more than hardcoded maximum of payments", () => {
+            const multiPayment = BuilderFactory.multiPayment()
+                .fee("50000000")
+                .network(23);
+
+            for (let i = 0; i < 500; i++) {
+                multiPayment.addPayment(Address.fromPassphrase(`recipient-${i}`), "1");
+            }
+
+            expect(() => multiPayment.addPayment(Address.fromPassphrase("recipient501"), "1")).toThrow(
+                Errors.MaximumPaymentCountExceededError,
+            );
+
+            const transaction = multiPayment.sign("dummy passphrase").build();
+            expect(transaction.verify()).toBeTrue();
+            expect(TransactionFactory.fromBytes(transaction.serialized, true).verify()).toBeTrue();
+        });
     });
 
     describe("ser/deserialize - htlc lock", () => {
@@ -613,8 +631,8 @@ describe("Transaction serializer / deserializer", () => {
     });
 
     describe("getBytesV1", () => {
-        beforeAll(() => configManager.getMilestone().aip11 = false);
-        afterAll(() => configManager.getMilestone().aip11 = true);
+        beforeAll(() => (configManager.getMilestone().aip11 = false));
+        afterAll(() => (configManager.getMilestone().aip11 = true));
         let bytes;
 
         // it('should return Buffer of simply transaction and buffer must be 292 length', () => {

--- a/__tests__/unit/crypto/transactions/schemas.test.ts
+++ b/__tests__/unit/crypto/transactions/schemas.test.ts
@@ -734,9 +734,11 @@ describe("Multi Payment Transaction", () => {
     });
 
     it("should be invalid with 501 payments", () => {
-        for (let i = 1; i <= 501; i++) {
+        for (let i = 0; i < 500; i++) {
             multiPayment.addPayment(address, `${i}`);
         }
+
+        multiPayment.data.asset.payments.push({ amount: Utils.BigNumber.ONE, recipientId: address });
         multiPayment.sign("passphrase");
 
         const { error } = Ajv.validate(transactionSchema.$id, "test");

--- a/packages/crypto/src/errors.ts
+++ b/packages/crypto/src/errors.ts
@@ -116,7 +116,7 @@ export class MissingMilestoneFeeError extends CryptoError {
 
 export class MaximumPaymentCountExceededError extends CryptoError {
     constructor(given: number) {
-        super(`Expected a maximum of 2258 payments, but got ${given}.`);
+        super(`Expected a maximum of 500 payments, but got ${given}.`);
     }
 }
 
@@ -136,8 +136,8 @@ export class PreviousBlockIdFormatError extends CryptoError {
     constructor(thisBlockHeight: number, previousBlockId: string) {
         super(
             `The config denotes that the block at height ${thisBlockHeight - 1} ` +
-                `must use full SHA256 block id, but the next block (at ${thisBlockHeight}) ` +
-                `contains previous block id "${previousBlockId}"`,
+            `must use full SHA256 block id, but the next block (at ${thisBlockHeight}) ` +
+            `contains previous block id "${previousBlockId}"`,
         );
     }
 }

--- a/packages/crypto/src/transactions/builders/transactions/multi-payment.ts
+++ b/packages/crypto/src/transactions/builders/transactions/multi-payment.ts
@@ -19,8 +19,8 @@ export class MultiPaymentBuilder extends TransactionBuilder<MultiPaymentBuilder>
     }
 
     public addPayment(recipientId: string, amount: string): MultiPaymentBuilder {
-        if (this.data.asset.payments.length >= 2258) {
-            throw new MaximumPaymentCountExceededError(this.data.asset.payments.length);
+        if (this.data.asset.payments.length >= 500) {
+            throw new MaximumPaymentCountExceededError(this.data.asset.payments.length + 1);
         }
 
         this.data.asset.payments.push({

--- a/packages/crypto/src/transactions/types/multi-payment.ts
+++ b/packages/crypto/src/transactions/types/multi-payment.ts
@@ -24,9 +24,9 @@ export class MultiPaymentTransaction extends Transaction {
 
     public serialize(options?: ISerializeOptions): ByteBuffer {
         const { data } = this;
-        const buffer: ByteBuffer = new ByteBuffer(64, true);
 
-        buffer.writeUint32(data.asset.payments.length);
+        const buffer: ByteBuffer = new ByteBuffer(2 + data.asset.payments.length * 29, true);
+        buffer.writeUint16(data.asset.payments.length);
 
         for (const p of data.asset.payments) {
             buffer.writeUint64(+BigNumber.make(p.amount).toFixed());
@@ -39,7 +39,7 @@ export class MultiPaymentTransaction extends Transaction {
     public deserialize(buf: ByteBuffer): void {
         const { data } = this;
         const payments: IMultiPaymentItem[] = [];
-        const total: number = buf.readUint32();
+        const total: number = buf.readUint16();
 
         for (let j = 0; j < total; j++) {
             payments.push({


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

We don't need 4 bytes to store the number of payments of a multipayment transaction.

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

## Does this PR release a new version?

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `develop` branch, _not_ the `master` branch
- [ ] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
