### PR TITLE
fix(core-blofix(core-blockchain): do not reset `noBlockCounter` when `downloadBlocks` succeeds

### DIFF
--- a/__tests__/unit/core-blockchain/stubs/state-storage.ts
+++ b/__tests__/unit/core-blockchain/stubs/state-storage.ts
@@ -10,8 +10,8 @@ export class StateStoreStub implements State.IStateStore {
     public started: boolean;
     public forkedBlock: Interfaces.IBlock | undefined;
     public wakeUpTimeout: any;
-    public noBlockCounter: number;
-    public p2pUpdateCounter: number;
+    public noBlockCounter: number = 0;
+    public p2pUpdateCounter: number = 0;
     public numberOfBlocksToRollback: number | undefined;
     public networkStart: boolean;
 
@@ -21,9 +21,9 @@ export class StateStoreStub implements State.IStateStore {
         return undefined;
     }
 
-    public clear(): void { }
+    public clear(): void {}
 
-    public clearWakeUpTimeout(): void { }
+    public clearWakeUpTimeout(): void {}
 
     public getCachedTransactionIds(): string[] {
         return [];
@@ -76,9 +76,9 @@ export class StateStoreStub implements State.IStateStore {
         };
     }
 
-    public clearCachedTransactionIds(): void { }
+    public clearCachedTransactionIds(): void {}
 
-    public reset(): void { }
+    public reset(): void {}
 
     public setLastBlock(block: Blocks.Block): void {
         this.lastDownloadedBlock = block.data;

--- a/packages/core-blockchain/src/state-machine.ts
+++ b/packages/core-blockchain/src/state-machine.ts
@@ -72,9 +72,7 @@ blockchainMachine.actionMap = (blockchain: Blockchain) => ({
             } else {
                 stateStorage.p2pUpdateCounter++;
             }
-        }
-
-        if (stateStorage.lastDownloadedBlock && blockchain.isSynced(stateStorage.lastDownloadedBlock)) {
+        } else if (stateStorage.lastDownloadedBlock && blockchain.isSynced(stateStorage.lastDownloadedBlock)) {
             stateStorage.noBlockCounter = 0;
             stateStorage.p2pUpdateCounter = 0;
 
@@ -226,9 +224,6 @@ blockchainMachine.actionMap = (blockchain: Blockchain) => ({
                     true,
                 )}`,
             );
-
-            stateStorage.noBlockCounter = 0;
-            stateStorage.p2pUpdateCounter = 0;
 
             try {
                 blockchain.enqueueBlocks(blocks);

--- a/packages/core-state/src/stores/state.ts
+++ b/packages/core-state/src/stores/state.ts
@@ -106,6 +106,9 @@ export class StateStore implements State.IStateStore {
         if (this.lastBlocks.size > app.resolveOptions("state").storage.maxLastBlocks) {
             this.lastBlocks = this.lastBlocks.delete(this.lastBlocks.first<Interfaces.IBlock>().data.height);
         }
+
+        this.noBlockCounter = 0;
+        this.p2pUpdateCounter = 0;
     }
 
     /**


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
Otherwise it is possible that the chain gets stuck, as it would never attempt to check for forks. Instead, reset inside `setLastBlock`.

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [X] Tests _(if necessary)_
- [X] Ready to be merged

<!-- Feel free to add additional comments. -->
