### PR TITLE
test(core-p2p): fix mock common block

### DIFF
--- a/__tests__/integration/core-p2p/peer-communicator.test.ts
+++ b/__tests__/integration/core-p2p/peer-communicator.test.ts
@@ -156,13 +156,18 @@ describe("PeerCommunicator", () => {
 
         it("should return true when peer has common block", async () => {
             await socketManager.resetAllMocks();
-            await socketManager.addMock("getCommonBlocks", { common: genesisBlock });
 
-            const commonBlocks = await communicator.hasCommonBlocks(stubPeer, [genesisBlock.id]);
+            const common = {
+                id: genesisBlock.id,
+                height: genesisBlock.height,
+                previousBlock: genesisBlock.previousBlock,
+                timestamp: genesisBlock.timestamp,
+            };
+            await socketManager.addMock("getCommonBlocks", { common });
 
-            expect(commonBlocks.id).toBe(genesisBlock.id);
-            expect(commonBlocks.height).toBe(genesisBlock.height);
-            expect(commonBlocks.transactions).toHaveLength(255);
+            const commonBlock = await communicator.hasCommonBlocks(stubPeer, [genesisBlock.id]);
+
+            expect(commonBlock).toEqual(common);
         });
     });
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

In "real life", common block response only has a few properties.

We mocked it in integration tests with a full block, the genesis block, which was causing the integration tests to fail as we were sending too large data to the p2p endpoint.

This fixes the test by mocking with a "valid" common block object.

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
