### PR TITLE
refactor(crypto): set minimum fee on transaction types

### DIFF
--- a/__tests__/unit/crypto/transactions/schemas.test.ts
+++ b/__tests__/unit/crypto/transactions/schemas.test.ts
@@ -340,6 +340,16 @@ describe("Delegate Registration Transaction", () => {
         expect(error).not.toBeUndefined();
     });
 
+    it("should be invalid due to zero fee", () => {
+        transaction
+            .usernameAsset("delegate1")
+            .fee("0")
+            .sign("passphrase");
+
+        const { error } = Ajv.validate(transactionSchema.$id, transaction.getStruct());
+        expect(error).not.toBeUndefined();
+    });
+
     it("should be invalid due to space in username", () => {
         transaction.usernameAsset("test 123").sign("passphrase");
 

--- a/packages/crypto/src/transactions/types/schemas.ts
+++ b/packages/crypto/src/transactions/types/schemas.ts
@@ -65,6 +65,7 @@ export const transfer = extend(transactionBaseSchema, {
     required: ["recipientId"],
     properties: {
         type: { transactionType: TransactionType.Transfer },
+        fee: { bignumber: { minimum: 1, bypassGenesis: true } },
         vendorField: { anyOf: [{ type: "null" }, { type: "string", format: "vendorField" }] },
         recipientId: { $ref: "address" },
         expiration: { type: "integer", minimum: 0 },
@@ -77,6 +78,7 @@ export const secondSignature = extend(transactionBaseSchema, {
     properties: {
         type: { transactionType: TransactionType.SecondSignature },
         amount: { bignumber: { minimum: 0, maximum: 0 } },
+        fee: { bignumber: { minimum: 1 } },
         secondSignature: { type: "null" },
         asset: {
             type: "object",
@@ -102,6 +104,7 @@ export const delegateRegistration = extend(transactionBaseSchema, {
     properties: {
         type: { transactionType: TransactionType.DelegateRegistration },
         amount: { bignumber: { minimum: 0, maximum: 0 } },
+        fee: { bignumber: { minimum: 1, bypassGenesis: true } },
         asset: {
             type: "object",
             required: ["delegate"],
@@ -124,6 +127,7 @@ export const vote = extend(transactionBaseSchema, {
     properties: {
         type: { transactionType: TransactionType.Vote },
         amount: { bignumber: { minimum: 0, maximum: 0 } },
+        fee: { bignumber: { minimum: 1 } },
         recipientId: { $ref: "address" },
         asset: {
             type: "object",
@@ -149,6 +153,7 @@ export const multiSignature = extend(transactionBaseSchema, {
     properties: {
         type: { transactionType: TransactionType.MultiSignature },
         amount: { bignumber: { minimum: 0, maximum: 0 } },
+        fee: { bignumber: { minimum: 1 } },
         asset: {
             anyOf: [
                 {
@@ -227,6 +232,7 @@ export const ipfs = extend(transactionBaseSchema, {
     properties: {
         type: { transactionType: TransactionType.Ipfs },
         amount: { bignumber: { minimum: 0, maximum: 0 } },
+        fee: { bignumber: { minimum: 1 } },
         asset: {
             type: "object",
             required: ["ipfs"],
@@ -245,6 +251,7 @@ export const htlcLock = extend(transactionBaseSchema, {
     properties: {
         type: { transactionType: TransactionType.HtlcLock },
         amount: { bignumber: { minimum: 1 } },
+        fee: { bignumber: { minimum: 1 } },
         recipientId: { $ref: "address" },
         vendorField: { anyOf: [{ type: "null" }, { type: "string", format: "vendorField" }] },
         asset: {
@@ -321,6 +328,7 @@ export const multiPayment = extend(transactionBaseSchema, {
     properties: {
         type: { transactionType: TransactionType.MultiPayment },
         amount: { bignumber: { minimum: 0, maximum: 0 } },
+        fee: { bignumber: { minimum: 1 } },
         vendorField: { anyOf: [{ type: "null" }, { type: "string", format: "vendorField" }] },
         asset: {
             type: "object",
@@ -350,6 +358,7 @@ export const delegateResignation = extend(transactionBaseSchema, {
     properties: {
         type: { transactionType: TransactionType.DelegateResignation },
         amount: { bignumber: { minimum: 0, maximum: 0 } },
+        fee: { bignumber: { minimum: 1 } },
     },
 });
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Overwrites the new minimum fee of zero introduced in #3275 to be positive again on certain transaction types:

- transfer
- second signature
- delegate registration
- delegate resignation
- vote
- multi signature
- ipfs
- htlc lock
- multi payment

Alternatively the unit tests for these transaction types can be adjusted to check for negative fees instead of zero fees.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
