### PR TITLE
chore(core-database): remove misleading order by expirationValue

### DIFF
--- a/packages/core-database/src/repositories/wallets-business-repository.ts
+++ b/packages/core-database/src/repositories/wallets-business-repository.ts
@@ -213,7 +213,7 @@ export class WalletsBusinessRepository implements Database.IWalletsBusinessRepos
         return {
             query,
             entries,
-            defaultOrder: ["expirationValue", "asc"],
+            defaultOrder: ["lockId", "asc"],
         };
     }
 


### PR DESCRIPTION
expirationValue could be either "height of the blockchain" or "seconds
since the genesis block", so sorting by it gives some misleading
impression that the returned results are sorted by expiration when they
are in fact not.

It is not possible to reliably convert from height to seconds, thus
ditch the ordering by expirationValue and order by lockId which will at
least deterministically return the results in the same order every time.

Closes https://github.com/ArkEcosystem/core/issues/3088

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
