### PR TITLE
fix(core-database-postgres): return early only if there are rows

### DIFF
--- a/packages/core-database-postgres/src/repositories/repository.ts
+++ b/packages/core-database-postgres/src/repositories/repository.ts
@@ -74,7 +74,7 @@ export abstract class Repository implements Database.IRepository {
 
         const rows = await this.findMany(selectQuery);
 
-        if (rows.length < paginate.limit) {
+        if (rows.length && rows.length < paginate.limit) {
             return { rows, count: paginate.offset + rows.length, countIsEstimate: false };
         }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Fixes #3236.

The following conditional will cause the `findManyWithCount` method to return early:

https://github.com/ArkEcosystem/core/blob/0257c3c442aa18b27aa4b0d787bc99737b3ebd52/packages/core-database-postgres/src/repositories/repository.ts#L77-L79

This works as intended as long as `rows.length > 0`. When there are no rows however, the offset (which is calculated based on the page param) is returned as count, resulting in the faulty meta data described in #3236. 

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
