### PR TITLE
fix(core-forger): don't swallow BIP38 errors

### DIFF
--- a/packages/core-forger/src/delegate.ts
+++ b/packages/core-forger/src/delegate.ts
@@ -38,19 +38,13 @@ export class Delegate {
         this.iterations = 5000;
 
         if (Crypto.bip38.verify(passphrase)) {
-            try {
-                this.keys = Delegate.decryptPassphrase(passphrase, network, password);
-                this.publicKey = this.keys.publicKey;
-                this.address = Identities.Address.fromPublicKey(this.keys.publicKey, network.pubKeyHash);
-                this.otpSecret = forge.random.getBytesSync(128);
-                this.bip38 = true;
+            this.keys = Delegate.decryptPassphrase(passphrase, network, password);
+            this.publicKey = this.keys.publicKey;
+            this.address = Identities.Address.fromPublicKey(this.keys.publicKey, network.pubKeyHash);
+            this.otpSecret = forge.random.getBytesSync(128);
+            this.bip38 = true;
 
-                this.encryptKeysWithOtp();
-            } catch (error) {
-                this.publicKey = undefined;
-                this.keys = undefined;
-                this.address = undefined;
-            }
+            this.encryptKeysWithOtp();
         } else {
             this.keys = Identities.Keys.fromPassphrase(passphrase);
             this.publicKey = this.keys.publicKey;


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

If anything with the provided bip38 or password was wrong it was just assumed that no delegate will be used. Now the exception will be thrown and nothing is assumed.

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
