### PR TITLE
fix(core-blockchain): pass IBlockData to processBlocks instead of IBlock

### DIFF
--- a/__tests__/integration/core-blockchain/blockchain.test.ts
+++ b/__tests__/integration/core-blockchain/blockchain.test.ts
@@ -56,7 +56,7 @@ const addBlocks = async untilHeight => {
     const lastHeight = blockchain.getLastHeight();
 
     for (let height = lastHeight + 1; height < untilHeight && height < 155; height++) {
-        const blockToProcess = Blocks.BlockFactory.fromData(allBlocks[height - 2]);
+        const blockToProcess = allBlocks[height - 2];
         await blockchain.processBlocks([blockToProcess], () => undefined);
     }
 };
@@ -218,7 +218,9 @@ describe("Blockchain", () => {
                 transactions,
             };
 
-            return Blocks.BlockFactory.make(data, Identities.Keys.fromPassphrase(generatorKeys.secret));
+            const blockInstance = Blocks.BlockFactory.make(data, Identities.Keys.fromPassphrase(generatorKeys.secret));
+
+            return { ...blockInstance.data, transactions: blockInstance.transactions.map(tx => tx.data) };
         };
 
         it("should restore vote balances after a rollback", async () => {

--- a/__tests__/integration/core-transaction-pool/wallet-manager.test.ts
+++ b/__tests__/integration/core-transaction-pool/wallet-manager.test.ts
@@ -3,6 +3,8 @@ import { Wallets } from "@arkecosystem/core-state";
 import { Handlers } from "@arkecosystem/core-transactions";
 import { Blocks, Identities, Utils } from "@arkecosystem/crypto";
 import { generateMnemonic } from "bip39";
+import { Blockchain as BlockchainClass } from "../../../packages/core-blockchain/src";
+import { BlockProcessor } from "../../../packages/core-blockchain/src/processor";
 import { WalletManager } from "../../../packages/core-transaction-pool/src/wallet-manager";
 import { TransactionFactory } from "../../helpers/transaction-factory";
 import { delegates, genesisBlock, wallets } from "../../utils/fixtures/unitnet";
@@ -209,8 +211,9 @@ describe("Apply transactions and block rewards to wallets on new block", () => {
         };
         const blockWithRewardVerified = Blocks.BlockFactory.fromData(blockWithReward);
         blockWithRewardVerified.verification.verified = true;
+        const processor = new BlockProcessor(blockchain as BlockchainClass);
 
-        await blockchain.processBlocks([blockWithRewardVerified], () => undefined);
+        await processor.process(blockWithRewardVerified);
 
         const delegateWallet = poolWalletManager.findByPublicKey(generatorPublicKey);
 

--- a/__tests__/unit/core-blockchain/blockchain.test.ts
+++ b/__tests__/unit/core-blockchain/blockchain.test.ts
@@ -116,7 +116,7 @@ describe("Blockchain", () => {
             const mockCallback = jest.fn(() => true);
             blockchain.state.blockchain = {};
 
-            await blockchain.processBlocks([BlockFactory.fromData(blocks2to100[2])], mockCallback);
+            await blockchain.processBlocks([blocks2to100[2]], mockCallback);
             await delay(200);
 
             expect(mockCallback.mock.calls.length).toBe(1);
@@ -124,13 +124,13 @@ describe("Blockchain", () => {
 
         it("should process a valid block already known", async () => {
             const mockCallback = jest.fn(() => true);
-            const lastBlock = blockchain.getLastBlock();
+            const lastBlock = blockchain.getLastBlock().data;
 
             await blockchain.processBlocks([lastBlock], mockCallback);
             await delay(200);
 
             expect(mockCallback.mock.calls.length).toBe(1);
-            expect(blockchain.getLastBlock()).toEqual(lastBlock);
+            expect(blockchain.getLastBlock().data).toEqual(lastBlock);
         });
 
         it("should process a new block with database saveBlocks failing once", async () => {
@@ -139,7 +139,7 @@ describe("Blockchain", () => {
             database.saveBlocks = jest.fn().mockRejectedValueOnce(new Error("oops"));
             jest.spyOn(blockchain, "removeTopBlocks").mockReturnValueOnce(undefined);
 
-            await blockchain.processBlocks([BlockFactory.fromData(blocks2to100[2])], mockCallback);
+            await blockchain.processBlocks([blocks2to100[2]], mockCallback);
             await delay(200);
 
             expect(mockCallback.mock.calls.length).toBe(1);
@@ -151,7 +151,7 @@ describe("Blockchain", () => {
             jest.spyOn(database, "saveBlocks").mockRejectedValueOnce(new Error("oops saveBlocks"));
             jest.spyOn(blockchain, "removeTopBlocks").mockReturnValueOnce(undefined);
 
-            await blockchain.processBlocks([BlockFactory.fromData(blocks2to100[2])], mockCallback);
+            await blockchain.processBlocks([blocks2to100[2]], mockCallback);
             await delay(200);
 
             expect(mockCallback.mock.calls.length).toBe(1);
@@ -162,8 +162,10 @@ describe("Blockchain", () => {
             jest.spyOn(Utils, "isBlockChained").mockReturnValueOnce(true);
 
             const mockCallback = jest.fn(() => true);
-            const lastBlock = blockchain.getLastBlock();
-            lastBlock.data.timestamp = Crypto.Slots.getSlotNumber() * 8000;
+            const lastBlock = blockchain.getLastBlock().data;
+            const spyGetSlotNumber = jest
+                .spyOn(Crypto.Slots, "getSlotNumber")
+                .mockReturnValue(Math.floor(lastBlock.timestamp / 8000));
 
             const broadcastBlock = jest.spyOn(getMonitor, "broadcastBlock");
 
@@ -172,6 +174,8 @@ describe("Blockchain", () => {
 
             expect(mockCallback.mock.calls.length).toBe(1);
             expect(broadcastBlock).toHaveBeenCalled();
+
+            spyGetSlotNumber.mockRestore();
         });
     });
 

--- a/packages/core-blockchain/src/blockchain.ts
+++ b/packages/core-blockchain/src/blockchain.ts
@@ -460,7 +460,7 @@ export class Blockchain implements blockchain.IBlockchain {
             lastProcessResult === BlockProcessorResult.Accepted ||
             lastProcessResult === BlockProcessorResult.DiscardedButCanBeBroadcasted
         ) {
-            const currentBlock: Interfaces.IBlock = Blocks.BlockFactory.fromData(blocks[blocks.length - 1]);
+            const currentBlock: Interfaces.IBlock = acceptedBlocks[acceptedBlocks.length - 1];
             const blocktime: number = config.getMilestone(currentBlock.data.height).blocktime;
 
             if (this.state.started && Crypto.Slots.getSlotNumber() * blocktime <= currentBlock.data.timestamp) {

--- a/packages/core-blockchain/src/replay/replay-blockchain.ts
+++ b/packages/core-blockchain/src/replay/replay-blockchain.ts
@@ -71,7 +71,7 @@ export class ReplayBlockchain extends Blockchain {
                 return this.disconnect();
             }
 
-            const blocks: Interfaces.IBlock[] = await this.fetchBatch(startHeight, batch, lastAcceptedHeight);
+            const blocks: Interfaces.IBlockData[] = await this.fetchBatch(startHeight, batch, lastAcceptedHeight);
 
             this.processBlocks(blocks, async (acceptedBlocks: Interfaces.IBlock[]) => {
                 if (acceptedBlocks.length !== blocks.length) {
@@ -89,14 +89,14 @@ export class ReplayBlockchain extends Blockchain {
         startHeight: number,
         batch: number,
         lastAcceptedHeight: number,
-    ): Promise<Interfaces.IBlock[]> {
+    ): Promise<Interfaces.IBlockData[]> {
         this.logger.info("Fetching blocks from database...");
 
         const offset: number = startHeight + (batch - 1) * this.chunkSize;
         const count: number = Math.min(this.targetHeight - lastAcceptedHeight, this.chunkSize);
         const blocks: Interfaces.IBlockData[] = await this.localDatabase.getBlocks(offset, count);
 
-        return blocks.map((block: Interfaces.IBlockData) => Blocks.BlockFactory.fromData(block));
+        return blocks;
     }
 
     private async processGenesisBlock(): Promise<void> {

--- a/packages/core-interfaces/src/core-blockchain/blockchain.ts
+++ b/packages/core-interfaces/src/core-blockchain/blockchain.ts
@@ -77,7 +77,7 @@ export interface IBlockchain {
      * @param  {Function} callback
      * @return {(Function|void)}
      */
-    processBlocks(blocks: Interfaces.IBlock[], callback: any): Promise<any>;
+    processBlocks(blocks: Interfaces.IBlockData[], callback: any): Promise<any>;
 
     /**
      * Called by forger to wake up and sync with the network.


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

Pass IBlockData to processBlocks instead of IBlock, to only create instance of IBlock when actually processing the block : this fixes an issue when reaching a new milestone in the middle of the downloaded blocks, as creating instance of IBlock verifies the transactions within it according to the current milestone.

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
