### PR TITLE
fix(core-database): don't assume blocksInCurrentRound is defined

### DIFF
--- a/packages/core-database/src/database-service.ts
+++ b/packages/core-database/src/database-service.ts
@@ -116,7 +116,7 @@ export class DatabaseService implements Database.IDatabaseService {
                     await this.setForgingDelegatesOfRound(roundInfo, delegates);
                     await this.saveRound(delegates);
 
-                    this.blocksInCurrentRound.length = 0;
+                    this.blocksInCurrentRound = [];
 
                     this.emitter.emit(ApplicationEvents.RoundApplied);
                 } catch (error) {


### PR DESCRIPTION
When resetting this.blocksInCurrentRound to an empty array assign [] to
it which also works if it is undefined.

Fixes https://github.com/ArkEcosystem/core/issues/3329

