### PR TITLE
refactor: enable htlc types via dedicated milestone

### DIFF
--- a/__tests__/helpers/transaction-factory.ts
+++ b/__tests__/helpers/transaction-factory.ts
@@ -363,10 +363,13 @@ export class TransactionFactory {
 
             if (sign) {
                 const aip11: boolean = Managers.configManager.getMilestone().aip11;
+                const htlcEnabled: boolean = Managers.configManager.getMilestone().htlcEnabled;
                 if (this.builder.data.version === 1 && aip11) {
                     Managers.configManager.getMilestone().aip11 = false;
+                    Managers.configManager.getMilestone().htlcEnabled = false;
                 } else if (testnet) {
                     Managers.configManager.getMilestone().aip11 = true;
+                    Managers.configManager.getMilestone().htlcEnabled = htlcEnabled;
                 }
 
                 this.builder.sign(this.passphrase);
@@ -380,6 +383,7 @@ export class TransactionFactory {
 
             if (testnet) {
                 Managers.configManager.getMilestone().aip11 = true;
+                Managers.configManager.getMilestone().htlcEnabled = true;
             }
 
             transactions.push(transaction);

--- a/__tests__/unit/core-state/wallets/wallet-manager-htlc.test.ts
+++ b/__tests__/unit/core-state/wallets/wallet-manager-htlc.test.ts
@@ -16,6 +16,7 @@ let walletManager: State.IWalletManager;
 
 beforeAll(() => {
     Managers.configManager.getMilestone().aip11 = true;
+    Managers.configManager.getMilestone().htlcEnabled = true;
     jest.spyOn(Handlers.Registry, "isKnownWalletAttribute").mockReturnValue(true);
 });
 

--- a/__tests__/unit/crypto/transactions/deserializer.test.ts
+++ b/__tests__/unit/crypto/transactions/deserializer.test.ts
@@ -391,8 +391,16 @@ describe("Transaction serializer / Deserializer", () => {
                 .build();
 
             configManager.getMilestone().aip11 = false;
+            configManager.getMilestone().htlcEnabled = true;
             expect(htlcLock.verify()).toBeFalse();
             configManager.getMilestone().aip11 = true;
+            configManager.getMilestone().htlcEnabled = false;
+            expect(htlcLock.verify()).toBeFalse();
+            configManager.getMilestone().aip11 = false;
+            configManager.getMilestone().htlcEnabled = false;
+            expect(htlcLock.verify()).toBeFalse();
+            configManager.getMilestone().aip11 = true;
+            configManager.getMilestone().htlcEnabled = true;
             expect(htlcLock.verify()).toBeTrue();
         });
     });

--- a/packages/core-database/src/database-service.ts
+++ b/packages/core-database/src/database-service.ts
@@ -42,6 +42,7 @@ export class DatabaseService implements Database.IDatabaseService {
     public async init(): Promise<void> {
         if (process.env.CORE_ENV === "test") {
             Managers.configManager.getMilestone().aip11 = false;
+            Managers.configManager.getMilestone().htlcEnabled = false;
         }
 
         this.emitter.emit(ApplicationEvents.StateStarting, this);
@@ -192,7 +193,7 @@ export class DatabaseService implements Database.IDatabaseService {
 
         delegates = cloneDeep(delegates);
         for (let i = 0, delCount = delegates.length; i < delCount; i++) {
-            for (let x = 0; x < 4 && i < delCount; i++, x++) {
+            for (let x = 0; x < 4 && i < delCount; i++ , x++) {
                 const newIndex = currentSeed[x] % delCount;
                 const b = delegates[newIndex];
                 delegates[newIndex] = delegates[i];
@@ -241,9 +242,9 @@ export class DatabaseService implements Database.IDatabaseService {
                     headersOnly || !block.transactions
                         ? undefined
                         : block.transactions.map(
-                              (transaction: string) =>
-                                  Transactions.TransactionFactory.fromBytesUnsafe(Buffer.from(transaction, "hex")).data,
-                          ),
+                            (transaction: string) =>
+                                Transactions.TransactionFactory.fromBytesUnsafe(Buffer.from(transaction, "hex")).data,
+                        ),
             }));
         }
 
@@ -384,6 +385,7 @@ export class DatabaseService implements Database.IDatabaseService {
 
         if (block.height === 1 && process.env.CORE_ENV === "test") {
             Managers.configManager.getMilestone().aip11 = true;
+            Managers.configManager.getMilestone().htlcEnabled = true;
         }
 
         return lastBlock;
@@ -642,6 +644,7 @@ export class DatabaseService implements Database.IDatabaseService {
 
         if (process.env.CORE_ENV === "test") {
             Managers.configManager.getMilestone().aip11 = true;
+            Managers.configManager.getMilestone().htlcEnabled = true;
         }
 
         this.configureState(lastBlock);

--- a/packages/core-transactions/src/handlers/htlc-claim.ts
+++ b/packages/core-transactions/src/handlers/htlc-claim.ts
@@ -31,7 +31,8 @@ export class HtlcClaimTransactionHandler extends TransactionHandler {
     }
 
     public async isActivated(): Promise<boolean> {
-        return Managers.configManager.getMilestone().aip11 === true;
+        const milestone = Managers.configManager.getMilestone();
+        return milestone.aip11 === true && milestone.htlcEnabled === true;
     }
 
     public dynamicFee(context: IDynamicFeeContext): Utils.BigNumber {
@@ -190,11 +191,11 @@ export class HtlcClaimTransactionHandler extends TransactionHandler {
         transaction: Interfaces.ITransaction,
         walletManager: State.IWalletManager,
         // tslint:disable-next-line: no-empty
-    ): Promise<void> {}
+    ): Promise<void> { }
 
     public async revertForRecipient(
         transaction: Interfaces.ITransaction,
         walletManager: State.IWalletManager,
         // tslint:disable-next-line: no-empty
-    ): Promise<void> {}
+    ): Promise<void> { }
 }

--- a/packages/core-transactions/src/handlers/htlc-lock.ts
+++ b/packages/core-transactions/src/handlers/htlc-lock.ts
@@ -52,7 +52,8 @@ export class HtlcLockTransactionHandler extends TransactionHandler {
     }
 
     public async isActivated(): Promise<boolean> {
-        return Managers.configManager.getMilestone().aip11 === true;
+        const milestone = Managers.configManager.getMilestone();
+        return milestone.aip11 === true && milestone.htlcEnabled === true;
     }
 
     public async throwIfCannotBeApplied(
@@ -138,11 +139,11 @@ export class HtlcLockTransactionHandler extends TransactionHandler {
         transaction: Interfaces.ITransaction,
         walletManager: State.IWalletManager,
         // tslint:disable-next-line: no-empty
-    ): Promise<void> {}
+    ): Promise<void> { }
 
     public async revertForRecipient(
         transaction: Interfaces.ITransaction,
         walletManager: State.IWalletManager,
         // tslint:disable-next-line: no-empty
-    ): Promise<void> {}
+    ): Promise<void> { }
 }

--- a/packages/core-transactions/src/handlers/htlc-refund.ts
+++ b/packages/core-transactions/src/handlers/htlc-refund.ts
@@ -31,7 +31,8 @@ export class HtlcRefundTransactionHandler extends TransactionHandler {
     }
 
     public async isActivated(): Promise<boolean> {
-        return Managers.configManager.getMilestone().aip11 === true;
+        const milestone = Managers.configManager.getMilestone();
+        return milestone.aip11 === true && milestone.htlcEnabled === true;
     }
 
     public dynamicFee(context: IDynamicFeeContext): Utils.BigNumber {
@@ -176,11 +177,11 @@ export class HtlcRefundTransactionHandler extends TransactionHandler {
         transaction: Interfaces.ITransaction,
         walletManager: State.IWalletManager,
         // tslint:disable-next-line: no-empty
-    ): Promise<void> {}
+    ): Promise<void> { }
 
     public async revertForRecipient(
         transaction: Interfaces.ITransaction,
         walletManager: State.IWalletManager,
         // tslint:disable-next-line: no-empty
-    ): Promise<void> {}
+    ): Promise<void> { }
 }

--- a/packages/core/bin/config/devnet/peers.json
+++ b/packages/core/bin/config/devnet/peers.json
@@ -1,25 +1,27 @@
 {
-    "list": [
-        {
-            "ip": "167.114.29.51",
-            "port": 4002
-        },
-        {
-            "ip": "167.114.29.52",
-            "port": 4002
-        },
-        {
-            "ip": "167.114.29.53",
-            "port": 4002
-        },
-        {
-            "ip": "167.114.29.54",
-            "port": 4002
-        },
-        {
-            "ip": "167.114.29.55",
-            "port": 4002
-        }
-    ],
-    "sources": ["https://raw.githubusercontent.com/ARKEcosystem/peers/master/devnet.json"]
+  "list": [
+    {
+      "ip": "167.114.29.51",
+      "port": 4002
+    },
+    {
+      "ip": "167.114.29.52",
+      "port": 4002
+    },
+    {
+      "ip": "167.114.29.53",
+      "port": 4002
+    },
+    {
+      "ip": "167.114.29.54",
+      "port": 4002
+    },
+    {
+      "ip": "167.114.29.55",
+      "port": 4002
+    }
+  ],
+  "sources": [
+    "https://raw.githubusercontent.com/ARKEcosystem/peers/master/devnet.json"
+  ]
 }

--- a/packages/crypto/src/networks/devnet/milestones.json
+++ b/packages/crypto/src/networks/devnet/milestones.json
@@ -76,14 +76,19 @@
     {
         "height": 3963000,
         "p2p": {
-            "minimumVersions": ["^2.6 || ^2.6.0-next.0"]
+            "minimumVersions": [
+                "^2.6 || ^2.6.0-next.0"
+            ]
         }
     },
     {
         "height": 4006000,
         "aip11": true,
+        "htlcEnabled": true,
         "p2p": {
-            "minimumVersions": ["^2.6 || ^2.6.0-next.5"]
+            "minimumVersions": [
+                "^2.6 || ^2.6.0-next.5"
+            ]
         }
     }
 ]

--- a/packages/crypto/src/networks/testnet/milestones.json
+++ b/packages/crypto/src/networks/testnet/milestones.json
@@ -30,7 +30,8 @@
     },
     {
         "height": 2,
-        "aip11": true
+        "aip11": true,
+        "htlcEnabled": true
     },
     {
         "height": 75600,

--- a/packages/crypto/src/networks/unitnet/milestones.json
+++ b/packages/crypto/src/networks/unitnet/milestones.json
@@ -27,7 +27,8 @@
         },
         "vendorFieldLength": 64,
         "multiPaymentLimit": 256,
-        "aip11": true
+        "aip11": true,
+        "htlcEnabled": true
     },
     {
         "height": 75600,

--- a/packages/crypto/src/transactions/types/htlc-claim.ts
+++ b/packages/crypto/src/transactions/types/htlc-claim.ts
@@ -18,7 +18,8 @@ export class HtlcClaimTransaction extends Transaction {
     protected static defaultStaticFee: BigNumber = BigNumber.ZERO;
 
     public verify(): boolean {
-        return configManager.getMilestone().aip11 && super.verify();
+        const milestone = configManager.getMilestone();
+        return milestone.aip11 === true && milestone.htlcEnabled === true && super.verify();
     }
 
     public serialize(options?: ISerializeOptions): ByteBuffer {

--- a/packages/crypto/src/transactions/types/htlc-lock.ts
+++ b/packages/crypto/src/transactions/types/htlc-lock.ts
@@ -20,7 +20,8 @@ export class HtlcLockTransaction extends Transaction {
     protected static defaultStaticFee: BigNumber = BigNumber.make("10000000");
 
     public verify(): boolean {
-        return configManager.getMilestone().aip11 && super.verify();
+        const milestone = configManager.getMilestone();
+        return milestone.aip11 === true && milestone.htlcEnabled === true && super.verify();
     }
 
     public hasVendorField(): boolean {

--- a/packages/crypto/src/transactions/types/htlc-refund.ts
+++ b/packages/crypto/src/transactions/types/htlc-refund.ts
@@ -18,7 +18,8 @@ export class HtlcRefundTransaction extends Transaction {
     protected static defaultStaticFee: BigNumber = BigNumber.ZERO;
 
     public verify(): boolean {
-        return configManager.getMilestone().aip11 && super.verify();
+        const milestone = configManager.getMilestone();
+        return milestone.aip11 === true && milestone.htlcEnabled === true && super.verify();
     }
 
     public serialize(options?: ISerializeOptions): ByteBuffer {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
Introduces a new milestone `htlcEnabled` to en-/disable HTLC transaction types independently of the other transaction types.

It is mostly duplicating the existing `aip11` milestone, which will be cleaned up properly in V3.

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
