### PR TITLE
fix(crypto): schema convert to bignumber earlier

### DIFF
--- a/packages/crypto/src/validation/keywords.ts
+++ b/packages/crypto/src/validation/keywords.ts
@@ -83,6 +83,10 @@ const bignumber = (ajv: Ajv) => {
                     return false;
                 }
 
+                if (parentObject && property) {
+                    parentObject[property] = bignum;
+                }
+
                 let bypassGenesis: boolean = false;
                 if (schema.bypassGenesis) {
                     if (parentObject.id) {
@@ -100,10 +104,6 @@ const bignumber = (ajv: Ajv) => {
 
                 if (bignum.isGreaterThan(maximum) && !bypassGenesis) {
                     return false;
-                }
-
-                if (parentObject && property) {
-                    parentObject[property] = bignum;
                 }
 
                 return true;


### PR DESCRIPTION
Convert to bignumber even if some of the min/max checks would fail. The
caller may want to continue regardless of those failures and would
expect the property to be converted from string to bignumber.

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
