### PR TITLE
fix(core-transaction-pool): wallet-manager fallback to database wallet manager findByIndex() when no "local" match

### DIFF
--- a/__tests__/integration/core-transaction-pool/wallet-manager.test.ts
+++ b/__tests__/integration/core-transaction-pool/wallet-manager.test.ts
@@ -224,7 +224,7 @@ describe("Apply transactions and block rewards to wallets on new block", () => {
     });
 });
 
-describe.only("findByIndex", () => {
+describe("findByIndex", () => {
     describe("when transaction pool wallet manager does not find a wallet by index", () => {
         it("should get the wallet from database wallet manager if it exists", async () => {
             const publicKey = "02664fe58caa4a960ed74169a5968a5f69587ba50b75087d268f5788af3a5bf56d";

--- a/__tests__/integration/core-transaction-pool/wallet-manager.test.ts
+++ b/__tests__/integration/core-transaction-pool/wallet-manager.test.ts
@@ -1,4 +1,5 @@
-import { Blockchain, Container, Database } from "@arkecosystem/core-interfaces";
+import { Blockchain, Container, Database, State } from "@arkecosystem/core-interfaces";
+import { Wallets } from "@arkecosystem/core-state";
 import { Handlers } from "@arkecosystem/core-transactions";
 import { Blocks, Identities, Utils } from "@arkecosystem/crypto";
 import { generateMnemonic } from "bip39";
@@ -220,5 +221,36 @@ describe("Apply transactions and block rewards to wallets on new block", () => {
         expect(+transferDelegateWallet.balance).toBe(+transferDelegate.balance - transferAmount - totalFee);
 
         expect(+delegateWallet.balance).toBe(+forgingDelegate.balance + reward + totalFee); // balance increased by reward + fee
+    });
+});
+
+describe.only("findByIndex", () => {
+    describe("when transaction pool wallet manager does not find a wallet by index", () => {
+        it("should get the wallet from database wallet manager if it exists", async () => {
+            const publicKey = "02664fe58caa4a960ed74169a5968a5f69587ba50b75087d268f5788af3a5bf56d";
+            const address = Identities.Address.fromPublicKey(publicKey);
+            const lockId = "cd08f14f049ea0ff0661635929ed267275e71509561c78d72a55a0bbccc48c30";
+            const walletWithHtlcLock = Object.assign(new Wallets.Wallet(address), {
+                attributes: {
+                    htlc: {
+                        locks: {
+                            [lockId]: {
+                                amount: Utils.BigNumber.make(10),
+                                recipientId: address,
+                                secretHash: lockId,
+                                expiration: {
+                                    type: 1,
+                                    value: 100,
+                                },
+                            },
+                        },
+                    },
+                },
+            });
+            container.resolvePlugin<Database.IDatabaseService>("database").walletManager.reindex(walletWithHtlcLock);
+
+            const poolWallet = poolWalletManager.findByIndex(State.WalletIndexes.Locks, lockId);
+            expect(poolWallet).toEqual(walletWithHtlcLock);
+        });
     });
 });

--- a/packages/core-transaction-pool/src/wallet-manager.ts
+++ b/packages/core-transaction-pool/src/wallet-manager.ts
@@ -32,6 +32,23 @@ export class WalletManager extends Wallets.WalletManager {
         return this.findByIndex(State.WalletIndexes.Addresses, address);
     }
 
+    public findByIndex(index: string | string[], key: string): State.IWallet | undefined {
+        const wallet = super.findByIndex(index, key);
+
+        if (wallet) {
+            return wallet;
+        }
+
+        const dbWallet = this.databaseService.walletManager.findByIndex(index, key);
+        if (dbWallet) {
+            const cloneWallet = clonedeep(dbWallet);
+            this.reindex(cloneWallet);
+            return cloneWallet;
+        }
+
+        return undefined;
+    }
+
     public forget(publicKey: string): void {
         this.forgetByPublicKey(publicKey);
         this.forgetByAddress(Identities.Address.fromPublicKey(publicKey));


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Resolves #3242 
<!-- What changes are being made? -->

Transaction pool wallet manager : try database wallet manager findByIndex() when local findByIndex() doesn't return a match.

<!-- Why are these changes necessary? -->

We might not have all existing wallets indexes on transaction pool wallet manager : so in case we get no match we should try with database wallet manager.

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
