### PR TITLE
fix(core-snapshots): remove bogus skipRoundRows

### DIFF
--- a/packages/core-snapshots/src/db/index.ts
+++ b/packages/core-snapshots/src/db/index.ts
@@ -97,7 +97,24 @@ export class Database {
             );
         }
 
-        const roundInfoStart: Shared.IRoundInfo = roundCalculator.calculateRound(meta.startHeight);
+        let startRound: number;
+
+        if (meta.startHeight <= 1) {
+            startRound = 1;
+        } else {
+            const roundInfoPrev: Shared.IRoundInfo = roundCalculator.calculateRound(meta.startHeight - 1);
+            const roundInfoStart: Shared.IRoundInfo = roundCalculator.calculateRound(meta.startHeight);
+
+            if (roundInfoPrev.round === roundInfoStart.round) {
+                // The lower snapshot contains this round, so skip it from this snapshot.
+                // For example: a snapshot of blocks 1-80 contains full rounds 1 and 2, so
+                // when we create a snapshot 81-... we must skip round 2 and start from 3.
+                startRound = roundInfoStart.round + 1;
+            } else {
+                startRound = roundInfoStart.round;
+            }
+        }
+
         const roundInfoEnd: Shared.IRoundInfo = roundCalculator.calculateRound(meta.endHeight);
 
         return {
@@ -110,7 +127,7 @@ export class Database {
                 end: endBlock.timestamp,
             }),
             rounds: rawQuery(this.pgp, queries.rounds.roundRange, {
-                startRound: roundInfoStart.round,
+                startRound: startRound,
                 endRound: roundInfoEnd.round,
             }),
         };

--- a/packages/core-snapshots/src/db/index.ts
+++ b/packages/core-snapshots/src/db/index.ts
@@ -85,7 +85,6 @@ export class Database {
     public async getExportQueries(meta: {
         startHeight: number;
         endHeight: number;
-        skipRoundRows: number;
         skipCompression: boolean;
         folder: string;
     }) {
@@ -113,7 +112,6 @@ export class Database {
             rounds: rawQuery(this.pgp, queries.rounds.roundRange, {
                 startRound: roundInfoStart.round,
                 endRound: roundInfoEnd.round,
-                skipRoundRows: meta.skipRoundRows,
             }),
         };
     }

--- a/packages/core-snapshots/src/db/queries/rounds/round-range.sql
+++ b/packages/core-snapshots/src/db/queries/rounds/round-range.sql
@@ -8,5 +8,3 @@ WHERE
   round BETWEEN ${startRound} AND ${endRound}
 ORDER BY
   round, balance DESC, public_key
-OFFSET
-  ${skipRoundRows}

--- a/packages/core-snapshots/src/utils.ts
+++ b/packages/core-snapshots/src/utils.ts
@@ -90,7 +90,6 @@ export const setSnapshotInfo = (options, lastBlock) => {
     const meta = {
         startHeight: options.start !== -1 ? options.start : 1,
         endHeight: options.end !== -1 ? options.end : lastBlock.height,
-        skipRoundRows: 0,
         skipCompression: options.skipCompression || false,
         folder: "",
     };
@@ -100,7 +99,6 @@ export const setSnapshotInfo = (options, lastBlock) => {
     if (options.blocks) {
         const oldMeta = this.getSnapshotInfo(options.blocks);
         meta.startHeight = oldMeta.endHeight + 1;
-        meta.skipRoundRows = oldMeta.rounds.count;
         meta.folder = `${oldMeta.startHeight}-${meta.endHeight}`;
     }
 


### PR DESCRIPTION
skipRoundRows was only set to something else than 0 when appending to an
existent snapshot and then it was set to the number of rows in the
rounds table in the appended-to snapshot. Then it would translate to an
OFFSET in the SQL query:

SELECT round, balance, public_key
FROM rounds
WHERE round BETWEEN 9804 AND 9902
ORDER BY round, balance DESC, public_key
OFFSET 500004

but the proper rows to be selected are already defined by the BETWEEN
clause.

So, the usage of OFFSET is wrong and leads to bogus results - when
appending to a snapshot the result would be a snapshot with missing rows
from the rounds table, and subsequently when that snapshot is restored -
gaps (missing rows) in the rounds table in the database.

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
