### PR TITLE
perf(core-transactions): disable TransactionReader

### DIFF
--- a/packages/core-transactions/src/transaction-reader.ts
+++ b/packages/core-transactions/src/transaction-reader.ts
@@ -15,7 +15,7 @@ export class TransactionReader {
         return reader;
     }
 
-    public bufferSize: number = 10000;
+    public bufferSize: number = 1000000000;
 
     private index: number;
     private count: number;


### PR DESCRIPTION
Disable the TransactionReader because it inflicts a minor performance
regression. However, do not completely delete it from the source code
because we may revisit it later when the database queries start
returning way too many rows to the nodejs app at once. The proper
solution is to execute the database query once and serve the results to
the app on portions using cursors, rather than executing the same query
multiple times and chopping the portions using OFFSET,LIMIT.

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
