### PR TITLE
fix(core-magistrate): use genesisHash for bridgechainId

### DIFF
--- a/__tests__/functional/transaction-forging/bridgechain-resignation.test.ts
+++ b/__tests__/functional/transaction-forging/bridgechain-resignation.test.ts
@@ -9,6 +9,12 @@ afterAll(support.tearDown);
 
 describe("Transaction Forging - Bridgechain resignation", () => {
     describe("Signed with 1 Passphrase", () => {
+        const bridgechainRegistrationAsset = {
+            name: "cryptoProject",
+            seedNodes: ["1.2.3.4", "2001:0db8:85a3:0000:0000:8a2e:0370:7334"],
+            genesisHash: "4fc82b26aecb47d2868c4efbe3581732a3e7cbcc6c2efb32062c08170a05eeb8",
+            bridgechainRepository: "http://www.repository.com/myorg/myrepo",
+        };
         it("should broadcast, accept and forge it [Signed with 1 Passphrase]", async () => {
             // Business registration
             const businessRegistration = TransactionFactory.businessRegistration({
@@ -23,12 +29,7 @@ describe("Transaction Forging - Bridgechain resignation", () => {
             await expect(businessRegistration.id).toBeForged();
 
             // Bridgechain registration
-            const bridgechainRegistration = TransactionFactory.bridgechainRegistration({
-                name: "cryptoProject",
-                seedNodes: ["1.2.3.4", "2001:0db8:85a3:0000:0000:8a2e:0370:7334"],
-                genesisHash: "4fc82b26aecb47d2868c4efbe3581732a3e7cbcc6c2efb32062c08170a05eeb8",
-                bridgechainRepository: "http://www.repository.com/myorg/myrepo",
-            })
+            const bridgechainRegistration = TransactionFactory.bridgechainRegistration(bridgechainRegistrationAsset)
                 .withPassphrase(secrets[0])
                 .createOne();
 
@@ -37,7 +38,9 @@ describe("Transaction Forging - Bridgechain resignation", () => {
             await expect(bridgechainRegistration.id).toBeForged();
 
             // Bridgechain resignation
-            const bridgechainResignation = TransactionFactory.bridgechainResignation(1)
+            const bridgechainResignation = TransactionFactory.bridgechainResignation(
+                bridgechainRegistrationAsset.genesisHash,
+            )
                 .withPassphrase(secrets[0])
                 .createOne();
 
@@ -47,7 +50,9 @@ describe("Transaction Forging - Bridgechain resignation", () => {
         });
 
         it("should reject bridgechain resignation, because bridgechain resigned [Signed with 1 Passphrase]", async () => {
-            const bridgechainResignation = TransactionFactory.bridgechainResignation(1)
+            const bridgechainResignation = TransactionFactory.bridgechainResignation(
+                bridgechainRegistrationAsset.genesisHash,
+            )
                 .withPassphrase(secrets[0])
                 .createOne();
 
@@ -58,12 +63,13 @@ describe("Transaction Forging - Bridgechain resignation", () => {
 
         it("should reject bridgechain resignation, because bridgechain resignation for same bridgechain is already in the pool [Signed with 1 Passphrase]", async () => {
             // Bridgechain registration
-            const bridgechainRegistration = TransactionFactory.bridgechainRegistration({
+            const bridgechainRegistrationAsset2 = {
                 name: "cryptoProject2",
                 seedNodes: ["1.2.3.4", "2001:0db8:85a3:0000:0000:8a2e:0370:7334"],
                 genesisHash: "6b51d431df5d7f141cbececcf79edf3dd861c3b4069f0b11661a3eefacbba918",
                 bridgechainRepository: "http://www.repository.com/myorg/myrepo",
-            })
+            };
+            const bridgechainRegistration = TransactionFactory.bridgechainRegistration(bridgechainRegistrationAsset2)
                 .withPassphrase(secrets[0])
                 .createOne();
 
@@ -71,11 +77,15 @@ describe("Transaction Forging - Bridgechain resignation", () => {
             await support.snoozeForBlock(1);
             await expect(bridgechainRegistration.id).toBeForged();
 
-            const bridgechainResignation = TransactionFactory.bridgechainResignation(2)
+            const bridgechainResignation = TransactionFactory.bridgechainResignation(
+                bridgechainRegistrationAsset2.genesisHash,
+            )
                 .withPassphrase(secrets[0])
                 .createOne();
 
-            const bridgechainResignation2 = TransactionFactory.bridgechainResignation(2)
+            const bridgechainResignation2 = TransactionFactory.bridgechainResignation(
+                bridgechainRegistrationAsset2.genesisHash,
+            )
                 .withPassphrase(secrets[0])
                 .withNonce(bridgechainResignation.nonce.plus(1))
                 .createOne();
@@ -125,12 +135,13 @@ describe("Transaction Forging - Bridgechain resignation", () => {
             await expect(businessRegistration.id).toBeForged();
 
             // Registering a bridgechain
-            const bridgechainRegistration = TransactionFactory.bridgechainRegistration({
+            const bridgechainRegistrationAsset = {
                 name: "cryptoProject",
                 seedNodes: ["2001:0db8:85a3:0000:0000:8a2e:0370:7334"],
                 genesisHash: "3fdba35f04dc8c462986c992bcf875546257113072a909c162f7e470e581e278",
                 bridgechainRepository: "http://www.repository.com/myorg/myrepo",
-            })
+            };
+            const bridgechainRegistration = TransactionFactory.bridgechainRegistration(bridgechainRegistrationAsset)
                 .withPassphrase(passphrase)
                 .withSecondPassphrase(secondPassphrase)
                 .createOne();
@@ -140,7 +151,9 @@ describe("Transaction Forging - Bridgechain resignation", () => {
             await expect(bridgechainRegistration.id).toBeForged();
 
             // Bridgechain resignation
-            const bridgechainResignation = TransactionFactory.bridgechainResignation(3)
+            const bridgechainResignation = TransactionFactory.bridgechainResignation(
+                bridgechainRegistrationAsset.genesisHash,
+            )
                 .withPassphrase(passphrase)
                 .withSecondPassphrase(secondPassphrase)
                 .createOne();
@@ -207,12 +220,13 @@ describe("Transaction Forging - Bridgechain resignation", () => {
             await expect(businessRegistration.id).toBeForged();
 
             // Registering a bridgechain
-            const bridgechainRegistration = TransactionFactory.bridgechainRegistration({
+            const bridgechainRegistrationAsset = {
                 name: "cryptoProject",
                 seedNodes: ["2001:0db8:85a3:0000:0000:8a2e:0370:7334"],
                 genesisHash: "8527a891e224136950ff32ca212b45bc93f69fbb801c3b1ebedac52775f99e61",
                 bridgechainRepository: "http://www.repository.com/myorg/myrepo",
-            })
+            };
+            const bridgechainRegistration = TransactionFactory.bridgechainRegistration(bridgechainRegistrationAsset)
                 .withSenderPublicKey(multiSigPublicKey)
                 .withPassphraseList(passphrases)
                 .createOne();
@@ -222,7 +236,9 @@ describe("Transaction Forging - Bridgechain resignation", () => {
             await expect(bridgechainRegistration.id).toBeForged();
 
             // Bridgechain resignation
-            const bridgechainResignation = TransactionFactory.bridgechainResignation(4)
+            const bridgechainResignation = TransactionFactory.bridgechainResignation(
+                bridgechainRegistrationAsset.genesisHash,
+            )
                 .withSenderPublicKey(multiSigPublicKey)
                 .withPassphraseList(passphrases)
                 .createOne();

--- a/__tests__/functional/transaction-forging/bridgechain-update.test.ts
+++ b/__tests__/functional/transaction-forging/bridgechain-update.test.ts
@@ -9,6 +9,13 @@ afterAll(support.tearDown);
 
 describe("Transaction Forging - Bridgechain update", () => {
     describe("Signed with 1 Passphrase", () => {
+        const bridgechainRegistrationAsset = {
+            name: "cryptoProject",
+            seedNodes: ["1.2.3.4", "2001:0db8:85a3:0000:0000:8a2e:0370:7334"],
+            genesisHash: "e629fa6598d732768f7c726b4b621285f9c3b85303900aa912017db7617d8bdb",
+            bridgechainRepository: "http://www.repository.com/myorg/myrepo",
+        };
+
         it("should broadcast, accept and forge it [Signed with 1 Passphrase]", async () => {
             // Registering a business
             const businessRegistration = TransactionFactory.businessRegistration({
@@ -23,12 +30,7 @@ describe("Transaction Forging - Bridgechain update", () => {
             await expect(businessRegistration.id).toBeForged();
 
             // Registering a bridgechain
-            const bridgechainRegistration = TransactionFactory.bridgechainRegistration({
-                name: "cryptoProject",
-                seedNodes: ["1.2.3.4", "2001:0db8:85a3:0000:0000:8a2e:0370:7334"],
-                genesisHash: "e629fa6598d732768f7c726b4b621285f9c3b85303900aa912017db7617d8bdb",
-                bridgechainRepository: "http://www.repository.com/myorg/myrepo",
-            })
+            const bridgechainRegistration = TransactionFactory.bridgechainRegistration(bridgechainRegistrationAsset)
                 .withPassphrase(secrets[0])
                 .createOne();
 
@@ -38,7 +40,7 @@ describe("Transaction Forging - Bridgechain update", () => {
 
             // Updating a bridgechain
             const bridgechainUpdate = TransactionFactory.bridgechainUpdate({
-                bridgechainId: 1,
+                bridgechainId: bridgechainRegistrationAsset.genesisHash,
                 seedNodes: ["1.2.3.4", "1.2.3.5", "192.168.1.0", "131.107.0.89"],
             })
                 .withPassphrase(secrets[0])
@@ -49,7 +51,9 @@ describe("Transaction Forging - Bridgechain update", () => {
             await expect(bridgechainUpdate.id).toBeForged();
 
             // Bridgechain resignation
-            const bridgechainResignation = TransactionFactory.bridgechainResignation(1)
+            const bridgechainResignation = TransactionFactory.bridgechainResignation(
+                bridgechainRegistrationAsset.genesisHash,
+            )
                 .withPassphrase(secrets[0])
                 .createOne();
 
@@ -61,7 +65,7 @@ describe("Transaction Forging - Bridgechain update", () => {
         it("should reject bridgechain update, because bridgechain resigned [Signed with 1 Passphrase]", async () => {
             // Updating a bridgechain after resignation
             const bridgechainUpdate = TransactionFactory.bridgechainUpdate({
-                bridgechainId: 1,
+                bridgechainId: bridgechainRegistrationAsset.genesisHash,
                 seedNodes: ["1.2.3.4", "1.2.3.5", "192.168.1.0", "131.107.0.89"],
             })
                 .withPassphrase(secrets[0])
@@ -74,12 +78,13 @@ describe("Transaction Forging - Bridgechain update", () => {
 
         it("should reject bridgechain update, because bridgechain update for same bridgechain is already in the pool [Signed with 1 Passphrase]", async () => {
             // Registering a bridgechain
-            const bridgechainRegistration = TransactionFactory.bridgechainRegistration({
+            const bridgechainRegistrationAsset2 = {
                 name: "cryptoProject2",
                 seedNodes: ["1.2.3.4", "2001:0db8:85a3:0000:0000:8a2e:0370:7334"],
                 genesisHash: "b17ef6d19c7a5b1ee83b907c595526dcb1eb06db8227d650d5dda0a9f4ce8cd9",
                 bridgechainRepository: "http://www.repository.com/myorg/myrepo",
-            })
+            };
+            const bridgechainRegistration = TransactionFactory.bridgechainRegistration(bridgechainRegistrationAsset2)
                 .withPassphrase(secrets[0])
                 .createOne();
 
@@ -88,14 +93,14 @@ describe("Transaction Forging - Bridgechain update", () => {
             await expect(bridgechainRegistration.id).toBeForged();
 
             const bridgechainUpdate = TransactionFactory.bridgechainUpdate({
-                bridgechainId: 2,
+                bridgechainId: bridgechainRegistrationAsset2.genesisHash,
                 seedNodes: ["1.2.3.4", "1.2.3.5", "192.168.1.0", "131.107.0.89"],
             })
                 .withPassphrase(secrets[0])
                 .createOne();
 
             const bridgechainUpdate2 = TransactionFactory.bridgechainUpdate({
-                bridgechainId: 2,
+                bridgechainId: bridgechainRegistrationAsset2.genesisHash,
                 seedNodes: ["1.2.3.4", "1.2.3.5", "192.168.1.0", "131.107.0.89"],
             })
                 .withPassphrase(secrets[0])
@@ -147,12 +152,13 @@ describe("Transaction Forging - Bridgechain update", () => {
             await expect(businessRegistration.id).toBeForged();
 
             // Registering a bridgechain
-            const bridgechainRegistration = TransactionFactory.bridgechainRegistration({
+            const bridgechainRegistrationAsset = {
                 name: "cryptoProject",
                 seedNodes: ["2001:0db8:85a3:0000:0000:8a2e:0370:7334"],
                 genesisHash: "4523540f1504cd17100c4835e85b7eefd49911580f8efff0599a8f283be6b9e3",
                 bridgechainRepository: "http://www.repository.com/myorg/myrepo",
-            })
+            };
+            const bridgechainRegistration = TransactionFactory.bridgechainRegistration(bridgechainRegistrationAsset)
                 .withPassphrase(passphrase)
                 .withSecondPassphrase(secondPassphrase)
                 .createOne();
@@ -163,7 +169,7 @@ describe("Transaction Forging - Bridgechain update", () => {
 
             // Update a bridgechain
             const bridgechainUpdate = TransactionFactory.bridgechainUpdate({
-                bridgechainId: 3,
+                bridgechainId: bridgechainRegistrationAsset.genesisHash,
                 seedNodes: ["1.2.3.4", "1.2.3.5", "192.168.1.0", "131.107.0.89"],
             })
                 .withPassphrase(passphrase)
@@ -231,12 +237,13 @@ describe("Transaction Forging - Bridgechain update", () => {
             await expect(businessRegistration.id).toBeForged();
 
             // Registering a bridgechain
-            const bridgechainRegistration = TransactionFactory.bridgechainRegistration({
+            const bridgechainRegistrationAsset = {
                 name: "cryptoProject",
                 seedNodes: ["2001:0db8:85a3:0000:0000:8a2e:0370:7334"],
                 genesisHash: "4ec9599fc203d176a301536c2e091a19bc852759b255bd6818810a42c5fed14a",
                 bridgechainRepository: "http://www.repository.com/myorg/myrepo",
-            })
+            };
+            const bridgechainRegistration = TransactionFactory.bridgechainRegistration(bridgechainRegistrationAsset)
                 .withSenderPublicKey(multiSigPublicKey)
                 .withPassphraseList(passphrases)
                 .createOne();
@@ -247,7 +254,7 @@ describe("Transaction Forging - Bridgechain update", () => {
 
             // Update a bridgechain
             const bridgechainUpdate = TransactionFactory.bridgechainUpdate({
-                bridgechainId: 4,
+                bridgechainId: bridgechainRegistrationAsset.genesisHash,
                 seedNodes: ["1.2.3.4", "1.2.3.5", "192.168.1.0", "131.107.0.89"],
             })
                 .withSenderPublicKey(multiSigPublicKey)

--- a/__tests__/helpers/transaction-factory.ts
+++ b/__tests__/helpers/transaction-factory.ts
@@ -143,9 +143,9 @@ export class TransactionFactory {
         return new TransactionFactory(bridgechainRegistrationBuilder);
     }
 
-    public static bridgechainResignation(registeredBridgechainId: number): TransactionFactory {
+    public static bridgechainResignation(registeredBridgechainId: string): TransactionFactory {
         const bridgechainResignationBuilder = new MagistrateBuilders.BridgechainResignationBuilder();
-        bridgechainResignationBuilder.businessResignationAsset(registeredBridgechainId);
+        bridgechainResignationBuilder.bridgechainResignationAsset(registeredBridgechainId);
         return new TransactionFactory(bridgechainResignationBuilder);
     }
 

--- a/__tests__/unit/core-magistrate/builders/bridgechain-resignation.test.ts
+++ b/__tests__/unit/core-magistrate/builders/bridgechain-resignation.test.ts
@@ -17,7 +17,9 @@ describe("Bridgechain resignation builder", () => {
     });
     describe("should test verification", () => {
         it("should be true", () => {
-            const actual = builder.businessResignationAsset(1).sign("passphrase");
+            const actual = builder
+                .bridgechainResignationAsset("8527a891e224136950ff32ca212b45bc93f69fbb801c3b1ebedac52775f99e61")
+                .sign("passphrase");
             expect(actual.build().verified).toBeTrue();
             expect(actual.verify()).toBeTrue();
         });

--- a/__tests__/unit/core-magistrate/builders/bridgechain-update.test.ts
+++ b/__tests__/unit/core-magistrate/builders/bridgechain-update.test.ts
@@ -6,6 +6,7 @@ import {
 } from "@arkecosystem/core-magistrate-crypto";
 import { Managers, Transactions } from "@arkecosystem/crypto";
 
+const genesisHash = "8527a891e224136950ff32ca212b45bc93f69fbb801c3b1ebedac52775f99e61";
 let builder: MagistrateBuilders.BridgechainUpdateBuilder;
 
 describe("Bridgechain update builder", () => {
@@ -21,7 +22,7 @@ describe("Bridgechain update builder", () => {
         it("should be true", () => {
             const actual = builder
                 .bridgechainUpdateAsset({
-                    bridgechainId: 1,
+                    bridgechainId: genesisHash,
                     seedNodes: ["192.168.1.0", "131.107.0.89"],
                 })
                 .sign("passphrase");

--- a/__tests__/unit/core-magistrate/handlers/bridgechain-handlers.test.ts
+++ b/__tests__/unit/core-magistrate/handlers/bridgechain-handlers.test.ts
@@ -163,8 +163,10 @@ describe("should test marketplace transaction handlers", () => {
                 ).toResolve();
 
                 expect(
-                    senderWallet.getAttribute<IBusinessWalletAttributes>("business").bridgechains["1"].bridgechainId,
-                ).toBe(1);
+                    senderWallet.getAttribute<IBusinessWalletAttributes>("business").bridgechains[
+                        bridgechainRegistrationAsset1.genesisHash
+                    ].bridgechainId,
+                ).toBe(bridgechainRegistrationAsset1.genesisHash);
 
                 bridgechainRegistration.bridgechainRegistrationAsset(bridgechainRegistrationAsset2).nonce("3");
                 await expect(
@@ -172,11 +174,13 @@ describe("should test marketplace transaction handlers", () => {
                 ).toResolve();
 
                 expect(
-                    senderWallet.getAttribute<IBusinessWalletAttributes>("business").bridgechains["2"].bridgechainId,
-                ).toBe(2);
+                    senderWallet.getAttribute<IBusinessWalletAttributes>("business").bridgechains[
+                        bridgechainRegistrationAsset2.genesisHash
+                    ].bridgechainId,
+                ).toBe(bridgechainRegistrationAsset2.genesisHash);
 
                 const bridgechainResignation = bridgechainResignationBuilder
-                    .businessResignationAsset(2)
+                    .bridgechainResignationAsset(bridgechainRegistrationAsset1.genesisHash)
                     .nonce("4")
                     .sign("clay harbor enemy utility margin pretty hub comic piece aerobic umbrella acquire");
 
@@ -215,7 +219,9 @@ describe("should test marketplace transaction handlers", () => {
                     );
 
                     expect(Object.keys(bridgechains).length).toEqual(1);
-                    expect(bridgechains["1"].bridgechainId).toEqual(1);
+                    expect(bridgechains[bridgechainRegistrationAsset1.genesisHash].bridgechainId).toEqual(
+                        bridgechainRegistrationAsset1.genesisHash,
+                    );
                 });
             });
         });

--- a/__tests__/unit/core-magistrate/handlers/bridgechain-handlers.test.ts
+++ b/__tests__/unit/core-magistrate/handlers/bridgechain-handlers.test.ts
@@ -165,7 +165,7 @@ describe("should test marketplace transaction handlers", () => {
                 expect(
                     senderWallet.getAttribute<IBusinessWalletAttributes>("business").bridgechains[
                         bridgechainRegistrationAsset1.genesisHash
-                    ].bridgechainId,
+                    ].bridgechainAsset.genesisHash,
                 ).toBe(bridgechainRegistrationAsset1.genesisHash);
 
                 bridgechainRegistration.bridgechainRegistrationAsset(bridgechainRegistrationAsset2).nonce("3");
@@ -176,7 +176,7 @@ describe("should test marketplace transaction handlers", () => {
                 expect(
                     senderWallet.getAttribute<IBusinessWalletAttributes>("business").bridgechains[
                         bridgechainRegistrationAsset2.genesisHash
-                    ].bridgechainId,
+                    ].bridgechainAsset.genesisHash,
                 ).toBe(bridgechainRegistrationAsset2.genesisHash);
 
                 const bridgechainResignation = bridgechainResignationBuilder
@@ -219,9 +219,9 @@ describe("should test marketplace transaction handlers", () => {
                     );
 
                     expect(Object.keys(bridgechains).length).toEqual(1);
-                    expect(bridgechains[bridgechainRegistrationAsset1.genesisHash].bridgechainId).toEqual(
-                        bridgechainRegistrationAsset1.genesisHash,
-                    );
+                    expect(
+                        bridgechains[bridgechainRegistrationAsset1.genesisHash].bridgechainAsset.genesisHash,
+                    ).toEqual(bridgechainRegistrationAsset1.genesisHash);
                 });
             });
         });

--- a/__tests__/unit/core-magistrate/transactions/bridgechain-resignation.test.ts
+++ b/__tests__/unit/core-magistrate/transactions/bridgechain-resignation.test.ts
@@ -5,6 +5,7 @@ import { Transactions as MagistrateTransactions } from "@arkecosystem/core-magis
 import { Managers, Transactions, Validation as Ajv } from "@arkecosystem/crypto";
 import { checkCommonFields } from "../helper";
 
+const genesisHash = "8527a891e224136950ff32ca212b45bc93f69fbb801c3b1ebedac52775f99e61";
 let builder: MagistrateBuilders.BridgechainResignationBuilder;
 
 describe("Bridgechain registration transaction", () => {
@@ -18,7 +19,7 @@ describe("Bridgechain registration transaction", () => {
     describe("Ser/deser", () => {
         it("should ser/deserialize giving back original fields", () => {
             const bridgechainResignation = builder
-                .businessResignationAsset(1)
+                .bridgechainResignationAsset(genesisHash)
                 .network(23)
                 .sign("passphrase")
                 .getStruct();
@@ -40,21 +41,21 @@ describe("Bridgechain registration transaction", () => {
         });
 
         it("should not throw any error", () => {
-            const bridgechainRegistration = builder.businessResignationAsset(1).sign("passphrase");
+            const bridgechainRegistration = builder.bridgechainResignationAsset(genesisHash).sign("passphrase");
 
             const { error } = Ajv.validator.validate(transactionSchema, bridgechainRegistration.getStruct());
             expect(error).toBeUndefined();
         });
 
         it("should not throw any error", () => {
-            const bridgechainRegistration = builder.businessResignationAsset(1).sign("passphrase");
+            const bridgechainRegistration = builder.bridgechainResignationAsset(genesisHash).sign("passphrase");
 
             const { error } = Ajv.validator.validate(transactionSchema, bridgechainRegistration.getStruct());
             expect(error).toBeUndefined();
         });
 
         it("should fail because invalid asset", () => {
-            const bridgechainRegistration = builder.businessResignationAsset(0).sign("passphrase");
+            const bridgechainRegistration = builder.bridgechainResignationAsset("wrongGenesisHash").sign("passphrase");
 
             const { error } = Ajv.validator.validate(transactionSchema, bridgechainRegistration.getStruct());
             expect(error).not.toBeUndefined();

--- a/__tests__/unit/core-magistrate/transactions/bridgechain-update.test.ts
+++ b/__tests__/unit/core-magistrate/transactions/bridgechain-update.test.ts
@@ -5,6 +5,7 @@ import { Transactions as MagistrateTransactions } from "@arkecosystem/core-magis
 import { Managers, Transactions } from "@arkecosystem/crypto";
 import { checkCommonFields } from "../helper";
 
+const genesisHash = "8527a891e224136950ff32ca212b45bc93f69fbb801c3b1ebedac52775f99e61";
 let builder: MagistrateBuilders.BridgechainUpdateBuilder;
 
 describe("Bridgechain update ser/deser", () => {
@@ -20,7 +21,7 @@ describe("Bridgechain update ser/deser", () => {
         const businessResignation = builder
             .network(23)
             .bridgechainUpdateAsset({
-                bridgechainId: 1,
+                bridgechainId: genesisHash,
                 seedNodes: ["74.125.224.72"],
             })
             .sign("passphrase")

--- a/__tests__/unit/core-magistrate/wallet.test.ts
+++ b/__tests__/unit/core-magistrate/wallet.test.ts
@@ -3,6 +3,7 @@ import { Wallets } from "@arkecosystem/core-state";
 import { Handlers } from "@arkecosystem/core-transactions";
 import { IBusinessWalletAttributes } from "../../../packages/core-magistrate-transactions/src/interfaces";
 
+const genesisHash = "8527a891e224136950ff32ca212b45bc93f69fbb801c3b1ebedac52775f99e61";
 describe("should test wallet", () => {
     it("should return the same data as added", () => {
         Handlers.Registry.registerTransactionHandler(BusinessRegistrationTransactionHandler);
@@ -15,8 +16,8 @@ describe("should test wallet", () => {
             },
             resigned: false,
             bridgechains: {
-                "1001": {
-                    bridgechainId: 1001,
+                [genesisHash]: {
+                    bridgechainId: genesisHash,
                     bridgechainAsset: {
                         name: "googleCrypto",
                         seedNodes: [

--- a/__tests__/unit/core-magistrate/wallet.test.ts
+++ b/__tests__/unit/core-magistrate/wallet.test.ts
@@ -17,7 +17,6 @@ describe("should test wallet", () => {
             resigned: false,
             bridgechains: {
                 [genesisHash]: {
-                    bridgechainId: genesisHash,
                     bridgechainAsset: {
                         name: "googleCrypto",
                         seedNodes: [

--- a/packages/core-api/src/handlers/bridgechains/schema.ts
+++ b/packages/core-api/src/handlers/bridgechains/schema.ts
@@ -9,18 +9,18 @@ export const index: object = {
             businessId: Joi.number()
                 .integer()
                 .min(1),
-            bridgechainId: Joi.number()
-                .integer()
-                .min(1),
+            bridgechainId: Joi.string()
+                .hex()
+                .length(64),
         },
     },
 };
 
 export const show: object = {
     params: {
-        id: Joi.number()
-            .integer()
-            .min(1),
+        id: Joi.string()
+            .hex()
+            .length(64),
     },
 };
 
@@ -32,9 +32,9 @@ export const search: object = {
         },
     },
     payload: {
-        bridgechainId: Joi.number()
-            .integer()
-            .min(1),
+        bridgechainId: Joi.string()
+            .hex()
+            .length(64),
         bridgechainRepository: Joi.string().max(80),
         businessId: Joi.number()
             .integer()

--- a/packages/core-api/src/handlers/bridgechains/schema.ts
+++ b/packages/core-api/src/handlers/bridgechains/schema.ts
@@ -9,9 +9,6 @@ export const index: object = {
             businessId: Joi.number()
                 .integer()
                 .min(1),
-            bridgechainId: Joi.string()
-                .hex()
-                .length(64),
         },
     },
 };
@@ -32,9 +29,6 @@ export const search: object = {
         },
     },
     payload: {
-        bridgechainId: Joi.string()
-            .hex()
-            .length(64),
         bridgechainRepository: Joi.string().max(80),
         businessId: Joi.number()
             .integer()

--- a/packages/core-database/src/repositories/wallets-business-repository.ts
+++ b/packages/core-database/src/repositories/wallets-business-repository.ts
@@ -212,9 +212,7 @@ export class WalletsBusinessRepository implements Database.IWalletsBusinessRepos
                         timestamp: lock.timestamp,
                         expirationType: lock.expiration.type,
                         expirationValue: lock.expiration.value,
-                        isExpired: expirationCalculator.calculateLockExpirationStatus(
-                            lock.expiration,
-                        ),
+                        isExpired: expirationCalculator.calculateLockExpirationStatus(lock.expiration),
                         vendorField: lock.vendorField,
                     });
                 }
@@ -256,7 +254,7 @@ export class WalletsBusinessRepository implements Database.IWalletsBusinessRepos
 
     private searchBridgechains(params: Database.IParameters = {}): ISearchContext<any> {
         const query: Record<string, string[]> = {
-            exact: ["bridgechainId", "businessId", "genesisHash"],
+            exact: ["bridgechainId", "businessId"],
             like: ["bridgechainRepository", "name"],
             every: ["seedNodes"],
         };

--- a/packages/core-magistrate-crypto/src/builders/bridgechain-resignation.ts
+++ b/packages/core-magistrate-crypto/src/builders/bridgechain-resignation.ts
@@ -13,7 +13,7 @@ export class BridgechainResignationBuilder extends Transactions.TransactionBuild
         this.data.asset = { bridgechainResignation: {} };
     }
 
-    public businessResignationAsset(bridgechainId: string): BridgechainResignationBuilder {
+    public bridgechainResignationAsset(bridgechainId: string): BridgechainResignationBuilder {
         this.data.asset.bridgechainResignation.bridgechainId = bridgechainId;
         return this;
     }

--- a/packages/core-magistrate-crypto/src/builders/bridgechain-resignation.ts
+++ b/packages/core-magistrate-crypto/src/builders/bridgechain-resignation.ts
@@ -13,7 +13,7 @@ export class BridgechainResignationBuilder extends Transactions.TransactionBuild
         this.data.asset = { bridgechainResignation: {} };
     }
 
-    public businessResignationAsset(bridgechainId: number): BridgechainResignationBuilder {
+    public businessResignationAsset(bridgechainId: string): BridgechainResignationBuilder {
         this.data.asset.bridgechainResignation.bridgechainId = bridgechainId;
         return this;
     }

--- a/packages/core-magistrate-crypto/src/interfaces.ts
+++ b/packages/core-magistrate-crypto/src/interfaces.ts
@@ -20,10 +20,10 @@ export interface IBridgechainRegistrationAsset {
 }
 
 export interface IBridgechainUpdateAsset {
-    bridgechainId: number;
+    bridgechainId: string;
     seedNodes: string[];
 }
 
 export interface IBridgechainResignationAsset {
-    bridgechainId: number;
+    bridgechainId: string;
 }

--- a/packages/core-magistrate-crypto/src/transactions/bridgechain-registration.ts
+++ b/packages/core-magistrate-crypto/src/transactions/bridgechain-registration.ts
@@ -65,9 +65,10 @@ export class BridgechainRegistrationTransaction extends Transactions.Transaction
 
         seedNodesBuffersLength += seedNodesBuffers.length;
 
-        const bridgechainGenesisHash: Buffer = Buffer.from(bridgechainRegistrationAsset.genesisHash, "utf8");
+        const bridgechainGenesisHash: Buffer = Buffer.from(bridgechainRegistrationAsset.genesisHash, "hex");
         const bridgechainRepository: Buffer = Buffer.from(bridgechainRegistrationAsset.bridgechainRepository, "utf8");
 
+        // TODO bytebuffer length init is probably wrong (initially should be +3 + depends on seedNodes)
         const buffer: ByteBuffer = new ByteBuffer(
             bridgechainName.length +
                 seedNodesBuffersLength +
@@ -108,7 +109,7 @@ export class BridgechainRegistrationTransaction extends Transactions.Transaction
             seedNodes.push(ip);
         }
 
-        const genesisHash: string = buf.readString(64);
+        const genesisHash: string = buf.readBytes(32).toString("hex");
         const repositoryLength: number = buf.readUint8();
         const bridgechainRepository: string = buf.readString(repositoryLength);
 

--- a/packages/core-magistrate-crypto/src/transactions/bridgechain-resignation.ts
+++ b/packages/core-magistrate-crypto/src/transactions/bridgechain-resignation.ts
@@ -1,7 +1,6 @@
 import { Transactions, Utils } from "@arkecosystem/crypto";
 import ByteBuffer from "bytebuffer";
 import { MagistrateTransactionGroup, MagistrateTransactionStaticFees, MagistrateTransactionType } from "../enums";
-import { IBridgechainResignationAsset } from "../interfaces";
 
 const { schemas } = Transactions;
 
@@ -28,7 +27,9 @@ export class BridgechainResignationTransaction extends Transactions.Transaction 
                             type: "object",
                             required: ["bridgechainId"],
                             properties: {
-                                bridgechainId: { type: "integer", minimum: 1 },
+                                bridgechainId: {
+                                    $ref: "transactionId",
+                                },
                             },
                         },
                     },
@@ -41,9 +42,8 @@ export class BridgechainResignationTransaction extends Transactions.Transaction 
     public serialize(): ByteBuffer {
         const { data } = this;
 
-        const bridgechainResignationAsset = data.asset.bridgechainResignation as IBridgechainResignationAsset;
-        const buffer: ByteBuffer = new ByteBuffer(4, true);
-        buffer.writeUint32(bridgechainResignationAsset.bridgechainId);
+        const buffer: ByteBuffer = new ByteBuffer(32, true);
+        buffer.append(ByteBuffer.fromHex(data.asset.bridgechainResignation.bridgechainId));
 
         return buffer;
     }
@@ -51,7 +51,7 @@ export class BridgechainResignationTransaction extends Transactions.Transaction 
     public deserialize(buf: ByteBuffer): void {
         const { data } = this;
 
-        const bridgechainId: number = buf.readUint32();
+        const bridgechainId: string = buf.readBytes(32).toString("hex");
         data.asset = {
             bridgechainResignation: {
                 bridgechainId,

--- a/packages/core-magistrate-crypto/src/transactions/bridgechain-update.ts
+++ b/packages/core-magistrate-crypto/src/transactions/bridgechain-update.ts
@@ -27,7 +27,9 @@ export class BridgechainUpdateTransaction extends Transactions.Transaction {
                             type: "object",
                             required: ["bridgechainId", "seedNodes"],
                             properties: {
-                                bridgechainId: { type: "integer", minimum: 1 },
+                                bridgechainId: {
+                                    $ref: "transactionId",
+                                },
                                 seedNodes: seedNodesSchema,
                             },
                         },
@@ -54,7 +56,7 @@ export class BridgechainUpdateTransaction extends Transactions.Transaction {
         }
 
         const buffer: ByteBuffer = new ByteBuffer(4 + 1 + seedNodesBuffersLength + seedNodes.length, true);
-        buffer.writeUint32(bridgechainUpdateAsset.bridgechainId);
+        buffer.append(ByteBuffer.fromHex(bridgechainUpdateAsset.bridgechainId));
 
         buffer.writeUint8(seedNodesBuffers.length);
         for (const seedBuf of seedNodesBuffers) {
@@ -67,7 +69,7 @@ export class BridgechainUpdateTransaction extends Transactions.Transaction {
 
     public deserialize(buf: ByteBuffer): void {
         const { data } = this;
-        const bridgechainId: number = buf.readUint32();
+        const bridgechainId: string = buf.readBytes(32).toString("hex");
 
         const seedNodes: string[] = [];
         const seedNodesLength: number = buf.readUint8();

--- a/packages/core-magistrate-transactions/src/handlers/bridgechain-registration.ts
+++ b/packages/core-magistrate-transactions/src/handlers/bridgechain-registration.ts
@@ -43,7 +43,6 @@ export class BridgechainRegistrationTransactionHandler extends MagistrateTransac
 
                 const bridgechainId: string = transaction.asset.bridgechainRegistration.genesisHash;
                 businessAttributes.bridgechains[bridgechainId] = {
-                    bridgechainId,
                     bridgechainAsset: transaction.asset.bridgechainRegistration,
                 };
 
@@ -132,7 +131,6 @@ export class BridgechainRegistrationTransactionHandler extends MagistrateTransac
 
         const bridgechainId: string = transaction.data.asset.bridgechainRegistration.genesisHash;
         businessAttributes.bridgechains[bridgechainId] = {
-            bridgechainId,
             bridgechainAsset: transaction.data.asset.bridgechainRegistration,
         };
 

--- a/packages/core-magistrate-transactions/src/handlers/bridgechain-registration.ts
+++ b/packages/core-magistrate-transactions/src/handlers/bridgechain-registration.ts
@@ -10,7 +10,6 @@ import {
 } from "../errors";
 import { MagistrateApplicationEvents } from "../events";
 import { IBridgechainWalletAttributes, IBusinessWalletAttributes } from "../interfaces";
-import { MagistrateIndex } from "../wallet-manager";
 import { BusinessRegistrationTransactionHandler } from "./business-registration";
 import { MagistrateTransactionHandler } from "./magistrate-handler";
 
@@ -42,8 +41,8 @@ export class BridgechainRegistrationTransactionHandler extends MagistrateTransac
                     businessAttributes.bridgechains = {};
                 }
 
-                const bridgechainId: number = this.getBridgechainId(walletManager);
-                businessAttributes.bridgechains[bridgechainId.toString()] = {
+                const bridgechainId: string = transaction.asset.bridgechainRegistration.genesisHash;
+                businessAttributes.bridgechains[bridgechainId] = {
                     bridgechainId,
                     bridgechainAsset: transaction.asset.bridgechainRegistration,
                 };
@@ -131,8 +130,8 @@ export class BridgechainRegistrationTransactionHandler extends MagistrateTransac
             businessAttributes.bridgechains = {};
         }
 
-        const bridgechainId: number = this.getBridgechainId(walletManager);
-        businessAttributes.bridgechains[bridgechainId.toString()] = {
+        const bridgechainId: string = transaction.data.asset.bridgechainRegistration.genesisHash;
+        businessAttributes.bridgechains[bridgechainId] = {
             bridgechainId,
             bridgechainAsset: transaction.data.asset.bridgechainRegistration,
         };
@@ -169,8 +168,4 @@ export class BridgechainRegistrationTransactionHandler extends MagistrateTransac
         walletManager: State.IWalletManager,
         // tslint:disable-next-line:no-empty
     ): Promise<void> {}
-
-    private getBridgechainId(walletManager: State.IWalletManager): number {
-        return walletManager.getIndex(MagistrateIndex.Bridgechains).values().length + 1;
-    }
 }

--- a/packages/core-magistrate-transactions/src/handlers/bridgechain-resignation.ts
+++ b/packages/core-magistrate-transactions/src/handlers/bridgechain-resignation.ts
@@ -71,7 +71,7 @@ export class BridgechainResignationTransactionHandler extends MagistrateTransact
         const bridgechainResignation: MagistrateInterfaces.IBridgechainResignationAsset =
             transaction.data.asset.bridgechainResignation;
         const bridgechainAttributes: IBridgechainWalletAttributes =
-            businessAttributes.bridgechains[bridgechainResignation.bridgechainId.toString()];
+            businessAttributes.bridgechains[bridgechainResignation.bridgechainId];
         if (!bridgechainAttributes) {
             throw new BridgechainIsNotRegisteredError();
         }
@@ -92,7 +92,7 @@ export class BridgechainResignationTransactionHandler extends MagistrateTransact
         pool: TransactionPool.IConnection,
         processor: TransactionPool.IProcessor,
     ): Promise<boolean> {
-        const { bridgechainId }: { bridgechainId: number } = data.asset.bridgechainResignation;
+        const { bridgechainId }: { bridgechainId: string } = data.asset.bridgechainResignation;
 
         const bridgechainResignationsInPool: Interfaces.ITransactionData[] = Array.from(
             await pool.getTransactionsByType(
@@ -132,7 +132,7 @@ export class BridgechainResignationTransactionHandler extends MagistrateTransact
 
         const bridgechainResignation: MagistrateInterfaces.IBridgechainResignationAsset =
             transaction.data.asset.bridgechainResignation;
-        businessAttributes.bridgechains[bridgechainResignation.bridgechainId.toString()].resigned = true;
+        businessAttributes.bridgechains[bridgechainResignation.bridgechainId].resigned = true;
     }
 
     public async revertForSender(
@@ -148,7 +148,7 @@ export class BridgechainResignationTransactionHandler extends MagistrateTransact
 
         const bridgechainResignation: MagistrateInterfaces.IBridgechainResignationAsset =
             transaction.data.asset.bridgechainResignation;
-        businessAttributes.bridgechains[bridgechainResignation.bridgechainId.toString()].resigned = false;
+        businessAttributes.bridgechains[bridgechainResignation.bridgechainId].resigned = false;
     }
 
     public async applyToRecipient(

--- a/packages/core-magistrate-transactions/src/handlers/bridgechain-update.ts
+++ b/packages/core-magistrate-transactions/src/handlers/bridgechain-update.ts
@@ -44,7 +44,7 @@ export class BridgechainUpdateTransactionHandler extends MagistrateTransactionHa
                 );
 
                 const { bridgechainId, seedNodes } = transaction.asset.bridgechainUpdate;
-                businessAttributes.bridgechains[bridgechainId.toString()].bridgechainAsset.seedNodes = seedNodes;
+                businessAttributes.bridgechains[bridgechainId].bridgechainAsset.seedNodes = seedNodes;
 
                 walletManager.reindex(wallet);
             }
@@ -70,7 +70,7 @@ export class BridgechainUpdateTransactionHandler extends MagistrateTransactionHa
         const bridgechainUpdate: MagistrateInterfaces.IBridgechainUpdateAsset =
             transaction.data.asset.bridgechainUpdate;
         const bridgechainAttributes: IBridgechainWalletAttributes =
-            businessAttributes.bridgechains[bridgechainUpdate.bridgechainId.toString()];
+            businessAttributes.bridgechains[bridgechainUpdate.bridgechainId];
 
         if (!bridgechainAttributes) {
             throw new BridgechainIsNotRegisteredByWalletError();
@@ -92,7 +92,7 @@ export class BridgechainUpdateTransactionHandler extends MagistrateTransactionHa
         pool: TransactionPool.IConnection,
         processor: TransactionPool.IProcessor,
     ): Promise<boolean> {
-        const { bridgechainId }: { bridgechainId: number } = data.asset.bridgechainUpdate;
+        const { bridgechainId }: { bridgechainId: string } = data.asset.bridgechainUpdate;
 
         const bridgechainUpdatesInPool: Interfaces.ITransactionData[] = Array.from(
             await pool.getTransactionsByType(
@@ -133,7 +133,7 @@ export class BridgechainUpdateTransactionHandler extends MagistrateTransactionHa
             transaction.data.asset.bridgechainUpdate;
 
         const bridgechainAttributes: IBridgechainWalletAttributes =
-            businessAttributes.bridgechains[bridgechainUpdate.bridgechainId.toString()];
+            businessAttributes.bridgechains[bridgechainUpdate.bridgechainId];
         bridgechainAttributes.bridgechainAsset.seedNodes = bridgechainUpdate.seedNodes;
 
         walletManager.reindex(wallet);
@@ -160,14 +160,13 @@ export class BridgechainUpdateTransactionHandler extends MagistrateTransactionHa
         if (updateTransactions.length > 1) {
             const updateTransaction: Database.IBootstrapTransaction = updateTransactions.pop();
             const { bridgechainId, seedNodes } = updateTransaction.asset.bridgechainUpdate;
-            const bridgechainAttributes: IBridgechainWalletAttributes =
-                businessAttributes.bridgechains[bridgechainId.toString()];
+            const bridgechainAttributes: IBridgechainWalletAttributes = businessAttributes.bridgechains[bridgechainId];
             bridgechainAttributes.bridgechainAsset.seedNodes = seedNodes;
         } else {
             // There are equally many bridgechain registrations as bridgechains a wallet posseses in the database.
             // By getting the index of the bridgechainId we can use it as an offset to get
             // the actual registration transaction.
-            const bridgechainId: string = transaction.data.asset.bridgechainUpdate.bridgechainId.toString();
+            const bridgechainId: string = transaction.data.asset.bridgechainUpdate.bridgechainId;
             const registrationIndex: number = Object.keys(businessAttributes.bridgechains).indexOf(bridgechainId);
 
             const bridgechainRegistration: MagistrateInterfaces.IBridgechainRegistrationAsset = (await app

--- a/packages/core-magistrate-transactions/src/interfaces.ts
+++ b/packages/core-magistrate-transactions/src/interfaces.ts
@@ -9,6 +9,6 @@ export interface IBusinessWalletAttributes {
 
 export interface IBridgechainWalletAttributes {
     bridgechainAsset: Interfaces.IBridgechainRegistrationAsset;
-    bridgechainId: number;
+    bridgechainId: string;
     resigned?: boolean;
 }

--- a/packages/core-magistrate-transactions/src/interfaces.ts
+++ b/packages/core-magistrate-transactions/src/interfaces.ts
@@ -9,6 +9,5 @@ export interface IBusinessWalletAttributes {
 
 export interface IBridgechainWalletAttributes {
     bridgechainAsset: Interfaces.IBridgechainRegistrationAsset;
-    bridgechainId: string;
     resigned?: boolean;
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Resolves #3257 

<!-- What changes are being made? -->

Use bridgechain genesisHash as id instead of using some index based on current bridgechains registered.

<!-- Why are these changes necessary? -->

The current bridgechain id logic is causing the #3257 issue , relying on wallet current registered bridgechains is a bit "weak" in my opinion (and as we have database vs tx pool wallet manager which can hold different states, it is dangerous).
Using genesisHash makes sense as it is enforced as unique and defines the bridgechain.

Also, in my opinion **business id should be updated too** as it uses the same mecanism and can be bug-prone. (will open an issue for it)

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->

**Important** : current devnet nodes cannot just update with this and be fine, as their database contains "old" ids and will mess up a lot, 2 options : 
- roll back to before the 1st typeGroup 2 transaction
- use an upgrade script (but doesn't make sense in my opinion as this is not on mainnet, better skip upgrade script when we can)