### PR TITLE
fix(crypto): run ajv validator again when encountering exceptions

### DIFF
--- a/__tests__/unit/crypto/blocks/factory.test.ts
+++ b/__tests__/unit/crypto/blocks/factory.test.ts
@@ -3,9 +3,9 @@ import "jest-extended";
 import { Block, BlockFactory } from "../../../../packages/crypto/src/blocks";
 import { IBlockData } from "../../../../packages/crypto/src/interfaces";
 import { configManager } from "../../../../packages/crypto/src/managers";
-import { dummyBlock } from "../fixtures/block";
+import { blockWithExceptions, dummyBlock } from "../fixtures/block";
 
-function expectBlock({ data }: { data: IBlockData }) {
+export const expectBlock = ({ data }: { data: IBlockData }) => {
     delete data.idHex;
 
     const blockWithoutTransactions: IBlockData = { ...dummyBlock };
@@ -36,6 +36,11 @@ describe("BlockFactory", () => {
         it("should create a block instance from an object", () => {
             expectBlock(BlockFactory.fromData(dummyBlock));
         });
+
+        it("should create a block with exceptions", () => {
+            // @ts-ignore
+            expect(() => BlockFactory.fromData(blockWithExceptions)).not.toThrow();
+        })
     });
 
     describe(".fromJson", () => {

--- a/__tests__/unit/crypto/fixtures/block.ts
+++ b/__tests__/unit/crypto/fixtures/block.ts
@@ -156,3 +156,52 @@ export const dummyBlock3 = {
         "304402204087bb1d2c82b9178b02b9b3f285de260cdf0778643064fe6c7aef27321d49520220594c57009c1fca543350126d277c6adeb674c00685a464c3e4bf0d634dc37e39",
     createdAt: "2018-09-11T16:48:58.431Z",
 };
+
+export const blockWithExceptions = {
+    "id": "15986760691378510176",
+    "version": 0,
+    "timestamp": 52310186,
+    "height": 766787,
+    "reward": "200000000",
+    "transactions": [
+        {
+            "version": 1,
+            "network": 30,
+            "type": 0,
+            "timestamp": 52308692,
+            "senderPublicKey": "039c09c66328ebe7569cd49aa441e45c9df96c1d644c7acf33f7bc763709c41c1f",
+            "fee": "10000000",
+            "amount": "0",
+            "vendorFieldHex": "54727565205061737461205765696768742e",
+            "expiration": 0,
+            "recipientId": "D5KU9KrMYXdkEsRbv4y8hvetGbsJwf9z3P",
+            "signature": "304402200ca79a6ebcd29cbf6bea42fa6890e0c7bfd82fd5e7cd327913f966b433b24086022051f127b1349af1ccb49cdc27595844d5228d612ef8c7d57d63dc5b75620c7e64",
+            "vendorField": "True Pasta Weight.",
+            "id": "3945e67bb5e864d2dd206293f1e778fa2181db5f81c2efc0a89e8fe53e2a2e7c"
+        },
+        {
+            "version": 1,
+            "network": 30,
+            "type": 0,
+            "timestamp": 52308443,
+            "senderPublicKey": "02364aaaf17c35f74e397433f988361aee408c5b5314eaad5b815c4f4f7c578b1e",
+            "fee": "10000000",
+            "amount": "250000000",
+            "vendorFieldHex": "54727565205061737461205765696768742e",
+            "expiration": 0,
+            "recipientId": "DJA2sqCbnmR63sD8doGrXrK3fCiqcA4GUw",
+            "signature": "3045022100f3a61a0460abe78a4705904216ac17a7bf50b19d70717624c15b64a94207cbeb022070a7bf3d97a3e690839ce1764413ce890ea233eb7eba202d373a376fc4b551b6",
+            "vendorField": "True Pasta Weight.",
+            "id": "8e4853ed764bb1853e58fda4a9c507f73b820dd738e4a9b197dafb37a22b6b0f"
+        }
+    ],
+    "previousBlock": "17296711371070322453",
+    "numberOfTransactions": 2,
+    "totalAmount": "250000000",
+    "totalFee": "20000000",
+    "payloadLength": 64,
+    "payloadHash": "53033d24a4f133e47fee3871d82bca12bdf8b58ec4ebf43ac2b7849e78278256",
+    "generatorPublicKey": "02d0244d939fad9004cc104f71b46b428d903e4f2988a65f39fdaa1b7482894c9e",
+    "blockSignature": "30440220053747c5d02b38c9f8980d771918a5c48c99080a0bba661d3609553ed14c3f0d022063da2ba62e002d91b0f3bdba4e0c822bf0f5ce88b95867192252a2418ec0556f",
+    "previousBlockHex": "f00a43599f1b3715"
+}

--- a/packages/crypto/src/blocks/block.ts
+++ b/packages/crypto/src/blocks/block.ts
@@ -18,6 +18,15 @@ export class Block implements IBlock {
             throw new BlockSchemaError(data.height, error);
         }
 
+        if (error) {
+            if (isException(value) || data.transactions.some((transaction: ITransactionData) => isException(transaction))) {
+                // Validate again without bailing out on the first error to ensure that all properties get properly converted if necessary
+                validator.validateException("block", data);
+            } else {
+                throw new BlockSchemaError(data.height, error);
+            }
+        }
+
         return value;
     }
 

--- a/packages/crypto/src/validation/index.ts
+++ b/packages/crypto/src/validation/index.ts
@@ -12,29 +12,10 @@ export class Validator {
     }
 
     private ajv: Ajv.Ajv;
-    private readonly transactionSchemas: Set<string> = new Set<string>();
+    private readonly transactionSchemas: Map<string, TransactionSchema> = new Map<string, TransactionSchema>();
 
     private constructor(options: Record<string, any>) {
-        const ajv = new Ajv({
-            ...{
-                $data: true,
-                schemas,
-                removeAdditional: true,
-                extendRefs: true,
-            },
-            ...options,
-        });
-        ajvKeywords(ajv);
-
-        for (const addKeyword of keywords) {
-            addKeyword(ajv);
-        }
-
-        for (const addFormat of formats) {
-            addFormat(ajv);
-        }
-
-        this.ajv = ajv;
+        this.ajv = this.instantiateAjv(options);
     }
 
     public getInstance(): Ajv.Ajv {
@@ -42,15 +23,17 @@ export class Validator {
     }
 
     public validate<T = any>(schemaKeyRef: string | boolean | object, data: T): ISchemaValidationResult<T> {
-        try {
-            this.ajv.validate(schemaKeyRef, data);
+        return this.validateSchema(this.ajv, schemaKeyRef, data);
+    }
 
-            const error = this.ajv.errors ? this.ajv.errorsText() : undefined;
+    public validateException<T = any>(schemaKeyRef: string | boolean | object, data: T): ISchemaValidationResult<T> {
+        const ajv = this.instantiateAjv({ allErrors: true });
 
-            return { value: data, error, errors: this.ajv.errors };
-        } catch (error) {
-            return { value: undefined, error: error.stack, errors: [] };
+        for (const schema of this.transactionSchemas.values()) {
+            this.extendTransactionSchema(ajv, schema);
         }
+
+        return this.validateSchema(ajv, schemaKeyRef, data);
     }
 
     public addFormat(name: string, format: Ajv.FormatDefinition): void {
@@ -74,33 +57,76 @@ export class Validator {
     }
 
     public extendTransaction(schema: TransactionSchema, remove?: boolean) {
+        this.extendTransactionSchema(this.ajv, schema, remove);
+    }
+
+    private validateSchema<T = any>(
+        ajv: Ajv.Ajv,
+        schemaKeyRef: string | boolean | object,
+        data: T,
+    ): ISchemaValidationResult<T> {
+        try {
+            ajv.validate(schemaKeyRef, data);
+
+            const error = ajv.errors ? ajv.errorsText() : undefined;
+
+            return { value: data, error, errors: ajv.errors };
+        } catch (error) {
+            return { value: undefined, error: error.stack, errors: [] };
+        }
+    }
+
+    private instantiateAjv(options: Record<string, any>) {
+        const ajv = new Ajv({
+            ...{
+                $data: true,
+                schemas,
+                removeAdditional: true,
+                extendRefs: true,
+            },
+            ...options,
+        });
+        ajvKeywords(ajv);
+
+        for (const addKeyword of keywords) {
+            addKeyword(ajv);
+        }
+
+        for (const addFormat of formats) {
+            addFormat(ajv);
+        }
+
+        return ajv;
+    }
+
+    private extendTransactionSchema(ajv: Ajv.Ajv, schema: TransactionSchema, remove?: boolean) {
         if (remove) {
             this.transactionSchemas.delete(schema.$id);
 
-            this.ajv.removeSchema(schema.$id);
-            this.ajv.removeSchema(`${schema.$id}Signed`);
-            this.ajv.removeSchema(`${schema.$id}Strict`);
+            ajv.removeSchema(schema.$id);
+            ajv.removeSchema(`${schema.$id}Signed`);
+            ajv.removeSchema(`${schema.$id}Strict`);
         } else {
-            this.transactionSchemas.add(schema.$id);
+            this.transactionSchemas.set(schema.$id, schema);
 
-            this.ajv.addSchema(schema);
-            this.ajv.addSchema(signedSchema(schema));
-            this.ajv.addSchema(strictSchema(schema));
+            ajv.addSchema(schema);
+            ajv.addSchema(signedSchema(schema));
+            ajv.addSchema(strictSchema(schema));
         }
 
-        this.updateTransactionArray();
+        this.updateTransactionArray(ajv);
     }
 
-    private updateTransactionArray() {
-        this.ajv.removeSchema("block");
-        this.ajv.removeSchema("transactions");
-        this.ajv.addSchema({
+    private updateTransactionArray(ajv: Ajv.Ajv) {
+        ajv.removeSchema("block");
+        ajv.removeSchema("transactions");
+        ajv.addSchema({
             $id: "transactions",
             type: "array",
             additionalItems: false,
-            items: { anyOf: [...this.transactionSchemas].map(schema => ({ $ref: `${schema}Signed` })) },
+            items: { anyOf: [...this.transactionSchemas.keys()].map(schema => ({ $ref: `${schema}Signed` })) },
         });
-        this.ajv.addSchema(schemas.block);
+        ajv.addSchema(schemas.block);
     }
 }
 

--- a/packages/crypto/src/validation/keywords.ts
+++ b/packages/crypto/src/validation/keywords.ts
@@ -83,6 +83,10 @@ const bignumber = (ajv: Ajv) => {
                     return false;
                 }
 
+                if (parentObject && property) {
+                    parentObject[property] = bignum;
+                }
+
                 let bypassGenesis: boolean = false;
                 if (schema.bypassGenesis) {
                     if (parentObject.id) {
@@ -100,10 +104,6 @@ const bignumber = (ajv: Ajv) => {
 
                 if (bignum.isGreaterThan(maximum) && !bypassGenesis) {
                     return false;
-                }
-
-                if (parentObject && property) {
-                    parentObject[property] = bignum;
                 }
 
                 return true;


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
If the block validation fails and there are any exceptions, instead of continuing right away, rerun the schema validation without bailing out on the first encountered error. This ensures all bignumber 
properties are properly converted.

Fixes #3003 
<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [X] Tests _(if necessary)_
- [X] Ready to be merged

<!-- Feel free to add additional comments. -->
