### PR TITLE
fix(core-blockchain): add transactions back to pool only after reverting all blocks

### DIFF
--- a/__tests__/functional/transaction-forging/bridgechain-registration.test.ts
+++ b/__tests__/functional/transaction-forging/bridgechain-registration.test.ts
@@ -48,7 +48,7 @@ describe("Transaction Forging - Bridgechain registration", () => {
                 .withPassphrase(secrets[0])
                 .createOne();
 
-            expect(bridgechainRegistration).toBeRejected();
+            await expect(bridgechainRegistration).toBeRejected();
             await support.snoozeForBlock(1);
             await expect(bridgechainRegistration.id).not.toBeForged();
         });
@@ -73,7 +73,7 @@ describe("Transaction Forging - Bridgechain registration", () => {
                 .withPassphrase(secrets[0])
                 .createOne();
 
-            expect(bridgechainRegistration).toBeRejected();
+            await expect(bridgechainRegistration).toBeRejected();
             await support.snoozeForBlock(1);
             await expect(bridgechainRegistration.id).not.toBeForged();
         });

--- a/__tests__/unit/core-blockchain/state-machine.test.ts
+++ b/__tests__/unit/core-blockchain/state-machine.test.ts
@@ -381,8 +381,8 @@ describe("State Machine", () => {
                 const loggerInfo = jest.spyOn(logger, "info");
 
                 const methodsCalled = [
-                    // @ts-ignore
-                    jest.spyOn(blockchain.transactionPool, "buildWallets").mockReturnValue(true),
+                    // // @ts-ignore
+                    // jest.spyOn(blockchain.transactionPool, "buildWallets").mockReturnValue(true),
                     // @ts-ignore
                     jest.spyOn(getMonitor, "refreshPeersAfterFork").mockReturnValue(true),
                     jest.spyOn(blockchain, "clearAndStopQueue"),

--- a/packages/core-blockchain/src/state-machine.ts
+++ b/packages/core-blockchain/src/state-machine.ts
@@ -270,7 +270,6 @@ blockchainMachine.actionMap = (blockchain: Blockchain) => ({
 
         logger.info(`Removed ${pluralize("block", blocksToRemove, true)}`);
 
-        await blockchain.transactionPool.buildWallets();
         await blockchain.p2p.getMonitor().refreshPeersAfterFork();
 
         blockchain.dispatch("SUCCESS");

--- a/packages/core-database/src/database-service.ts
+++ b/packages/core-database/src/database-service.ts
@@ -429,7 +429,7 @@ export class DatabaseService implements Database.IDatabaseService {
 
     public async revertBlock(block: Interfaces.IBlock): Promise<void> {
         await this.revertRound(block.data.height);
-        this.walletManager.revertBlock(block);
+        await this.walletManager.revertBlock(block);
 
         assert(this.blocksInCurrentRound.pop().data.id === block.data.id);
 

--- a/packages/core-interfaces/src/core-transaction-pool/connection.ts
+++ b/packages/core-interfaces/src/core-transaction-pool/connection.ts
@@ -24,6 +24,7 @@ export interface IConnection {
     }>;
     acceptChainedBlock(block: Interfaces.IBlock): Promise<void>;
     buildWallets(): Promise<void>;
+    replay(transactions: Interfaces.ITransaction[]): Promise<void>;
     flush(): void;
     getTransaction(id: string): Promise<Interfaces.ITransaction>;
     getTransactionIdsForForging(start: number, size: number): Promise<string[]>;


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
Replay all transactions on the pool in the correct order for sender and recipient after a rollback finished. Otherwise they cannot be applied due to nonce conflicts.

I.e.
```
[2019-10-24 02:26:16.101] ERROR: Cannot apply a transaction with nonce 32: the sender 03395ce74f7d696edee6e34bc68b7c41348f558ee99766389adcf93e6291d8c37b has nonce 32.
[2019-10-24 02:26:16.104] ERROR: Cannot apply a transaction with nonce 50: the sender 02afe630a4feaacdb12162a0107ac395189548246a0c148ebfdb79641a25778a16 has nonce 51.
[2019-10-24 02:26:16.106] ERROR: Cannot apply a transaction with nonce 51: the sender 02afe630a4feaacdb12162a0107ac395189548246a0c148ebfdb79641a25778a16 has nonce 51.
[2019-10-24 02:26:16.107] ERROR: Cannot apply a transaction with nonce 58: the sender 02ec03ed1353c578a79dec8b20f56f253cc929c5b5a9550598592ab6fbccee1a7e has nonce 60.
[2019-10-24 02:26:16.113] ERROR: Cannot apply a transaction with nonce 59: the sender 02ec03ed1353c578a79dec8b20f56f253cc929c5b5a9550598592ab6fbccee1a7e has nonce 60.
[2019-10-24 02:26:16.115] ERROR: Cannot apply a transaction with nonce 60: the sender 02ec03ed1353c578a79dec8b20f56f253cc929c5b5a9550598592ab6fbccee1a7e has nonce 60.
[2019-10-24 02:26:16.118] ERROR: Cannot apply a transaction with nonce 46: the sender 03b73401ada208b1c79522bf9698c74b6e40cb7d3f645566e5fd33053a955aa3b9 has nonce 48.
[2019-10-24 02:26:16.119] ERROR: Cannot apply a transaction with nonce 47: the sender 03b73401ada208b1c79522bf9698c74b6e40cb7d3f645566e5fd33053a955aa3b9 has nonce 48.
[2019-10-24 02:26:16.128] ERROR: Cannot apply a transaction with nonce 48: the sender 03b73401ada208b1c79522bf9698c74b6e40cb7d3f645566e5fd33053a955aa3b9 has nonce 48
```

Also adds a missing await call, which could sometimes cause some weird side effects.

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [X] Ready to be merged

<!-- Feel free to add additional comments. -->
