### PR TITLE
chore: document canEnterTransactionPool()

### DIFF
--- a/packages/core-transactions/src/handlers/delegate-resignation.ts
+++ b/packages/core-transactions/src/handlers/delegate-resignation.ts
@@ -83,17 +83,7 @@ export class DelegateResignationTransactionHandler extends TransactionHandler {
         pool: TransactionPool.IConnection,
         processor: TransactionPool.IProcessor,
     ): Promise<boolean> {
-        if (await this.typeFromSenderAlreadyInPool(data, pool, processor)) {
-            const wallet: State.IWallet = pool.walletManager.findByPublicKey(data.senderPublicKey);
-            processor.pushError(
-                data,
-                "ERR_PENDING",
-                `Delegate resignation for "${wallet.getAttribute("delegate.username")}" already in the pool`,
-            );
-            return false;
-        }
-
-        return true;
+        return !await this.typeFromSenderAlreadyInPool(data, pool, processor);
     }
 
     public async applyToSender(

--- a/packages/core-transactions/src/handlers/multi-signature.ts
+++ b/packages/core-transactions/src/handlers/multi-signature.ts
@@ -96,11 +96,7 @@ export class MultiSignatureTransactionHandler extends TransactionHandler {
         pool: TransactionPool.IConnection,
         processor: TransactionPool.IProcessor,
     ): Promise<boolean> {
-        if (await this.typeFromSenderAlreadyInPool(data, pool, processor)) {
-            return false;
-        }
-
-        return true;
+        return !await this.typeFromSenderAlreadyInPool(data, pool, processor);
     }
 
     public async applyToSender(

--- a/packages/core-transactions/src/handlers/second-signature.ts
+++ b/packages/core-transactions/src/handlers/second-signature.ts
@@ -55,11 +55,7 @@ export class SecondSignatureTransactionHandler extends TransactionHandler {
         pool: TransactionPool.IConnection,
         processor: TransactionPool.IProcessor,
     ): Promise<boolean> {
-        if (await this.typeFromSenderAlreadyInPool(data, pool, processor)) {
-            return false;
-        }
-
-        return true;
+        return !await this.typeFromSenderAlreadyInPool(data, pool, processor);
     }
 
     public async applyToSender(

--- a/packages/core-transactions/src/handlers/vote.ts
+++ b/packages/core-transactions/src/handlers/vote.ts
@@ -106,11 +106,7 @@ export class VoteTransactionHandler extends TransactionHandler {
         pool: TransactionPool.IConnection,
         processor: TransactionPool.IProcessor,
     ): Promise<boolean> {
-        if (await this.typeFromSenderAlreadyInPool(data, pool, processor)) {
-            return false;
-        }
-
-        return true;
+        return !await this.typeFromSenderAlreadyInPool(data, pool, processor);
     }
 
     public async applyToSender(

--- a/packages/core-transactions/src/interfaces.ts
+++ b/packages/core-transactions/src/interfaces.ts
@@ -25,6 +25,12 @@ export interface ITransactionHandler {
     apply(transaction: Interfaces.ITransaction, walletManager: State.IWalletManager): Promise<void>;
     revert(transaction: Interfaces.ITransaction, walletManager: State.IWalletManager): Promise<void>;
 
+    /**
+     * Check if a transaction of this type can enter the pool.
+     * If `false` is returned to designate that the transaction cannot enter the pool,
+     * then this method will have called processor.pushError() to give a detailed
+     * description of the reason.
+     */
     canEnterTransactionPool(
         data: Interfaces.ITransactionData,
         pool: TransactionPool.IConnection,


### PR DESCRIPTION
Explain that if canEnterTransactionPool() returns false it would have
called processor.pushError().

In addition:

Simplify some code that did "if (A) { return false } return true"
to "return !A".

Remove redundant processor.pushError() from
DelegateResignationTransactionHandler() because
typeFromSenderAlreadyInPool() would have already pushed a very similar
error message.

Closes https://github.com/ArkEcosystem/core/issues/3322
