### PR TITLE
perf: use lodash to efficiently remove forged transactions

### DIFF
--- a/packages/core-transaction-pool/package.json
+++ b/packages/core-transaction-pool/package.json
@@ -40,6 +40,7 @@
         "delay": "^4.3.0",
         "fs-extra": "^8.1.0",
         "lodash.clonedeep": "^4.5.0",
+        "lodash.differencewith": "^4.5.0",
         "pluralize": "^8.0.0"
     },
     "devDependencies": {

--- a/packages/core-transaction-pool/src/connection.ts
+++ b/packages/core-transaction-pool/src/connection.ts
@@ -11,6 +11,7 @@ import { Memory } from "./memory";
 import { Processor } from "./processor";
 import { Storage } from "./storage";
 import { WalletManager } from "./wallet-manager";
+import differencewith from "lodash.differencewith";
 
 export class Connection implements TransactionPool.IConnection {
     // @TODO: make this private, requires some bigger changes to tests
@@ -480,9 +481,7 @@ export class Connection implements TransactionPool.IConnection {
         const validTransactions: string[] = [];
         const forgedIds: string[] = await this.removeForgedTransactions(transactions);
 
-        const unforgedTransactions = transactions.filter(
-            (transaction: Interfaces.ITransaction) => !forgedIds.includes(transaction.id),
-        );
+        const unforgedTransactions = differencewith(transactions, forgedIds, (t, forgedId) => t.id === forgedId);
 
         const databaseWalletManager: State.IWalletManager = this.databaseService.walletManager;
         const localWalletManager: Wallets.TempWalletManager = new Wallets.TempWalletManager(databaseWalletManager);


### PR DESCRIPTION
transactions.filter(t => !forgedIds.includes(t.id)) has
complexity O(transactions.length * forgedIds.length). Use the efficient
lodash.differencewith instead (which has O(transactions.length +
forgedIds.length), maybe).

A comparison between .filter(... .includes()) and differencewith() ran
over two arrays with 50k elements (integers and strings):

int lodash:        15ms
int poor man's:  1969ms
str lodash:        21ms
str poor man's: 35102ms

<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

A summary of what changes this PR introduces and why they were made.

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

## Does this PR release a new version?

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `develop` branch, _not_ the `master` branch
- [ ] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
