### PR TITLE
[WIP] refactor(core-api): stricter validation of orderBy iteratees

### DIFF
--- a/__tests__/unit/core-database/repositories/delegates-business-repository.test.ts
+++ b/__tests__/unit/core-database/repositories/delegates-business-repository.test.ts
@@ -104,7 +104,7 @@ describe("Wallet Repository - Delegates", () => {
             const wallets = generateWallets();
             walletManager.index(wallets);
 
-            const { count, rows } = search({ offset: 10, limit: 10, orderBy: "rate:desc" });
+            const { count, rows } = search({ offset: 10, limit: 10, orderBy: ["rate", "desc"] });
             expect(count).toBe(52);
             expect(rows).toHaveLength(10);
             expect((rows as any).sort((a, b) => a.rate > b.rate)).toEqual(rows);

--- a/__tests__/unit/core-database/repositories/transactions-business-repository.test.ts
+++ b/__tests__/unit/core-database/repositories/transactions-business-repository.test.ts
@@ -33,7 +33,7 @@ describe("Transactions Business Repository", () => {
                     id: "id",
                     offset: 10,
                     limit: 1000,
-                    orderBy: "id:asc",
+                    orderBy: ["id", "asc"],
                 },
                 "asc",
             );

--- a/__tests__/unit/core-database/repositories/utils/search-parameter-converter.test.ts
+++ b/__tests__/unit/core-database/repositories/utils/search-parameter-converter.test.ts
@@ -87,7 +87,7 @@ describe("SearchParameterConverter", () => {
 
     it("should parse orderBy & paginate from params", () => {
         const params = {
-            orderBy: "field:asc",
+            orderBy: ["field", "asc"],
             offset: 20,
             limit: 50,
         };

--- a/packages/core-api/src/handlers/peers/controller.ts
+++ b/packages/core-api/src/handlers/peers/controller.ts
@@ -28,9 +28,9 @@ export class PeersController extends Controller {
             offset = 0;
         }
 
-        const [iteratee, direction] = request.query.orderBy as string[];
-
         if (request.query.orderBy && request.query.orderBy.length === 2) {
+            const [iteratee, direction] = request.query.orderBy as string[];
+
             switch (iteratee) {
                 case "version": {
                     result =

--- a/packages/core-api/src/handlers/peers/controller.ts
+++ b/packages/core-api/src/handlers/peers/controller.ts
@@ -28,7 +28,7 @@ export class PeersController extends Controller {
             offset = 0;
         }
 
-        const order: string = request.query.orderBy as string[];
+        const order: string[] = request.query.orderBy as string[];
         if (order && order.length === 2) {
             switch (order[0]) {
                 case "version": {

--- a/packages/core-api/src/handlers/peers/controller.ts
+++ b/packages/core-api/src/handlers/peers/controller.ts
@@ -28,22 +28,23 @@ export class PeersController extends Controller {
             offset = 0;
         }
 
-        const order: string[] = request.query.orderBy as string[];
-        if (order && order.length === 2) {
-            switch (order[0]) {
+        const [iteratee, direction] = request.query.orderBy as string[];
+
+        if (request.query.orderBy && request.query.orderBy.length === 2) {
+            switch (iteratee) {
                 case "version": {
                     result =
-                        order[1] === "asc"
-                            ? result.sort((a, b) => semver.compare(a[order[0]], b[order[0]]))
-                            : result.sort((a, b) => semver.rcompare(a[order[0]], b[order[0]]));
+                        direction === "asc"
+                            ? result.sort((a, b) => semver.compare(a[iteratee], b[iteratee]))
+                            : result.sort((a, b) => semver.rcompare(a[iteratee], b[iteratee]));
                     break;
                 }
                 case "height": {
-                    result = orderBy(result, el => el.state[order[0]], order[1] === "asc" ? "asc" : "desc");
+                    result = orderBy(result, el => el.state[iteratee], direction === "asc" ? "asc" : "desc");
                     break;
                 }
                 case "latency": {
-                    result = orderBy(result, order[0], order[1] === "asc" ? "asc" : "desc");
+                    result = orderBy(result, iteratee, direction === "asc" ? "asc" : "desc");
                     break;
                 }
                 default: {

--- a/packages/core-api/src/handlers/peers/controller.ts
+++ b/packages/core-api/src/handlers/peers/controller.ts
@@ -28,28 +28,22 @@ export class PeersController extends Controller {
             offset = 0;
         }
 
-        const order: string = request.query.orderBy as string;
-        if (order) {
-            const orderByMapped = order.split(":").map(p => p.toLowerCase());
-
-            switch (orderByMapped[0]) {
+        const order: string = request.query.orderBy as string[];
+        if (order && order.length === 2) {
+            switch (order[0]) {
                 case "version": {
                     result =
-                        orderByMapped[1] === "asc"
-                            ? result.sort((a, b) => semver.compare(a[orderByMapped[0]], b[orderByMapped[0]]))
-                            : result.sort((a, b) => semver.rcompare(a[orderByMapped[0]], b[orderByMapped[0]]));
+                        order[1] === "asc"
+                            ? result.sort((a, b) => semver.compare(a[order[0]], b[order[0]]))
+                            : result.sort((a, b) => semver.rcompare(a[order[0]], b[order[0]]));
                     break;
                 }
                 case "height": {
-                    result = orderBy(
-                        result,
-                        el => el.state[orderByMapped[0]],
-                        orderByMapped[1] === "asc" ? "asc" : "desc",
-                    );
+                    result = orderBy(result, el => el.state[order[0]], order[1] === "asc" ? "asc" : "desc");
                     break;
                 }
                 case "latency": {
-                    result = orderBy(result, orderByMapped[0], orderByMapped[1] === "asc" ? "asc" : "desc");
+                    result = orderBy(result, order[0], order[1] === "asc" ? "asc" : "desc");
                     break;
                 }
                 default: {

--- a/packages/core-api/src/handlers/shared/schemas/order-by.ts
+++ b/packages/core-api/src/handlers/shared/schemas/order-by.ts
@@ -6,52 +6,62 @@ const customJoi = Joi.extend(joi => ({
     coerce: (value, state, options) => (value && value.split ? value.split(":") : undefined),
 }));
 
+const validIteratees = [
+    "address",
+    "amount",
+    "approval",
+    "balance",
+    "blockId",
+    "confirmations",
+    "expirationType",
+    "expirationValue",
+    "fee",
+    "forgedFees",
+    "forgedRewards",
+    "forgedTotal",
+    "generatorPublicKey",
+    "height",
+    "id",
+    "isDelegate",
+    "isResigned",
+    "latency",
+    "lockedBalance",
+    "nonce",
+    "producedBlocks",
+    "publicKey",
+    "rank",
+    "recipient",
+    "sender",
+    "senderPublicKey",
+    "signature",
+    "signSignature",
+    "timestamp",
+    "transactions",
+    "type",
+    "typeGroup",
+    "username",
+    "vendorField",
+    "version",
+    "voteBalance",
+    "votes",
+];
+
+const validDirections = ["asc", "desc"];
+
 export const orderBy = customJoi
     .orderBy()
     .length(2)
     .items(
         Joi.string()
-            .valid(
-                "address",
-                "amount",
-                "approval",
-                "balance",
-                "blockId",
-                "confirmations",
-                "expirationType",
-                "expirationValue",
-                "fee",
-                "forgedFees",
-                "forgedRewards",
-                "forgedTotal",
-                "generatorPublicKey",
-                "height",
-                "id",
-                "isDelegate",
-                "isResigned",
-                "latency",
-                "lockedBalance",
-                "nonce",
-                "producedBlocks",
-                "publicKey",
-                "rank",
-                "recipient",
-                "sender",
-                "senderPublicKey",
-                "signature",
-                "signSignature",
-                "timestamp",
-                "transactions",
-                "type",
-                "typeGroup",
-                "username",
-                "vendorField",
-                "version",
-                "voteBalance",
-                "votes",
-            )
+            .valid(...validIteratees)
             .required(),
         Joi.string()
-            .valid("asc", "desc")
+            .valid(...validDirections)
             .required(),
+    )
+    .error(
+        () =>
+            `"orderBy" must have the following format <iteratee>:<direction>, where <iteratee> is one of: ${validIteratees.join(
+                ", ",
+            )} and <direction> one of: ${validDirections.join(", ")}`,
     );

--- a/packages/core-api/src/handlers/shared/schemas/order-by.ts
+++ b/packages/core-api/src/handlers/shared/schemas/order-by.ts
@@ -7,7 +7,6 @@ const customJoi = Joi.extend(joi => ({
 }));
 
 export const orderBy = customJoi
-    .array()
     .orderBy()
     .length(2)
     .items(

--- a/packages/core-api/src/handlers/shared/schemas/order-by.ts
+++ b/packages/core-api/src/handlers/shared/schemas/order-by.ts
@@ -3,7 +3,7 @@ import Joi from "@hapi/joi";
 const customJoi = Joi.extend(joi => ({
     base: joi.array(),
     name: "orderBy",
-    coerce: (value, state, options) => (value.split ? value.split(":") : value),
+    coerce: (value, state, options) => (value && value.split ? value.split(":") : undefined),
 }));
 
 export const orderBy = customJoi

--- a/packages/core-api/src/handlers/shared/schemas/order-by.ts
+++ b/packages/core-api/src/handlers/shared/schemas/order-by.ts
@@ -1,6 +1,58 @@
 import Joi from "@hapi/joi";
 
-export const orderBy = Joi.string().regex(
-    /^[a-z._]{1,40}:(asc|desc)$/i,
-    "orderBy query parameter (<iteratee>:<direction>)",
-);
+const customJoi = Joi.extend(joi => ({
+    base: joi.array(),
+    name: "orderBy",
+    coerce: (value, state, options) => (value.split ? value.split(":") : value),
+}));
+
+export const orderBy = customJoi
+    .array()
+    .orderBy()
+    .length(2)
+    .items(
+        Joi.string()
+            .valid(
+                "address",
+                "amount",
+                "approval",
+                "balance",
+                "blockId",
+                "confirmations",
+                "expirationType",
+                "expirationValue",
+                "fee",
+                "forgedFees",
+                "forgedRewards",
+                "forgedTotal",
+                "generatorPublicKey",
+                "height",
+                "id",
+                "isDelegate",
+                "isResigned",
+                "latency",
+                "lockedBalance",
+                "nonce",
+                "producedBlocks",
+                "publicKey",
+                "rank",
+                "recipient",
+                "sender",
+                "senderPublicKey",
+                "signature",
+                "signSignature",
+                "timestamp",
+                "transactions",
+                "type",
+                "typeGroup",
+                "username",
+                "vendorField",
+                "version",
+                "voteBalance",
+                "votes",
+            )
+            .required(),
+        Joi.string()
+            .valid("asc", "desc")
+            .required(),
+    );

--- a/packages/core-database/package.json
+++ b/packages/core-database/package.json
@@ -33,7 +33,6 @@
         "dottie": "^2.0.1",
         "lodash.clonedeep": "^4.5.0",
         "lodash.compact": "^3.0.1",
-        "lodash.snakecase": "^4.1.1",
         "lodash.uniq": "^4.5.0",
         "pluralize": "^8.0.0"
     },
@@ -41,7 +40,6 @@
         "@types/dottie": "^2.0.3",
         "@types/lodash.clonedeep": "^4.5.6",
         "@types/lodash.compact": "^3.0.6",
-        "@types/lodash.snakecase": "^4.1.6",
         "@types/lodash.uniq": "^4.5.6",
         "@types/pluralize": "^0.0.29"
     },

--- a/packages/core-database/package.json
+++ b/packages/core-database/package.json
@@ -33,6 +33,7 @@
         "dottie": "^2.0.1",
         "lodash.clonedeep": "^4.5.0",
         "lodash.compact": "^3.0.1",
+        "lodash.snakecase": "^4.1.1",
         "lodash.uniq": "^4.5.0",
         "pluralize": "^8.0.0"
     },
@@ -40,6 +41,7 @@
         "@types/dottie": "^2.0.3",
         "@types/lodash.clonedeep": "^4.5.6",
         "@types/lodash.compact": "^3.0.6",
+        "@types/lodash.snakecase": "^4.1.6",
         "@types/lodash.uniq": "^4.5.6",
         "@types/pluralize": "^0.0.29"
     },

--- a/packages/core-database/src/repositories/utils/search-entries.ts
+++ b/packages/core-database/src/repositories/utils/search-entries.ts
@@ -40,17 +40,11 @@ const applyOrder = (
 ): [CallbackFunctionVariadicVoidReturn | string, string] => {
     const assignOrder = (params, value) => (params.orderBy = value);
 
-    if (!params.orderBy) {
+    if (!params.orderBy || orderBy.length !== 2) {
         return assignOrder(params, defaultOrder);
     }
 
-    const orderByMapped: string[] = params.orderBy.split(":");
-
-    if (orderByMapped.length !== 2) {
-        return assignOrder(params, defaultOrder);
-    }
-
-    return assignOrder(params, [manipulateIteratee(orderByMapped[0]), orderByMapped[1]]);
+    return assignOrder(params, [manipulateIteratee(orderBy[0]), orderBy[1]]);
 };
 
 const manipulateIteratee = (iteratee): any => {

--- a/packages/core-database/src/repositories/utils/search-entries.ts
+++ b/packages/core-database/src/repositories/utils/search-entries.ts
@@ -44,9 +44,9 @@ const applyOrder = (
         return assignOrder(params, defaultOrder);
     }
 
-    const orderByMapped: string[] = params.orderBy.split(":").map(p => p.toLowerCase());
+    const orderByMapped: string[] = params.orderBy.split(":");
 
-    if (orderByMapped.length !== 2 || ["desc", "asc"].includes(orderByMapped[1]) !== true) {
+    if (orderByMapped.length !== 2) {
         return assignOrder(params, defaultOrder);
     }
 
@@ -61,12 +61,6 @@ const manipulateIteratee = (iteratee): any => {
             return delegateCalculator.calculateForgedTotal;
         case "votes":
             return "voteBalance";
-        case "vendorfield":
-            return "vendorField";
-        case "expirationvalue":
-            return "expirationValue";
-        case "expirationtype":
-            return "expirationType";
         default:
             return iteratee;
     }

--- a/packages/core-database/src/repositories/utils/search-entries.ts
+++ b/packages/core-database/src/repositories/utils/search-entries.ts
@@ -40,11 +40,11 @@ const applyOrder = (
 ): [CallbackFunctionVariadicVoidReturn | string, string] => {
     const assignOrder = (params, value) => (params.orderBy = value);
 
-    if (!params.orderBy || orderBy.length !== 2) {
+    if (!params.orderBy || params.orderBy.length !== 2) {
         return assignOrder(params, defaultOrder);
     }
 
-    return assignOrder(params, [manipulateIteratee(orderBy[0]), orderBy[1]]);
+    return assignOrder(params, [manipulateIteratee(params.orderBy[0]), params.orderBy[1]]);
 };
 
 const manipulateIteratee = (iteratee): any => {

--- a/packages/core-database/src/repositories/utils/search-parameter-converter.ts
+++ b/packages/core-database/src/repositories/utils/search-parameter-converter.ts
@@ -42,14 +42,15 @@ export class SearchParameterConverter implements Database.IISearchParameterConve
     }
 
     private parseOrderBy(searchParameters: Database.ISearchParameters, orderBy?: any) {
-        if (orderBy && typeof orderBy === "string") {
-            const fieldDirection = orderBy.split(":").map(o => o.toLowerCase());
-            if (fieldDirection.length === 2 && (fieldDirection[1] === "asc" || fieldDirection[1] === "desc")) {
-                searchParameters.orderBy.push({
-                    field: snakeCase(fieldDirection[0]),
-                    direction: fieldDirection[1] as "asc" | "desc",
-                });
-            }
+        if (
+            Array.isArray(orderBy) &&
+            orderBy.length === 2 &&
+            (orderBy[1] === "asc" || orderBy[1] === "desc")
+        ) {
+            searchParameters.orderBy.push({
+                field: orderBy[0],
+                direction: orderBy[1] as "asc" | "desc",
+            });
         }
     }
 

--- a/packages/core-database/src/repositories/utils/search-parameter-converter.ts
+++ b/packages/core-database/src/repositories/utils/search-parameter-converter.ts
@@ -1,5 +1,4 @@
 import { Database } from "@arkecosystem/core-interfaces";
-import snakeCase from "lodash.snakecase";
 
 export class SearchParameterConverter implements Database.IISearchParameterConverter {
     constructor(private databaseModel: Database.IModel) {}

--- a/packages/core-database/src/repositories/utils/search-parameter-converter.ts
+++ b/packages/core-database/src/repositories/utils/search-parameter-converter.ts
@@ -1,4 +1,5 @@
 import { Database } from "@arkecosystem/core-interfaces";
+import snakeCase from "lodash.snakecase";
 
 export class SearchParameterConverter implements Database.IISearchParameterConverter {
     constructor(private databaseModel: Database.IModel) {}
@@ -41,13 +42,9 @@ export class SearchParameterConverter implements Database.IISearchParameterConve
     }
 
     private parseOrderBy(searchParameters: Database.ISearchParameters, orderBy?: any) {
-        if (
-            Array.isArray(orderBy) &&
-            orderBy.length === 2 &&
-            (orderBy[1] === "asc" || orderBy[1] === "desc")
-        ) {
+        if (Array.isArray(orderBy) && orderBy.length === 2 && (orderBy[1] === "asc" || orderBy[1] === "desc")) {
             searchParameters.orderBy.push({
-                field: orderBy[0],
+                field: snakeCase(orderBy[0]),
                 direction: orderBy[1] as "asc" | "desc",
             });
         }

--- a/packages/core-database/src/repositories/wallets-business-repository.ts
+++ b/packages/core-database/src/repositories/wallets-business-repository.ts
@@ -87,7 +87,7 @@ export class WalletsBusinessRepository implements Database.IWalletsBusinessRepos
     }
 
     public top(scope: Database.SearchScope, params: Database.IParameters = {}): Database.IRowsPaginated<State.IWallet> {
-        return this.search(scope, { ...params, ...{ orderBy: "balance:desc" } });
+        return this.search(scope, { ...params, ...{ orderBy: ["balance", "desc"] } });
     }
 
     private searchWallets(params: Database.IParameters): ISearchContext<State.IWallet> {

--- a/packages/core-interfaces/src/core-database/business-repository/parameters.ts
+++ b/packages/core-interfaces/src/core-database/business-repository/parameters.ts
@@ -1,6 +1,6 @@
 export interface IParameters {
     offset?: number;
     limit?: number;
-    orderBy?: string;
+    orderBy?: string[];
     [key: string]: object | number | string | boolean;
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Closes #3315 by providing a global whitelist of accepted iteratees with a verbose error message if the validation fails:

```
{
  "statusCode": 422,
  "error": "Unprocessable Entity",
  "message": "child \"orderBy\" fails because [\"orderBy\" must have the following format <iteratee>:<direction>, where <iteratee> is one of: address, amount, approval, balance, blockId, confirmations, expirationType, expirationValue, fee, forgedFees, forgedRewards, forgedTotal, generatorPublicKey, height, id, isDelegate, isResigned, latency, lockedBalance, nonce, producedBlocks, publicKey, rank, recipient, sender, senderPublicKey, signature, signSignature, timestamp, transactions, type, typeGroup, username, vendorField, version, voteBalance, votes and <direction> one of: asc, desc]"
}
```
<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
