### PR TITLE
Block schema validation

### DIFF
--- a/__tests__/unit/crypto/blocks/factory.test.ts
+++ b/__tests__/unit/crypto/blocks/factory.test.ts
@@ -41,6 +41,26 @@ describe("BlockFactory", () => {
             // @ts-ignore
             expect(() => BlockFactory.fromData(blockWithExceptions)).not.toThrow();
         });
+
+        it("should throw on invalid input data - block property has an unexpected value", () => {
+            const b1 = Object.assign({}, blockWithExceptions, { timestamp: 'abcd' });
+            expect(() => BlockFactory.fromData(b1 as any)).toThrowError(
+                /Invalid.*timestamp.*integer.*abcd/i
+            );
+
+            const b2 = Object.assign({}, blockWithExceptions, { totalAmount: 'abcd' });
+            expect(() => BlockFactory.fromData(b2 as any)).toThrowError(
+                /Invalid.*totalAmount.*bignumber.*abcd/i
+            );
+        });
+
+        it("should throw on invalid input data - required block property is missing", () => {
+            const b = Object.assign({}, blockWithExceptions);
+            delete b.generatorPublicKey;
+            expect(() => BlockFactory.fromData(b as any)).toThrowError(
+                /Invalid.*required property.*generatorPublicKey/i
+            );
+        });
     });
 
     describe(".fromJson", () => {

--- a/packages/crypto/src/blocks/block.ts
+++ b/packages/crypto/src/blocks/block.ts
@@ -9,21 +9,40 @@ import { Serializer } from "./serializer";
 
 export class Block implements IBlock {
     public static applySchema(data: IBlockData): IBlockData {
-        const { value, error } = validator.validate("block", data);
+        let result = validator.validate("block", data);
 
-        if (error) {
-            if (
-                isException(value) ||
-                data.transactions.some((transaction: ITransactionData) => isException(transaction))
-            ) {
-                // Validate again without bailing out on the first error to ensure that all properties get properly converted if necessary
-                validator.validateException("block", data);
+        if (!result.error) {
+            return result.value;
+        }
+
+        result = validator.validateException("block", data);
+
+        for (const err of result.errors) {
+            let fatal = false;
+
+            const match = err.dataPath.match(/\.transactions\[([0-9]+)\]/);
+            if (match === null) {
+                if (!isException(data)) {
+                    fatal = true;
+                }
             } else {
-                throw new BlockSchemaError(data.height, error);
+                const txIndex = match[1];
+                const tx = data.transactions[txIndex];
+                if (tx.id === undefined || !isException(tx)) {
+                    fatal = true;
+                }
+            }
+
+            if (fatal) {
+                throw new BlockSchemaError(
+                    data.height,
+                    `Invalid data${err.dataPath ? ' at ' + err.dataPath : ''}: ` +
+                    `${err.message}: ${JSON.stringify(err.data)}`
+                );
             }
         }
 
-        return value;
+        return result.value;
     }
 
     public static deserialize(hexString: string, headerOnly: boolean = false): IBlockData {

--- a/packages/crypto/src/validation/index.ts
+++ b/packages/crypto/src/validation/index.ts
@@ -27,7 +27,7 @@ export class Validator {
     }
 
     public validateException<T = any>(schemaKeyRef: string | boolean | object, data: T): ISchemaValidationResult<T> {
-        const ajv = this.instantiateAjv({ allErrors: true });
+        const ajv = this.instantiateAjv({ allErrors: true, verbose: true });
 
         for (const schema of this.transactionSchemas.values()) {
             this.extendTransactionSchema(ajv, schema);


### PR DESCRIPTION
fix(crypto): strengthen schema validation checks

Check each schema error:
* if it originated from the block, then the block must be an exception
* if it originated from a transaction, then the transaction must be an
exception

Also print the value should validation fail to make it easier to
diagnose problems.
