### PR TITLE
refactor(core-state): move apply and revert block functions out of wallet

### DIFF
--- a/__tests__/unit/core-state/wallets/wallet-manager.test.ts
+++ b/__tests__/unit/core-state/wallets/wallet-manager.test.ts
@@ -80,8 +80,8 @@ describe("Wallet Manager", () => {
             walletManager.reindex(generatorWallet);
 
             // @ts-ignore
-            jest.spyOn(walletManager, "applyBlockGeneratorWallet");
-            jest.spyOn(walletManager, "revertBlockGeneratorWallet");
+            jest.spyOn(walletManager, "applyBlockToGeneratorWallet");
+            jest.spyOn(walletManager, "revertBlockToGeneratorWallet");
             jest.spyOn(walletManager, "applyTransaction").mockImplementation();
             jest.spyOn(walletManager, "revertTransaction").mockImplementation();
 
@@ -102,7 +102,7 @@ describe("Wallet Manager", () => {
             it("should aplly the block of the delegate", async () => {
                 await walletManager.applyBlock(block);
 
-                expect(walletManager.applyBlockGeneratorWallet).toHaveBeenCalledWith(block);
+                expect(walletManager.applyBlockToGeneratorWallet).toHaveBeenCalledWith(block);
 
                 const delegate = generatorWallet.getAttribute<State.IWalletDelegateAttributes>("delegate");
                 expect(delegate.producedBlocks).toBe(101);
@@ -191,7 +191,7 @@ describe("Wallet Manager", () => {
             it("should revert the block of the delegate", async () => {
                 await walletManager.revertBlock(block);
 
-                expect(walletManager.revertBlockGeneratorWallet).toHaveBeenCalledWith(block);
+                expect(walletManager.revertBlockToGeneratorWallet).toHaveBeenCalledWith(block);
 
                 const delegate = generatorWallet.getAttribute<State.IWalletDelegateAttributes>("delegate");
                 expect(delegate.producedBlocks).toBe(99);

--- a/__tests__/unit/core-state/wallets/wallet-manager.test.ts
+++ b/__tests__/unit/core-state/wallets/wallet-manager.test.ts
@@ -14,7 +14,9 @@ import wallets from "../__fixtures__/wallets.json";
 const { BlockFactory } = Blocks;
 const { SATOSHI } = Constants;
 
-const block3 = fixtures.blocks2to100[1];
+const block3 = Object.assign({}, fixtures.blocks2to100[1], {
+    totalFee: Utils.BigNumber.make(17 * SATOSHI),
+});
 const block = BlockFactory.fromData(block3);
 
 const walletData1 = wallets[0];
@@ -51,57 +53,62 @@ describe("Wallet Manager", () => {
     });
 
     describe("block processing", () => {
-        let delegateMock;
+        let generatorWallet: State.IWallet;
         let block2: Interfaces.IBlock;
 
-        const delegatePublicKey = block3.generatorPublicKey; // '0299deebff24ebf2bb53ad78f3ea3ada5b3c8819132e191b02c263ee4aa4af3d9b'
+        const generatorPublicKey = block3.generatorPublicKey; // '0299deebff24ebf2bb53ad78f3ea3ada5b3c8819132e191b02c263ee4aa4af3d9b'
 
         const txs: Interfaces.ITransaction[] = [];
         for (let i = 0; i < 3; i++) {
             txs[i] = Transactions.BuilderFactory.vote()
                 .sign(Math.random().toString(36))
-                .votesAsset([`+${delegatePublicKey}`])
+                .votesAsset([`+${generatorPublicKey}`])
                 .build();
         }
 
         beforeEach(() => {
-            delegateMock = {
-                applyBlock: jest.fn(),
-                revertBlock: jest.fn(),
-                publicKey: delegatePublicKey,
-                isDelegate: () => false,
-                getAttribute: jest.fn(),
-            };
+            generatorWallet = new Wallet(Identities.Address.fromPublicKey(generatorPublicKey));
+            generatorWallet.publicKey = generatorPublicKey;
+            generatorWallet.setAttribute<State.IWalletDelegateAttributes>("delegate", {
+                username: "generator",
+                voteBalance: Utils.BigNumber.ZERO,
+                forgedFees: Utils.BigNumber.make(100 * SATOSHI),
+                forgedRewards: Utils.BigNumber.make(50 * SATOSHI),
+                producedBlocks: 100,
+                rank: undefined,
+            });
+            walletManager.reindex(generatorWallet);
 
             // @ts-ignore
-            jest.spyOn(walletManager, "findByPublicKey").mockReturnValue(delegateMock);
+            jest.spyOn(walletManager, "applyBlockGeneratorWallet");
+            jest.spyOn(walletManager, "revertBlockGeneratorWallet");
             jest.spyOn(walletManager, "applyTransaction").mockImplementation();
             jest.spyOn(walletManager, "revertTransaction").mockImplementation();
 
-            const { data } = block;
-            data.transactions = [];
-            data.transactions.push(txs[0].data);
-            data.transactions.push(txs[1].data);
-            data.transactions.push(txs[2].data);
-            data.numberOfTransactions = 3; // NOTE: if transactions are added to a fixture the NoT needs to be increased
-            block2 = BlockFactory.fromData(data);
-
-            walletManager.reindex(delegateMock);
+            block.data.transactions = [txs[0].data, txs[1].data, txs[2].data];
+            block.data.numberOfTransactions = 3; // NOTE: if transactions are added to a fixture the NoT needs to be increased
+            block2 = BlockFactory.fromData(block.data);
+            block2.data.reward = Utils.BigNumber.make(11 * SATOSHI);
         });
 
         describe("applyBlock", () => {
-            it("should apply sequentially the transactions of the block", async () => {
+            it("should apply transactions of the block in order", async () => {
                 await walletManager.applyBlock(block2);
-
                 for (let i = 0; i < block2.transactions.length; i++) {
                     expect(walletManager.applyTransaction).toHaveBeenNthCalledWith(i + 1, block2.transactions[i]);
                 }
             });
 
-            it("should apply the block data to the delegate", async () => {
+            it("should aplly the block of the delegate", async () => {
                 await walletManager.applyBlock(block);
 
-                expect(delegateMock.applyBlock).toHaveBeenCalledWith(block.data);
+                expect(walletManager.applyBlockGeneratorWallet).toHaveBeenCalledWith(block);
+
+                const delegate = generatorWallet.getAttribute<State.IWalletDelegateAttributes>("delegate");
+                expect(delegate.producedBlocks).toBe(101);
+                expect(delegate.forgedFees).toEqual(Utils.BigNumber.make(100 * SATOSHI).plus(block.data.totalFee));
+                expect(delegate.forgedRewards).toEqual(Utils.BigNumber.make(50 * SATOSHI).plus(block.data.reward));
+                expect(delegate.lastBlock).toBeObject();
             });
 
             describe("when 1 transaction fails while applying it", () => {
@@ -173,9 +180,25 @@ describe("Wallet Manager", () => {
         });
 
         describe("revertBlock", () => {
-            it.todo("should revert all transactions of the block");
+            it("should apply transactions of the block in reverse order", async () => {
+                await walletManager.revertBlock(block2);
+                const reversedTransactions = block2.transactions.slice().reverse();
+                for (let i = 0; i < reversedTransactions.length; i++) {
+                    expect(walletManager.revertTransaction).toHaveBeenNthCalledWith(i + 1, reversedTransactions[i]);
+                }
+            });
 
-            it.todo("should revert the block of the delegate");
+            it("should revert the block of the delegate", async () => {
+                await walletManager.revertBlock(block);
+
+                expect(walletManager.revertBlockGeneratorWallet).toHaveBeenCalledWith(block);
+
+                const delegate = generatorWallet.getAttribute<State.IWalletDelegateAttributes>("delegate");
+                expect(delegate.producedBlocks).toBe(99);
+                expect(delegate.forgedFees).toEqual(Utils.BigNumber.make(100 * SATOSHI).minus(block.data.totalFee));
+                expect(delegate.forgedRewards).toEqual(Utils.BigNumber.make(50 * SATOSHI).minus(block.data.reward));
+                expect(delegate.lastBlock).toBeUndefined(); // actually it shouldn't
+            });
 
             it("should return the current block", async () => {
                 expect(walletManager.getCurrentBlock()).toBeUndefined();

--- a/packages/core-interfaces/src/core-state/wallets.ts
+++ b/packages/core-interfaces/src/core-state/wallets.ts
@@ -129,9 +129,9 @@ export interface IWalletManager {
 
     revertTransaction(transaction: Interfaces.ITransaction): Promise<void>;
 
-    applyBlockGeneratorWallet(block: Interfaces.IBlock): void;
+    applyBlockToGeneratorWallet(block: Interfaces.IBlock): void;
 
-    revertBlockGeneratorWallet(block: Interfaces.IBlock): void;
+    revertBlockToGeneratorWallet(block: Interfaces.IBlock): void;
 
     increaseDelegateVoteBalance(wallet: IWallet, amount: Utils.BigNumber): void;
 

--- a/packages/core-interfaces/src/core-state/wallets.ts
+++ b/packages/core-interfaces/src/core-state/wallets.ts
@@ -19,9 +19,6 @@ export interface IWallet {
     balance: Utils.BigNumber;
     nonce: Utils.BigNumber;
 
-    applyBlock(block: Interfaces.IBlockData): boolean;
-    revertBlock(block: Interfaces.IBlockData): boolean;
-
     auditApply(transaction: Interfaces.ITransactionData): any[];
     toString(): string;
 
@@ -131,6 +128,14 @@ export interface IWalletManager {
     applyTransaction(transaction: Interfaces.ITransaction): Promise<void>;
 
     revertTransaction(transaction: Interfaces.ITransaction): Promise<void>;
+
+    applyBlockGeneratorWallet(block: Interfaces.IBlock): void;
+
+    revertBlockGeneratorWallet(block: Interfaces.IBlock): void;
+
+    increaseDelegateVoteBalance(wallet: IWallet, amount: Utils.BigNumber): void;
+
+    decreaseDelegateVoteBalance(wallet: IWallet, amount: Utils.BigNumber): void;
 
     canBePurged(wallet: IWallet): boolean;
 

--- a/packages/core-state/src/wallets/wallet-manager.ts
+++ b/packages/core-state/src/wallets/wallet-manager.ts
@@ -242,10 +242,8 @@ export class WalletManager implements State.IWalletManager {
     public buildVoteBalances(): void {
         for (const voter of this.allByPublicKey()) {
             if (voter.hasVoted()) {
-                const delegate: State.IWallet = this.findByPublicKey(voter.getAttribute<string>("vote"));
-                const voteBalance: Utils.BigNumber = delegate.getAttribute("delegate.voteBalance");
-                const lockedBalance = voter.getAttribute("htlc.lockedBalance", Utils.BigNumber.ZERO);
-                delegate.setAttribute("delegate.voteBalance", voteBalance.plus(voter.balance).plus(lockedBalance));
+                this.increaseDelegateVoteBalance(voter, voter.balance);
+                this.increaseDelegateVoteBalance(voter, voter.getAttribute("htlc.lockedBalance", Utils.BigNumber.ZERO));
             }
         }
     }

--- a/packages/core-state/src/wallets/wallet-manager.ts
+++ b/packages/core-state/src/wallets/wallet-manager.ts
@@ -258,7 +258,7 @@ export class WalletManager implements State.IWalletManager {
                 await this.applyTransaction(transaction);
                 appliedTransactions.push(transaction);
             }
-            this.applyBlockGeneratorWallet(block);
+            this.applyBlockToGeneratorWallet(block);
         } catch (error) {
             this.logger.error("Failed to apply all transactions in block - reverting latest transactions");
             for (const transaction of appliedTransactions.reverse()) {
@@ -278,7 +278,7 @@ export class WalletManager implements State.IWalletManager {
                 await this.revertTransaction(transaction);
                 revertedTransactions.push(transaction);
             }
-            this.revertBlockGeneratorWallet(block);
+            this.revertBlockToGeneratorWallet(block);
         } catch (error) {
             this.logger.error("Failed to revert all transaction in block - applying latest transactions back");
             for (const transaction of revertedTransactions.reverse()) {
@@ -332,7 +332,7 @@ export class WalletManager implements State.IWalletManager {
         this.updateVoteBalances(sender, recipient, transaction.data, lockWallet, lockTransaction, true);
     }
 
-    public applyBlockGeneratorWallet(block: Interfaces.IBlock) {
+    public applyBlockToGeneratorWallet(block: Interfaces.IBlock) {
         if (!this.has(block.data.generatorPublicKey)) {
             app.forceExit(`Failed to lookup generator '${block.data.generatorPublicKey}' of block '${block.data.id}'.`);
         }
@@ -350,7 +350,7 @@ export class WalletManager implements State.IWalletManager {
         }
     }
 
-    public revertBlockGeneratorWallet(block: Interfaces.IBlock) {
+    public revertBlockToGeneratorWallet(block: Interfaces.IBlock) {
         if (!this.has(block.data.generatorPublicKey)) {
             app.forceExit(`Failed to lookup generator '${block.data.generatorPublicKey}' of block '${block.data.id}'.`);
         }

--- a/packages/core-state/src/wallets/wallet-manager.ts
+++ b/packages/core-state/src/wallets/wallet-manager.ts
@@ -381,7 +381,7 @@ export class WalletManager implements State.IWalletManager {
         const delegatePublicKey = voterWallet.getAttribute<string>("vote");
         const delegateWallet = this.findByPublicKey(delegatePublicKey);
         const oldDelegateVoteBalance = delegateWallet.getAttribute<Utils.BigNumber>("delegate.voteBalance");
-        const newDelegateVoteBalance = oldDelegateVoteBalance.minus(amount);
+        const newDelegateVoteBalance = oldDelegateVoteBalance.plus(amount);
         delegateWallet.setAttribute("delegate.voteBalance", newDelegateVoteBalance);
     }
 

--- a/packages/core-state/src/wallets/wallet-manager.ts
+++ b/packages/core-state/src/wallets/wallet-manager.ts
@@ -378,19 +378,11 @@ export class WalletManager implements State.IWalletManager {
     }
 
     public increaseDelegateVoteBalance(voterWallet: State.IWallet, amount: Utils.BigNumber): void {
-        const delegatePublicKey = voterWallet.getAttribute<string>("vote");
-        const delegateWallet = this.findByPublicKey(delegatePublicKey);
-        const oldDelegateVoteBalance = delegateWallet.getAttribute<Utils.BigNumber>("delegate.voteBalance");
-        const newDelegateVoteBalance = oldDelegateVoteBalance.plus(amount);
-        delegateWallet.setAttribute("delegate.voteBalance", newDelegateVoteBalance);
+        this.changeDelegateVoteBalance(voterWallet, amount);
     }
 
     public decreaseDelegateVoteBalance(voterWallet: State.IWallet, amount: Utils.BigNumber): void {
-        const delegatePublicKey = voterWallet.getAttribute<string>("vote");
-        const delegateWallet = this.findByPublicKey(delegatePublicKey);
-        const oldDelegateVoteBalance = delegateWallet.getAttribute<Utils.BigNumber>("delegate.voteBalance");
-        const newDelegateVoteBalance = oldDelegateVoteBalance.minus(amount);
-        delegateWallet.setAttribute("delegate.voteBalance", newDelegateVoteBalance);
+        this.changeDelegateVoteBalance(voterWallet, amount.times(-1));
     }
 
     public canBePurged(wallet: State.IWallet): boolean {
@@ -450,6 +442,14 @@ export class WalletManager implements State.IWalletManager {
         }
 
         return delegatesSorted;
+    }
+
+    private changeDelegateVoteBalance(voterWallet: State.IWallet, amount: Utils.BigNumber): void {
+        const delegatePublicKey = voterWallet.getAttribute<string>("vote");
+        const delegateWallet = this.findByPublicKey(delegatePublicKey);
+        const oldDelegateVoteBalance = delegateWallet.getAttribute<Utils.BigNumber>("delegate.voteBalance");
+        const newDelegateVoteBalance = oldDelegateVoteBalance.plus(amount);
+        delegateWallet.setAttribute("delegate.voteBalance", newDelegateVoteBalance);
     }
 
     /**

--- a/packages/core-state/src/wallets/wallet-manager.ts
+++ b/packages/core-state/src/wallets/wallet-manager.ts
@@ -1,6 +1,6 @@
 import { app } from "@arkecosystem/core-container";
 import { Logger, Shared, State } from "@arkecosystem/core-interfaces";
-import { Handlers, Interfaces as TransactionInterfaces } from "@arkecosystem/core-transactions";
+import { Handlers } from "@arkecosystem/core-transactions";
 import { Enums, Identities, Interfaces, Utils } from "@arkecosystem/crypto";
 import pluralize from "pluralize";
 import { WalletIndexAlreadyRegisteredError, WalletIndexNotFoundError } from "./errors";

--- a/packages/core-state/src/wallets/wallet-manager.ts
+++ b/packages/core-state/src/wallets/wallet-manager.ts
@@ -291,11 +291,6 @@ export class WalletManager implements State.IWalletManager {
     }
 
     public async applyTransaction(transaction: Interfaces.ITransaction): Promise<void> {
-        const transactionHandler: Handlers.TransactionHandler = await Handlers.Registry.get(
-            transaction.type,
-            transaction.typeGroup,
-        );
-
         let lockWallet: State.IWallet;
         let lockTransaction: Interfaces.ITransactionData;
         if (
@@ -307,20 +302,17 @@ export class WalletManager implements State.IWalletManager {
             lockTransaction = lockWallet.getAttribute("htlc.locks", {})[lockId];
         }
 
+        const transactionHandler = await Handlers.Registry.get(transaction.type, transaction.typeGroup);
         await transactionHandler.apply(transaction, this);
 
-        const sender: State.IWallet = this.findByPublicKey(transaction.data.senderPublicKey);
-        const recipient: State.IWallet = this.findByAddress(transaction.data.recipientId);
+        const sender = this.findByPublicKey(transaction.data.senderPublicKey);
+        const recipient = this.findByAddress(transaction.data.recipientId);
 
         this.updateVoteBalances(sender, recipient, transaction.data, lockWallet, lockTransaction, false);
     }
 
     public async revertTransaction(transaction: Interfaces.ITransaction): Promise<void> {
-        const transactionHandler: TransactionInterfaces.ITransactionHandler = await Handlers.Registry.get(
-            transaction.type,
-            transaction.typeGroup,
-        );
-
+        const transactionHandler = await Handlers.Registry.get(transaction.type, transaction.typeGroup);
         await transactionHandler.revert(transaction, this);
 
         let lockWallet: State.IWallet;
@@ -334,10 +326,9 @@ export class WalletManager implements State.IWalletManager {
             lockTransaction = lockWallet.getAttribute("htlc.locks", {})[lockId];
         }
 
-        const sender: State.IWallet = this.findByPublicKey(transaction.data.senderPublicKey);
-        const recipient: State.IWallet = this.findByAddress(transaction.data.recipientId);
+        const sender = this.findByPublicKey(transaction.data.senderPublicKey);
+        const recipient = this.findByAddress(transaction.data.recipientId);
 
-        // Revert vote balance updates
         this.updateVoteBalances(sender, recipient, transaction.data, lockWallet, lockTransaction, true);
     }
 

--- a/packages/core-state/src/wallets/wallet.ts
+++ b/packages/core-state/src/wallets/wallet.ts
@@ -1,6 +1,6 @@
 import { State } from "@arkecosystem/core-interfaces";
 import { Errors, Handlers } from "@arkecosystem/core-transactions";
-import { Enums, Identities, Interfaces, Transactions, Utils } from "@arkecosystem/crypto";
+import { Enums, Interfaces, Transactions, Utils } from "@arkecosystem/crypto";
 import assert from "assert";
 import dottie from "dottie";
 
@@ -60,48 +60,6 @@ export class Wallet implements State.IWallet {
         const hasAttributes = Object.keys(this.attributes).length > 0;
         const lockedBalance = this.getAttribute("htlc.lockedBalance", Utils.BigNumber.ZERO);
         return this.balance.isZero() && lockedBalance.isZero() && !hasAttributes;
-    }
-
-    public applyBlock(block: Interfaces.IBlockData): boolean {
-        if (
-            block.generatorPublicKey === this.publicKey ||
-            Identities.Address.fromPublicKey(block.generatorPublicKey) === this.address
-        ) {
-            this.balance = this.balance.plus(block.reward).plus(block.totalFee);
-
-            const delegate: State.IWalletDelegateAttributes = this.getAttribute("delegate");
-
-            delegate.producedBlocks++;
-            delegate.forgedFees = delegate.forgedFees.plus(block.totalFee);
-            delegate.forgedRewards = delegate.forgedRewards.plus(block.reward);
-            delegate.lastBlock = block;
-
-            return true;
-        }
-
-        return false;
-    }
-
-    public revertBlock(block: Interfaces.IBlockData): boolean {
-        if (
-            block.generatorPublicKey === this.publicKey ||
-            Identities.Address.fromPublicKey(block.generatorPublicKey) === this.address
-        ) {
-            this.balance = this.balance.minus(block.reward).minus(block.totalFee);
-
-            const delegate: State.IWalletDelegateAttributes = this.getAttribute("delegate");
-
-            delegate.forgedFees = delegate.forgedFees.minus(block.totalFee);
-            delegate.forgedRewards = delegate.forgedRewards.minus(block.reward);
-            delegate.producedBlocks--;
-
-            // TODO: get it back from database?
-            delegate.lastBlock = undefined;
-
-            return true;
-        }
-
-        return false;
     }
 
     public verifySignatures(


### PR DESCRIPTION
## Summary

Refactoring as part of #3303. Block rewards calculations and delegate vote balance update are moved into separate functions in wallet manager. Wallet tests are re-implemented for wallet manager.

## Checklist

- [x] Tests
- [x] Ready to be merged

I introduced 6 new code climate warnings, but fixed 8. I deliberately made code similar and I cannot find a way to get rid of them without making code worse. This one is the prime example:

```typescript
for (const transaction of block.transactions) {
    await this.applyTransaction(transaction);
    appliedTransactions.push(transaction);
}
```

```typescript
for (const transaction of block.transactions.slice().reverse()) {
    await this.revertTransaction(transaction);
    revertedTransactions.push(transaction);
}
```