### PR TITLE
fix(core-transactions): HTLC unlock secret format

### DIFF
--- a/__tests__/e2e/tests/scenarios/scenario1/htlc-claim/1.create-lock-txs.action.js
+++ b/__tests__/e2e/tests/scenarios/scenario1/htlc-claim/1.create-lock-txs.action.js
@@ -5,6 +5,7 @@ const utils = require("./utils");
 const shared = require("./shared");
 const testUtils = require("../../../../lib/utils/test-utils");
 const { TransactionFactory } = require('../../../../../helpers/transaction-factory');
+const { htlcSecretHashHex } = require('../../../../../utils/fixtures');
 
 /**
  * Send lock transactions, we need 4 lock transactions to then test :
@@ -24,7 +25,7 @@ module.exports = async options => {
     // "normal" htlc lock transaction that will allow to claim without issue
     shared.lockTransactions.normal = TransactionFactory.htlcLock(
             {
-                secretHash: Crypto.HashAlgorithms.sha256(utils.htlcRecipient1.address.slice(0, 32)).toString("hex"),
+                secretHash: htlcSecretHashHex,
                 expiration: {
                     type: 2,
                     value: lastHeight + 51 + 12,
@@ -37,10 +38,10 @@ module.exports = async options => {
         .withPassphrase(utils.htlcSender.passphrase)
         .createOne();
 
-    // htlc lock transaction that we will claim with a wrong secret hash
+    // htlc lock transaction that we will claim with a wrong unlock secret
     shared.lockTransactions.wrongSecret = TransactionFactory.htlcLock(
             {
-                secretHash: Crypto.HashAlgorithms.sha256(utils.htlcRecipient2.address.slice(0, 32)).toString("hex"),
+                secretHash: htlcSecretHashHex,
                 expiration: {
                     type: 2,
                     value: lastHeight + 51 + 12,
@@ -57,7 +58,7 @@ module.exports = async options => {
     // htlc lock transaction that we will claim with a wallet not recipient of the lock tx
     shared.lockTransactions.notRecipient = TransactionFactory.htlcLock(
             {
-                secretHash: Crypto.HashAlgorithms.sha256(utils.htlcRecipient3.address.slice(0, 32)).toString("hex"),
+                secretHash: htlcSecretHashHex,
                 expiration: {
                     type: 2,
                     value: lastHeight + 51 + 12,
@@ -74,7 +75,7 @@ module.exports = async options => {
     // htlc lock transaction that we will claim after lock expiration
     shared.lockTransactions.lockExpired = TransactionFactory.htlcLock(
             {
-                secretHash: Crypto.HashAlgorithms.sha256(utils.htlcRecipient4.address.slice(0, 32)).toString("hex"),
+                secretHash: htlcSecretHashHex,
                 expiration: {
                     type: 2,
                     value: lastHeight + 51 + 4,

--- a/__tests__/e2e/tests/scenarios/scenario1/htlc-claim/3.create-claim-txs.action.js
+++ b/__tests__/e2e/tests/scenarios/scenario1/htlc-claim/3.create-claim-txs.action.js
@@ -5,6 +5,7 @@ const utils = require("./utils");
 const shared = require("./shared");
 const testUtils = require("../../../../lib/utils/test-utils");
 const { TransactionFactory } = require('../../../../../helpers/transaction-factory');
+const { htlcSecretHex } = require('../../../../../utils/fixtures');
 
 /**
  * Send claim transactions, we need 4 claim transactions to test when :
@@ -22,17 +23,17 @@ module.exports = async options => {
     shared.claimTransactions.normal = TransactionFactory.htlcClaim(
             {
                 lockTransactionId: shared.lockTransactions.normal.id,
-                unlockSecret: shared.lockTransactions.normal.recipientId.slice(0, 32),
+                unlockSecret: htlcSecretHex,
             }
         )
         .withPassphrase(utils.htlcRecipient1.passphrase)
         .createOne();
 
-    // 2nd transaction : htlc lock transaction that we claim with a wrong secret hash
+    // 2nd transaction : htlc lock transaction that we claim with a wrong unlock secret
     shared.claimTransactions.wrongSecret = TransactionFactory.htlcClaim(
             {
                 lockTransactionId: shared.lockTransactions.wrongSecret.id,
-                unlockSecret: "thatisasecretthatissooooooowrong",
+                unlockSecret: "0000000000000000000000000000000000000000000000000000000000000000",
             }
         )
         .withPassphrase(utils.htlcRecipient2.passphrase)
@@ -42,7 +43,7 @@ module.exports = async options => {
     shared.claimTransactions.notRecipient = TransactionFactory.htlcClaim(
             {
                 lockTransactionId: shared.lockTransactions.notRecipient.id,
-                unlockSecret: shared.lockTransactions.notRecipient.recipientId.slice(0, 32),
+                unlockSecret: htlcSecretHex,
             }
         )
         .withPassphrase(utils.htlcNotRecipient.passphrase)
@@ -52,7 +53,7 @@ module.exports = async options => {
     shared.claimTransactions.lockExpired = TransactionFactory.htlcClaim(
             {
                 lockTransactionId: shared.lockTransactions.lockExpired.id,
-                unlockSecret: shared.lockTransactions.lockExpired.recipientId.slice(0, 32),
+                unlockSecret: htlcSecretHex,
             }
         )
         .withPassphrase(utils.htlcRecipient4.passphrase)

--- a/__tests__/e2e/tests/scenarios/scenario1/htlc-refund/1.create-lock-txs.action.js
+++ b/__tests__/e2e/tests/scenarios/scenario1/htlc-refund/1.create-lock-txs.action.js
@@ -5,6 +5,7 @@ const utils = require("./utils");
 const shared = require("./shared");
 const testUtils = require("../../../../lib/utils/test-utils");
 const { TransactionFactory } = require('../../../../../helpers/transaction-factory');
+const { htlcSecretHashHex } = require('../../../../../utils/fixtures');
 
 /**
  * Send lock transactions, we need 3 lock transactions to then test :
@@ -23,7 +24,7 @@ module.exports = async options => {
     // "normal" htlc lock transaction that will allow to refund without issue
     shared.lockTransactions.normal = TransactionFactory.htlcLock(
             {
-                secretHash: Crypto.HashAlgorithms.sha256(utils.htlcRecipient1.address.slice(0, 32)).toString("hex"),
+                secretHash: htlcSecretHashHex,
                 expiration: {
                     type: 2,
                     value: lastHeight + 51 + 4,
@@ -39,7 +40,7 @@ module.exports = async options => {
     // htlc lock transaction that we will refund with a wallet not sender of the lock tx
     shared.lockTransactions.notSender = TransactionFactory.htlcLock(
             {
-                secretHash: Crypto.HashAlgorithms.sha256(utils.htlcRecipient2.address.slice(0, 32)).toString("hex"),
+                secretHash: htlcSecretHashHex,
                 expiration: {
                     type: 2,
                     value: lastHeight + 51 + 4,
@@ -56,7 +57,7 @@ module.exports = async options => {
     // htlc lock transaction that we will refund before lock expiration
     shared.lockTransactions.lockNotExpired = TransactionFactory.htlcLock(
             {
-                secretHash: Crypto.HashAlgorithms.sha256(utils.htlcRecipient3.address.slice(0, 32)).toString("hex"),
+                secretHash: htlcSecretHashHex,
                 expiration: {
                     type: 2,
                     value: lastHeight + 51 + 12,

--- a/__tests__/e2e/tests/scenarios/scenario1/multisig-htlc-claim/4.create-lock-multisig-txs.action.js
+++ b/__tests__/e2e/tests/scenarios/scenario1/multisig-htlc-claim/4.create-lock-multisig-txs.action.js
@@ -5,6 +5,7 @@ const utils = require("./utils");
 const shared = require("./shared");
 const testUtils = require("../../../../lib/utils/test-utils");
 const { TransactionFactory } = require('../../../../../helpers/transaction-factory');
+const { htlcSecretHashHex } = require('../../../../../utils/fixtures');
 
 /**
  * Send valid multisig htlc lock transaction
@@ -22,7 +23,7 @@ module.exports = async options => {
     // "normal" htlc lock transaction that will allow to claim without issue
     shared.lockTransactions.normal = TransactionFactory.htlcLock(
             {
-                secretHash: Crypto.HashAlgorithms.sha256(utils.randomWallet1.address.slice(0, 32)).toString("hex"),
+                secretHash: htlcSecretHashHex,
                 expiration: {
                     type: 2,
                     value: lastHeight + 51 + 12,

--- a/__tests__/e2e/tests/scenarios/scenario1/multisig-htlc-claim/5.create-claim-multisig-txs.action.js
+++ b/__tests__/e2e/tests/scenarios/scenario1/multisig-htlc-claim/5.create-claim-multisig-txs.action.js
@@ -5,6 +5,7 @@ const utils = require("./utils");
 const shared = require("./shared");
 const testUtils = require("../../../../lib/utils/test-utils");
 const { TransactionFactory } = require('../../../../../helpers/transaction-factory');
+const { htlcSecretHex } = require('../../../../../utils/fixtures');
 
 /**
  * Claim signing tx with multisig wallet
@@ -20,7 +21,7 @@ module.exports = async options => {
     shared.claimTransactions.normal = TransactionFactory.htlcClaim(
             {
                 lockTransactionId: shared.lockTransactions.normal.id,
-                unlockSecret: shared.lockTransactions.normal.recipientId.slice(0, 32),
+                unlockSecret: htlcSecretHex,
             }
         )
         .withSenderPublicKey(multisigPublicKey)

--- a/__tests__/e2e/tests/scenarios/scenario1/multisig-htlc-refund/4.create-lock-multisig-txs.action.js
+++ b/__tests__/e2e/tests/scenarios/scenario1/multisig-htlc-refund/4.create-lock-multisig-txs.action.js
@@ -5,6 +5,7 @@ const utils = require("./utils");
 const shared = require("./shared");
 const testUtils = require("../../../../lib/utils/test-utils");
 const { TransactionFactory } = require('../../../../../helpers/transaction-factory');
+const { htlcSecretHashHex } = require('../../../../../utils/fixtures');
 
 /**
  * Send valid multisig htlc lock transaction
@@ -22,7 +23,7 @@ module.exports = async options => {
     // "normal" htlc lock transaction that will allow to claim without issue
     shared.lockTransactions.normal = TransactionFactory.htlcLock(
             {
-                secretHash: Crypto.HashAlgorithms.sha256(utils.randomWallet1.address.slice(0, 32)).toString("hex"),
+                secretHash: htlcSecretHashHex,
                 expiration: {
                     type: 2,
                     value: lastHeight + 51 + 1,

--- a/__tests__/functional/transaction-forging/htlc-claim.test.ts
+++ b/__tests__/functional/transaction-forging/htlc-claim.test.ts
@@ -1,6 +1,7 @@
 import { Crypto, Enums, Identities } from "@arkecosystem/crypto";
 import { TransactionFactory } from "../../helpers/transaction-factory";
 import { secrets } from "../../utils/config/testnet/delegates.json";
+import { htlcSecretHex, htlcSecretHashHex } from "../../utils/fixtures";
 import * as support from "./__support__";
 
 const { passphrase, secondPassphrase } = support.passphrases;
@@ -22,11 +23,9 @@ describe("Transaction Forging - HTLC Claim", () => {
         await expect(initialFunds.id).toBeForged();
 
         // Submit htlc lock transaction
-        const secret = "my secret that should be 32bytes";
-        const secretHash = Crypto.HashAlgorithms.sha256(secret).toString("hex");
         const lockTransaction = TransactionFactory.htlcLock(
             {
-                secretHash,
+                secretHash: htlcSecretHashHex,
                 expiration: {
                     type: EpochTimestamp,
                     value: Crypto.Slots.getTime() + 1000,
@@ -43,7 +42,7 @@ describe("Transaction Forging - HTLC Claim", () => {
 
         // Submit htlc claim transaction
         const transaction = TransactionFactory.htlcClaim({
-            unlockSecret: secret,
+            unlockSecret: htlcSecretHex,
             lockTransactionId: lockTransaction.id,
         })
             .withPassphrase(secrets[1])
@@ -77,11 +76,9 @@ describe("Transaction Forging - HTLC Claim", () => {
         await expect(secondSignature.id).toBeForged();
 
         // Initial htlc lock transaction
-        const secret = "my secret that should be 32bytes";
-        const secretHash = Crypto.HashAlgorithms.sha256(secret).toString("hex");
         const lockTransaction = TransactionFactory.htlcLock(
             {
-                secretHash,
+                secretHash: htlcSecretHashHex,
                 expiration: {
                     type: EpochTimestamp,
                     value: Crypto.Slots.getTime() + 1000,
@@ -98,7 +95,7 @@ describe("Transaction Forging - HTLC Claim", () => {
 
         // Submit htlc claim transaction
         const claimTransaction = TransactionFactory.htlcClaim({
-            unlockSecret: secret,
+            unlockSecret: htlcSecretHex,
             lockTransactionId: lockTransaction.id,
         })
             .withPassphrasePair({ passphrase, secondPassphrase })
@@ -149,11 +146,9 @@ describe("Transaction Forging - HTLC Claim", () => {
         await expect(multiSignatureFunds.id).toBeForged();
 
         // Initial htlc lock transaction
-        const secret = "my secret that should be 32bytes";
-        const secretHash = Crypto.HashAlgorithms.sha256(secret).toString("hex");
         const lockTransaction = TransactionFactory.htlcLock(
             {
-                secretHash,
+                secretHash: htlcSecretHashHex,
                 expiration: {
                     type: EpochTimestamp,
                     value: Crypto.Slots.getTime() + 1000,
@@ -170,7 +165,7 @@ describe("Transaction Forging - HTLC Claim", () => {
 
         // Submit htlc claim transaction
         const claimTransaction = TransactionFactory.htlcClaim({
-            unlockSecret: secret,
+            unlockSecret: htlcSecretHex,
             lockTransactionId: lockTransaction.id,
         })
             .withSenderPublicKey(multiSigPublicKey)

--- a/__tests__/integration/core-tester-cli/commands/send/htlc-claim.test.ts
+++ b/__tests__/integration/core-tester-cli/commands/send/htlc-claim.test.ts
@@ -1,9 +1,10 @@
 import "jest-extended";
 
 import { httpie } from "@arkecosystem/core-utils";
-import { Enums, Identities, Managers } from "@arkecosystem/crypto";
+import { Enums, Managers } from "@arkecosystem/crypto";
 import nock from "nock";
 import { HtlcClaimCommand } from "../../../../../packages/core-tester-cli/src/commands/send/htlc-claim";
+import { htlcSecretHex } from "../../../../utils/fixtures";
 import { arkToSatoshi, captureTransactions, toFlags } from "../../shared";
 
 beforeEach(() => {
@@ -46,9 +47,7 @@ describe("Commands - Htlc claim", () => {
             .filter(tx => tx.type === Enums.TransactionType.HtlcClaim)
             .map(tx => {
                 expect(tx.fee).toEqual(arkToSatoshi(opts.htlcClaimFee));
-                expect(tx.asset.claim.unlockSecret).toEqual(
-                    Identities.Address.fromPublicKey(tx.senderPublicKey).slice(0, 32),
-                );
+                expect(tx.asset.claim.unlockSecret).toEqual(htlcSecretHex);
                 expect(tx.asset.claim.lockTransactionId).toBeDefined();
             });
     });
@@ -70,9 +69,7 @@ describe("Commands - Htlc claim", () => {
             .filter(tx => tx.type === Enums.TransactionType.HtlcClaim)
             .map(tx => {
                 expect(tx.fee).toEqual(arkToSatoshi(0.1));
-                expect(tx.asset.claim.unlockSecret).toEqual(
-                    Identities.Address.fromPublicKey(tx.senderPublicKey).slice(0, 32),
-                );
+                expect(tx.asset.claim.unlockSecret).toEqual(htlcSecretHex);
                 expect(tx.asset.claim.lockTransactionId).toBeDefined();
             });
     });

--- a/__tests__/integration/core-tester-cli/commands/send/htlc-lock.test.ts
+++ b/__tests__/integration/core-tester-cli/commands/send/htlc-lock.test.ts
@@ -1,10 +1,11 @@
 import "jest-extended";
 
 import { httpie } from "@arkecosystem/core-utils";
-import { Crypto, Enums, Identities, Managers } from "@arkecosystem/crypto";
+import { Enums, Managers } from "@arkecosystem/crypto";
 import nock from "nock";
 import { HtlcLockCommand } from "../../../../../packages/core-tester-cli/src/commands/send/htlc-lock";
 import { arkToSatoshi, captureTransactions, toFlags } from "../../shared";
+import { htlcSecretHashHex } from "../../../../utils/fixtures";
 
 beforeEach(() => {
     // Just passthru. We'll test the Command class logic in its own test file more thoroughly
@@ -46,11 +47,7 @@ describe("Commands - Htlc lock", () => {
             .filter(tx => tx.type === Enums.TransactionType.HtlcLock)
             .map(tx => {
                 expect(tx.fee).toEqual(arkToSatoshi(opts.htlcLockFee));
-                expect(tx.asset.lock.secretHash).toEqual(
-                    Crypto.HashAlgorithms.sha256(
-                        Identities.Address.fromPublicKey(tx.senderPublicKey).slice(0, 32),
-                    ).toString("hex"),
-                );
+                expect(tx.asset.lock.secretHash).toEqual(htlcSecretHashHex);
             });
     });
 
@@ -71,11 +68,7 @@ describe("Commands - Htlc lock", () => {
             .filter(tx => tx.type === Enums.TransactionType.HtlcLock)
             .map(tx => {
                 expect(tx.fee).toEqual(arkToSatoshi(0.1));
-                expect(tx.asset.lock.secretHash).toEqual(
-                    Crypto.HashAlgorithms.sha256(
-                        Identities.Address.fromPublicKey(tx.senderPublicKey).slice(0, 32),
-                    ).toString("hex"),
-                );
+                expect(tx.asset.lock.secretHash).toEqual(htlcSecretHashHex);
             });
     });
 });

--- a/__tests__/integration/core-transactions/handlers/htlc-claim.test.ts
+++ b/__tests__/integration/core-transactions/handlers/htlc-claim.test.ts
@@ -1,11 +1,12 @@
 import { Container, Database } from "@arkecosystem/core-interfaces";
-import { Crypto, Networks, Utils } from "@arkecosystem/crypto";
+import { Networks, Utils } from "@arkecosystem/crypto";
 import { StateBuilder } from "../../../../packages/core-database-postgres/src";
 import { Delegate } from "../../../../packages/core-forger/src/delegate";
 import { WalletManager } from "../../../../packages/core-state/src/wallets";
 import { TransactionFactory } from "../../../helpers/transaction-factory";
 import { genesisBlock } from "../../../utils/config/unitnet/genesisBlock";
 import { wallets } from "../../../utils/fixtures/unitnet";
+import { htlcSecretHex, htlcSecretHashHex } from "../../../utils/fixtures";
 import { setUp, tearDown } from "../__support__/setup";
 
 let container: Container.IContainer;
@@ -52,10 +53,8 @@ describe("Htlc claim handler bootstrap", () => {
         };
         const sender = wallets[11];
         const recipientId = "APmKYrtyyP34BdqQKyk71NbzQ2VKjG8sB3";
-        const secret = "my secret that should be 32bytes";
-        const secretHash = Crypto.HashAlgorithms.sha256(secret).toString("hex");
         const htlcLockAsset = {
-            secretHash,
+            secretHash: htlcSecretHashHex,
             expiration: {
                 type: 1,
                 value: makeTimestamp(99),
@@ -74,7 +73,7 @@ describe("Htlc claim handler bootstrap", () => {
 
         const claimer = wallets[14];
         const claimTransaction = TransactionFactory.htlcClaim({
-            unlockSecret: secret,
+            unlockSecret: htlcSecretHex,
             lockTransactionId: lockTransaction.id,
         })
             .withNetwork("unitnet")

--- a/__tests__/unit/core-state/wallets/wallet-manager-htlc.test.ts
+++ b/__tests__/unit/core-state/wallets/wallet-manager-htlc.test.ts
@@ -7,6 +7,7 @@ import { Handlers } from "@arkecosystem/core-transactions";
 import { Crypto, Enums, Identities, Managers, Transactions, Utils } from "@arkecosystem/crypto";
 import { Wallet, WalletManager } from "../../../../packages/core-state/src/wallets";
 import { TransactionFactory } from "../../../helpers/transaction-factory";
+import { htlcSecretHex, htlcSecretHashHex } from "../../../utils/fixtures";
 
 jest.mock("@arkecosystem/core-container", () => require("../mocks/container").container);
 
@@ -60,10 +61,8 @@ describe("Wallet Manager", () => {
             it("should update balance and vote balance when lock wallet votes for a delegate", async () => {
                 // prepare htlc lock transaction
                 const amount = 6 * 1e8;
-                const secret = "my secret that should be 32bytes";
-                const secretHash = Crypto.HashAlgorithms.sha256(secret).toString("hex");
                 const htlcLockAsset = {
-                    secretHash,
+                    secretHash: htlcSecretHashHex,
                     expiration: {
                         type: EpochTimestamp,
                         value: Crypto.Slots.getTime() + 99,
@@ -78,7 +77,7 @@ describe("Wallet Manager", () => {
                 // prepare claim transaction
                 const htlcClaimAsset = {
                     lockTransactionId: lockTransaction.id,
-                    unlockSecret: secret,
+                    unlockSecret: htlcSecretHex,
                 };
                 const claimTransaction = TransactionFactory.htlcClaim(htlcClaimAsset)
                     .withPassphrase(claimPassphrase)
@@ -184,10 +183,8 @@ describe("Wallet Manager", () => {
 
                 // prepare htlc lock transaction
                 const amount = 6 * 1e8;
-                const secret = "my secret that should be 32bytes";
-                const secretHash = Crypto.HashAlgorithms.sha256(secret).toString("hex");
                 const htlcLockAsset = {
-                    secretHash,
+                    secretHash: htlcSecretHashHex,
                     expiration: {
                         type: EpochTimestamp,
                         value: Crypto.Slots.getTime() + 99,
@@ -201,7 +198,7 @@ describe("Wallet Manager", () => {
                 // prepare claim transaction
                 const htlcClaimAsset = {
                     lockTransactionId: lockTransaction.id,
-                    unlockSecret: secret,
+                    unlockSecret: htlcSecretHex,
                 };
                 const claimTransaction = TransactionFactory.htlcClaim(htlcClaimAsset)
                     .withPassphrase(claimPassphrase)
@@ -324,10 +321,8 @@ describe("Wallet Manager", () => {
                 lockWallet.nonce = Utils.BigNumber.ZERO;
                 // prepare htlc lock transaction
                 const amount = 6 * 1e8;
-                const secret = "my secret that should be 32bytes";
-                const secretHash = Crypto.HashAlgorithms.sha256(secret).toString("hex");
                 const htlcLockAsset = {
-                    secretHash,
+                    secretHash: htlcSecretHashHex,
                     expiration: {
                         type: EpochTimestamp,
                         value: Crypto.Slots.getTime(),

--- a/__tests__/unit/core-transactions/handler.test.ts
+++ b/__tests__/unit/core-transactions/handler.test.ts
@@ -30,6 +30,7 @@ import {
 } from "../../../packages/core-transactions/src/errors";
 import { Handlers, Interfaces as TransactionsInterfaces } from "../../../packages/core-transactions/src/index";
 import { TransactionFactory } from "../../helpers/transaction-factory";
+import { htlcSecretHex, htlcSecretHashHex } from "../../utils/fixtures";
 
 const { EpochTimestamp, BlockHeight } = Enums.HtlcLockExpirationType;
 
@@ -1082,7 +1083,7 @@ describe("DelegateResignationTransaction", () => {
 
 describe.each([EpochTimestamp, BlockHeight])("Htlc lock - expiration type %i", expirationType => {
     const htlcLockAsset = {
-        secretHash: "0f128d401958b1b30ad0d10406f47f9489321017b4614e6cb993fc63913c5454",
+        secretHash: htlcSecretHashHex,
         expiration: {
             type: expirationType,
             value: makeNotExpiredTimestamp(expirationType),
@@ -1212,10 +1213,8 @@ describe.each([EpochTimestamp, BlockHeight])("Htlc claim - expiration type %i", 
         walletManager.reindex(claimWallet);
 
         const amount = 6 * 1e8;
-        const secret = "my secret that should be 32bytes";
-        const secretHash = Crypto.HashAlgorithms.sha256(secret).toString("hex");
         const htlcLockAsset = {
-            secretHash,
+            secretHash: htlcSecretHashHex,
             expiration: {
                 type: expirationType,
                 value: makeNotExpiredTimestamp(expirationType),
@@ -1227,7 +1226,7 @@ describe.each([EpochTimestamp, BlockHeight])("Htlc claim - expiration type %i", 
 
         htlcClaimAsset = {
             lockTransactionId: lockTransaction.id,
-            unlockSecret: secret,
+            unlockSecret: htlcSecretHex,
         };
 
         lockWallet.setAttribute("htlc.locks", {
@@ -1265,7 +1264,7 @@ describe.each([EpochTimestamp, BlockHeight])("Htlc claim - expiration type %i", 
         it("should throw if secret hash does not match", async () => {
             transaction = TransactionFactory.htlcClaim({
                 lockTransactionId: lockTransaction.id,
-                unlockSecret: "wrong 32 bytes unlock secret =((",
+                unlockSecret: "0000000000000000000000000000000000000000000000000000000000000000",
             })
                 .withPassphrase(claimPassphrase)
                 .createOne();
@@ -1288,7 +1287,7 @@ describe.each([EpochTimestamp, BlockHeight])("Htlc claim - expiration type %i", 
 
             const htlcClaimAsset = {
                 lockTransactionId: lockTransaction.id,
-                unlockSecret: "my secret that should be 32bytes",
+                unlockSecret: htlcSecretHex,
             };
 
             transaction = TransactionFactory.htlcClaim(htlcClaimAsset)
@@ -1303,10 +1302,8 @@ describe.each([EpochTimestamp, BlockHeight])("Htlc claim - expiration type %i", 
 
         it("should throw if lock expired", async () => {
             const amount = 1e9;
-            const secret = "my secret that should be 32bytes";
-            const secretHash = Crypto.HashAlgorithms.sha256(secret).toString("hex");
             const htlcLockAsset = {
-                secretHash,
+                secretHash: htlcSecretHashHex,
                 expiration: {
                     type: expirationType,
                     value: makeExpiredTimestamp(expirationType),
@@ -1318,7 +1315,7 @@ describe.each([EpochTimestamp, BlockHeight])("Htlc claim - expiration type %i", 
 
             const htlcClaimAsset = {
                 lockTransactionId: lockTransaction.id,
-                unlockSecret: secret,
+                unlockSecret: htlcSecretHex,
             };
 
             lockWallet.setAttribute("htlc.locks", {
@@ -1474,10 +1471,8 @@ describe.each([EpochTimestamp, BlockHeight])("Htlc refund - expiration type %i",
         walletManager.reindex(lockWallet);
 
         const amount = 6 * 1e8;
-        const secret = "my secret that should be 32bytes";
-        const secretHash = Crypto.HashAlgorithms.sha256(secret).toString("hex");
         const htlcLockAsset = {
-            secretHash,
+            secretHash: htlcSecretHashHex,
             expiration: {
                 type: expirationType,
                 value: makeExpiredTimestamp(expirationType),
@@ -1547,10 +1542,8 @@ describe.each([EpochTimestamp, BlockHeight])("Htlc refund - expiration type %i",
 
         it("should throw if lock didn't expire - expiration type %i", async () => {
             const amount = 6 * 1e8;
-            const secret = "my secret that should be 32bytes";
-            const secretHash = Crypto.HashAlgorithms.sha256(secret).toString("hex");
             const htlcLockAsset = {
-                secretHash,
+                secretHash: htlcSecretHashHex,
                 expiration: {
                     type: expirationType,
                     value: makeNotExpiredTimestamp(expirationType),

--- a/__tests__/unit/crypto/transactions/builders/transactions/htlc-claim.test.ts
+++ b/__tests__/unit/crypto/transactions/builders/transactions/htlc-claim.test.ts
@@ -6,6 +6,7 @@ import { HtlcClaimBuilder } from "../../../../../../packages/crypto/src/transact
 import { HtlcClaimTransaction } from "../../../../../../packages/crypto/src/transactions/types/htlc-claim";
 import { BigNumber } from "../../../../../../packages/crypto/src/utils";
 import { transactionBuilder } from "./__shared__/transaction-builder";
+import { htlcSecretHex } from "../../../../../utils/fixtures";
 
 let builder: HtlcClaimBuilder;
 
@@ -27,7 +28,7 @@ describe("Htlc claim Transaction", () => {
         it("should set the htlc claim asset", () => {
             const htlcClaimAsset = {
                 lockTransactionId: "943c220691e711c39c79d437ce185748a0018940e1a4144293af9d05627d2eb4",
-                unlockSecret: "my secret that should be 32bytes",
+                unlockSecret: htlcSecretHex,
             };
 
             builder.htlcClaimAsset(htlcClaimAsset);
@@ -39,7 +40,7 @@ describe("Htlc claim Transaction", () => {
     describe("verify", () => {
         const htlcClaimAsset = {
             lockTransactionId: "943c220691e711c39c79d437ce185748a0018940e1a4144293af9d05627d2eb4",
-            unlockSecret: "my secret that should be 32bytes",
+            unlockSecret: htlcSecretHex,
         };
 
         it("should be valid with a signature", () => {

--- a/__tests__/unit/crypto/transactions/deserializer.test.ts
+++ b/__tests__/unit/crypto/transactions/deserializer.test.ts
@@ -18,6 +18,7 @@ import { BuilderFactory } from "../../../../packages/crypto/src/transactions/bui
 import { Deserializer } from "../../../../packages/crypto/src/transactions/deserializer";
 import { Serializer } from "../../../../packages/crypto/src/transactions/serializer";
 import { legacyMultiSignatureRegistration } from "./__fixtures__/transaction";
+import { htlcSecretHex, htlcSecretHashHex } from "../../../utils/fixtures";
 
 configManager.setHeight(2); // aip11 (v2 transactions) is true from height 2 on testnet
 
@@ -350,7 +351,7 @@ describe("Transaction serializer / Deserializer", () => {
 
     describe("ser/deserialize - htlc lock", () => {
         const htlcLockAsset = {
-            secretHash: "0f128d401958b1b30ad0d10406f47f9489321017b4614e6cb993fc63913c5454",
+            secretHash: htlcSecretHashHex,
             expiration: {
                 type: Enums.HtlcLockExpirationType.EpochTimestamp,
                 value: Math.floor(Date.now() / 1000),
@@ -408,7 +409,7 @@ describe("Transaction serializer / Deserializer", () => {
     describe("ser/deserialize - htlc claim", () => {
         const htlcClaimAsset = {
             lockTransactionId: "943c220691e711c39c79d437ce185748a0018940e1a4144293af9d05627d2eb4",
-            unlockSecret: "my secret that should be 32bytes",
+            unlockSecret: htlcSecretHex,
         };
 
         beforeAll(() => {

--- a/__tests__/unit/crypto/transactions/schemas.test.ts
+++ b/__tests__/unit/crypto/transactions/schemas.test.ts
@@ -8,6 +8,7 @@ import { BuilderFactory } from "../../../../packages/crypto/src/transactions";
 import { TransactionTypeFactory } from "../../../../packages/crypto/src/transactions";
 import { TransactionSchema } from "../../../../packages/crypto/src/transactions/types/schemas";
 import { validator as Ajv } from "../../../../packages/crypto/src/validation";
+import { htlcSecretHex, htlcSecretHashHex } from "../../../utils/fixtures"
 
 let transaction;
 let transactionSchema: TransactionSchema;
@@ -806,7 +807,7 @@ describe("HTLC Lock Transaction", () => {
     const fee = 1 * ARKTOSHI;
     const amount = 10 * ARKTOSHI;
     const htlcLockAsset = {
-        secretHash: "0f128d401958b1b30ad0d10406f47f9489321017b4614e6cb993fc63913c5454",
+        secretHash: htlcSecretHashHex,
         expiration: {
             type: HtlcLockExpirationType.EpochTimestamp,
             value: Math.floor(Date.now() / 1000),
@@ -922,7 +923,7 @@ describe("HTLC Claim Transaction", () => {
     const fee = "0";
     const htlcClaimAsset = {
         lockTransactionId: "943c220691e711c39c79d437ce185748a0018940e1a4144293af9d05627d2eb4",
-        unlockSecret: "my secret that should be 32bytes",
+        unlockSecret: htlcSecretHex,
     };
 
     beforeAll(() => {
@@ -947,7 +948,7 @@ describe("HTLC Claim Transaction", () => {
         transaction
             .htlcClaimAsset({
                 lockTransactionId: "943c220691e711c39c79d437ce185748a0018940e1a4144293af9d05627d2eb",
-                unlockSecret: "my secret that should be 32bytes",
+                unlockSecret: htlcSecretHex,
             })
             .recipientId(address)
             .fee(fee)
@@ -961,7 +962,7 @@ describe("HTLC Claim Transaction", () => {
         transaction
             .htlcClaimAsset({
                 lockTransactionId: "943c220691e711c39c79d437ce185748a0018940e1a4144293af9d05627d2ebw",
-                unlockSecret: "my secret that should be 32bytes",
+                unlockSecret: htlcSecretHex,
             })
             .recipientId(address)
             .fee(fee)
@@ -975,7 +976,7 @@ describe("HTLC Claim Transaction", () => {
         transaction
             .htlcClaimAsset({
                 lockTransactionId: "943c220691e711c39c79d437ce185748a0018940e1a4144293af9d05627d2eb",
-                unlockSecret: "my secret that should be 32bytes but is not",
+                unlockSecret: "00112233",
             })
             .recipientId(address)
             .fee(fee)

--- a/packages/core-tester-cli/src/commands/send/htlc-claim.ts
+++ b/packages/core-tester-cli/src/commands/send/htlc-claim.ts
@@ -1,6 +1,7 @@
 import { Identities } from "@arkecosystem/crypto";
 import { satoshiFlag } from "../../flags";
 import { SendCommand } from "../../shared/send";
+import { htlcSecretHex } from "../../shared/htlc-secret";
 import { HtlcLockCommand } from "./htlc-lock";
 
 export class HtlcClaimCommand extends SendCommand {
@@ -28,11 +29,8 @@ export class HtlcClaimCommand extends SendCommand {
         const transactions = [];
 
         for (const wallet of Object.values(wallets)) {
-            const unlockSecret = wallet.address.slice(0, 32);
-            // we use the 32 first chars of wallet address as secret
-
             const claimAsset = {
-                unlockSecret,
+                unlockSecret: htlcSecretHex,
                 lockTransactionId: wallet.lockTransaction.id,
             };
 

--- a/packages/core-tester-cli/src/commands/send/htlc-lock.ts
+++ b/packages/core-tester-cli/src/commands/send/htlc-lock.ts
@@ -1,7 +1,8 @@
-import { Crypto, Identities } from "@arkecosystem/crypto";
+import { Identities } from "@arkecosystem/crypto";
 import { flags } from "@oclif/command";
 import { satoshiFlag } from "../../flags";
 import { SendCommand } from "../../shared/send";
+import { htlcSecretHashHex } from "../../shared/htlc-secret";
 import { TransferCommand } from "./transfer";
 
 export class HtlcLockCommand extends SendCommand {
@@ -35,11 +36,8 @@ export class HtlcLockCommand extends SendCommand {
         const transactions = [];
 
         for (const wallet of Object.values(wallets)) {
-            const secret = wallet.address.slice(0, 32);
-            // we use the 32 first chars of wallet address as secret
-
             const lockAsset = {
-                secretHash: Crypto.HashAlgorithms.sha256(secret).toString("hex"),
+                secretHash: htlcSecretHashHex,
                 expiration: { type: 1, value: Math.floor((Date.now() + flags.expiration * 1000) / 1000) },
             };
 

--- a/packages/core-tester-cli/src/shared/htlc-secret.ts
+++ b/packages/core-tester-cli/src/shared/htlc-secret.ts
@@ -1,5 +1,2 @@
-export * from "./testnet"; // export testnet by default, if we want a different one we import from its path
-
 export const htlcSecretHex = "c27f1ce845d8c29eebc9006be932b604fd06755521b1a8b0be4204c65377151a";
-// SHA256(c2 7f ...) = 9c 1a ...
 export const htlcSecretHashHex = "9c1a3815d49e0c9f78b872bfb017e825ea2db708158b70815526a830c85912b4";

--- a/packages/core-transactions/src/handlers/htlc-claim.ts
+++ b/packages/core-transactions/src/handlers/htlc-claim.ts
@@ -64,7 +64,8 @@ export class HtlcClaimTransactionHandler extends TransactionHandler {
             throw new HtlcLockExpiredError();
         }
 
-        const unlockSecretHash: string = Crypto.HashAlgorithms.sha256(claimAsset.unlockSecret).toString("hex");
+        const unlockSecretBytes = Buffer.from(claimAsset.unlockSecret, "hex");
+        const unlockSecretHash: string = Crypto.HashAlgorithms.sha256(unlockSecretBytes).toString("hex");
         if (lock.secretHash !== unlockSecretHash) {
             throw new HtlcSecretHashMismatchError();
         }

--- a/packages/crypto/src/transactions/types/htlc-claim.ts
+++ b/packages/crypto/src/transactions/types/htlc-claim.ts
@@ -28,7 +28,7 @@ export class HtlcClaimTransaction extends Transaction {
         const buffer: ByteBuffer = new ByteBuffer(32 + 32, true);
 
         buffer.append(Buffer.from(data.asset.claim.lockTransactionId, "hex"));
-        buffer.writeString(data.asset.claim.unlockSecret);
+        buffer.append(Buffer.from(data.asset.claim.unlockSecret, "hex"));
 
         return buffer;
     }
@@ -37,7 +37,7 @@ export class HtlcClaimTransaction extends Transaction {
         const { data } = this;
 
         const lockTransactionId: string = buf.readBytes(32).toString("hex");
-        const unlockSecret: string = buf.readString(32);
+        const unlockSecret: string = buf.readBytes(32).toString("hex");
 
         data.asset = {
             claim: {

--- a/packages/crypto/src/transactions/types/schemas.ts
+++ b/packages/crypto/src/transactions/types/schemas.ts
@@ -293,7 +293,7 @@ export const htlcClaim = extend(transactionBaseSchema, {
                     required: ["lockTransactionId", "unlockSecret"],
                     properties: {
                         lockTransactionId: { $ref: "transactionId" },
-                        unlockSecret: { type: "string", minLength: 32, maxLength: 32 },
+                        unlockSecret: { allOf: [{ minLength: 64, maxLength: 64 }, { $ref: "hex" }] },
                     },
                 },
             },


### PR DESCRIPTION
Previously the HTLC unlock secret (preimage) would be required to be 32
printable ASCII characters.

Fix this so that it can be any 32 bytes. To accommodate this we print it
in hex (64 chars) in the HTLC claim transaction JSON.

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
