### PR TITLE
refactor(core-magistrate-transactions): more verbose static fee mismatch error

### DIFF
--- a/__tests__/unit/core-magistrate/handlers/bridgechain-handlers.test.ts
+++ b/__tests__/unit/core-magistrate/handlers/bridgechain-handlers.test.ts
@@ -8,7 +8,7 @@ import { Managers, Utils } from "@arkecosystem/crypto";
 import {
     BridgechainAlreadyRegisteredError,
     BridgechainIsResignedError,
-    InvalidFeeError,
+    StaticFeeMismatchError,
     WalletIsNotBusinessError,
 } from "../../../../packages/core-magistrate-transactions/src/errors";
 import {
@@ -137,7 +137,7 @@ describe("should test marketplace transaction handlers", () => {
 
                 await expect(
                     bridgechainRegistrationHandler.throwIfCannotBeApplied(actual.build(), senderWallet, walletManager),
-                ).rejects.toThrow(InvalidFeeError);
+                ).rejects.toThrow(StaticFeeMismatchError);
             });
         });
 

--- a/packages/core-magistrate-transactions/src/errors.ts
+++ b/packages/core-magistrate-transactions/src/errors.ts
@@ -3,60 +3,60 @@ import { Errors } from "@arkecosystem/core-transactions";
 
 export class BusinessAlreadyRegisteredError extends Errors.TransactionError {
     constructor() {
-        super(`Failed to apply transaction, because wallet was already registered as a business.`);
+        super("Failed to apply transaction, because wallet was already registered as a business.");
     }
 }
 
 export class BusinessIsNotRegisteredError extends Errors.TransactionError {
     constructor() {
-        super(`Failed to apply transaction, because wallet is not a business.`);
+        super("Failed to apply transaction, because wallet is not a business.");
     }
 }
 
 export class WalletIsNotBusinessError extends Errors.TransactionError {
     constructor() {
-        super(`Failed to apply transaction, because wallet is not a business.`);
+        super("Failed to apply transaction, because wallet is not a business.");
     }
 }
 
 export class BusinessIsResignedError extends Errors.TransactionError {
     constructor() {
-        super(`Failed to apply transaction, because business is resigned.`);
+        super("Failed to apply transaction, because business is resigned.");
     }
 }
 
 export class BridgechainAlreadyRegisteredError extends Errors.TransactionError {
     constructor() {
-        super(`Failed to apply transaction, because bridgechain is already registered.`);
+        super("Failed to apply transaction, because bridgechain is already registered.");
     }
 }
 
 export class BridgechainIsNotRegisteredError extends Errors.TransactionError {
     constructor() {
-        super(`Failed to apply transaction, because bridgechain is not registered.`);
+        super("Failed to apply transaction, because bridgechain is not registered.");
     }
 }
 
 export class BridgechainIsNotRegisteredByWalletError extends Errors.TransactionError {
     constructor() {
-        super(`Failed to apply transaction, because bridgechain is not registered by wallet.`);
+        super("Failed to apply transaction, because bridgechain is not registered by wallet.");
     }
 }
 
 export class BridgechainIsResignedError extends Errors.TransactionError {
     constructor() {
-        super(`Failed to apply transaction, because bridgechain is resigned.`);
+        super("Failed to apply transaction, because bridgechain is resigned.");
     }
 }
 
 export class GenesisHashAlreadyRegisteredError extends Errors.TransactionError {
     constructor() {
-        super(`Failed to apply transaction, because genesis hash is already registered by another bridgechain.`);
+        super("Failed to apply transaction, because genesis hash is already registered by another bridgechain.");
     }
 }
 
-export class InvalidFeeError extends Errors.TransactionError {
-    constructor() {
-        super(`Failed to apply transaction, because fee is invalid.`);
+export class StaticFeeMismatchError extends Errors.TransactionError {
+    constructor(staticFee: number) {
+        super(`Failed to apply transaction, because fee doesn't match static fee ${staticFee}.`);
     }
 }

--- a/packages/core-magistrate-transactions/src/errors.ts
+++ b/packages/core-magistrate-transactions/src/errors.ts
@@ -56,7 +56,7 @@ export class GenesisHashAlreadyRegisteredError extends Errors.TransactionError {
 }
 
 export class StaticFeeMismatchError extends Errors.TransactionError {
-    constructor(staticFee: number) {
+    constructor(staticFee: string) {
         super(`Failed to apply transaction, because fee doesn't match static fee ${staticFee}.`);
     }
 }

--- a/packages/core-magistrate-transactions/src/handlers/magistrate-handler.ts
+++ b/packages/core-magistrate-transactions/src/handlers/magistrate-handler.ts
@@ -21,9 +21,9 @@ export abstract class MagistrateTransactionHandler extends Handlers.TransactionH
             return;
         }
 
-        const staticFee = this.getConstructor().staticFee();
+        const staticFee: Utils.BigNumber = this.getConstructor().staticFee();
         if (!transaction.data.fee.isEqualTo(staticFee)) {
-            throw new StaticFeeMismatchError(staticFee);
+            throw new StaticFeeMismatchError(staticFee.toFixed());
         }
 
         return super.throwIfCannotBeApplied(transaction, wallet, walletManager);

--- a/packages/core-magistrate-transactions/src/handlers/magistrate-handler.ts
+++ b/packages/core-magistrate-transactions/src/handlers/magistrate-handler.ts
@@ -1,7 +1,7 @@
 import { State } from "@arkecosystem/core-interfaces";
 import { Handlers, Interfaces } from "@arkecosystem/core-transactions";
 import { Interfaces as CryptoInterfaces, Managers, Utils } from "@arkecosystem/crypto";
-import { InvalidFeeError } from "../errors";
+import { StaticFeeMismatchError } from "../errors";
 
 export abstract class MagistrateTransactionHandler extends Handlers.TransactionHandler {
     public async isActivated(): Promise<boolean> {
@@ -21,8 +21,9 @@ export abstract class MagistrateTransactionHandler extends Handlers.TransactionH
             return;
         }
 
-        if (!transaction.data.fee.isEqualTo(this.getConstructor().staticFee())) {
-            throw new InvalidFeeError();
+        const staticFee = this.getConstructor().staticFee();
+        if (!transaction.data.fee.isEqualTo(staticFee)) {
+            throw new StaticFeeMismatchError(staticFee);
         }
 
         return super.throwIfCannotBeApplied(transaction, wallet, walletManager);


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Increase verbosity of error that appears when not using the required static fee on core-magistrate transactions. Closes #3249.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
