### PR TITLE
refactor(core-api): add `vendorField` and `timestamp` to `/locks` endpoint

### DIFF
--- a/__tests__/integration/core-api/handlers/locks.test.ts
+++ b/__tests__/integration/core-api/handlers/locks.test.ts
@@ -1,9 +1,9 @@
 import "../../../utils";
 
 import { app } from "@arkecosystem/core-container";
-import { Database } from '@arkecosystem/core-interfaces';
-import { Identities, Utils } from "@arkecosystem/crypto";
-import { TransactionFactory } from '../../../helpers';
+import { Database } from "@arkecosystem/core-interfaces";
+import { Crypto, Identities, Interfaces, Utils } from "@arkecosystem/crypto";
+import { TransactionFactory } from "../../../helpers";
 import { genesisBlock } from "../../../utils/fixtures/testnet/block-model";
 import { setUp, tearDown } from "../__support__/setup";
 import { utils } from "../utils";
@@ -14,8 +14,11 @@ afterAll(async () => await tearDown());
 describe("API 2.0 - Locks", () => {
     let wallets;
     let lockIds;
-    beforeAll(() => {
-        const walletManager = app.resolvePlugin("database").walletManager;
+    let walletManager;
+
+    beforeEach(() => {
+        walletManager = app.resolvePlugin("database").walletManager;
+        walletManager.reset();
 
         wallets = [
             walletManager.findByAddress(Identities.Address.fromPassphrase("1")),
@@ -45,6 +48,7 @@ describe("API 2.0 - Locks", () => {
                         type: j % 2 === 0 ? 1 : 2,
                         value: 100 * (j + 1),
                     },
+                    timestamp: (i + 1) * 100000,
                 };
             }
 
@@ -138,6 +142,30 @@ describe("API 2.0 - Locks", () => {
     });
 
     describe("POST /locks/search", () => {
+        const createWallet = (secret: string, lock: Partial<Interfaces.IHtlcLock> = {}) => {
+            const wallet = walletManager.findByPublicKey(Identities.PublicKey.fromPassphrase(secret));
+            const transactionId = Crypto.HashAlgorithms.sha256(secret).toString("hex");
+
+            wallet.setAttribute("htlc.locks", {
+                [transactionId]: {
+                    ...{
+                        amount: Utils.BigNumber.make(10000),
+                        recipientId: wallet.address,
+                        secretHash: transactionId,
+                        expiration: {
+                            type: 1,
+                            value: 1000000,
+                        },
+                        timestamp: 9999,
+                        vendorField: "HTLC",
+                    },
+                    ...lock,
+                },
+            });
+
+            return wallet;
+        };
+
         it("should POST a search for locks with the exact specified lockId", async () => {
             const response = await utils.request("POST", "locks/search", {
                 lockId: lockIds[0],
@@ -153,7 +181,44 @@ describe("API 2.0 - Locks", () => {
             expect(lock.lockId).toBe(lockIds[0]);
         });
 
-        // TODO: more coverage
+        it("should POST a search for locks with the exact vendorField", async () => {
+            const wallet = createWallet("secret", { vendorField: "HTLC" });
+            walletManager.reindex(wallet);
+
+            const response = await utils.request("POST", "locks/search", {
+                vendorField: "HTLC",
+            });
+
+            expect(response).toBeSuccessfulResponse();
+            expect(response.data.data).toBeArray();
+
+            expect(response.data.data).toHaveLength(1);
+
+            const lock = response.data.data[0];
+            utils.expectLock(lock);
+            expect(lock.vendorField).toBe("HTLC");
+        });
+
+        it("should POST a search for locks within the timestamp range", async () => {
+            const wallet = createWallet("secret", { timestamp: 5000 });
+            walletManager.reindex(wallet);
+
+            const response = await utils.request("POST", "locks/search", {
+                timestamp: {
+                    from: 4000,
+                    to: 6000,
+                },
+            });
+
+            expect(response).toBeSuccessfulResponse();
+            expect(response.data.data).toBeArray();
+
+            expect(response.data.data).toHaveLength(1);
+
+            const lock = response.data.data[0];
+            utils.expectLock(lock);
+            expect(lock.timestamp).toBe(5000);
+        });
     });
 
     describe("POST /locks/unlocked", () => {
@@ -164,7 +229,9 @@ describe("API 2.0 - Locks", () => {
 
             const databaseService = app.resolvePlugin<Database.IDatabaseService>("database");
 
-            jest.spyOn(databaseService.transactionsBusinessRepository, "findByHtlcLocks").mockResolvedValueOnce([refundTransaction as any])
+            jest.spyOn(databaseService.transactionsBusinessRepository, "findByHtlcLocks").mockResolvedValueOnce([
+                refundTransaction as any,
+            ]);
 
             const response = await utils.request("POST", "locks/unlocked", {
                 ids: [lockIds[0]],

--- a/__tests__/integration/core-api/utils.ts
+++ b/__tests__/integration/core-api/utils.ts
@@ -139,6 +139,7 @@ class Helpers {
         expect(lock).toHaveProperty("recipientId");
         expect(lock).toHaveProperty("amount");
         expect(lock).toHaveProperty("secretHash");
+        expect(lock).toHaveProperty("timestamp");
         expect(lock).toHaveProperty("expirationType");
         expect(lock).toHaveProperty("expirationValue");
     }

--- a/__tests__/unit/crypto/transactions/deserializer.test.ts
+++ b/__tests__/unit/crypto/transactions/deserializer.test.ts
@@ -305,6 +305,7 @@ describe("Transaction serializer / deserializer", () => {
                 .network(23)
                 .addPayment("AW5wtiimZntaNvxH6QBi7bBpH2rDtFeD8C", "1555")
                 .addPayment("AW5wtiimZntaNvxH6QBi7bBpH2rDtFeD8C", "5000")
+                .vendorField("Multipayment")
                 .sign("dummy passphrase")
                 .getStruct();
 
@@ -367,6 +368,7 @@ describe("Transaction serializer / deserializer", () => {
                 .amount("10000")
                 .fee("50000000")
                 .network(23)
+                .vendorField("HTLC")
                 .htlcLockAsset(htlcLockAsset)
                 .sign("dummy passphrase")
                 .getStruct();

--- a/packages/core-api/src/handlers/locks/schema.ts
+++ b/packages/core-api/src/handlers/locks/schema.ts
@@ -65,6 +65,17 @@ export const search: object = {
                 .integer()
                 .min(0),
         }),
+        timestamp: Joi.object().keys({
+            from: Joi.number()
+                .integer()
+                .min(0),
+            to: Joi.number()
+                .integer()
+                .min(0),
+        }),
+        vendorField: Joi.string()
+            .min(1)
+            .max(255),
         expirationType: Joi.number().only(1, 2),
         expirationValue: Joi.object().keys({
             from: Joi.number()

--- a/packages/core-database/src/repositories/utils/search-entries.ts
+++ b/packages/core-database/src/repositories/utils/search-entries.ts
@@ -61,6 +61,8 @@ const manipulateIteratee = (iteratee): any => {
             return delegateCalculator.calculateForgedTotal;
         case "votes":
             return "voteBalance";
+        case "vendorfield":
+            return "vendorField";
         case "expirationvalue":
             return "expirationValue";
         case "expirationtype":

--- a/packages/core-database/src/repositories/wallets-business-repository.ts
+++ b/packages/core-database/src/repositories/wallets-business-repository.ts
@@ -190,28 +190,25 @@ export class WalletsBusinessRepository implements Database.IWalletsBusinessRepos
         const entries: IUnwrappedHtlcLock[] = this.databaseServiceProvider()
             .walletManager.getIndex(State.WalletIndexes.Locks)
             .entries()
-            .reduce(
-                (acc, [lockId, wallet]) => {
-                    const locks: Interfaces.IHtlcLocks = wallet.getAttribute("htlc.locks");
-                    if (locks && locks[lockId]) {
-                        const lock: Interfaces.IHtlcLock = locks[lockId];
-                        acc.push({
-                            lockId,
-                            amount: lock.amount,
-                            secretHash: lock.secretHash,
-                            senderPublicKey: wallet.publicKey,
-                            recipientId: lock.recipientId,
-                            timestamp: lock.timestamp,
-                            expirationType: lock.expiration.type,
-                            expirationValue: lock.expiration.value,
-                            vendorField: lock.vendorField,
-                        });
-                    }
+            .reduce<IUnwrappedHtlcLock[]>((acc, [lockId, wallet]) => {
+                const locks: Interfaces.IHtlcLocks = wallet.getAttribute("htlc.locks");
+                if (locks && locks[lockId]) {
+                    const lock: Interfaces.IHtlcLock = locks[lockId];
+                    acc.push({
+                        lockId,
+                        amount: lock.amount,
+                        secretHash: lock.secretHash,
+                        senderPublicKey: wallet.publicKey,
+                        recipientId: lock.recipientId,
+                        timestamp: lock.timestamp,
+                        expirationType: lock.expiration.type,
+                        expirationValue: lock.expiration.value,
+                        vendorField: lock.vendorField,
+                    });
+                }
 
-                    return acc;
-                },
-                [] as IUnwrappedHtlcLock[],
-            );
+                return acc;
+            }, []);
 
         return {
             query,

--- a/packages/core-database/src/repositories/wallets-business-repository.ts
+++ b/packages/core-database/src/repositories/wallets-business-repository.ts
@@ -20,7 +20,7 @@ interface IUnwrappedHtlcLock {
 }
 
 export class WalletsBusinessRepository implements Database.IWalletsBusinessRepository {
-    public constructor(private readonly databaseServiceProvider: () => Database.IDatabaseService) { }
+    public constructor(private readonly databaseServiceProvider: () => Database.IDatabaseService) {}
 
     public search<T>(scope: Database.SearchScope, params: Database.IParameters = {}): Database.IRowsPaginated<T> {
         let searchContext: ISearchContext;
@@ -188,11 +188,11 @@ export class WalletsBusinessRepository implements Database.IWalletsBusinessRepos
         const entries: IUnwrappedHtlcLock[] = this.databaseServiceProvider()
             .walletManager.getIndex(State.WalletIndexes.Locks)
             .entries()
-            .map(([lockId, wallet]) => {
+            .reduce((acc, [lockId, wallet]) => {
                 const locks: Interfaces.IHtlcLocks = wallet.getAttribute("htlc.locks");
                 if (locks && locks[lockId]) {
                     const lock: Interfaces.IHtlcLock = locks[lockId];
-                    return {
+                    acc.push({
                         lockId,
                         amount: lock.amount,
                         secretHash: lock.secretHash,
@@ -200,12 +200,11 @@ export class WalletsBusinessRepository implements Database.IWalletsBusinessRepos
                         recipientId: lock.recipientId,
                         expirationType: lock.expiration.type,
                         expirationValue: lock.expiration.value,
-                    };
+                    });
                 }
 
-                return undefined;
-            })
-            .filter(lock => !!lock);
+                return acc;
+            }, []);
 
         return {
             query,

--- a/packages/core-interfaces/src/core-database/database-repository/transactions-repository.ts
+++ b/packages/core-interfaces/src/core-database/database-repository/transactions-repository.ts
@@ -11,6 +11,7 @@ export interface IBootstrapTransaction {
     recipientId: string;
     fee: string;
     amount: string;
+    vendorFieldHex: string;
     asset: Interfaces.ITransactionAsset;
 }
 

--- a/packages/core-transactions/src/handlers/htlc-claim.ts
+++ b/packages/core-transactions/src/handlers/htlc-claim.ts
@@ -186,7 +186,9 @@ export class HtlcClaimTransactionHandler extends TransactionHandler {
             amount: lockTransaction.amount,
             recipientId: lockTransaction.recipientId,
             timestamp: lockTransaction.timestamp,
-            vendorField: Buffer.from(lockTransaction.vendorFieldHex, "hex").toString("utf8"),
+            vendorField: lockTransaction.vendorFieldHex
+                ? Buffer.from(lockTransaction.vendorFieldHex, "hex").toString("utf8")
+                : undefined,
             ...lockTransaction.asset.lock,
         };
 

--- a/packages/core-transactions/src/handlers/htlc-claim.ts
+++ b/packages/core-transactions/src/handlers/htlc-claim.ts
@@ -185,6 +185,8 @@ export class HtlcClaimTransactionHandler extends TransactionHandler {
         locks[lockTransaction.id] = {
             amount: lockTransaction.amount,
             recipientId: lockTransaction.recipientId,
+            timestamp: lockTransaction.timestamp,
+            vendorField: Buffer.from(lockTransaction.vendorFieldHex, "hex").toString("utf8"),
             ...lockTransaction.asset.lock,
         };
 

--- a/packages/core-transactions/src/handlers/htlc-lock.ts
+++ b/packages/core-transactions/src/handlers/htlc-lock.ts
@@ -27,6 +27,10 @@ export class HtlcLockTransactionHandler extends TransactionHandler {
             locks[transaction.id] = {
                 amount: Utils.BigNumber.make(transaction.amount),
                 recipientId: transaction.recipientId,
+                timestamp: transaction.timestamp,
+                vendorField: transaction.vendorFieldHex
+                    ? Buffer.from(transaction.vendorFieldHex, "hex").toString("utf8")
+                    : undefined,
                 ...transaction.asset.lock,
             };
             wallet.setAttribute("htlc.locks", locks);
@@ -95,6 +99,8 @@ export class HtlcLockTransactionHandler extends TransactionHandler {
         locks[transaction.id] = {
             amount: transaction.data.amount,
             recipientId: transaction.data.recipientId,
+            timestamp: transaction.timestamp,
+            vendorField: transaction.data.vendorField,
             ...transaction.data.asset.lock,
         };
         sender.setAttribute("htlc.locks", locks);

--- a/packages/core-transactions/src/handlers/htlc-refund.ts
+++ b/packages/core-transactions/src/handlers/htlc-refund.ts
@@ -173,7 +173,9 @@ export class HtlcRefundTransactionHandler extends TransactionHandler {
             amount: lockTransaction.amount,
             recipientId: lockTransaction.recipientId,
             timestamp: lockTransaction.timestamp,
-            vendorField: lockTransaction.vendorField,
+            vendorField: lockTransaction.vendorFieldHex
+                ? Buffer.from(lockTransaction.vendorFieldHex, "hex").toString("utf8")
+                : undefined,
             ...lockTransaction.asset.lock,
         };
 

--- a/packages/core-transactions/src/handlers/htlc-refund.ts
+++ b/packages/core-transactions/src/handlers/htlc-refund.ts
@@ -172,6 +172,8 @@ export class HtlcRefundTransactionHandler extends TransactionHandler {
         locks[lockTransaction.id] = {
             amount: lockTransaction.amount,
             recipientId: lockTransaction.recipientId,
+            timestamp: lockTransaction.timestamp,
+            vendorField: lockTransaction.vendorField,
             ...lockTransaction.asset.lock,
         };
 

--- a/packages/crypto/src/interfaces/transactions.ts
+++ b/packages/crypto/src/interfaces/transactions.ts
@@ -150,6 +150,8 @@ export interface IHtlcRefundAsset {
 export interface IHtlcLock extends IHtlcLockAsset {
     amount: BigNumber;
     recipientId: string;
+    timestamp: number;
+    vendorField: string;
 }
 
 export type IHtlcLocks = Record<string, IHtlcLock>;

--- a/packages/crypto/src/transactions/builders/transactions/htlc-lock.ts
+++ b/packages/crypto/src/transactions/builders/transactions/htlc-lock.ts
@@ -12,6 +12,7 @@ export class HtlcLockBuilder extends TransactionBuilder<HtlcLockBuilder> {
         this.data.recipientId = undefined;
         this.data.amount = BigNumber.ZERO;
         this.data.fee = HtlcLockTransaction.staticFee();
+        this.data.vendorField = undefined;
         this.data.asset = {};
     }
 
@@ -27,6 +28,7 @@ export class HtlcLockBuilder extends TransactionBuilder<HtlcLockBuilder> {
         const struct: ITransactionData = super.getStruct();
         struct.recipientId = this.data.recipientId;
         struct.amount = this.data.amount;
+        struct.vendorField = this.data.vendorField;
         struct.asset = this.data.asset;
         return struct;
     }

--- a/packages/crypto/src/transactions/builders/transactions/multi-payment.ts
+++ b/packages/crypto/src/transactions/builders/transactions/multi-payment.ts
@@ -11,7 +11,7 @@ export class MultiPaymentBuilder extends TransactionBuilder<MultiPaymentBuilder>
         this.data.type = MultiPaymentTransaction.type;
         this.data.typeGroup = MultiPaymentTransaction.typeGroup;
         this.data.fee = MultiPaymentTransaction.staticFee();
-        this.data.vendorFieldHex = undefined;
+        this.data.vendorField = undefined;
         this.data.asset = {
             payments: [],
         };
@@ -34,7 +34,7 @@ export class MultiPaymentBuilder extends TransactionBuilder<MultiPaymentBuilder>
     public getStruct(): ITransactionData {
         const struct: ITransactionData = super.getStruct();
         struct.senderPublicKey = this.data.senderPublicKey;
-        struct.vendorFieldHex = this.data.vendorFieldHex;
+        struct.vendorField = this.data.vendorField;
         struct.amount = this.data.amount;
         struct.asset = this.data.asset;
 

--- a/packages/crypto/src/transactions/types/htlc-lock.ts
+++ b/packages/crypto/src/transactions/types/htlc-lock.ts
@@ -22,6 +22,10 @@ export class HtlcLockTransaction extends Transaction {
         return configManager.getMilestone().aip11 && super.verify();
     }
 
+    public hasVendorField(): boolean {
+        return true;
+    }
+
     public serialize(options?: ISerializeOptions): ByteBuffer {
         const { data } = this;
 

--- a/packages/crypto/src/transactions/types/multi-payment.ts
+++ b/packages/crypto/src/transactions/types/multi-payment.ts
@@ -22,6 +22,10 @@ export class MultiPaymentTransaction extends Transaction {
         return configManager.getMilestone().aip11 && super.verify();
     }
 
+    public hasVendorField(): boolean {
+        return true;
+    }
+
     public serialize(options?: ISerializeOptions): ByteBuffer {
         const { data } = this;
 

--- a/packages/crypto/src/transactions/types/schemas.ts
+++ b/packages/crypto/src/transactions/types/schemas.ts
@@ -208,6 +208,8 @@ export const htlcLock = extend(transactionBaseSchema, {
         type: { transactionType: TransactionType.HtlcLock },
         amount: { bignumber: { minimum: 1 } },
         recipientId: { $ref: "address" },
+        vendorField: { anyOf: [{ type: "null" }, { type: "string", format: "vendorField" }] },
+        vendorFieldHex: { anyOf: [{ type: "null" }, { type: "string", format: "vendorFieldHex" }] },
         asset: {
             type: "object",
             required: ["lock"],
@@ -282,6 +284,8 @@ export const multiPayment = extend(transactionBaseSchema, {
     properties: {
         type: { transactionType: TransactionType.MultiPayment },
         amount: { bignumber: { minimum: 0, maximum: 0 } },
+        vendorField: { anyOf: [{ type: "null" }, { type: "string", format: "vendorField" }] },
+        vendorFieldHex: { anyOf: [{ type: "null" }, { type: "string", format: "vendorFieldHex" }] },
         asset: {
             type: "object",
             required: ["payments"],


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
Adds `vendorField` and `timestamp` to the `/locks` endpoint.

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [X] Tests _(if necessary)_
- [X] Ready to be merged

<!-- Feel free to add additional comments. -->
