### PR TITLE
ci: use different test coverage directories for each type

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
             - name: Install & Build
               run: yarn setup
             - name: Test
-              run: yarn test:unit:coverage
+              run: yarn test:unit:coverage --coverageDirectory .coverage/unit/
             - name: Codecov
               run: ./node_modules/.bin/codecov --token=${{ secrets.CODECOV_TOKEN }}
 
@@ -61,7 +61,7 @@ jobs:
             - name: Create .core/database directory
               run: mkdir -p $HOME/.core/database
             - name: Integration tests
-              run: yarn test:integration:coverage
+              run: yarn test:integration:coverage --coverageDirectory .coverage/integration/
             - name: Codecov
               run: ./node_modules/.bin/codecov --token=${{ secrets.CODECOV_TOKEN }}
 
@@ -105,7 +105,7 @@ jobs:
             - name: Create .core/database directory
               run: mkdir -p $HOME/.core/database
             - name: Functional tests
-              run: yarn test:functional:coverage
+              run: yarn test:functional:coverage --coverageDirectory .coverage/functional/
             - name: Codecov
               run: ./node_modules/.bin/codecov --token=${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
             - name: Install & Build
               run: yarn setup
             - name: Test
-              run: yarn test:unit:coverage --coverageDirectory .coverage/unit/
+              run: yarn test:unit:coverage --coverageDirectory .coverage/unit/ --maxWorkers=2
             - name: Codecov
               run: ./node_modules/.bin/codecov --token=${{ secrets.CODECOV_TOKEN }}
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Coverage reporting seems to be acting out after the move to GitHub Actions, using different directories for each type of test should force codecov to merge them.

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
