### PR TITLE
fix(core-p2p): remove banning when peer opens multiple sockets

### DIFF
--- a/packages/core-p2p/src/socket-server/worker.ts
+++ b/packages/core-p2p/src/socket-server/worker.ts
@@ -34,12 +34,8 @@ export class Worker extends SCWorker {
                 client =>
                     client.remoteAddress === req.socket.remoteAddress && client.remotePort !== req.socket.remotePort,
             );
-            if (existingSockets.length > 0) {
-                for (const socket of existingSockets) {
-                    socket.terminate();
-                }
-                this.setErrorForIpAndTerminate(ws, req);
-                return;
+            for (const socket of existingSockets) {
+                socket.terminate();
             }
             this.handlePayload(ws, req);
         });


### PR DESCRIPTION

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Remove banning when peer opens multiple sockets.

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
