### PR TITLE
fix(core): read `paths.config` instead of env variable

### DIFF
--- a/__tests__/unit/core-transaction-pool/__stubs__/connection.ts
+++ b/__tests__/unit/core-transaction-pool/__stubs__/connection.ts
@@ -117,6 +117,10 @@ export class Connection implements TransactionPool.IConnection {
         return;
     }
 
+    public async replay(transactions: Interfaces.ITransaction[]): Promise<void> {
+        return;
+    }
+
     public purgeByPublicKey(senderPublicKey: string): void {
         return;
     }

--- a/packages/core/src/commands/chain/replay.ts
+++ b/packages/core/src/commands/chain/replay.ts
@@ -21,9 +21,9 @@ export class ReplayCommand extends BaseCommand {
     };
 
     public async run(): Promise<void> {
-        const { flags } = await this.parseWithNetwork(ReplayCommand);
+        const { flags, paths } = await this.parseWithNetwork(ReplayCommand);
 
-        await setUpLite(flags);
+        await setUpLite(flags, paths);
 
         if (!app.has("blockchain")) {
             this.error("The @arkecosystem/core-blockchain plugin is not installed.");

--- a/packages/core/src/commands/core/run.ts
+++ b/packages/core/src/commands/core/run.ts
@@ -43,12 +43,12 @@ $ ark core:run --launchMode=seed
     };
 
     public async run(): Promise<void> {
-        const { flags } = await this.parseWithNetwork(RunCommand);
+        const { flags, paths } = await this.parseWithNetwork(RunCommand);
 
         await this.buildApplication(
             app,
             flags,
-            deepmerge(getCliConfig(flags), {
+            deepmerge(getCliConfig(flags, paths), {
                 exclude: [],
                 options: {
                     "@arkecosystem/core-p2p": this.buildPeerOptions(flags),

--- a/packages/core/src/commands/forger/run.ts
+++ b/packages/core/src/commands/forger/run.ts
@@ -26,12 +26,12 @@ $ ark forger:run --bip38="..." --password="..."
     };
 
     public async run(): Promise<void> {
-        const { flags } = await this.parseWithNetwork(RunCommand);
+        const { flags, paths } = await this.parseWithNetwork(RunCommand);
 
         await this.buildApplication(
             app,
             flags,
-            deepmerge(getCliConfig(flags), {
+            deepmerge(getCliConfig(flags, paths), {
                 include: [
                     "@arkecosystem/core-event-emitter",
                     "@arkecosystem/core-config",

--- a/packages/core/src/commands/relay/run.ts
+++ b/packages/core/src/commands/relay/run.ts
@@ -42,12 +42,12 @@ $ ark relay:run --launchMode=seed
     };
 
     public async run(): Promise<void> {
-        const { flags } = await this.parseWithNetwork(RunCommand);
+        const { flags, paths } = await this.parseWithNetwork(RunCommand);
 
         await super.buildApplication(
             app,
             flags,
-            deepmerge(getCliConfig(flags), {
+            deepmerge(getCliConfig(flags, paths), {
                 exclude: ["@arkecosystem/core-forger"],
                 options: {
                     "@arkecosystem/core-p2p": this.buildPeerOptions(flags),

--- a/packages/core/src/commands/snapshot/dump.ts
+++ b/packages/core/src/commands/snapshot/dump.ts
@@ -24,9 +24,9 @@ export class DumpCommand extends BaseCommand {
     };
 
     public async run(): Promise<void> {
-        const { flags } = await this.parseWithNetwork(DumpCommand);
+        const { flags, paths } = await this.parseWithNetwork(DumpCommand);
 
-        await setUpLite(flags);
+        await setUpLite(flags, paths);
 
         if (!app.has("snapshots")) {
             this.error("The @arkecosystem/core-snapshots plugin is not installed.");

--- a/packages/core/src/commands/snapshot/restore.ts
+++ b/packages/core/src/commands/snapshot/restore.ts
@@ -27,9 +27,9 @@ export class RestoreCommand extends BaseCommand {
     };
 
     public async run(): Promise<void> {
-        const { flags } = await this.parseWithNetwork(RestoreCommand);
+        const { flags, paths } = await this.parseWithNetwork(RestoreCommand);
 
-        await setUpLite(flags);
+        await setUpLite(flags, paths);
 
         if (!app.has("snapshots")) {
             this.error("The @arkecosystem/core-snapshots plugin is not installed.");

--- a/packages/core/src/commands/snapshot/rollback.ts
+++ b/packages/core/src/commands/snapshot/rollback.ts
@@ -19,9 +19,9 @@ export class RollbackCommand extends BaseCommand {
     };
 
     public async run(): Promise<void> {
-        const { flags } = await this.parseWithNetwork(RollbackCommand);
+        const { flags, paths } = await this.parseWithNetwork(RollbackCommand);
 
-        await setUpLite(flags);
+        await setUpLite(flags, paths);
 
         if (!app.has("snapshots")) {
             this.error("The @arkecosystem/core-snapshots plugin is not installed.");

--- a/packages/core/src/commands/snapshot/truncate.ts
+++ b/packages/core/src/commands/snapshot/truncate.ts
@@ -7,9 +7,9 @@ export class TruncateCommand extends BaseCommand {
     public static description: string = "truncate blockchain database";
 
     public async run(): Promise<void> {
-        const { flags } = await this.parseWithNetwork(TruncateCommand);
+        const { flags, paths } = await this.parseWithNetwork(TruncateCommand);
 
-        await setUpLite(flags);
+        await setUpLite(flags, paths);
 
         if (!app.has("snapshots")) {
             this.error("The @arkecosystem/core-snapshots plugin is not installed.");

--- a/packages/core/src/commands/snapshot/verify.ts
+++ b/packages/core/src/commands/snapshot/verify.ts
@@ -19,9 +19,9 @@ export class VerifyCommand extends BaseCommand {
     };
 
     public async run(): Promise<void> {
-        const { flags } = await this.parseWithNetwork(VerifyCommand);
+        const { flags, paths } = await this.parseWithNetwork(VerifyCommand);
 
-        await setUpLite(flags);
+        await setUpLite(flags, paths);
 
         if (!app.has("snapshots")) {
             this.error("The @arkecosystem/core-snapshots plugin is not installed.");

--- a/packages/core/src/helpers/replay.ts
+++ b/packages/core/src/helpers/replay.ts
@@ -1,16 +1,17 @@
 import { app } from "@arkecosystem/core-container";
 import { Container } from "@arkecosystem/core-interfaces";
 import deepmerge from "deepmerge";
+import envPaths from "env-paths";
 import { getCliConfig } from "../utils";
 
 // tslint:disable-next-line:no-var-requires
 const { version } = require("../../package.json");
 
-export const setUpLite = async (options): Promise<Container.IContainer> => {
+export const setUpLite = async (options, paths: envPaths.Paths): Promise<Container.IContainer> => {
     await app.setUp(
         version,
         options,
-        deepmerge(getCliConfig(options), {
+        deepmerge(getCliConfig(options, paths), {
             options: {
                 "@arkecosystem/core-blockchain": { replay: true },
             },

--- a/packages/core/src/helpers/snapshot.ts
+++ b/packages/core/src/helpers/snapshot.ts
@@ -1,6 +1,7 @@
 import { app } from "@arkecosystem/core-container";
 import { Container } from "@arkecosystem/core-interfaces";
 import deepmerge from "deepmerge";
+import envPaths from "env-paths";
 import { lstatSync, readdirSync } from "fs";
 import prompts from "prompts";
 import { CommandFlags } from "../types";
@@ -9,11 +10,11 @@ import { getCliConfig } from "../utils";
 // tslint:disable-next-line:no-var-requires
 const { version } = require("../../package.json");
 
-export const setUpLite = async (options): Promise<Container.IContainer> => {
+export const setUpLite = async (options, paths: envPaths.Paths): Promise<Container.IContainer> => {
     await app.setUp(
         version,
         options,
-        deepmerge(getCliConfig(options), {
+        deepmerge(getCliConfig(options, paths), {
             include: [
                 "@arkecosystem/core-event-emitter",
                 "@arkecosystem/core-logger-pino",

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1,5 +1,6 @@
 import Table from "cli-table3";
 import dottie from "dottie";
+import envPaths from "env-paths";
 import envfile from "envfile";
 import { writeFileSync } from "fs-extra";
 import { existsSync } from "fs-extra";
@@ -31,8 +32,12 @@ export const updateEnvironmentVariables = (envFile: string, variables: Environme
     writeFileSync(envFile, envfile.stringifySync(env));
 };
 
-export const getCliConfig = (options: Record<string, any>, defaultValue = {}): Record<string, any> => {
-    const configPath: string = `${process.env.CORE_PATH_CONFIG}/app.js`;
+export const getCliConfig = (
+    options: Record<string, any>,
+    paths: envPaths.Paths,
+    defaultValue = {},
+): Record<string, any> => {
+    const configPath: string = `${paths.config}/app.js`;
     if (!existsSync(configPath)) {
         return defaultValue;
     }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
Fixes the config lookup. Additionally, `packages/core/bin/config/{network}/app.js` needs to be manually copied to `~/.config/ark-core/{network}` or `ark config:reset`.

Resolves:
```
10|ark-forger  | [2019-10-26 11:44:26.760] ERROR: InvalidTransactionBytesError: Failed to deserialize transaction, encountered invalid bytes: Unknown transaction type: 2/2
10|ark-forger  |     at Function.fromBytesUnsafe (/home/ark/core/packages/crypto/dist/transactions/factory.js:34:19)
10|ark-forger  |     at response.transactions.map (/home/ark/core/packages/core-forger/dist/manager.js:147:106)
10|ark-forger  |     at Array.map (<anonymous>)
10|ark-forger  |     at ForgerManager.getTransactionsForForging 
```
<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
