### PR TITLE
misc(crypto): add devnet milestones

### DIFF
--- a/packages/core-p2p/src/defaults.ts
+++ b/packages/core-p2p/src/defaults.ts
@@ -8,7 +8,7 @@ export const defaults = {
     /**
      * The minimum peer version we expect
      */
-    minimumVersions: ["^2.4 || ^2.5", "^2.4.0-next.0 || ^2.5.0-next.0"],
+    minimumVersions: ["^2.4 || ^2.5 || ^2.6", "^2.4.0-next.0 || ^2.5.0-next.0 || ^2.6.0-next.0"],
     /**
      * The number of peers we expect to be available to start a relay
      */

--- a/packages/crypto/src/networks/devnet/milestones.json
+++ b/packages/crypto/src/networks/devnet/milestones.json
@@ -74,6 +74,12 @@
         }
     },
     {
+        "height": 3967000,
+        "p2p": {
+            "minimumVersions": ["^2.6"]
+        }
+    },
+    {
         "height": 4006000,
         "aip11": true
     }

--- a/packages/crypto/src/networks/devnet/milestones.json
+++ b/packages/crypto/src/networks/devnet/milestones.json
@@ -72,5 +72,9 @@
         "block": {
             "acceptExpiredTransactionTimestamps": false
         }
+    },
+    {
+        "height": 4006000,
+        "aip11": true
     }
 ]


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
Two new devnet milestones:
- Height `3967000`:
The `p2p.minimumVersions` milestone is used to switch to a `2.6` only network after a few days. All <2.6 nodes should get dropped  then.

- Height `4006000`:
The `aip11` milestone which is scheduled to happen next week. That's when the network will switch from V1 to V2 transactions including the new types

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
