### PR TITLE
fix(core-magistrate-transactions): check for an exception before checking for invalid fees

### DIFF
--- a/packages/core-magistrate-transactions/src/handlers/magistrate-handler.ts
+++ b/packages/core-magistrate-transactions/src/handlers/magistrate-handler.ts
@@ -17,6 +17,10 @@ export abstract class MagistrateTransactionHandler extends Handlers.TransactionH
         wallet: State.IWallet,
         walletManager: State.IWalletManager,
     ): Promise<void> {
+        if (Utils.isException(transaction.data)) {
+            return;
+        }
+
         if (!transaction.data.fee.isEqualTo(this.getConstructor().staticFee())) {
             throw new InvalidFeeError();
         }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Exceptions for https://github.com/ArkEcosystem/core/commit/312abcfe70d1c8055ef82380c00a8a8acd284225 won't work because the invalid fees are checked before exceptions are checked.

Needed for https://github.com/ArkEcosystem/core/pull/3214

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
