### PR TITLE
fix(core): remove password flag constraint for core:forger command

### DIFF
--- a/packages/core/src/commands/command.ts
+++ b/packages/core/src/commands/command.ts
@@ -53,11 +53,10 @@ export abstract class BaseCommand extends Command {
         }),
         bip39: flags.string({
             description: "the plain text bip39 passphrase",
-            exclusive: ["bip38", "password"],
+            exclusive: ["bip38"],
         }),
         password: flags.string({
             description: "the password for the encrypted bip38",
-            dependsOn: ["bip38"],
         }),
         suffix: flags.string({
             hidden: true,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Removes the `bip38` constraint from the `--password` flag so that it can be used as documented on docs.ark.io. This makes it possible to run the `core:forger` command directly instead of the underlying commands.

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
