### PR TITLE
refactor(core-database): convert htlc lock vendorfield to string during bootstrap

### DIFF
--- a/packages/core-transactions/src/handlers/htlc-lock.ts
+++ b/packages/core-transactions/src/handlers/htlc-lock.ts
@@ -28,7 +28,9 @@ export class HtlcLockTransactionHandler extends TransactionHandler {
                 amount: Utils.BigNumber.make(transaction.amount),
                 recipientId: transaction.recipientId,
                 timestamp: transaction.timestamp,
-                vendorField: transaction.vendorField ? transaction.vendorField : undefined,
+                vendorField: transaction.vendorField
+                    ? Buffer.from(transaction.vendorField, "hex").toString("utf8")
+                    : undefined,
                 ...transaction.asset.lock,
             };
             wallet.setAttribute("htlc.locks", locks);


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Closes #3134.

Judging by the current state of the dexplorer node (https://dexplorer.ark.io/api/locks) the vendorfield of bootstrapped lock transactions isn't converted to strings. New transactions applied to senders however show the vendorfield as expected.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
