### PR TITLE
refactor(core-api): add schema for orderBy query param

### DIFF
--- a/__tests__/integration/core-api/handlers/blocks.test.ts
+++ b/__tests__/integration/core-api/handlers/blocks.test.ts
@@ -37,9 +37,9 @@ describe("API 2.0 - Blocks", () => {
         });
     });
 
-    describe("GET /blocks?orderBy=height:", () => {
+    describe("GET /blocks?orderBy=height:desc", () => {
         it("should GET all the blocks in descending order", async () => {
-            const response = await utils.request("GET", "blocks?orderBy=height:");
+            const response = await utils.request("GET", "blocks", { orderBy: "height:desc" });
 
             expect(response).toBeSuccessfulResponse();
             expect(response).toBePaginated();

--- a/packages/core-api/src/handlers/blocks/schema.ts
+++ b/packages/core-api/src/handlers/blocks/schema.ts
@@ -1,12 +1,11 @@
 import Joi from "@hapi/joi";
-import { blockId } from "../shared/schemas/block-id";
-import { pagination } from "../shared/schemas/pagination";
+import { blockId, orderBy, pagination } from "../shared/schemas";
 
 export const index: object = {
     query: {
         ...pagination,
         ...{
-            orderBy: Joi.string(),
+            orderBy,
             id: blockId,
             version: Joi.number()
                 .integer()
@@ -71,7 +70,7 @@ export const transactions: object = {
     query: {
         ...pagination,
         ...{
-            orderBy: Joi.string(),
+            orderBy,
             id: Joi.string()
                 .hex()
                 .length(66),

--- a/packages/core-api/src/handlers/bridgechains/schema.ts
+++ b/packages/core-api/src/handlers/bridgechains/schema.ts
@@ -1,11 +1,11 @@
 import Joi from "@hapi/joi";
-import { pagination } from "../shared/schemas/pagination";
+import { orderBy, pagination } from "../shared/schemas";
 
 export const index: object = {
     query: {
         ...pagination,
         ...{
-            orderBy: Joi.string(),
+            orderBy,
             businessId: Joi.number()
                 .integer()
                 .min(1),
@@ -28,7 +28,7 @@ export const search: object = {
     query: {
         ...pagination,
         ...{
-            orderBy: Joi.string(),
+            orderBy,
         },
     },
     payload: {

--- a/packages/core-api/src/handlers/businesses/schema.ts
+++ b/packages/core-api/src/handlers/businesses/schema.ts
@@ -1,11 +1,11 @@
 import Joi from "@hapi/joi";
-import { pagination } from "../shared/schemas/pagination";
+import { orderBy, pagination } from "../shared/schemas";
 
 export const index: object = {
     query: {
         ...pagination,
         ...{
-            orderBy: Joi.string(),
+            orderBy,
             businessId: Joi.number()
                 .integer()
                 .min(1),
@@ -30,7 +30,7 @@ export const bridgechains: object = {
     query: {
         ...pagination,
         ...{
-            orderBy: Joi.string(),
+            orderBy,
         },
     },
 };
@@ -39,7 +39,7 @@ export const search: object = {
     query: {
         ...pagination,
         ...{
-            orderBy: Joi.string(),
+            orderBy,
         },
     },
     payload: {

--- a/packages/core-api/src/handlers/delegates/schema.ts
+++ b/packages/core-api/src/handlers/delegates/schema.ts
@@ -1,7 +1,6 @@
 import { app } from "@arkecosystem/core-container";
 import Joi from "@hapi/joi";
-import { blockId } from "../shared/schemas/block-id";
-import { pagination } from "../shared/schemas/pagination";
+import { blockId, orderBy, pagination } from "../shared/schemas";
 
 const config = app.getConfig();
 
@@ -39,7 +38,7 @@ export const index: object = {
     query: {
         ...pagination,
         ...{
-            orderBy: Joi.string(),
+            orderBy,
             type: Joi.string().valid("resigned", "never-forged"),
             address: Joi.string()
                 .alphanum()
@@ -77,7 +76,7 @@ export const search: object = {
     query: {
         ...pagination,
         ...{
-            orderBy: Joi.string(),
+            orderBy,
         },
     },
     payload: {
@@ -109,7 +108,7 @@ export const blocks: object = {
     query: {
         ...pagination,
         ...{
-            orderBy: Joi.string(),
+            orderBy,
             id: blockId,
             version: Joi.number()
                 .integer()
@@ -153,7 +152,7 @@ export const voters: object = {
     query: {
         ...pagination,
         ...{
-            orderBy: Joi.string(),
+            orderBy,
             address: Joi.string()
                 .alphanum()
                 .length(34),

--- a/packages/core-api/src/handlers/locks/schema.ts
+++ b/packages/core-api/src/handlers/locks/schema.ts
@@ -1,12 +1,12 @@
 import { Enums } from "@arkecosystem/crypto";
 import Joi from "@hapi/joi";
-import { pagination } from "../shared/schemas/pagination";
+import { orderBy, pagination } from "../shared/schemas";
 
 export const index: object = {
     query: {
         ...pagination,
         ...{
-            orderBy: Joi.string(),
+            orderBy,
             recipientId: Joi.string()
                 .alphanum()
                 .length(34),
@@ -25,8 +25,7 @@ export const index: object = {
             expirationValue: Joi.number()
                 .integer()
                 .min(0),
-            expirationType: Joi.number()
-                .only(...Object.values(Enums.HtlcLockExpirationType)),
+            expirationType: Joi.number().only(...Object.values(Enums.HtlcLockExpirationType)),
             isExpired: Joi.bool(),
         },
     },
@@ -44,7 +43,7 @@ export const search: object = {
     query: {
         ...pagination,
         ...{
-            orderBy: Joi.string(),
+            orderBy,
         },
     },
     payload: {
@@ -79,8 +78,7 @@ export const search: object = {
         vendorField: Joi.string()
             .min(1)
             .max(255),
-        expirationType: Joi.number()
-            .only(...Object.values(Enums.HtlcLockExpirationType)),
+        expirationType: Joi.number().only(...Object.values(Enums.HtlcLockExpirationType)),
         expirationValue: Joi.object().keys({
             from: Joi.number()
                 .integer()
@@ -97,7 +95,7 @@ export const unlocked: object = {
     query: {
         ...pagination,
         ...{
-            orderBy: Joi.string(),
+            orderBy,
         },
     },
     payload: {

--- a/packages/core-api/src/handlers/peers/schema.ts
+++ b/packages/core-api/src/handlers/peers/schema.ts
@@ -1,5 +1,5 @@
 import Joi from "@hapi/joi";
-import { pagination } from "../shared/schemas/pagination";
+import { orderBy, pagination } from "../shared/schemas";
 
 export const index: object = {
     query: {
@@ -7,7 +7,7 @@ export const index: object = {
         ...{
             ip: Joi.string().ip(),
             version: Joi.string(),
-            orderBy: Joi.string(),
+            orderBy,
         },
     },
 };

--- a/packages/core-api/src/handlers/shared/schemas/index.ts
+++ b/packages/core-api/src/handlers/shared/schemas/index.ts
@@ -1,0 +1,6 @@
+import { blockId } from "./block-id";
+import { orderBy } from "./order-by";
+import { pagination } from "./pagination";
+import { walletId } from "./wallet-id";
+
+export { blockId, orderBy, pagination, walletId };

--- a/packages/core-api/src/handlers/shared/schemas/order-by.ts
+++ b/packages/core-api/src/handlers/shared/schemas/order-by.ts
@@ -1,0 +1,6 @@
+import Joi from "@hapi/joi";
+
+export const orderBy = Joi.string().regex(
+    /^[a-z._]{1,40}:(asc|desc)$/i,
+    "orderBy query parameter (<iteratee>:<direction>)",
+);

--- a/packages/core-api/src/handlers/transactions/schema.ts
+++ b/packages/core-api/src/handlers/transactions/schema.ts
@@ -1,7 +1,6 @@
 import { app } from "@arkecosystem/core-container";
 import Joi from "@hapi/joi";
-import { blockId } from "../shared/schemas/block-id";
-import { pagination } from "../shared/schemas/pagination";
+import { blockId, orderBy, pagination } from "../shared/schemas";
 
 const address: object = Joi.string()
     .alphanum()
@@ -11,7 +10,7 @@ export const index: object = {
     query: {
         ...pagination,
         ...{
-            orderBy: Joi.string(),
+            orderBy,
             id: Joi.string()
                 .hex()
                 .length(64),
@@ -101,7 +100,7 @@ export const search: object = {
         },
     },
     payload: {
-        orderBy: Joi.string(),
+        orderBy,
         id: Joi.string()
             .hex()
             .length(64),

--- a/packages/core-api/src/handlers/votes/schema.ts
+++ b/packages/core-api/src/handlers/votes/schema.ts
@@ -1,12 +1,11 @@
 import Joi from "@hapi/joi";
-import { blockId } from "../shared/schemas/block-id";
-import { pagination } from "../shared/schemas/pagination";
+import { blockId, orderBy, pagination } from "../shared/schemas";
 
 export const index: object = {
     query: {
         ...pagination,
         ...{
-            orderBy: Joi.string(),
+            orderBy,
             id: Joi.string()
                 .hex()
                 .length(64),

--- a/packages/core-api/src/handlers/wallets/schema.ts
+++ b/packages/core-api/src/handlers/wallets/schema.ts
@@ -1,7 +1,5 @@
 import Joi from "@hapi/joi";
-import { blockId } from "../shared/schemas/block-id";
-import { pagination } from "../shared/schemas/pagination";
-import { walletId } from "../shared/schemas/wallet-id";
+import { blockId, orderBy, pagination, walletId } from "../shared/schemas";
 
 const address: object = Joi.string()
     .alphanum()
@@ -11,7 +9,7 @@ export const index: object = {
     query: {
         ...pagination,
         ...{
-            orderBy: Joi.string(),
+            orderBy,
             address: Joi.string()
                 .alphanum()
                 .length(34),
@@ -49,7 +47,7 @@ export const transactions: object = {
     query: {
         ...pagination,
         ...{
-            orderBy: Joi.string(),
+            orderBy,
             id: Joi.string()
                 .hex()
                 .length(64),
@@ -88,7 +86,7 @@ export const transactionsSent: object = {
     query: {
         ...pagination,
         ...{
-            orderBy: Joi.string(),
+            orderBy,
             id: Joi.string()
                 .hex()
                 .length(64),
@@ -130,7 +128,7 @@ export const transactionsReceived: object = {
     query: {
         ...pagination,
         ...{
-            orderBy: Joi.string(),
+            orderBy,
             id: Joi.string()
                 .hex()
                 .length(64),
@@ -188,7 +186,7 @@ export const locks: object = {
         ...pagination,
         ...{
             isExpired: Joi.bool(),
-            orderBy: Joi.string(),
+            orderBy,
         },
     },
 };
@@ -197,7 +195,7 @@ export const search: object = {
     query: {
         ...pagination,
         ...{
-            orderBy: Joi.string(),
+            orderBy,
         },
     },
     payload: {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Closes #3237 by adding a basic schema to validate against `<iteratee>:<direction`, where `iteratee` is a string between 1 and 40 characters, `direction` is either `asc` or `desc`.

Using an invalid `orderBy` param will result in a 422 error:

```
{
  "statusCode": 422,
  "error": "Unprocessable Entity",
  "message": "child \"orderBy\" fails because [\"orderBy\" with value \"foo:bar\" fails to match the orderBy query parameter (<iteratee>:<direction>) pattern]"
}
```

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
