### PR TITLE
fix(core-database): set last height before initializing last block to use correct milestones

### DIFF
--- a/packages/core-database/src/database-service.ts
+++ b/packages/core-database/src/database-service.ts
@@ -597,6 +597,16 @@ export class DatabaseService implements Database.IDatabaseService {
         let lastBlock: Interfaces.IBlock;
         let tries = 5;
 
+        // Ensure the config manager is initialized, before attempting to call `fromData`
+        // which otherwise uses potentially wrong milestones.
+        let lastHeight: number = 1;
+        const latest: Interfaces.IBlockData = await this.connection.blocksRepository.latest();
+        if (latest) {
+            lastHeight = latest.height;
+        }
+
+        Managers.configManager.setHeight(lastHeight);
+
         const getLastBlock = async (): Promise<Interfaces.IBlock> => {
             try {
                 return await this.getLastBlock();


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
