### PR TITLE
fix(crypto): htlc lock buffer allocation

### DIFF
--- a/packages/crypto/src/transactions/types/htlc-lock.ts
+++ b/packages/crypto/src/transactions/types/htlc-lock.ts
@@ -25,7 +25,7 @@ export class HtlcLockTransaction extends Transaction {
     public serialize(options?: ISerializeOptions): ByteBuffer {
         const { data } = this;
 
-        const buffer: ByteBuffer = new ByteBuffer(8 + 32 + 1 + 8 + 21, true);
+        const buffer: ByteBuffer = new ByteBuffer(8 + 32 + 1 + 4 + 21, true);
 
         buffer.writeUint64(+data.amount);
         buffer.append(Buffer.from(data.asset.lock.secretHash, "hex"));

--- a/packages/crypto/src/transactions/types/htlc-lock.ts
+++ b/packages/crypto/src/transactions/types/htlc-lock.ts
@@ -25,7 +25,7 @@ export class HtlcLockTransaction extends Transaction {
     public serialize(options?: ISerializeOptions): ByteBuffer {
         const { data } = this;
 
-        const buffer: ByteBuffer = new ByteBuffer(8 + 32 + 4 + 8 + 21, true);
+        const buffer: ByteBuffer = new ByteBuffer(8 + 32 + 1 + 8 + 21, true);
 
         buffer.writeUint64(+data.amount);
         buffer.append(Buffer.from(data.asset.lock.secretHash, "hex"));


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

Changing the size of bytebuffer in htlc serialization, because is larger then needed

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Does this PR release a new version?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch
- [x] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
