### PR TITLE
chore: add tmp-shm and tmp-wal to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,6 +96,8 @@ Sessionx.vim
 # Temporary
 .netrwhist
 *~
+tmp-shm
+tmp-wal
 # Auto-generated tag files
 tags
 # Persistent undo


### PR DESCRIPTION
`tmp-shm` and `tmp-wal` are generated by integration tests. These files should be added to project root gitignore.