### PR TITLE
feat(core-api): filter locks by expiration status

### DIFF
--- a/__tests__/integration/core-api/handlers/locks.test.ts
+++ b/__tests__/integration/core-api/handlers/locks.test.ts
@@ -46,7 +46,7 @@ describe("API 2.0 - Locks", () => {
                     secretHash: transaction.id,
                     expiration: {
                         type: j % 2 === 0 ? 1 : 2,
-                        value: 100 * (j + 1),
+                        value: !j ? 0 : (100 * (j + 1)),
                     },
                     timestamp: (i + 1) * 100000,
                 };
@@ -99,7 +99,7 @@ describe("API 2.0 - Locks", () => {
         });
 
         it("should GET all the locks that are not expired", async () => {
-            const response = await utils.request("GET", "locks", { isExpired: true });
+            const response = await utils.request("GET", "locks", { isExpired: false });
             expect(response).toBeSuccessfulResponse();
             expect(response.data.data).toBeArray();
             expect(response.data.data).not.toBeEmpty();

--- a/__tests__/integration/core-api/handlers/locks.test.ts
+++ b/__tests__/integration/core-api/handlers/locks.test.ts
@@ -71,7 +71,7 @@ describe("API 2.0 - Locks", () => {
             const response = await utils.request("GET", "locks", { orderBy: "expirationValue:asc" });
             expect(response).toBeSuccessfulResponse();
             expect(response.data.data).toBeArray();
-            expect(response.data.data[0].expirationValue).toBe(100);
+            expect(response.data.data[0].expirationValue).toBe(0);
         });
 
         it("should GET all the locks by epoch expiration", async () => {
@@ -95,7 +95,7 @@ describe("API 2.0 - Locks", () => {
             expect(response).toBeSuccessfulResponse();
             expect(response.data.data).toBeArray();
             expect(response.data.data).not.toBeEmpty();
-            expect(response.data.data.every(lock => !lock.isExpired)).toBeTrue();
+            expect(response.data.data.every(lock => lock.isExpired)).toBeTrue();
         });
 
         it("should GET all the locks that are not expired", async () => {
@@ -103,7 +103,7 @@ describe("API 2.0 - Locks", () => {
             expect(response).toBeSuccessfulResponse();
             expect(response.data.data).toBeArray();
             expect(response.data.data).not.toBeEmpty();
-            expect(response.data.data.every(lock => lock.isExpired)).toBeTrue();
+            expect(response.data.data.every(lock => !lock.isExpired)).toBeTrue();
         });
 
         describe("orderBy", () => {

--- a/__tests__/integration/core-api/handlers/locks.test.ts
+++ b/__tests__/integration/core-api/handlers/locks.test.ts
@@ -90,6 +90,22 @@ describe("API 2.0 - Locks", () => {
             expect(response.data.data.every(lock => lock.expirationType === 2)).toBeTrue();
         });
 
+        it("should GET all the locks that are expired", async () => {
+            const response = await utils.request("GET", "locks", { isExpired: true });
+            expect(response).toBeSuccessfulResponse();
+            expect(response.data.data).toBeArray();
+            expect(response.data.data).not.toBeEmpty();
+            expect(response.data.data.every(lock => !lock.isExpired)).toBeTrue();
+        });
+
+        it("should GET all the locks that are not expired", async () => {
+            const response = await utils.request("GET", "locks", { isExpired: true });
+            expect(response).toBeSuccessfulResponse();
+            expect(response.data.data).toBeArray();
+            expect(response.data.data).not.toBeEmpty();
+            expect(response.data.data.every(lock => lock.isExpired)).toBeTrue();
+        });
+
         describe("orderBy", () => {
             it("should be ordered by amount:desc", async () => {
                 const response = await utils.request("GET", "locks", { orderBy: "amount:desc", expirationType: 2 });
@@ -104,7 +120,7 @@ describe("API 2.0 - Locks", () => {
                 }
             });
 
-            it("should be ordered by amount:ascs", async () => {
+            it("should be ordered by amount:asc", async () => {
                 const response = await utils.request("GET", "locks", { orderBy: "amount:asc", expirationType: 2 });
                 expect(response).toBeSuccessfulResponse();
                 expect(response.data.data).toBeArray();

--- a/__tests__/unit/core-database/repositories/wallets-business-repository.test.ts
+++ b/__tests__/unit/core-database/repositories/wallets-business-repository.test.ts
@@ -11,6 +11,7 @@ import { WalletsBusinessRepository } from "../../../../packages/core-database/sr
 import { DatabaseService } from "../../../../packages/core-database/src/database-service";
 import { Wallets } from "../../../../packages/core-state/src";
 import { Address } from "../../../../packages/crypto/src/identities";
+import { stateStorageStub } from "../__fixtures__/state-storage-stub";
 
 let genesisSenders;
 let repository: Database.IWalletsBusinessRepository;
@@ -265,6 +266,8 @@ describe("Wallet Repository", () => {
         it("should return all locks", () => {
             const wallets = generateHtlcLocks();
             walletManager.index(wallets);
+
+            jest.spyOn(stateStorageStub, "getLastBlock").mockReturnValueOnce(genesisBlock);
 
             const locks = repository.search(Database.SearchScope.Locks, {});
             expect(locks.rows).toHaveLength(genesisBlock.transactions.length);

--- a/__tests__/unit/core-database/repositories/wallets-business-repository.test.ts
+++ b/__tests__/unit/core-database/repositories/wallets-business-repository.test.ts
@@ -267,7 +267,7 @@ describe("Wallet Repository", () => {
             const wallets = generateHtlcLocks();
             walletManager.index(wallets);
 
-            jest.spyOn(stateStorageStub, "getLastBlock").mockReturnValueOnce(genesisBlock);
+            jest.spyOn(stateStorageStub, "getLastBlock").mockReturnValue(genesisBlock);
 
             const locks = repository.search(Database.SearchScope.Locks, {});
             expect(locks.rows).toHaveLength(genesisBlock.transactions.length);

--- a/packages/core-api/src/handlers/locks/schema.ts
+++ b/packages/core-api/src/handlers/locks/schema.ts
@@ -25,6 +25,7 @@ export const index: object = {
                 .integer()
                 .min(0),
             expirationType: Joi.number().only(1, 2),
+            isExpired: Joi.bool(),
         },
     },
 };
@@ -85,6 +86,7 @@ export const search: object = {
                 .integer()
                 .min(0),
         }),
+        isExpired: Joi.bool(),
     },
 };
 

--- a/packages/core-api/src/handlers/locks/transformer.ts
+++ b/packages/core-api/src/handlers/locks/transformer.ts
@@ -1,14 +1,10 @@
 import { formatTimestamp } from "@arkecosystem/core-utils";
-import { expirationCalculator } from "@arkecosystem/core-utils";
+import { Interfaces } from "@arkecosystem/crypto";
 
-export const transformLock = lock => {
+export const transformLock = (lock: Interfaces.IHtlcLock) => {
     return {
         ...lock,
         amount: lock.amount.toFixed(),
         timestamp: formatTimestamp(lock.timestamp),
-        isExpired: expirationCalculator.calculateLockExpirationStatus({
-            type: lock.expirationType,
-            value: lock.expirationValue,
-        }),
     };
 };

--- a/packages/core-api/src/handlers/wallets/schema.ts
+++ b/packages/core-api/src/handlers/wallets/schema.ts
@@ -187,6 +187,7 @@ export const locks: object = {
     query: {
         ...pagination,
         ...{
+            isExpired: Joi.bool(),
             orderBy: Joi.string(),
         },
     },

--- a/packages/core-database/src/repositories/utils/filter-rows.ts
+++ b/packages/core-database/src/repositories/utils/filter-rows.ts
@@ -12,7 +12,7 @@ export = <T = any>(rows: ReadonlyArray<T>, params: Database.IParameters, filters
     return rows.filter(item => {
         if (filters.hasOwnProperty("exact")) {
             for (const elem of filters.exact) {
-                if (params[elem] && getProperty(item, elem) !== params[elem]) {
+                if (params[elem] !== undefined && getProperty(item, elem) !== params[elem]) {
                     return false;
                 }
             }

--- a/packages/core-database/src/repositories/wallets-business-repository.ts
+++ b/packages/core-database/src/repositories/wallets-business-repository.ts
@@ -1,5 +1,5 @@
 import { Database, State } from "@arkecosystem/core-interfaces";
-import { delegateCalculator, hasSomeProperty } from "@arkecosystem/core-utils";
+import { delegateCalculator, expirationCalculator, hasSomeProperty } from "@arkecosystem/core-utils";
 import { Interfaces, Utils } from "@arkecosystem/crypto";
 import { searchEntries } from "./utils/search-entries";
 
@@ -18,6 +18,7 @@ interface IUnwrappedHtlcLock {
     timestamp: number;
     expirationType: number;
     expirationValue: number;
+    isExpired: boolean;
     vendorField: string;
 }
 
@@ -179,7 +180,15 @@ export class WalletsBusinessRepository implements Database.IWalletsBusinessRepos
 
     private searchLocks(params: Database.IParameters = {}): ISearchContext<IUnwrappedHtlcLock> {
         const query: Record<string, string[]> = {
-            exact: ["senderPublicKey", "lockId", "recipientId", "secretHash", "expirationType", "vendorField"],
+            exact: [
+                "expirationType",
+                "isExpired",
+                "lockId",
+                "recipientId",
+                "secretHash",
+                "senderPublicKey",
+                "vendorField",
+            ],
             between: ["expirationValue", "amount", "timestamp"],
         };
 
@@ -203,6 +212,9 @@ export class WalletsBusinessRepository implements Database.IWalletsBusinessRepos
                         timestamp: lock.timestamp,
                         expirationType: lock.expiration.type,
                         expirationValue: lock.expiration.value,
+                        isExpired: expirationCalculator.calculateLockExpirationStatus(
+                            lock.expiration,
+                        ),
                         vendorField: lock.vendorField,
                     });
                 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Closes #3224. The calculation of the expiration status needed to be moved out of the transformer, as the respective field is needed earlier when the filter is applied to the rows.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
