### PR TITLE
fix(core-database): handle forgedTotal and voteBalance in orderBy query param

### DIFF
--- a/packages/core-database/src/repositories/utils/search-entries.ts
+++ b/packages/core-database/src/repositories/utils/search-entries.ts
@@ -57,6 +57,10 @@ const manipulateIteratee = (iteratee): any => {
     switch (iteratee) {
         case "approval":
             return delegateCalculator.calculateApproval;
+        case "forgedfees":
+            return "forgedFees";
+        case "forgedrewards":
+            return "forgedRewards";
         case "forgedtotal":
             return delegateCalculator.calculateForgedTotal;
         case "votes":

--- a/packages/core-database/src/repositories/utils/search-entries.ts
+++ b/packages/core-database/src/repositories/utils/search-entries.ts
@@ -57,9 +57,10 @@ const manipulateIteratee = (iteratee): any => {
     switch (iteratee) {
         case "approval":
             return delegateCalculator.calculateApproval;
-        case "forgedTotal":
+        case "forgedtotal":
             return delegateCalculator.calculateForgedTotal;
         case "votes":
+        case "votebalance":
             return "voteBalance";
         case "vendorfield":
             return "vendorField";

--- a/packages/core-database/src/repositories/utils/sort-entries.ts
+++ b/packages/core-database/src/repositories/utils/sort-entries.ts
@@ -11,7 +11,7 @@ export const sortEntries = <T extends Record<string, any>>(
 ): T[] => {
     const [iteratee, order] = params.orderBy ? params.orderBy : defaultOrder;
 
-    if (["balance", "voteBalance", "lockedBalance", "amount"].includes(iteratee)) {
+    if (["amount", "balance", "forgedFees", "forgedRewards", "lockedBalance", "voteBalance"].includes(iteratee)) {
         return Object.values(entries).sort((a: T, b: T) => {
             const iterateeA: Utils.BigNumber = getProperty(a, iteratee) || Utils.BigNumber.ZERO;
             const iterateeB: Utils.BigNumber = getProperty(b, iteratee) || Utils.BigNumber.ZERO;

--- a/packages/core-database/src/repositories/wallets-business-repository.ts
+++ b/packages/core-database/src/repositories/wallets-business-repository.ts
@@ -1,5 +1,5 @@
 import { Database, State } from "@arkecosystem/core-interfaces";
-import { expirationCalculator } from "@arkecosystem/core-utils";
+import { delegateCalculator, expirationCalculator, hasSomeProperty } from "@arkecosystem/core-utils";
 import { Interfaces, Utils } from "@arkecosystem/crypto";
 import { searchEntries } from "./utils/search-entries";
 
@@ -152,6 +152,23 @@ export class WalletsBusinessRepository implements Database.IWalletsBusinessRepos
                 entries = this.databaseServiceProvider().walletManager.allByUsername();
                 break;
             }
+        }
+
+        const manipulators = {
+            approval: delegateCalculator.calculateApproval,
+            forgedTotal: delegateCalculator.calculateForgedTotal,
+        };
+
+        if (hasSomeProperty(params, Object.keys(manipulators))) {
+            entries = entries.map(delegate => {
+                for (const [prop, method] of Object.entries(manipulators)) {
+                    if (params.hasOwnProperty(prop)) {
+                        delegate.setAttribute(`delegate.${prop}`, method(delegate));
+                    }
+                }
+
+                return delegate;
+            });
         }
 
         return {

--- a/packages/core-database/src/repositories/wallets-business-repository.ts
+++ b/packages/core-database/src/repositories/wallets-business-repository.ts
@@ -1,5 +1,5 @@
 import { Database, State } from "@arkecosystem/core-interfaces";
-import { delegateCalculator, expirationCalculator, hasSomeProperty } from "@arkecosystem/core-utils";
+import { expirationCalculator } from "@arkecosystem/core-utils";
 import { Interfaces, Utils } from "@arkecosystem/crypto";
 import { searchEntries } from "./utils/search-entries";
 
@@ -152,23 +152,6 @@ export class WalletsBusinessRepository implements Database.IWalletsBusinessRepos
                 entries = this.databaseServiceProvider().walletManager.allByUsername();
                 break;
             }
-        }
-
-        const manipulators = {
-            approval: delegateCalculator.calculateApproval,
-            forgedTotal: delegateCalculator.calculateForgedTotal,
-        };
-
-        if (hasSomeProperty(params, Object.keys(manipulators))) {
-            entries = entries.map(delegate => {
-                for (const [prop, method] of Object.entries(manipulators)) {
-                    if (params.hasOwnProperty(prop)) {
-                        delegate.setAttribute(`delegate.${prop}`, method(delegate));
-                    }
-                }
-
-                return delegate;
-            });
         }
 
         return {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Adds cases to properly order by `voteBalance` and `forgedTotal`.

~https://github.com/ArkEcosystem/core/blob/develop/packages/core-database/src/repositories/wallets-business-repository.ts#L157-L172~

~These lines were removed as I don't see the reason for the delegate attributes to be set. The `searchEntries` method manipulates each of these iteratees to be a method, which is then used for the actual sorting - the attributes aren't accessed, which makes the mapping superfluous imho.~

The above seems to be necessary for the _filtering_, not _sorting_.
 
Fixes the specific issue described in #3315.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
