### PR TITLE
fix(core-database-postgres): store vendor field in bytea

### DIFF
--- a/packages/core-database-postgres/src/migrations/20191003000000-migrate-vendor-field-hex.sql
+++ b/packages/core-database-postgres/src/migrations/20191003000000-migrate-vendor-field-hex.sql
@@ -1,6 +1,3 @@
-ALTER TABLE transactions
-    ALTER COLUMN vendor_field_hex SET DATA TYPE varchar(255)
-	USING
-		ENCODE(('\x' || ENCODE(vendor_field_hex, 'escape'))::bytea, 'escape');
+UPDATE transactions SET vendor_field_hex = ('\x' || ENCODE(vendor_field_hex, 'escape'))::BYTEA;
 
 ALTER TABLE transactions RENAME vendor_field_hex TO vendor_field;


### PR DESCRIPTION
* We support utf8 strings for vendor field
* \u0000 (nul byte) is a valid utf8 string
* PostgreSQL cannot store \u0000 in VARCHAR

It follows that we cannot use VARCHAR for storing vendor field.
So use bytea for that.
