### PR TITLE
chore(install): don't delete .cache dir

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -106,7 +106,7 @@ success "Installed system dependencies!"
 heading "Installing node.js & npm..."
 
 sudo rm -rf /usr/local/{lib/node{,/.npm,_modules},bin,share/man}/{npm*,node*,man1/node*}
-sudo rm -rf ~/{.npm,.forever,.node*,.cache,.nvm}
+sudo rm -rf ~/{.npm,.forever,.node*,.nvm}
 
 if [[ ! -z $DEB ]]; then
     sudo wget --quiet -O - https://deb.nodesource.com/gpgkey/nodesource.gpg.key | sudo apt-key add -


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Deleting the `.cache` dir in `install.sh` causes file permission issues when it's automatically re-created by one of the modules (npm or yarn). Not deleting the directory fixes this.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
