### PR TITLE
fix: htlc refund handler to use performGenericWalletChecks (+ fix e2e tests)

### DIFF
--- a/__tests__/e2e/tests/scenarios/scenario1/htlc-claim/1.create-lock-txs.action.js
+++ b/__tests__/e2e/tests/scenarios/scenario1/htlc-claim/1.create-lock-txs.action.js
@@ -77,7 +77,7 @@ module.exports = async options => {
                 secretHash: Crypto.HashAlgorithms.sha256(utils.htlcRecipient4.address.slice(0, 32)).toString("hex"),
                 expiration: {
                     type: 2,
-                    value: lastHeight + 1,
+                    value: lastHeight + 4,
                 },
             },
             utils.htlcRecipient4.address,

--- a/__tests__/e2e/tests/scenarios/scenario1/htlc-refund/1.create-lock-txs.action.js
+++ b/__tests__/e2e/tests/scenarios/scenario1/htlc-refund/1.create-lock-txs.action.js
@@ -26,7 +26,7 @@ module.exports = async options => {
                 secretHash: Crypto.HashAlgorithms.sha256(utils.htlcRecipient1.address.slice(0, 32)).toString("hex"),
                 expiration: {
                     type: 2,
-                    value: lastHeight + 1,
+                    value: lastHeight + 4,
                 },
             },
             utils.htlcRecipient1.address,
@@ -42,7 +42,7 @@ module.exports = async options => {
                 secretHash: Crypto.HashAlgorithms.sha256(utils.htlcRecipient2.address.slice(0, 32)).toString("hex"),
                 expiration: {
                     type: 2,
-                    value: lastHeight + 1,
+                    value: lastHeight + 4,
                 },
             },
             utils.htlcRecipient2.address,

--- a/packages/core-transactions/src/handlers/htlc-refund.ts
+++ b/packages/core-transactions/src/handlers/htlc-refund.ts
@@ -53,7 +53,7 @@ export class HtlcRefundTransactionHandler extends TransactionHandler {
         sender: State.IWallet,
         databaseWalletManager: State.IWalletManager,
     ): Promise<void> {
-        await super.throwIfCannotBeApplied(transaction, sender, databaseWalletManager);
+        await this.performGenericWalletChecks(transaction, sender, databaseWalletManager);
 
         // Specific HTLC refund checks
         const refundAsset: Interfaces.IHtlcRefundAsset = transaction.data.asset.refund;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

HTLC refund handler needs to use performGenericWalletChecks just like claim handler.

Also fixed e2e tests (needed to give a bit more expiration time for htlc lock txs).

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Performance
- [x] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Does this PR release a new version?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch
- [x] All tests are passing
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
