### PR TITLE
perf(core-database-postgres): add index on transactions.type

### DIFF
--- a/packages/core-database-postgres/src/migrations/20191008000000-add-type-index-to-transactions-table.sql
+++ b/packages/core-database-postgres/src/migrations/20191008000000-add-type-index-to-transactions-table.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS "transactions_type" ON ${schema~}.transactions ("type");


### PR DESCRIPTION
On mainnet database (9912558 blocks, 3171992 transactions):

SELECT * FROM transactions WHERE type = 6;
no index: 700ms, with index: 1ms

SELECT * FROM transactions WHERE type = 1;
no index: 650ms, with index: 14ms

SELECT * FROM transactions WHERE type = 3;
no index: 1280ms, with index: 480ms

SELECT * FROM transactions WHERE type = 0;
no index: 11500ms, with index: 11500ms (the index is not used)

bootstrap
no index: 22sec, with index: 20sec

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
