### PR TITLE
feat(core): add command to clear transaction pool

### DIFF
--- a/packages/core/src/commands/pool/clear.ts
+++ b/packages/core/src/commands/pool/clear.ts
@@ -1,0 +1,41 @@
+import { readdirSync } from "fs";
+import { removeSync } from "fs-extra";
+import { confirm } from "../../helpers/prompts";
+import { CommandFlags } from "../../types";
+import { BaseCommand } from "../command";
+
+export class ClearCommand extends BaseCommand {
+    public static description: string = "Clear the transaction pool";
+
+    public static flags: CommandFlags = {
+        ...BaseCommand.flagsNetwork,
+    };
+
+    public async run(): Promise<void> {
+        const { flags, paths } = await this.parseWithNetwork(ClearCommand);
+
+        this.abortRunningProcess(`${flags.token}-core`);
+        this.abortRunningProcess(`${flags.token}-forger`);
+        this.abortRunningProcess(`${flags.token}-relay`);
+
+        if (flags.force) {
+            return this.removeFiles(paths.data);
+        }
+
+        try {
+            await confirm("Are you sure you want to clear the transaction pool?", async () => {
+                this.removeFiles(paths.data);
+            });
+        } catch (err) {
+            this.error(err.message);
+        }
+    }
+
+    private removeFiles(dataPath: string) {
+        const files: string[] = readdirSync(dataPath).filter((file: string) => file.includes("transaction-pool"));
+
+        for (const file of files) {
+            removeSync(`${dataPath}/${file}`);
+        }
+    }
+}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Adds a CLI command to delete the files belonging to the transaction pool as an easy to remember alternative to manually deleting the files.

Usage: `ark pool:clear`

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
