### PR TITLE
perf(crypto): memoize base58 de/encoding

### DIFF
--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -48,7 +48,8 @@
         "otplib": "^11.0.1",
         "pluralize": "^8.0.0",
         "tiny-glob": "^0.2.6",
-        "wif": "^2.0.6"
+        "wif": "^2.0.6",
+        "fast-memoize": "^2.5.1"
     },
     "devDependencies": {
         "@types/bip32": "^1.0.2",

--- a/packages/crypto/src/crypto/bip38.ts
+++ b/packages/crypto/src/crypto/bip38.ts
@@ -19,7 +19,7 @@ import {
 } from "../errors";
 import { Keys } from "../identities";
 import { IDecryptResult } from "../interfaces";
-import { Base58 } from "../utils";
+import { Base58 } from "../utils/base58";
 
 const SCRYPT_PARAMS = {
     N: 16384, // specified by BIP38

--- a/packages/crypto/src/identities/address.ts
+++ b/packages/crypto/src/identities/address.ts
@@ -2,7 +2,7 @@ import { HashAlgorithms } from "../crypto";
 import { PublicKeyError } from "../errors";
 import { IMultiSignatureAsset } from "../interfaces";
 import { configManager } from "../managers";
-import { Base58 } from "../utils";
+import { Base58 } from "../utils/base58";
 import { PublicKey } from "./public-key";
 
 export class Address {

--- a/packages/crypto/src/transactions/serializer.ts
+++ b/packages/crypto/src/transactions/serializer.ts
@@ -7,7 +7,8 @@ import { Address } from "../identities";
 import { ITransaction, ITransactionData } from "../interfaces";
 import { ISerializeOptions } from "../interfaces";
 import { configManager } from "../managers/config";
-import { Base58, isSupportedTansactionVersion } from "../utils";
+import { isSupportedTansactionVersion } from "../utils";
+import { Base58 } from "../utils/base58";
 import { TransactionTypeFactory } from "./types";
 
 // Reference: https://github.com/ArkEcosystem/AIPs/blob/master/AIPS/aip-11.md

--- a/packages/crypto/src/utils/base58.ts
+++ b/packages/crypto/src/utils/base58.ts
@@ -1,22 +1,26 @@
 import { base58 } from "bstring";
+import moize from "fast-memoize";
 import { HashAlgorithms } from "../crypto";
 
-export class Base58 {
-    public static encodeCheck(buffer: Buffer): string {
-        const checksum: Buffer = HashAlgorithms.hash256(buffer);
+const encodeCheck = (buffer: Buffer): string => {
+    const checksum: Buffer = HashAlgorithms.hash256(buffer);
 
-        return base58.encode(Buffer.concat([buffer, checksum], buffer.length + 4));
+    return base58.encode(Buffer.concat([buffer, checksum], buffer.length + 4));
+};
+
+const decodeCheck = (address: string): Buffer => {
+    const buffer: Buffer = base58.decode(address);
+    const payload: Buffer = buffer.slice(0, -4);
+    const checksum: Buffer = HashAlgorithms.hash256(payload);
+
+    if (checksum.readUInt32LE(0) !== buffer.slice(-4).readUInt32LE(0)) {
+        throw new Error("Invalid checksum");
     }
 
-    public static decodeCheck(address: string): Buffer {
-        const buffer: Buffer = base58.decode(address);
-        const payload: Buffer = buffer.slice(0, -4);
-        const checksum: Buffer = HashAlgorithms.hash256(payload);
+    return payload;
+};
 
-        if (checksum.readUInt32LE(0) !== buffer.slice(-4).readUInt32LE(0)) {
-            throw new Error("Invalid checksum");
-        }
-
-        return payload;
-    }
-}
+export const Base58 = {
+    encodeCheck: moize(encodeCheck),
+    decodeCheck: moize(decodeCheck),
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -5777,6 +5777,11 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
 
+fast-memoize@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/fast-memoize/-/fast-memoize-2.5.1.tgz#c3519241e80552ce395e1a32dcdde8d1fd680f5d"
+  integrity sha512-xdmw296PCL01tMOXx9mdJSmWY29jQgxyuZdq0rEHMu+Tpe1eOEtCycoG6chzlcrWsNgpZP7oL8RiQr7+G6Bl6g==
+
 fast-redact@^1.4.4:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/fast-redact/-/fast-redact-1.5.0.tgz#302892f566750c4f5eec7b830bfc9bc473484034"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
Memoize Base58 functions to speed up multipayment processing by up to 50%.
```
Before:
 ✓  Block.fromData (Multipayments 500 recipients) x 10.46 ops/sec ±1.14% (29 runs sampled)
After:
 ✓  Block.fromData (Multipayments 500 recipients) x 15.92 ops/sec ±3.32% (43 runs sampled)
```

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
