### PR TITLE
refactor(core): use default heap size regardless of available memory

### DIFF
--- a/packages/core/src/shared/start.ts
+++ b/packages/core/src/shared/start.ts
@@ -1,6 +1,5 @@
 import cli from "cli-ux";
 
-import { freemem, totalmem } from "os";
 import { BaseCommand } from "../commands/command";
 import { processManager } from "../process-manager";
 import { CommandFlags, ProcessOptions } from "../types";
@@ -38,10 +37,6 @@ export abstract class AbstractStartCommand extends BaseCommand {
 
             flagsProcess.name = processName;
 
-            const totalMemGb: number = totalmem() / Math.pow(1024, 3);
-            const freeMemGb: number = freemem() / Math.pow(1024, 3);
-            const potato: boolean = totalMemGb < 2 || freeMemGb < 1.5;
-
             processManager.start(
                 {
                     ...options,
@@ -50,7 +45,6 @@ export abstract class AbstractStartCommand extends BaseCommand {
                             NODE_ENV: "production",
                             CORE_ENV: flags.env,
                         },
-                        node_args: potato ? { max_old_space_size: 500 } : undefined,
                     },
                 },
                 flagsProcess,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
This was added to trigger the GC sooner on nodes with low memory, as they tend to run out of memory during a long running sync. However, all this did was to just work around a symptom and not the actual issue (*cough* Socketcluster timeouts something *cough*). Now it is causing issues during bootstrap, because V8 hits the allocation limit and just kills itself. Since the former is the latter evil, rather take the risk to run out of memory during a long running sync than during bootstrap.

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
