### PR TITLE
feat(core-p2p): improve incoming WS message check + IP banning on worker

### DIFF
--- a/__tests__/integration/core-p2p/socket-server/peer.test.ts
+++ b/__tests__/integration/core-p2p/socket-server/peer.test.ts
@@ -151,6 +151,10 @@ describe("Peer socket endpoint", () => {
                 await delay(1000);
 
                 expect(socket.state).toBe("closed");
+
+                // kill workers to reset ipLastError (or we won't pass handshake for 1 minute)
+                server.killWorkers({ immediate: true });
+                await delay(2000); // give time to workers to respawn
             });
 
             it("should disconnect the client if it sends too many pongs too quickly", async () => {
@@ -172,6 +176,10 @@ describe("Peer socket endpoint", () => {
                 await delay(1000);
 
                 expect(socket.state).toBe("closed");
+
+                // kill workers to reset ipLastError (or we won't pass handshake for 1 minute)
+                server.killWorkers({ immediate: true });
+                await delay(2000); // give time to workers to respawn
             });
 
             it("should disconnect the client if it sends a ping frame", async () => {
@@ -183,6 +191,10 @@ describe("Peer socket endpoint", () => {
                 ping();
                 await delay(500);
                 expect(socket.state).toBe("closed");
+
+                // kill workers to reset ipLastError (or we won't pass handshake for 1 minute)
+                server.killWorkers({ immediate: true });
+                await delay(2000); // give time to workers to respawn
             });
 
             it("should disconnect the client if it sends a pong frame", async () => {
@@ -194,6 +206,10 @@ describe("Peer socket endpoint", () => {
                 pong();
                 await delay(500);
                 expect(socket.state).toBe("closed");
+
+                // kill workers to reset ipLastError (or we won't pass handshake for 1 minute)
+                server.killWorkers({ immediate: true });
+                await delay(2000); // give time to workers to respawn
             });
         });
     });

--- a/packages/core-p2p/src/socket-server/worker.ts
+++ b/packages/core-p2p/src/socket-server/worker.ts
@@ -9,6 +9,7 @@ const ajv = new Ajv();
 
 export class Worker extends SCWorker {
     private config: Record<string, any>;
+    private ipLastError: Record<string, number> = {};
     private rateLimiter: RateLimiter;
 
     public async run() {
@@ -64,13 +65,13 @@ export class Worker extends SCWorker {
     }
 
     private handlePayload(ws, req) {
-        ws.on("ping", () => {
-            ws.terminate();
+        ws.prependListener("ping", () => {
+            this.setErrorForIpAndTerminate(ws, req);
         });
-        ws.on("pong", () => {
-            ws.terminate();
+        ws.prependListener("pong", () => {
+            this.setErrorForIpAndTerminate(ws, req);
         });
-        ws.on("message", message => {
+        ws.prependListener("message", message => {
             try {
                 const InvalidMessagePayloadError: Error = this.createError(
                     SocketErrors.InvalidMessagePayload,
@@ -82,6 +83,10 @@ export class Worker extends SCWorker {
                         throw InvalidMessagePayloadError;
                     }
                     ws._lastPingTime = timeNow;
+                } else if (message.length < 10) {
+                    // except for #2 message, we should have JSON with some required properties
+                    // (see below) which implies that message length should be longer than 10 chars
+                    this.setErrorForIpAndTerminate(ws, req);
                 } else {
                     const parsed = JSON.parse(message);
                     if (
@@ -90,13 +95,18 @@ export class Worker extends SCWorker {
                         (typeof parsed.cid !== "number" &&
                             (parsed.event === "#disconnect" && typeof parsed.cid !== "undefined"))
                     ) {
-                        throw InvalidMessagePayloadError;
+                        this.setErrorForIpAndTerminate(ws, req);
                     }
                 }
             } catch (error) {
-                ws.terminate();
+                this.setErrorForIpAndTerminate(ws, req);
             }
         });
+    }
+
+    private setErrorForIpAndTerminate(ws, req): void {
+        this.ipLastError[req.socket.remoteAddress] = Date.now();
+        ws.terminate();
     }
 
     private async handleConnection(socket): Promise<void> {
@@ -117,14 +127,20 @@ export class Worker extends SCWorker {
     }
 
     private async handleHandshake(req, next): Promise<void> {
-        const isBlocked = await this.rateLimiter.isBlocked(req.socket.remoteAddress);
-        const isBlacklisted = (this.config.blacklist || []).includes(req.socket.remoteAddress);
+        const ip = req.socket.remoteAddress;
+        if (this.ipLastError[ip] && this.ipLastError[ip] > Date.now() - 60 * 1000) {
+            req.socket.destroy();
+            return;
+        }
+
+        const isBlocked = await this.rateLimiter.isBlocked(ip);
+        const isBlacklisted = (this.config.blacklist || []).includes(ip);
         if (isBlocked || isBlacklisted) {
             next(this.createError(SocketErrors.Forbidden, "Blocked due to rate limit or blacklisted."));
             return;
         }
 
-        const cidrRemoteAddress = cidr(`${req.socket.remoteAddress}/24`);
+        const cidrRemoteAddress = cidr(`${ip}/24`);
         const sameSubnetSockets = Object.values({ ...this.scServer.clients, ...this.scServer.pendingClients }).filter(
             client => cidr(`${client.remoteAddress}/24`) === cidrRemoteAddress,
         );


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Improve incoming WS message check by discarding too small messages (no need to even try to JSON parse those).

IP banning on worker for errors at WS level (no need to call master, we shut down socket and ban the IP for 1 minute).

Use `prependListener` for our WS message listeners so that our listeners are called before SC ones.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
