### PR TITLE
perf: Avoid O(m*n) when filtering pool txs and simplify the code

### DIFF
--- a/packages/core-transaction-pool/src/connection.ts
+++ b/packages/core-transaction-pool/src/connection.ts
@@ -53,11 +53,8 @@ export class Connection implements TransactionPool.IConnection {
         }
 
         this.emitter.once("internal.stateBuilder.finished", async () => {
-            const validTransactions = await this.validateTransactions(transactionsFromDisk);
-            transactionsFromDisk = transactionsFromDisk.filter(transaction =>
-                validTransactions.includes(transaction.serialized.toString("hex")),
-            );
-
+            // Remove from the pool invalid entries found in `transactionsFromDisk`.
+            await this.validateTransactions(transactionsFromDisk);
             await this.purgeExpired();
             this.syncToPersistentStorage();
         });
@@ -361,16 +358,11 @@ export class Connection implements TransactionPool.IConnection {
 
         let transactionBytes: number = 0;
 
-        const removeInvalid = async (transactions: Interfaces.ITransaction[]): Promise<Interfaces.ITransaction[]> => {
-            const valid = await this.validateTransactions(transactions);
-            return transactions.filter(transaction => valid.includes(transaction.serialized.toString("hex")));
-        };
-
         let i = 0;
         const allTransactions: Interfaces.ITransaction[] = [...this.memory.allSortedByFee()];
         for (const transaction of allTransactions) {
             if (data.length === size) {
-                data = await removeInvalid(data);
+                data = await this.validateTransactions(data);
                 if (data.length === size) {
                     return data;
                 } else {
@@ -401,7 +393,7 @@ export class Connection implements TransactionPool.IConnection {
             }
         }
 
-        return removeInvalid(data);
+        return this.validateTransactions(data);
     }
 
     private async addTransaction(
@@ -476,8 +468,12 @@ export class Connection implements TransactionPool.IConnection {
         this.storage.bulkRemoveById(this.memory.pullDirtyRemoved());
     }
 
-    private async validateTransactions(transactions: Interfaces.ITransaction[]): Promise<string[]> {
-        const validTransactions: string[] = [];
+    /**
+     * Validate the given transactions and return only the valid ones - a subset of the input.
+     * The invalid ones are removed from the pool.
+     */
+    private async validateTransactions(transactions: Interfaces.ITransaction[]): Promise<Interfaces.ITransaction[]> {
+        const validTransactions: Interfaces.ITransaction[] = [];
         const forgedIds: string[] = await this.removeForgedTransactions(transactions);
 
         const unforgedTransactions = transactions.filter(
@@ -514,7 +510,7 @@ export class Connection implements TransactionPool.IConnection {
                     await handler.applyToRecipient(transaction, localWalletManager);
                 }
 
-                validTransactions.push(deserialized.serialized.toString("hex"));
+                validTransactions.push(transaction);
             } catch (error) {
                 this.removeTransactionById(transaction.id);
                 this.logger.error(


### PR DESCRIPTION
validateTransactions() would take an array of transaction objects and
return a subset of it, but just the serialized property, not the entire
transaction object.

The two callers of validateTransactions() would then filter the array
they provided to validateTransactions() so that it contains only the
returned valid transactions. But, given that the returned array is a
subset of the provided array that means that the returned array is
the same as the filtered input. On top of this the unnecessary filtering
was done using an ineffective O(m*n) algorithm.

So, change validateTransactions() to return the transaction objects
instead of just the serialized property and use the returned array
directly (avoid the unnecessary filtering altogether).

<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

A summary of what changes this PR introduces and why they were made.

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

## Does this PR release a new version?

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `develop` branch, _not_ the `master` branch
- [ ] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
