### PR TITLE
refactor(core-api): accept address, publicKey, delegate name as business id

### DIFF
--- a/__tests__/integration/core-api/handlers/businesses.test.ts
+++ b/__tests__/integration/core-api/handlers/businesses.test.ts
@@ -5,6 +5,8 @@ import { Database, State } from "@arkecosystem/core-interfaces";
 import { setUp, tearDown } from "../__support__/setup";
 import { utils } from "../utils";
 
+const username = "username";
+const address = "AG8kwwk4TsYfA2HdwaWBVAJQBj6VhdcpMo";
 const publicKey = "0377f81a18d25d77b100cb17e829a72259f08334d064f6c887298917a04df8f647";
 
 beforeAll(async () => await setUp());
@@ -12,34 +14,38 @@ afterAll(async () => await tearDown());
 
 describe("API 2.0 - Businesses", () => {
     let walletManager: State.IWalletManager;
+
+    const bridgechainAsset = {
+        name: "arkecosystem1",
+        seedNodes: ["74.125.224.71", "74.125.224.72", "64.233.173.193", "2001:4860:4860::8888", "2001:4860:4860::8844"],
+        genesisHash: "127e6fbfe24a750e72930c220a8e138275656b8e5d8f48a98c3c92df2caba935",
+        bridgechainRepository: "http://www.repository.com/myorg/myrepo",
+        ports: { "@arkecosystem/core-api": 4003 },
+    };
+
     const businessAttribute = {
         businessAsset: {
             name: "bizzz",
             website: "biz.com",
             bridgechains: {
                 "127e6fbfe24a750e72930c220a8e138275656b8e5d8f48a98c3c92df2caba935": {
-                    bridgechainAsset: {
-                        name: "arkecosystem1",
-                        seedNodes: [
-                            "74.125.224.71",
-                            "74.125.224.72",
-                            "64.233.173.193",
-                            "2001:4860:4860::8888",
-                            "2001:4860:4860::8844",
-                        ],
-                        genesisHash: "127e6fbfe24a750e72930c220a8e138275656b8e5d8f48a98c3c92df2caba935",
-                        bridgechainRepository: "http://www.repository.com/myorg/myrepo",
-                        ports: { "@arkecosystem/core-api": 4003 },
-                    },
+                    bridgechainAsset,
                 },
             },
         },
+    };
+
+    const validIdentifiers = {
+        username,
+        address,
+        publicKey,
     };
 
     beforeAll(() => {
         walletManager = app.resolvePlugin<Database.IDatabaseService>("database").walletManager;
 
         const wallet = walletManager.findByPublicKey(publicKey);
+        wallet.setAttribute("delegate.username", username);
         wallet.setAttribute("business", businessAttribute);
         wallet.setAttribute("business.bridgechains", businessAttribute.businessAsset.bridgechains);
 
@@ -60,21 +66,35 @@ describe("API 2.0 - Businesses", () => {
     });
 
     describe("GET /businesses/:id", () => {
-        it("should GET business by id (wallet publicKey)", async () => {
-            const response = await utils.request("GET", `businesses/${publicKey}`);
-            expect(response).toBeSuccessfulResponse();
-            expect(response.data.data).toBeObject();
-            expect(response.data.data.attributes.business).toEqual(businessAttribute);
+        it("should GET a business by the given valid identifier", async () => {
+            for (const identifier of Object.values(validIdentifiers)) {
+                const response = await utils.request("GET", `businesses/${identifier}`);
+                expect(response).toBeSuccessfulResponse();
+                expect(response.data.data).toBeObject();
+
+                expect(response.data.data.attributes.business).toEqual(businessAttribute);
+            }
+        });
+
+        it("should fail to GET a business by an unknown identifier", async () => {
+            utils.expectError(await utils.request("GET", "businesses/i_do_not_exist"), 404);
         });
     });
 
     describe("GET /businesses/:id/bridgechains", () => {
         it("should GET business bridgechains", async () => {
-            const response = await utils.request("GET", `businesses/${publicKey}/bridgechains`);
-            expect(response).toBeSuccessfulResponse();
-            expect(response.data.data).toBeArray();
-            expect(response.data.data).toHaveLength(1);
-            // TODO check bridgechainId is correct (after bridgechainId = genesisHash PR is merged)
+            for (const identifier of Object.values(validIdentifiers)) {
+                const response = await utils.request("GET", `businesses/${identifier}/bridgechains`);
+                expect(response).toBeSuccessfulResponse();
+                expect(response.data.data).toBeArray();
+                expect(response.data.data).toHaveLength(1);
+
+                expect(response.data.data[0].genesisHash).toEqual(bridgechainAsset.genesisHash);
+            }
+        });
+
+        it("should fail to GET business bridgechains by an unknown identifier", async () => {
+            utils.expectError(await utils.request("GET", "businesses/i_do_not_exist/bridgechains"), 404);
         });
     });
 

--- a/packages/core-api/src/handlers/businesses/methods.ts
+++ b/packages/core-api/src/handlers/businesses/methods.ts
@@ -16,26 +16,24 @@ const index = async request => {
 };
 
 const show = async request => {
-    const business = databaseService.walletManager.findByPublicKey(request.params.id);
+    const wallet = databaseService.wallets.findById(Database.SearchScope.Wallets, request.params.id);
 
-    if (!business) {
+    if (!wallet || !wallet.hasAttribute("business")) {
         return Boom.notFound("Business not found");
     }
 
-    return respondWithResource(business, "business");
+    return respondWithResource(wallet, "business");
 };
 
 const bridgechains = async request => {
-    const business = databaseService.wallets.search(Database.SearchScope.Businesses, {
-        publicKey: request.params.id,
-    });
+    const wallet = databaseService.wallets.findById(Database.SearchScope.Wallets, request.params.id);
 
-    if (!business) {
+    if (!wallet || !wallet.hasAttribute("business")) {
         return Boom.notFound("Business not found");
     }
 
     const bridgechains = databaseService.wallets.search(Database.SearchScope.Bridgechains, {
-        publicKey: request.params.id,
+        publicKey: wallet.publicKey,
         ...request.query,
         ...paginate(request),
     });

--- a/packages/core-api/src/handlers/businesses/schema.ts
+++ b/packages/core-api/src/handlers/businesses/schema.ts
@@ -1,5 +1,5 @@
 import Joi from "@hapi/joi";
-import { orderBy, pagination } from "../shared/schemas";
+import { orderBy, pagination, walletId } from "../shared/schemas";
 
 export const index: object = {
     query: {
@@ -16,17 +16,13 @@ export const index: object = {
 
 export const show: object = {
     params: {
-        id: Joi.string()
-            .hex()
-            .length(66),
+        id: walletId,
     },
 };
 
 export const bridgechains: object = {
     params: {
-        id: Joi.string()
-            .hex()
-            .length(66),
+        id: walletId,
     },
     query: {
         ...pagination,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

With these changes it will be possible to retrieve a business and its bridgechains by using the associated wallets address, publicKey or delegate name.

Fixes #3308 and fixes #3309.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
