### PR TITLE
fix(core-p2p): call next() with Error for "app is not ready"

### DIFF
--- a/packages/core-p2p/src/socket-server/worker.ts
+++ b/packages/core-p2p/src/socket-server/worker.ts
@@ -121,6 +121,7 @@ export class Worker extends SCWorker {
             // Check that blockchain, tx-pool and p2p are ready
             const isAppReady: boolean = (await this.sendToMasterAsync("p2p.utils.isAppReady")).data.ready;
             if (!isAppReady) {
+                next(new Error("Application is not ready"));
                 return;
             }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
When application is not ready, we don't want to terminate brutally socket, but we do not want either to let the request proceed as our plugins are not up and running and we would be unable to provide the data requested.

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
