### PR TITLE
core-p2p: relax postBlock rate limit

### DIFF
--- a/__tests__/integration/core-p2p/socket-server/peer.test.ts
+++ b/__tests__/integration/core-p2p/socket-server/peer.test.ts
@@ -109,7 +109,7 @@ describe("Peer socket endpoint", () => {
                         data: {},
                         headers,
                     }),
-                ).rejects.toHaveProperty("name", "BadConnectionError");
+                ).rejects.toHaveProperty("name", "Error");
             });
         });
 
@@ -247,17 +247,11 @@ describe("Peer socket endpoint", () => {
 
             const block = BlockFactory.createDummy().toJson();
 
-            await emit("p2p.peer.postBlock", {
-                headers,
-                data: { block },
-            });
+            const postBlock = () => emit("p2p.peer.postBlock", { headers, data: { block } });
 
-            await expect(
-                emit("p2p.peer.postBlock", {
-                    headers,
-                    data: { block },
-                }),
-            ).rejects.toHaveProperty("name", "BadConnectionError");
+            await expect(postBlock()).toResolve();
+            await expect(postBlock()).toResolve();
+            await expect(postBlock()).rejects.toHaveProperty("name", "BadConnectionError");
 
             await expect(
                 emit("p2p.peer.getStatus", {
@@ -268,12 +262,7 @@ describe("Peer socket endpoint", () => {
 
             await delay(4000);
 
-            await expect(
-                emit("p2p.peer.postBlock", {
-                    headers,
-                    data: { block },
-                }),
-            ).toResolve();
+            await expect(postBlock()).toResolve();
         });
 
         it("should close the connection when the event length is > 128", async () => {

--- a/packages/core-p2p/src/utils/build-rate-limiter.ts
+++ b/packages/core-p2p/src/utils/build-rate-limiter.ts
@@ -15,7 +15,7 @@ export const buildRateLimiter = options => {
             },
             endpoints: [
                 {
-                    rateLimit: 1,
+                    rateLimit: 2,
                     duration: 4,
                     endpoint: "p2p.peer.postBlock",
                 },


### PR DESCRIPTION
This allows two blocks to be sent/received shortly one after another, in
case we have late blocks.

Will maybe fix https://github.com/ArkEcosystem/core/issues/3349

