### PR TITLE
fix: relax network interface check for seednode ips

### DIFF
--- a/__tests__/unit/crypto/utils/is-valid-peer.test.ts
+++ b/__tests__/unit/crypto/utils/is-valid-peer.test.ts
@@ -51,4 +51,26 @@ describe("isValidPeer", () => {
         expect(isValidPeer({ ip: "5.196.105.32" })).toBeTrue();
         expect(isValidPeer({ ip: "5.196.105.32" })).toBeTrue();
     });
+
+    it("should be ok if IP is from network interface", () => {
+        const ips = [
+            "167.114.29.51",
+            "167.114.29.52",
+            "167.114.29.53",
+            "167.114.29.54",
+            "167.114.29.55"
+        ];
+
+        const spy = jest.spyOn(os, "networkInterfaces").mockReturnValue({
+            "eth0": ips.map(ip => ({ address: ip }) as any)
+        });
+
+        for (const ip of ips) {
+            expect(isValidPeer({ ip }, false)).toBeTrue();
+            expect(isValidPeer({ ip })).toBeFalse();
+        }
+
+        spy.mockRestore();
+    });
+
 });

--- a/packages/crypto/src/utils/is-valid-peer.ts
+++ b/packages/crypto/src/utils/is-valid-peer.ts
@@ -1,18 +1,22 @@
 import { parse, process } from "ipaddr.js";
 import os from "os";
 
-export const isLocalHost = (ip: string): boolean => {
+export const isLocalHost = (ip: string, includeNetworkInterfaces: boolean = true): boolean => {
     try {
         const parsed = parse(ip);
         if (parsed.range() === "loopback" || ip.startsWith("0") || ["127.0.0.1", "::ffff:127.0.0.1"].includes(ip)) {
             return true;
         }
 
-        const interfaces: {
-            [index: string]: os.NetworkInterfaceInfo[];
-        } = os.networkInterfaces();
+        if (includeNetworkInterfaces) {
+            const interfaces: {
+                [index: string]: os.NetworkInterfaceInfo[];
+            } = os.networkInterfaces();
 
-        return Object.keys(interfaces).some(ifname => interfaces[ifname].some(iface => iface.address === ip));
+            return Object.keys(interfaces).some(ifname => interfaces[ifname].some(iface => iface.address === ip));
+        }
+
+        return false;
     } catch (error) {
         return false;
     }
@@ -26,14 +30,13 @@ const sanitizeRemoteAddress = (ip: string): string | undefined => {
     }
 };
 
-export const isValidPeer = (peer: { ip: string; status?: string | number }): boolean => {
+export const isValidPeer = (peer: { ip: string }, includeNetworkInterfaces: boolean = true): boolean => {
     peer.ip = sanitizeRemoteAddress(peer.ip);
-
     if (!peer.ip) {
         return false;
     }
 
-    if (isLocalHost(peer.ip)) {
+    if (isLocalHost(peer.ip, includeNetworkInterfaces)) {
         return false;
     }
 

--- a/packages/crypto/src/validation/formats.ts
+++ b/packages/crypto/src/validation/formats.ts
@@ -14,7 +14,7 @@ const vendorField = (ajv: Ajv) => {
 const validPeer = (ajv: Ajv) => {
     ajv.addFormat("peer", (ip: string) => {
         try {
-            return isValidPeer({ ip });
+            return isValidPeer({ ip }, false);
         } catch {
             return false;
         }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
The schema used to validate seednodes uses `isValidPeer` which in addition to checking for localhost will refuse any ip that comes `os.networkInterfaces()`. But in this case the additional network interface restriction is not desired and therefore lifted.

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
