### PR TITLE
fix(core-transactions): update sender's wallet after validation

### DIFF
--- a/packages/core-transactions/src/handlers/transaction.ts
+++ b/packages/core-transactions/src/handlers/transaction.ts
@@ -181,8 +181,6 @@ export abstract class TransactionHandler implements ITransactionHandler {
             nonce = sender.nonce.plus(1);
         }
 
-        sender.nonce = nonce;
-
         const newBalance: Utils.BigNumber = sender.balance.minus(data.amount).minus(data.fee);
 
         if (process.env.CORE_ENV === "test") {
@@ -192,13 +190,14 @@ export abstract class TransactionHandler implements ITransactionHandler {
                 const negativeBalanceExceptions: Record<string, Record<string, string>> =
                     Managers.configManager.get("exceptions.negativeBalances") || {};
                 const negativeBalances: Record<string, string> = negativeBalanceExceptions[sender.publicKey] || {};
-                if (!newBalance.isEqualTo(negativeBalances[sender.nonce.toString()] || 0)) {
+                if (!newBalance.isEqualTo(negativeBalances[nonce.toString()] || 0)) {
                     throw new InsufficientBalanceError();
                 }
             }
         }
 
         sender.balance = newBalance;
+        sender.nonce = nonce;
     }
 
     public async revertForSender(

--- a/packages/core-transactions/src/handlers/transaction.ts
+++ b/packages/core-transactions/src/handlers/transaction.ts
@@ -208,12 +208,11 @@ export abstract class TransactionHandler implements ITransactionHandler {
         const sender: State.IWallet = walletManager.findByPublicKey(transaction.data.senderPublicKey);
         const data: Interfaces.ITransactionData = transaction.data;
 
-        sender.balance = sender.balance.plus(data.amount).plus(data.fee);
-
         if (data.version > 1) {
             sender.verifyTransactionNonceRevert(transaction);
         }
 
+        sender.balance = sender.balance.plus(data.amount).plus(data.fee);
         sender.nonce = sender.nonce.minus(1);
     }
 


### PR DESCRIPTION
## Summary

While applying and reverting transactions update sender's state only after everything is validated, otherwise wallet may end up in inconsistent state.

## Checklist

- [x] Ready to be merged