### PR TITLE
refactor(crypto): fix hypothetical cache poisoning

### DIFF
--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -39,7 +39,6 @@
         "bytebuffer": "^5.0.1",
         "dayjs": "^1.8.15",
         "deepmerge": "^4.0.0",
-        "fast-memoize": "^2.5.1",
         "ipaddr.js": "^1.9.0",
         "lodash.get": "^4.4.2",
         "lodash.set": "^4.3.2",

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -45,6 +45,7 @@
         "lodash.set": "^4.3.2",
         "lodash.sumby": "^4.6.0",
         "long": "~3",
+        "memoize-weak": "^1.0.2",
         "tiny-glob": "^0.2.6",
         "wif": "^2.0.6"
     },

--- a/packages/crypto/src/utils/base58.ts
+++ b/packages/crypto/src/utils/base58.ts
@@ -1,5 +1,5 @@
 import { base58 } from "bstring";
-import moize from "fast-memoize";
+import memoize from "memoize-weak";
 import { HashAlgorithms } from "../crypto";
 
 const encodeCheck = (buffer: Buffer): string => {
@@ -21,6 +21,6 @@ const decodeCheck = (address: string): Buffer => {
 };
 
 export const Base58 = {
-    encodeCheck: moize(encodeCheck),
-    decodeCheck: moize(decodeCheck),
+    encodeCheck: memoize(encodeCheck),
+    decodeCheck: memoize(decodeCheck),
 };

--- a/packages/crypto/src/utils/index.ts
+++ b/packages/crypto/src/utils/index.ts
@@ -1,12 +1,9 @@
+import memoize from "memoize-weak";
 import { SATOSHI } from "../constants";
 import { configManager } from "../managers/config";
 import { Base58 } from "./base58";
 import { BigNumber } from "./bignum";
 import { isLocalHost, isValidPeer } from "./is-valid-peer";
-
-let genesisTransactions: { [key: string]: boolean };
-let whitelistedBlockAndTransactionIds: { [key: string]: boolean };
-let currentNetwork: number;
 
 /**
  * Get human readable string from satoshis
@@ -25,31 +22,32 @@ export const formatSatoshi = (amount: BigNumber): string => {
  */
 export const isException = (blockOrTransaction: { id?: string }): boolean => {
     const network: number = configManager.get("network.pubKeyHash");
-
-    if (!whitelistedBlockAndTransactionIds || currentNetwork !== network) {
-        currentNetwork = network;
-
-        whitelistedBlockAndTransactionIds = [
-            ...(configManager.get("exceptions.blocks") || []),
-            ...(configManager.get("exceptions.transactions") || []),
-        ].reduce((acc, curr) => Object.assign(acc, { [curr]: true }), {});
-    }
-
-    return !!whitelistedBlockAndTransactionIds[blockOrTransaction.id];
+    const exceptionalIds = memoize(() => {
+        const s = new Set<string>();
+        const blockIds = configManager.get("exceptions.blocks") || [];
+        const transactionIds = configManager.get("exceptions.transactions") || [];
+        for (const blockId of blockIds) {
+            s.add(blockId);
+        }
+        for (const transactionId of transactionIds) {
+            s.add(transactionId);
+        }
+        return s;
+    })(network);
+    return exceptionalIds.has(blockOrTransaction.id);
 };
 
 export const isGenesisTransaction = (id: string): boolean => {
     const network: number = configManager.get("network.pubKeyHash");
-
-    if (!genesisTransactions || currentNetwork !== network) {
-        currentNetwork = network;
-
-        genesisTransactions = configManager
-            .get("genesisBlock.transactions")
-            .reduce((acc, curr) => Object.assign(acc, { [curr.id]: true }), {});
-    }
-
-    return genesisTransactions[id];
+    const genesisIds = memoize(() => {
+        const s = new Set<string>();
+        const genesisTransactions = configManager.get("genesisBlock.transactions") || [];
+        for (const transaction of genesisTransactions) {
+            s.add(transaction.id);
+        }
+        return s;
+    })(network);
+    return genesisIds.has(id);
 };
 
 export const numberToHex = (num: number, padding = 2): string => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6238,11 +6238,6 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.4:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
-fast-memoize@^2.5.1:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/fast-memoize/-/fast-memoize-2.5.1.tgz#c3519241e80552ce395e1a32dcdde8d1fd680f5d"
-  integrity sha512-xdmw296PCL01tMOXx9mdJSmWY29jQgxyuZdq0rEHMu+Tpe1eOEtCycoG6chzlcrWsNgpZP7oL8RiQr7+G6Bl6g==
-
 fast-redact@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fast-redact/-/fast-redact-2.0.0.tgz#17bb8f5e1f56ecf4a38c8455985e5eab4c478431"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9105,6 +9105,11 @@ mem@^4.0.0:
     mimic-fn "^2.0.0"
     p-is-promise "^2.0.0"
 
+memoize-weak@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/memoize-weak/-/memoize-weak-1.0.2.tgz#d0015a4c7c6cff2263dbbb49db1dc206ebb94916"
+  integrity sha1-0AFaTHxs/yJj27tJ2x3CBuu5SRY=
+
 meow@^3.3.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/meow/-/meow-3.7.0.tgz#72cb668b425228290abbfa856892587308a801fb"


### PR DESCRIPTION
## Summary

Due to insufficient checks `whitelistedBlockAndTransactionIds` may end up containing ids from a different network. Fixed it by doing proper memoization.

## Checklist

- [x] Ready to be merged

Also swapped memoization implementation with one that doesn't keep cache forever.