### PR TITLE
fix(core-forger): use correct IV length for encryption

### DIFF
--- a/__tests__/unit/core-forger/delegate.test.ts
+++ b/__tests__/unit/core-forger/delegate.test.ts
@@ -44,7 +44,11 @@ describe("Delegate", () => {
 
     describe("encryptPassphrase", () => {
         it("should pass with valid data", () => {
-            const passphrase = Delegate.encryptPassphrase(dummy.plainPassphrase, Networks.testnet.network, "bip38-password");
+            const passphrase = Delegate.encryptPassphrase(
+                dummy.plainPassphrase,
+                Networks.testnet.network,
+                "bip38-password",
+            );
 
             expect(passphrase).toBe(dummy.bip38Passphrase);
         });
@@ -58,7 +62,11 @@ describe("Delegate", () => {
 
     describe("decryptPassphrase", () => {
         it("should pass with a valid password", () => {
-            const { publicKey } = Delegate.decryptPassphrase(dummy.bip38Passphrase, Networks.testnet.network, "bip38-password");
+            const { publicKey } = Delegate.decryptPassphrase(
+                dummy.bip38Passphrase,
+                Networks.testnet.network,
+                "bip38-password",
+            );
 
             expect(publicKey).toBe(dummy.publicKey);
         });

--- a/packages/core-forger/src/delegate.ts
+++ b/packages/core-forger/src/delegate.ts
@@ -60,7 +60,7 @@ export class Delegate {
     }
 
     public encryptKeysWithOtp(): void {
-        this.otp = authenticator.generate(this.otpSecret);
+        this.otp = forge.random.getBytesSync(16);
 
         const wifKey: string = Identities.WIF.fromKeys(this.keys, this.network);
 
@@ -132,7 +132,7 @@ export class Delegate {
             "AES-CBC",
             forge.pkcs5.pbkdf2(password, this.otpSecret, this.iterations, this.keySize),
         );
-        cipher.start({ iv: forge.util.decode64(this.otp) });
+        cipher.start({ iv: this.otp });
         cipher.update(forge.util.createBuffer(content));
         cipher.finish();
 
@@ -144,7 +144,7 @@ export class Delegate {
             "AES-CBC",
             forge.pkcs5.pbkdf2(password, this.otpSecret, this.iterations, this.keySize),
         );
-        decipher.start({ iv: forge.util.decode64(this.otp) });
+        decipher.start({ iv: this.otp });
         decipher.update(forge.util.createBuffer(forge.util.decode64(cipherText)));
         decipher.finish();
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Commit https://github.com/digitalbazaar/forge/commit/99791690247f27972c314ffd2273d258c17da0ed in `node-forge` introduced a new error that is thrown when the IV length isn't matching what would be expected https://github.com/digitalbazaar/forge/commit/99791690247f27972c314ffd2273d258c17da0ed#diff-e118e6ad049019e947a73be26a7d966cR972-R976

Previously this just worked even though the IV length was invalid but now `node-forge` throws an exception like below.

```
Error: Invalid IV length; got 6 bytes and expected 16 bytes.
    at transformIV (/Users/dev/Code/core/node_modules/node-forge/lib/cipherModes.js:973:11)
    at Object.<anonymous>.modes.cbc.start (/Users/dev/Code/core/node_modules/node-forge/lib/cipherModes.js:122:16)
    at Object.<anonymous>.forge.cipher.BlockCipher.Object.<anonymous>.BlockCipher.start (/Users/dev/Code/core/node_modules/node-forge/lib/cipher.js:158:13)
    at Delegate.encryptDataWithOtp (/Users/dev/Code/core/packages/core-forger/src/delegate.ts:137:16)
    at Delegate.encryptKeysWithOtp (/Users/dev/Code/core/packages/core-forger/src/delegate.ts:68:35)
    at new Delegate (/Users/dev/Code/core/packages/core-forger/src/delegate.ts:49:22)
    at Object.<anonymous> (/Users/dev/Code/core/__tests__/unit/core-forger/delegate.test.ts:28:34)
    at Object.asyncJestTest (/Users/dev/Code/core/node_modules/jest-jasmine2/build/jasmineAsyncInstall.js:102:37)
    at /Users/dev/Code/core/node_modules/jest-jasmine2/build/queueRunner.js:43:12
    at new Promise (<anonymous>)
```

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
