### PR TITLE
fix(core-api): businesses/bridgechains search by name

### DIFF
--- a/packages/core-api/src/handlers/blocks/schema.ts
+++ b/packages/core-api/src/handlers/blocks/schema.ts
@@ -1,5 +1,5 @@
 import Joi from "@hapi/joi";
-import { blockId, orderBy, pagination } from "../shared/schemas";
+import { address, blockId, orderBy, pagination, publicKey } from "../shared/schemas";
 
 export const index: object = {
     query: {
@@ -33,9 +33,7 @@ export const index: object = {
                 .integer()
                 .positive(),
             payloadHash: Joi.string().hex(),
-            generatorPublicKey: Joi.string()
-                .hex()
-                .length(66),
+            generatorPublicKey: publicKey,
             blockSignature: Joi.string().hex(),
             transform: Joi.bool().default(true),
         },
@@ -73,7 +71,7 @@ export const transactions: object = {
             orderBy,
             id: Joi.string()
                 .hex()
-                .length(66),
+                .length(64),
             blockId,
             type: Joi.number()
                 .integer()
@@ -81,15 +79,9 @@ export const transactions: object = {
             version: Joi.number()
                 .integer()
                 .min(0),
-            senderPublicKey: Joi.string()
-                .hex()
-                .length(66),
-            senderId: Joi.string()
-                .alphanum()
-                .length(34),
-            recipientId: Joi.string()
-                .alphanum()
-                .length(34),
+            senderPublicKey: publicKey,
+            senderId: address,
+            recipientId: address,
             timestamp: Joi.number()
                 .integer()
                 .min(0),
@@ -119,9 +111,7 @@ export const search: object = {
             .min(0),
         previousBlock: blockId,
         payloadHash: Joi.string().hex(),
-        generatorPublicKey: Joi.string()
-            .hex()
-            .length(66),
+        generatorPublicKey: publicKey,
         blockSignature: Joi.string().hex(),
         timestamp: Joi.object().keys({
             from: Joi.number()

--- a/packages/core-api/src/handlers/bridgechains/schema.ts
+++ b/packages/core-api/src/handlers/bridgechains/schema.ts
@@ -1,14 +1,12 @@
 import Joi from "@hapi/joi";
-import { genericName, orderBy, pagination } from "../shared/schemas";
+import { address, genericName, orderBy, pagination, publicKey } from "../shared/schemas";
 
 export const index: object = {
     query: {
         ...pagination,
         ...{
             orderBy,
-            publicKey: Joi.string()
-                .hex()
-                .length(66),
+            publicKey,
             isResigned: Joi.bool(),
         },
     },
@@ -30,10 +28,9 @@ export const search: object = {
         },
     },
     payload: {
+        address,
+        publicKey,
         bridgechainRepository: Joi.string().max(80),
-        publicKey: Joi.string()
-            .hex()
-            .length(66),
         genesisHash: Joi.string()
             .hex()
             .length(64),

--- a/packages/core-api/src/handlers/bridgechains/schema.ts
+++ b/packages/core-api/src/handlers/bridgechains/schema.ts
@@ -1,5 +1,5 @@
 import Joi from "@hapi/joi";
-import { orderBy, pagination } from "../shared/schemas";
+import { genericName, orderBy, pagination } from "../shared/schemas";
 
 export const index: object = {
     query: {
@@ -37,9 +37,7 @@ export const search: object = {
         genesisHash: Joi.string()
             .hex()
             .length(64),
-        name: Joi.string()
-            .regex(/^[a-zA-Z0-9_-]+$/)
-            .max(40),
+        name: genericName,
         seedNodes: Joi.array()
             .unique()
             .min(1)

--- a/packages/core-api/src/handlers/businesses/schema.ts
+++ b/packages/core-api/src/handlers/businesses/schema.ts
@@ -1,5 +1,5 @@
 import Joi from "@hapi/joi";
-import { orderBy, pagination } from "../shared/schemas";
+import { genericName, orderBy, pagination } from "../shared/schemas";
 
 export const index: object = {
     query: {
@@ -48,9 +48,7 @@ export const search: object = {
         publicKey: Joi.string()
             .hex()
             .length(66),
-        name: Joi.string()
-            .regex(/^[a-zA-Z0-9_-]+$/)
-            .max(40),
+        name: genericName,
         website: Joi.string().max(80),
         vat: Joi.string()
             .alphanum()

--- a/packages/core-api/src/handlers/businesses/schema.ts
+++ b/packages/core-api/src/handlers/businesses/schema.ts
@@ -1,14 +1,12 @@
 import Joi from "@hapi/joi";
-import { genericName, orderBy, pagination } from "../shared/schemas";
+import { address, genericName, orderBy, pagination, publicKey } from "../shared/schemas";
 
 export const index: object = {
     query: {
         ...pagination,
         ...{
             orderBy,
-            publicKey: Joi.string()
-                .hex()
-                .length(66),
+            publicKey,
             isResigned: Joi.bool(),
         },
     },
@@ -45,9 +43,8 @@ export const search: object = {
         },
     },
     payload: {
-        publicKey: Joi.string()
-            .hex()
-            .length(66),
+        address,
+        publicKey,
         name: genericName,
         website: Joi.string().max(80),
         vat: Joi.string()

--- a/packages/core-api/src/handlers/delegates/schema.ts
+++ b/packages/core-api/src/handlers/delegates/schema.ts
@@ -1,6 +1,6 @@
 import { app } from "@arkecosystem/core-container";
 import Joi from "@hapi/joi";
-import { blockId, orderBy, pagination, walletId } from "../shared/schemas";
+import { address, blockId, orderBy, pagination, publicKey, walletId } from "../shared/schemas";
 
 const config = app.getConfig();
 
@@ -35,18 +35,10 @@ export const index: object = {
         ...{
             orderBy,
             type: Joi.string().valid("resigned", "never-forged"),
-            address: Joi.string()
-                .alphanum()
-                .length(34),
-            publicKey: Joi.string()
-                .hex()
-                .length(66),
-            secondPublicKey: Joi.string()
-                .hex()
-                .length(66),
-            vote: Joi.string()
-                .hex()
-                .length(66),
+            address,
+            publicKey,
+            secondPublicKey: publicKey,
+            vote: publicKey,
             username: schemaUsername,
             balance: Joi.number()
                 .integer()
@@ -75,12 +67,8 @@ export const search: object = {
         },
     },
     payload: {
-        address: Joi.string()
-            .alphanum()
-            .length(34),
-        publicKey: Joi.string()
-            .hex()
-            .length(66),
+        address,
+        publicKey,
         username: schemaUsername,
         usernames: Joi.array()
             .unique()
@@ -131,9 +119,7 @@ export const blocks: object = {
                 .integer()
                 .min(0),
             payloadHash: Joi.string().hex(),
-            generatorPublicKey: Joi.string()
-                .hex()
-                .length(66),
+            generatorPublicKey: publicKey,
             blockSignature: Joi.string().hex(),
             transform: Joi.bool().default(true),
         },
@@ -148,18 +134,10 @@ export const voters: object = {
         ...pagination,
         ...{
             orderBy,
-            address: Joi.string()
-                .alphanum()
-                .length(34),
-            publicKey: Joi.string()
-                .hex()
-                .length(66),
-            secondPublicKey: Joi.string()
-                .hex()
-                .length(66),
-            vote: Joi.string()
-                .hex()
-                .length(66),
+            address,
+            publicKey,
+            secondPublicKey: publicKey,
+            vote: publicKey,
             username: schemaUsername,
             balance: Joi.number()
                 .integer()

--- a/packages/core-api/src/handlers/delegates/schema.ts
+++ b/packages/core-api/src/handlers/delegates/schema.ts
@@ -1,13 +1,8 @@
 import { app } from "@arkecosystem/core-container";
 import Joi from "@hapi/joi";
-import { blockId, orderBy, pagination } from "../shared/schemas";
+import { blockId, orderBy, pagination, walletId } from "../shared/schemas";
 
 const config = app.getConfig();
-
-const schemaIdentifier = Joi.string()
-    .regex(/^[a-zA-Z0-9!@$&_.]+$/)
-    .min(1)
-    .max(66);
 
 const schemaUsername = Joi.string()
     .regex(/^[a-z0-9!@$&_.]+$/)
@@ -68,7 +63,7 @@ export const index: object = {
 
 export const show: object = {
     params: {
-        id: schemaIdentifier,
+        id: walletId,
     },
 };
 
@@ -103,7 +98,7 @@ export const search: object = {
 
 export const blocks: object = {
     params: {
-        id: schemaIdentifier,
+        id: walletId,
     },
     query: {
         ...pagination,
@@ -147,7 +142,7 @@ export const blocks: object = {
 
 export const voters: object = {
     params: {
-        id: schemaIdentifier,
+        id: walletId,
     },
     query: {
         ...pagination,

--- a/packages/core-api/src/handlers/locks/schema.ts
+++ b/packages/core-api/src/handlers/locks/schema.ts
@@ -1,18 +1,14 @@
 import { Enums } from "@arkecosystem/crypto";
 import Joi from "@hapi/joi";
-import { orderBy, pagination } from "../shared/schemas";
+import { address, orderBy, pagination, publicKey } from "../shared/schemas";
 
 export const index: object = {
     query: {
         ...pagination,
         ...{
             orderBy,
-            recipientId: Joi.string()
-                .alphanum()
-                .length(34),
-            senderPublicKey: Joi.string()
-                .hex()
-                .length(66),
+            recipientId: address,
+            senderPublicKey: publicKey,
             lockId: Joi.string()
                 .hex()
                 .length(64),
@@ -47,12 +43,8 @@ export const search: object = {
         },
     },
     payload: {
-        recipientId: Joi.string()
-            .alphanum()
-            .length(34),
-        senderPublicKey: Joi.string()
-            .hex()
-            .length(66),
+        recipientId: address,
+        senderPublicKey: publicKey,
         lockId: Joi.string()
             .hex()
             .length(64),

--- a/packages/core-api/src/handlers/shared/schemas/address.ts
+++ b/packages/core-api/src/handlers/shared/schemas/address.ts
@@ -1,0 +1,5 @@
+import Joi from "@hapi/joi";
+
+export const address = Joi.string()
+    .alphanum()
+    .length(34);

--- a/packages/core-api/src/handlers/shared/schemas/generic-name.ts
+++ b/packages/core-api/src/handlers/shared/schemas/generic-name.ts
@@ -1,0 +1,6 @@
+import Joi from "@hapi/joi";
+
+export const genericName = Joi.string()
+    .regex(/^[a-zA-Z0-9]+(( - |[ ._-])[a-zA-Z0-9]+)*[.]?$/)
+    .min(1)
+    .max(40);

--- a/packages/core-api/src/handlers/shared/schemas/index.ts
+++ b/packages/core-api/src/handlers/shared/schemas/index.ts
@@ -1,6 +1,7 @@
 import { blockId } from "./block-id";
+import { genericName } from "./generic-name";
 import { orderBy } from "./order-by";
 import { pagination } from "./pagination";
 import { walletId } from "./wallet-id";
 
-export { blockId, orderBy, pagination, walletId };
+export { blockId, genericName, orderBy, pagination, walletId };

--- a/packages/core-api/src/handlers/shared/schemas/index.ts
+++ b/packages/core-api/src/handlers/shared/schemas/index.ts
@@ -1,7 +1,9 @@
+import { address } from "./address";
 import { blockId } from "./block-id";
 import { genericName } from "./generic-name";
 import { orderBy } from "./order-by";
 import { pagination } from "./pagination";
+import { publicKey } from "./public-key";
 import { walletId } from "./wallet-id";
 
-export { blockId, genericName, orderBy, pagination, walletId };
+export { address, blockId, genericName, orderBy, pagination, publicKey, walletId };

--- a/packages/core-api/src/handlers/shared/schemas/public-key.ts
+++ b/packages/core-api/src/handlers/shared/schemas/public-key.ts
@@ -1,0 +1,5 @@
+import Joi from "@hapi/joi";
+
+export const publicKey = Joi.string()
+    .hex()
+    .length(66);

--- a/packages/core-api/src/handlers/transactions/schema.ts
+++ b/packages/core-api/src/handlers/transactions/schema.ts
@@ -1,10 +1,6 @@
 import { app } from "@arkecosystem/core-container";
 import Joi from "@hapi/joi";
-import { blockId, orderBy, pagination } from "../shared/schemas";
-
-const address: object = Joi.string()
-    .alphanum()
-    .length(34);
+import { address, blockId, orderBy, pagination, publicKey } from "../shared/schemas";
 
 export const index: object = {
     query: {
@@ -24,15 +20,9 @@ export const index: object = {
             version: Joi.number()
                 .integer()
                 .positive(),
-            senderPublicKey: Joi.string()
-                .hex()
-                .length(66),
-            senderId: Joi.string()
-                .alphanum()
-                .length(34),
-            recipientId: Joi.string()
-                .alphanum()
-                .length(34),
+            senderPublicKey: publicKey,
+            senderId: address,
+            recipientId: address,
             timestamp: Joi.number()
                 .integer()
                 .min(0),
@@ -114,9 +104,7 @@ export const search: object = {
         version: Joi.number()
             .integer()
             .positive(),
-        senderPublicKey: Joi.string()
-            .hex()
-            .length(66),
+        senderPublicKey: publicKey,
         senderId: address,
         recipientId: address,
         addresses: Joi.array()

--- a/packages/core-api/src/handlers/votes/schema.ts
+++ b/packages/core-api/src/handlers/votes/schema.ts
@@ -1,5 +1,5 @@
 import Joi from "@hapi/joi";
-import { blockId, orderBy, pagination } from "../shared/schemas";
+import { address, blockId, orderBy, pagination, publicKey } from "../shared/schemas";
 
 export const index: object = {
     query: {

--- a/packages/core-api/src/handlers/votes/schema.ts
+++ b/packages/core-api/src/handlers/votes/schema.ts
@@ -13,15 +13,9 @@ export const index: object = {
             version: Joi.number()
                 .integer()
                 .positive(),
-            senderPublicKey: Joi.string()
-                .hex()
-                .length(66),
-            senderId: Joi.string()
-                .alphanum()
-                .length(34),
-            recipientId: Joi.string()
-                .alphanum()
-                .length(34),
+            senderPublicKey: publicKey,
+            senderId: address,
+            recipientId: address,
             timestamp: Joi.number()
                 .integer()
                 .min(0),

--- a/packages/core-api/src/handlers/wallets/schema.ts
+++ b/packages/core-api/src/handlers/wallets/schema.ts
@@ -1,27 +1,15 @@
 import Joi from "@hapi/joi";
-import { blockId, orderBy, pagination, walletId } from "../shared/schemas";
-
-const address: object = Joi.string()
-    .alphanum()
-    .length(34);
+import { address, blockId, orderBy, pagination, publicKey, walletId } from "../shared/schemas";
 
 export const index: object = {
     query: {
         ...pagination,
         ...{
             orderBy,
-            address: Joi.string()
-                .alphanum()
-                .length(34),
-            publicKey: Joi.string()
-                .hex()
-                .length(66),
-            secondPublicKey: Joi.string()
-                .hex()
-                .length(66),
-            vote: Joi.string()
-                .hex()
-                .length(66),
+            address,
+            publicKey,
+            secondPublicKey: publicKey,
+            vote: publicKey,
             username: Joi.string(),
             balance: Joi.number().integer(),
             voteBalance: Joi.number()
@@ -100,9 +88,7 @@ export const transactionsSent: object = {
             version: Joi.number()
                 .integer()
                 .positive(),
-            recipientId: Joi.string()
-                .alphanum()
-                .length(34),
+            recipientId: address,
             timestamp: Joi.number()
                 .integer()
                 .min(0),
@@ -142,12 +128,8 @@ export const transactionsReceived: object = {
             version: Joi.number()
                 .integer()
                 .positive(),
-            senderPublicKey: Joi.string()
-                .hex()
-                .length(66),
-            senderId: Joi.string()
-                .alphanum()
-                .length(34),
+            senderPublicKey: publicKey,
+            senderId: address,
             timestamp: Joi.number()
                 .integer()
                 .min(0),
@@ -205,15 +187,9 @@ export const search: object = {
             .min(1)
             .max(50)
             .items(address),
-        publicKey: Joi.string()
-            .hex()
-            .length(66),
-        secondPublicKey: Joi.string()
-            .hex()
-            .length(66),
-        vote: Joi.string()
-            .hex()
-            .length(66),
+        publicKey,
+        secondPublicKey: publicKey,
+        vote: publicKey,
         username: Joi.string(),
         producedBlocks: Joi.number()
             .integer()

--- a/packages/crypto/src/validation/schemas.ts
+++ b/packages/crypto/src/validation/schemas.ts
@@ -54,7 +54,7 @@ export const schemas = {
     genericName: {
         $id: "genericName",
         allOf: [
-            { type: "string", pattern: "^[a-zA-Z0-9]+([ ._-][a-zA-Z0-9]+)*[.]?$" },
+            { type: "string", pattern: "^[a-zA-Z0-9]+(( - |[ ._-])[a-zA-Z0-9]+)*[.]?$" },
             { minLength: 1, maxLength: 40 },
         ],
     },


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Fixes the validation of the name param on the businesses and bridgechains search endpoints.

This PR also:
- adjusts the `genericName` to allow dashes surrounded by spaces (` - `) between words, to allow names such as `ARK - Just Forge It`
- replaces the `schemaIdentifier` schema on the delegate endpoints with the stricter shared `walletId` schema
- adds `address` to the businesses and bridgechains search schema (#3312)
- adds shared schemas for `address` and `publicKey` which are used almost everywhere
- fixes a bug in the `blocks/{id}/transactions` endpoint where the transaction id param is required to be 66 characters long

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
