### PR TITLE
refactor: call `checkNetworkHealth` more deterministically

### DIFF
--- a/packages/core-blockchain/src/blockchain.ts
+++ b/packages/core-blockchain/src/blockchain.ts
@@ -62,6 +62,7 @@ export class Blockchain implements blockchain.IBlockchain {
     public queue: async.AsyncQueue<any>;
     protected blockProcessor: BlockProcessor;
     private actions: any;
+    private missedBlocks: number = 0;
 
     /**
      * Create a new blockchain manager instance.
@@ -157,6 +158,23 @@ export class Blockchain implements blockchain.IBlockchain {
         }
 
         this.p2p.getMonitor().cleansePeers({ forcePing: true, peerCount: 10 });
+
+        emitter.on(ApplicationEvents.ForgerMissing, async () => {
+            this.missedBlocks++;
+            if (this.missedBlocks >= 51 / 3 - 1) {
+                const networkStatus = await this.p2p.getMonitor().checkNetworkHealth();
+                if (networkStatus.forked) {
+                    this.state.numberOfBlocksToRollback = networkStatus.blocksToRollback;
+                    this.dispatch("FORK");
+                }
+
+                this.missedBlocks = 0;
+            }
+        });
+
+        emitter.on(ApplicationEvents.RoundApplied, () => {
+            this.missedBlocks = 0;
+        });
 
         return true;
     }

--- a/packages/core-blockchain/src/blockchain.ts
+++ b/packages/core-blockchain/src/blockchain.ts
@@ -161,7 +161,7 @@ export class Blockchain implements blockchain.IBlockchain {
 
         emitter.on(ApplicationEvents.ForgerMissing, async () => {
             this.missedBlocks++;
-            if (this.missedBlocks >= 51 / 3 - 1) {
+            if (this.missedBlocks >= Managers.configManager.getMilestone().activeDelegates / 3 - 1) {
                 const networkStatus = await this.p2p.getMonitor().checkNetworkHealth();
                 if (networkStatus.forked) {
                     this.state.numberOfBlocksToRollback = networkStatus.blocksToRollback;

--- a/packages/core-state/src/stores/state.ts
+++ b/packages/core-state/src/stores/state.ts
@@ -238,7 +238,7 @@ export class StateStore implements State.IStateStore {
         if (this.blockPing) {
             app.resolvePlugin<Logger.ILogger>("logger").info(
                 `Previous block ${this.blockPing.block.height.toLocaleString()} pinged blockchain ${
-                    this.blockPing.count
+                this.blockPing.count
                 } times`,
             );
         }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
Currently, Core only detects forks and eventually attempts to rollback when `checkNetworkHealth` is called after consecutively failing to download blocks. However, this does not work so reliable when there are not enough missed blocks (e.g network split evenly) which constantly causes the `noBlockCounter` to reset.

So now we also listen to missed blocks events and call `checkNetworkHealth` when the number of missed blocks in a round is > 51/3. This should prevent situations where nodes aren't aware of other forks and therefore never attempt a fork recovery.

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
