### PR TITLE
fix(core): prevent snapshot commands from running if core is running

### DIFF
--- a/packages/core/src/commands/snapshot/dump.ts
+++ b/packages/core/src/commands/snapshot/dump.ts
@@ -26,6 +26,10 @@ export class DumpCommand extends BaseCommand {
     public async run(): Promise<void> {
         const { flags, paths } = await this.parseWithNetwork(DumpCommand);
 
+        this.abortRunningProcess(`${flags.token}-core`);
+        this.abortRunningProcess(`${flags.token}-forger`);
+        this.abortRunningProcess(`${flags.token}-relay`);
+
         await setUpLite(flags, paths);
 
         if (!app.has("snapshots")) {

--- a/packages/core/src/commands/snapshot/restore.ts
+++ b/packages/core/src/commands/snapshot/restore.ts
@@ -29,6 +29,10 @@ export class RestoreCommand extends BaseCommand {
     public async run(): Promise<void> {
         const { flags, paths } = await this.parseWithNetwork(RestoreCommand);
 
+        this.abortRunningProcess(`${flags.token}-core`);
+        this.abortRunningProcess(`${flags.token}-forger`);
+        this.abortRunningProcess(`${flags.token}-relay`);
+
         await setUpLite(flags, paths);
 
         if (!app.has("snapshots")) {

--- a/packages/core/src/commands/snapshot/rollback.ts
+++ b/packages/core/src/commands/snapshot/rollback.ts
@@ -21,6 +21,10 @@ export class RollbackCommand extends BaseCommand {
     public async run(): Promise<void> {
         const { flags, paths } = await this.parseWithNetwork(RollbackCommand);
 
+        this.abortRunningProcess(`${flags.token}-core`);
+        this.abortRunningProcess(`${flags.token}-forger`);
+        this.abortRunningProcess(`${flags.token}-relay`);
+
         await setUpLite(flags, paths);
 
         if (!app.has("snapshots")) {

--- a/packages/core/src/commands/snapshot/truncate.ts
+++ b/packages/core/src/commands/snapshot/truncate.ts
@@ -9,6 +9,10 @@ export class TruncateCommand extends BaseCommand {
     public async run(): Promise<void> {
         const { flags, paths } = await this.parseWithNetwork(TruncateCommand);
 
+        this.abortRunningProcess(`${flags.token}-core`);
+        this.abortRunningProcess(`${flags.token}-forger`);
+        this.abortRunningProcess(`${flags.token}-relay`);
+
         await setUpLite(flags, paths);
 
         if (!app.has("snapshots")) {

--- a/packages/core/src/commands/snapshot/verify.ts
+++ b/packages/core/src/commands/snapshot/verify.ts
@@ -21,6 +21,10 @@ export class VerifyCommand extends BaseCommand {
     public async run(): Promise<void> {
         const { flags, paths } = await this.parseWithNetwork(VerifyCommand);
 
+        this.abortRunningProcess(`${flags.token}-core`);
+        this.abortRunningProcess(`${flags.token}-forger`);
+        this.abortRunningProcess(`${flags.token}-relay`);
+
         await setUpLite(flags, paths);
 
         if (!app.has("snapshots")) {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Abort the execution of snapshots command if any core process is active to avoid unexpected side-effects.

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
