### PR TITLE
fix: use strict comparison to decide if a transaction should be enabled

### DIFF
--- a/packages/core-magistrate-transactions/src/handlers/bridgechain-registration.ts
+++ b/packages/core-magistrate-transactions/src/handlers/bridgechain-registration.ts
@@ -22,7 +22,7 @@ export class BridgechainRegistrationTransactionHandler extends Handlers.Transact
     }
 
     public async isActivated(): Promise<boolean> {
-        return !!Managers.configManager.getMilestone().aip11;
+        return Managers.configManager.getMilestone().aip11 === true;
     }
 
     public async bootstrap(connection: Database.IConnection, walletManager: State.IWalletManager): Promise<void> {

--- a/packages/core-magistrate-transactions/src/handlers/bridgechain-resignation.ts
+++ b/packages/core-magistrate-transactions/src/handlers/bridgechain-resignation.ts
@@ -27,7 +27,7 @@ export class BridgechainResignationTransactionHandler extends Handlers.Transacti
     }
 
     public async isActivated(): Promise<boolean> {
-        return !!Managers.configManager.getMilestone().aip11;
+        return Managers.configManager.getMilestone().aip11 === true;
     }
 
     public async bootstrap(connection: Database.IConnection, walletManager: State.IWalletManager): Promise<void> {
@@ -140,11 +140,11 @@ export class BridgechainResignationTransactionHandler extends Handlers.Transacti
         transaction: Interfaces.ITransaction,
         walletManager: State.IWalletManager,
         // tslint:disable-next-line: no-empty
-    ): Promise<void> { }
+    ): Promise<void> {}
 
     public async revertForRecipient(
         transaction: Interfaces.ITransaction,
         walletManager: State.IWalletManager,
         // tslint:disable-next-line:no-empty
-    ): Promise<void> { }
+    ): Promise<void> {}
 }

--- a/packages/core-magistrate-transactions/src/handlers/bridgechain-update.ts
+++ b/packages/core-magistrate-transactions/src/handlers/bridgechain-update.ts
@@ -31,7 +31,7 @@ export class BridgechainUpdateTransactionHandler extends Handlers.TransactionHan
     }
 
     public async isActivated(): Promise<boolean> {
-        return !!Managers.configManager.getMilestone().aip11;
+        return Managers.configManager.getMilestone().aip11 === true;
     }
 
     public async bootstrap(connection: Database.IConnection, walletManager: State.IWalletManager): Promise<void> {

--- a/packages/core-magistrate-transactions/src/handlers/business-registration.ts
+++ b/packages/core-magistrate-transactions/src/handlers/business-registration.ts
@@ -27,7 +27,7 @@ export class BusinessRegistrationTransactionHandler extends Handlers.Transaction
     }
 
     public async isActivated(): Promise<boolean> {
-        return !!Managers.configManager.getMilestone().aip11;
+        return Managers.configManager.getMilestone().aip11 === true;
     }
 
     public async bootstrap(connection: Database.IConnection, walletManager: State.IWalletManager): Promise<void> {

--- a/packages/core-magistrate-transactions/src/handlers/business-resignation.ts
+++ b/packages/core-magistrate-transactions/src/handlers/business-resignation.ts
@@ -21,7 +21,7 @@ export class BusinessResignationTransactionHandler extends Handlers.TransactionH
     }
 
     public async isActivated(): Promise<boolean> {
-        return !!Managers.configManager.getMilestone().aip11;
+        return Managers.configManager.getMilestone().aip11 === true;
     }
 
     public async bootstrap(connection: Database.IConnection, walletManager: State.IWalletManager): Promise<void> {

--- a/packages/core-magistrate-transactions/src/handlers/business-update.ts
+++ b/packages/core-magistrate-transactions/src/handlers/business-update.ts
@@ -23,7 +23,7 @@ export class BusinessUpdateTransactionHandler extends Handlers.TransactionHandle
     }
 
     public async isActivated(): Promise<boolean> {
-        return !!Managers.configManager.getMilestone().aip11;
+        return Managers.configManager.getMilestone().aip11 === true;
     }
 
     public async bootstrap(connection: Database.IConnection, walletManager: State.IWalletManager): Promise<void> {

--- a/packages/core-transactions/src/handlers/delegate-resignation.ts
+++ b/packages/core-transactions/src/handlers/delegate-resignation.ts
@@ -35,7 +35,7 @@ export class DelegateResignationTransactionHandler extends TransactionHandler {
     }
 
     public async isActivated(): Promise<boolean> {
-        return !!Managers.configManager.getMilestone().aip11;
+        return Managers.configManager.getMilestone().aip11 === true;
     }
 
     public async throwIfCannotBeApplied(

--- a/packages/core-transactions/src/handlers/htlc-claim.ts
+++ b/packages/core-transactions/src/handlers/htlc-claim.ts
@@ -29,7 +29,7 @@ export class HtlcClaimTransactionHandler extends TransactionHandler {
     }
 
     public async isActivated(): Promise<boolean> {
-        return !!Managers.configManager.getMilestone().aip11;
+        return Managers.configManager.getMilestone().aip11 === true;
     }
 
     public dynamicFee(

--- a/packages/core-transactions/src/handlers/htlc-lock.ts
+++ b/packages/core-transactions/src/handlers/htlc-lock.ts
@@ -46,7 +46,7 @@ export class HtlcLockTransactionHandler extends TransactionHandler {
     }
 
     public async isActivated(): Promise<boolean> {
-        return !!Managers.configManager.getMilestone().aip11;
+        return Managers.configManager.getMilestone().aip11 === true;
     }
 
     public async throwIfCannotBeApplied(

--- a/packages/core-transactions/src/handlers/htlc-refund.ts
+++ b/packages/core-transactions/src/handlers/htlc-refund.ts
@@ -29,7 +29,7 @@ export class HtlcRefundTransactionHandler extends TransactionHandler {
     }
 
     public async isActivated(): Promise<boolean> {
-        return !!Managers.configManager.getMilestone().aip11;
+        return Managers.configManager.getMilestone().aip11 === true;
     }
 
     public dynamicFee(

--- a/packages/core-transactions/src/handlers/ipfs.ts
+++ b/packages/core-transactions/src/handlers/ipfs.ts
@@ -35,7 +35,7 @@ export class IpfsTransactionHandler extends TransactionHandler {
     }
 
     public async isActivated(): Promise<boolean> {
-        return !!Managers.configManager.getMilestone().aip11;
+        return Managers.configManager.getMilestone().aip11 === true;
     }
 
     public async throwIfCannotBeApplied(

--- a/packages/core-transactions/src/handlers/multi-payment.ts
+++ b/packages/core-transactions/src/handlers/multi-payment.ts
@@ -35,7 +35,7 @@ export class MultiPaymentTransactionHandler extends TransactionHandler {
     }
 
     public async isActivated(): Promise<boolean> {
-        return !!Managers.configManager.getMilestone().aip11;
+        return Managers.configManager.getMilestone().aip11 === true;
     }
 
     public async throwIfCannotBeApplied(


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Use strict comparison to decide if AIP11 is active or not. Using `!!` means any [truthy](https://developer.mozilla.org/en-US/docs/Glossary/Truthy) value would indicate that AIP11 is active.

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
