### PR TITLE
refactor(core-api): validate expiration type based on enum

### DIFF
--- a/packages/core-api/src/handlers/locks/schema.ts
+++ b/packages/core-api/src/handlers/locks/schema.ts
@@ -1,3 +1,4 @@
+import { Enums } from "@arkecosystem/crypto";
 import Joi from "@hapi/joi";
 import { pagination } from "../shared/schemas/pagination";
 
@@ -24,7 +25,8 @@ export const index: object = {
             expirationValue: Joi.number()
                 .integer()
                 .min(0),
-            expirationType: Joi.number().only(1, 2),
+            expirationType: Joi.number()
+                .only(...Object.values(Enums.HtlcLockExpirationType)),
         },
     },
 };
@@ -76,7 +78,8 @@ export const search: object = {
         vendorField: Joi.string()
             .min(1)
             .max(255),
-        expirationType: Joi.number().only(1, 2),
+        expirationType: Joi.number()
+            .only(...Object.values(Enums.HtlcLockExpirationType)),
         expirationValue: Joi.object().keys({
             from: Joi.number()
                 .integer()


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Changes the schema for `expirationType` to be based on the `HtlcLockExpirationType` enum instead of using hardcoded values.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
