### PR TITLE
refactor(crypto): overwrite arrays when merging milestones

### DIFF
--- a/__tests__/unit/crypto/managers/config.test.ts
+++ b/__tests__/unit/crypto/managers/config.test.ts
@@ -32,6 +32,18 @@ describe("Configuration", () => {
         expect(configManager.getMilestones()).toEqual(devnet.milestones);
     });
 
+    it('should build milestones without concatenating the "minimumVersions" array', () => {
+        configManager.setHeight(4006000);
+
+        const lastVersions = devnet.milestones
+            .sort((a, b) => a.height - b.height)
+            .find(milestone => !!milestone.p2p && !!milestone.p2p.minimumVersions);
+
+        if (lastVersions && !!configManager.getMilestone().p2p) {
+            expect(configManager.getMilestone().p2p.minimumVersions).toEqual(lastVersions);
+        }
+    });
+
     it("should get milestone for height", () => {
         expect(configManager.getMilestone(21600)).toEqual(devnet.milestones[2]);
     });

--- a/__tests__/unit/crypto/managers/config.test.ts
+++ b/__tests__/unit/crypto/managers/config.test.ts
@@ -33,11 +33,10 @@ describe("Configuration", () => {
     });
 
     it('should build milestones without concatenating the "minimumVersions" array', () => {
-        configManager.setHeight(4006000);
+        const milestones = devnet.milestones.sort((a, b) => a.height - b.height);
+        configManager.setHeight(milestones[0].height);
 
-        const lastVersions = devnet.milestones
-            .sort((a, b) => a.height - b.height)
-            .find(milestone => !!milestone.p2p && !!milestone.p2p.minimumVersions);
+        const lastVersions = milestones.find(milestone => !!milestone.p2p && !!milestone.p2p.minimumVersions);
 
         if (lastVersions && !!configManager.getMilestone().p2p) {
             expect(configManager.getMilestone().p2p.minimumVersions).toEqual(lastVersions);

--- a/__tests__/unit/crypto/managers/config.test.ts
+++ b/__tests__/unit/crypto/managers/config.test.ts
@@ -36,10 +36,10 @@ describe("Configuration", () => {
         const milestones = devnet.milestones.sort((a, b) => a.height - b.height);
         configManager.setHeight(milestones[0].height);
 
-        const lastVersions = milestones.find(milestone => !!milestone.p2p && !!milestone.p2p.minimumVersions);
+        const lastMilestone = milestones.find(milestone => !!milestone.p2p && !!milestone.p2p.minimumVersions);
 
-        if (lastVersions && !!configManager.getMilestone().p2p) {
-            expect(configManager.getMilestone().p2p.minimumVersions).toEqual(lastVersions);
+        if (lastMilestone && lastMilestone.p2p && configManager.getMilestone().p2p) {
+            expect(configManager.getMilestone().p2p.minimumVersions).toEqual(lastMilestone.p2p.minimumVersions);
         }
     });
 

--- a/packages/crypto/src/managers/config.ts
+++ b/packages/crypto/src/managers/config.ts
@@ -100,8 +100,12 @@ export class ConfigManager {
 
         let lastMerged = 0;
 
+        const overwriteMerge = (dest, source, options) => source;
+
         while (lastMerged < this.milestones.length - 1) {
-            this.milestones[lastMerged + 1] = deepmerge(this.milestones[lastMerged], this.milestones[lastMerged + 1]);
+            this.milestones[lastMerged + 1] = deepmerge(this.milestones[lastMerged], this.milestones[lastMerged + 1], {
+                arrayMerge: overwriteMerge,
+            });
             lastMerged++;
         }
     }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

Instead of concatenating arrays, overwrite them with the `source` array. In the particular case of `minimumVersions` we don't want to keep older values around, this PR is a solution targeted at this case and is not intended as a general solution for merging arrays - although as of now the `minimumVersions` array is the only array used in milestones.

Possibly closes #3105.

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
