### PR TITLE
fix(core-p2p): convert isAppReady response to object

### DIFF
--- a/packages/core-p2p/src/socket-server/versions/utils.ts
+++ b/packages/core-p2p/src/socket-server/versions/utils.ts
@@ -3,8 +3,11 @@ import { isWhitelisted } from "../../utils/is-whitelisted";
 import * as internalHandlers from "./internal";
 import * as peerHandlers from "./peer";
 
-export const isAppReady = (): boolean => {
-    return !!app.resolvePlugin("transaction-pool") && !!app.resolvePlugin("blockchain") && !!app.resolvePlugin("p2p");
+export const isAppReady = (): { ready: boolean } => {
+    return {
+        ready:
+            !!app.resolvePlugin("transaction-pool") && !!app.resolvePlugin("blockchain") && !!app.resolvePlugin("p2p"),
+    };
 };
 
 export const getHandlers = (): { [key: string]: string[] } => {

--- a/packages/core-p2p/src/socket-server/worker.ts
+++ b/packages/core-p2p/src/socket-server/worker.ts
@@ -130,7 +130,7 @@ export class Worker extends SCWorker {
             }
 
             // Check that blockchain, tx-pool and p2p are ready
-            const isAppReady: boolean = await this.sendToMasterAsync("p2p.utils.isAppReady");
+            const isAppReady: boolean = (await this.sendToMasterAsync("p2p.utils.isAppReady")).data.ready;
             if (!isAppReady) {
                 req.socket.terminate();
                 return;


### PR DESCRIPTION
## Summary

Fixes #3047 by returning an object rather than a primitive.

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
