### PR TITLE
feat(crypto): allow passing height to `configManager.isNewMilestone`

### DIFF
--- a/__tests__/unit/crypto/managers/config.test.ts
+++ b/__tests__/unit/crypto/managers/config.test.ts
@@ -56,5 +56,8 @@ describe("Configuration", () => {
 
         configManager.setHeight(999999);
         expect(configManager.isNewMilestone()).toBeFalse();
+
+        configManager.setHeight(1);
+        expect(configManager.isNewMilestone(999999)).toBeFalse();
     });
 });

--- a/packages/crypto/src/managers/config.ts
+++ b/packages/crypto/src/managers/config.ts
@@ -59,7 +59,7 @@ export class ConfigManager {
 
     public isNewMilestone(height?: number): boolean {
         height = height || this.height;
-        return this.milestones.map(milestone => milestone.height).includes(height);
+        return this.milestones.some(milestone => milestone.height === height);
     }
 
     public getMilestone(height?: number): { [key: string]: any } {

--- a/packages/crypto/src/managers/config.ts
+++ b/packages/crypto/src/managers/config.ts
@@ -57,8 +57,9 @@ export class ConfigManager {
         return this.height;
     }
 
-    public isNewMilestone(): boolean {
-        return this.milestones.map(milestone => milestone.height).includes(this.height);
+    public isNewMilestone(height?: number): boolean {
+        height = height || this.height;
+        return this.milestones.map(milestone => milestone.height).includes(height);
     }
 
     public getMilestone(height?: number): { [key: string]: any } {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
Before one had to call `setHeight` before to check an explicit height, but now the height can be passed in directly.

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
