### PR TITLE
fix(core-magistrate-crypto): improve 'name' field validation to avoid illegal characters

### DIFF
--- a/__tests__/functional/transaction-forging/bridgechain-registration.test.ts
+++ b/__tests__/functional/transaction-forging/bridgechain-registration.test.ts
@@ -53,6 +53,38 @@ describe("Transaction Forging - Bridgechain registration", () => {
             await expect(bridgechainRegistration.id).not.toBeForged();
         });
 
+        it("should reject bridgechain registration, because bridgechain name contains unicode control characters [Signed with 1 Passphrase]", async () => {
+            // Bridgechain registration
+            const bridgechainRegistration = TransactionFactory.bridgechainRegistration({
+                name: "\u0008mybridgechain",
+                seedNodes: ["1.2.3.4", "2001:0db8:85a3:0000:0000:8a2e:0370:7334"],
+                genesisHash: "127e6fbfe24a750e72930c220a8e138275656b8e5d8f48a98c3c92df2caba935",
+                bridgechainRepository: "somerepository",
+            })
+                .withPassphrase(secrets[0])
+                .createOne();
+
+            await expect(bridgechainRegistration).toBeRejected();
+            await support.snoozeForBlock(1);
+            await expect(bridgechainRegistration.id).not.toBeForged();
+        });
+
+        it("should reject bridgechain registration, because bridgechain name contains disallowed characters [Signed with 1 Passphrase]", async () => {
+            // Bridgechain registration
+            const bridgechainRegistration = TransactionFactory.bridgechainRegistration({
+                name: "mybridgech@in",
+                seedNodes: ["1.2.3.4", "2001:0db8:85a3:0000:0000:8a2e:0370:7334"],
+                genesisHash: "127e6fbfe24a750e72930c220a8e138275656b8e5d8f48a98c3c92df2caba935",
+                bridgechainRepository: "somerepository",
+            })
+                .withPassphrase(secrets[0])
+                .createOne();
+
+            await expect(bridgechainRegistration).toBeRejected();
+            await support.snoozeForBlock(1);
+            await expect(bridgechainRegistration.id).not.toBeForged();
+        });
+
         it("should reject bridgechain registration, because business resigned [Signed with 1 Passphrase]", async () => {
             // Business resignation
             const businessResignation = TransactionFactory.businessResignation()

--- a/__tests__/functional/transaction-forging/business-registration.test.ts
+++ b/__tests__/functional/transaction-forging/business-registration.test.ts
@@ -47,6 +47,34 @@ describe("Transaction Forging - Business registration", () => {
             await support.snoozeForBlock(1);
             await expect(businessRegistration.id).not.toBeForged();
         });
+
+        it("should be rejected, because name business contains unicode control characters [Signed with 1 Passphrase]", async () => {
+            // Registering a business with unicode control characters in its name
+            const businessRegistration = TransactionFactory.businessRegistration({
+                name: "\u0000ark",
+                website: "ark.io",
+            })
+                .withPassphrase(passphrase)
+                .createOne();
+
+            await expect(businessRegistration).toBeRejected();
+            await support.snoozeForBlock(1);
+            await expect(businessRegistration.id).not.toBeForged();
+        });
+
+        it("should be rejected, because business name contains disallowed characters [Signed with 1 Passphrase]", async () => {
+            // Registering a business with disallowed characters in its name
+            const businessRegistration = TransactionFactory.businessRegistration({
+                name: "ark+",
+                website: "ark.io",
+            })
+                .withPassphrase(passphrase)
+                .createOne();
+
+            await expect(businessRegistration).toBeRejected();
+            await support.snoozeForBlock(1);
+            await expect(businessRegistration.id).not.toBeForged();
+        });
     });
 
     describe("Signed with 2 Passphrases", () => {

--- a/__tests__/functional/transaction-forging/business-update.test.ts
+++ b/__tests__/functional/transaction-forging/business-update.test.ts
@@ -55,6 +55,56 @@ describe("Transaction Forging - Business update", () => {
             await support.snoozeForBlock(1);
             await expect(businessUpdate.id).not.toBeForged();
         });
+
+        it("should be rejected, because updated business name contains unicode control characters [Signed with 1 Passphrase]", async () => {
+            // Registering a business
+            const businessRegistration = TransactionFactory.businessRegistration({
+                name: "ark-ecosystem",
+                website: "ark.io",
+            })
+                .withPassphrase(secrets[3])
+                .createOne();
+
+            await expect(businessRegistration).toBeAccepted();
+            await support.snoozeForBlock(1);
+            await expect(businessRegistration.id).toBeForged();
+
+            // Updating a business
+            const businessUpdate = TransactionFactory.businessUpdate({
+                name: "\u0000ark",
+            })
+                .withPassphrase(secrets[3])
+                .createOne();
+
+            expect(businessUpdate).toBeRejected();
+            await support.snoozeForBlock(1);
+            await expect(businessUpdate.id).not.toBeForged();
+        });
+
+        it("should be rejected, because updated business name contains disallowed characters [Signed with 1 Passphrase]", async () => {
+            // Registering a business
+            const businessRegistration = TransactionFactory.businessRegistration({
+                name: "ark",
+                website: "ark.io",
+            })
+                .withPassphrase(secrets[4])
+                .createOne();
+
+            await expect(businessRegistration).toBeAccepted();
+            await support.snoozeForBlock(1);
+            await expect(businessRegistration.id).toBeForged();
+
+            // Updating a business
+            const businessUpdate = TransactionFactory.businessUpdate({
+                name: "ark:)",
+            })
+                .withPassphrase(secrets[4])
+                .createOne();
+
+            expect(businessUpdate).toBeRejected();
+            await support.snoozeForBlock(1);
+            await expect(businessUpdate.id).not.toBeForged();
+        });
     });
 
     describe("Signed with 2 Passphases", () => {

--- a/packages/core-magistrate-crypto/src/transactions/bridgechain-registration.ts
+++ b/packages/core-magistrate-crypto/src/transactions/bridgechain-registration.ts
@@ -30,9 +30,7 @@ export class BridgechainRegistrationTransaction extends Transactions.Transaction
                             additionalProperties: false,
                             properties: {
                                 name: {
-                                    type: "string",
-                                    minLength: 1,
-                                    maxLength: 40,
+                                    $ref: "genericName",
                                 },
                                 seedNodes: seedNodesSchema,
                                 genesisHash: {

--- a/packages/core-magistrate-crypto/src/transactions/utils/business-schema.ts
+++ b/packages/core-magistrate-crypto/src/transactions/utils/business-schema.ts
@@ -1,8 +1,6 @@
 export const businessSchema = {
     name: {
-        type: "string",
-        minLength: 1,
-        maxLength: 40,
+        $ref: "genericName",
     },
     website: {
         type: "string",

--- a/packages/crypto/src/validation/schemas.ts
+++ b/packages/crypto/src/validation/schemas.ts
@@ -51,6 +51,11 @@ export const schemas = {
         ],
     },
 
+    genericName: {
+        $id: "genericName",
+        allOf: [{ type: "string", pattern: "^[a-zA-Z0-9_-]+$" }, { minLength: 1, maxLength: 40 }],
+    },
+
     blockHeader: {
         $id: "blockHeader",
         type: "object",


### PR DESCRIPTION
## Summary

Closes #3125.

The chosen validation for Business and Bridgechain names is a RegEx that validates for alphanumeric characters, with the addition of a lowercase and dash. This validation has been saved as the 'genericName' schema.

Addtional schemas and validation on the `website` and `repository` fields has intentionally not been created as it's out of scope of this PR (+ ongoing discussion in #3106 ).

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [X] Ready to be merged

<!-- Feel free to add additional comments. -->
