### PR TITLE
fix(core-database): allow legacy transaction in getBlocksForRound

### DIFF
--- a/__tests__/unit/crypto/blocks/factory.test.ts
+++ b/__tests__/unit/crypto/blocks/factory.test.ts
@@ -37,6 +37,16 @@ describe("BlockFactory", () => {
             expectBlock(BlockFactory.fromData(dummyBlock));
         });
 
+        it("should create a block instance when aip11 is true, block transactions are v1, and option deserializeTransactionsUnchecked is true", () => {
+            const milestone = configManager.getMilestone();
+            const spyGetMilestone = jest.spyOn(configManager, "getMilestone").mockReturnValue({
+                ...milestone,
+                aip11: true
+            });
+            expectBlock(BlockFactory.fromData(dummyBlock, { deserializeTransactionsUnchecked: true }));
+            spyGetMilestone.mockRestore();
+        });
+
         it("should create a block with exceptions", () => {
             // @ts-ignore
             expect(() => BlockFactory.fromData(blockWithExceptions)).not.toThrow();

--- a/packages/core-database/src/database-service.ts
+++ b/packages/core-database/src/database-service.ts
@@ -350,7 +350,7 @@ export class DatabaseService implements Database.IDatabaseService {
                         .getGenesisBlock();
                 }
 
-                return Blocks.BlockFactory.fromData(block);
+                return Blocks.BlockFactory.fromData(block, { deserializeTransactionsUnchecked: true });
             },
         );
     }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

Resolves #3370 

Allowing legacy transactions in getBlocksForRound, disabling checks with deserializeTransactionsUnchecked as we get the transactions from our own database. (that was previously verified)

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
