### PR TITLE
fix(core-tester-cli): set network height on configManager

### DIFF
--- a/__tests__/integration/core-tester-cli/commands/send/delegate-registration.test.ts
+++ b/__tests__/integration/core-tester-cli/commands/send/delegate-registration.test.ts
@@ -5,6 +5,7 @@ import { Managers } from "@arkecosystem/crypto";
 import nock from "nock";
 import { DelegateRegistrationCommand } from "../../../../../packages/core-tester-cli/src/commands/send/delegate-registration";
 import { arkToSatoshi, captureTransactions, expectTransactions, toFlags } from "../../shared";
+import { nodeStatusResponse } from "./fixtures";
 
 beforeEach(() => {
     // Just passthru. We'll test the Command class logic in its own test file more thoroughly
@@ -17,6 +18,11 @@ beforeEach(() => {
         .get("/api/node/configuration/crypto")
         .thrice()
         .reply(200, { data: Managers.configManager.getPreset("unitnet") });
+
+    nock("http://localhost:4003")
+        .get("/api/node/status")
+        .thrice()
+        .reply(200, nodeStatusResponse);
 
     jest.spyOn(httpie, "get");
     jest.spyOn(httpie, "post");

--- a/__tests__/integration/core-tester-cli/commands/send/fixtures.ts
+++ b/__tests__/integration/core-tester-cli/commands/send/fixtures.ts
@@ -1,0 +1,8 @@
+export const nodeStatusResponse = {
+    data: {
+        synced: true,
+        now: 2,
+        blocksCount: 0,
+        timestamp: 90273881,
+    },
+};

--- a/__tests__/integration/core-tester-cli/commands/send/htlc-claim.test.ts
+++ b/__tests__/integration/core-tester-cli/commands/send/htlc-claim.test.ts
@@ -6,6 +6,7 @@ import nock from "nock";
 import { HtlcClaimCommand } from "../../../../../packages/core-tester-cli/src/commands/send/htlc-claim";
 import { htlcSecretHex } from "../../../../utils/fixtures";
 import { arkToSatoshi, captureTransactions, toFlags } from "../../shared";
+import { nodeStatusResponse } from "./fixtures";
 
 beforeEach(() => {
     // Just passthru. We'll test the Command class logic in its own test file more thoroughly
@@ -18,6 +19,11 @@ beforeEach(() => {
         .get("/api/node/configuration/crypto")
         .times(6)
         .reply(200, { data: Managers.configManager.getPreset("unitnet") });
+
+    nock("http://localhost:4003")
+        .get("/api/node/status")
+        .times(6)
+        .reply(200, nodeStatusResponse);
 
     jest.spyOn(httpie, "get");
     jest.spyOn(httpie, "post");

--- a/__tests__/integration/core-tester-cli/commands/send/htlc-lock.test.ts
+++ b/__tests__/integration/core-tester-cli/commands/send/htlc-lock.test.ts
@@ -4,8 +4,9 @@ import { httpie } from "@arkecosystem/core-utils";
 import { Enums, Managers } from "@arkecosystem/crypto";
 import nock from "nock";
 import { HtlcLockCommand } from "../../../../../packages/core-tester-cli/src/commands/send/htlc-lock";
-import { arkToSatoshi, captureTransactions, toFlags } from "../../shared";
 import { htlcSecretHashHex } from "../../../../utils/fixtures";
+import { arkToSatoshi, captureTransactions, toFlags } from "../../shared";
+import { nodeStatusResponse } from "./fixtures";
 
 beforeEach(() => {
     // Just passthru. We'll test the Command class logic in its own test file more thoroughly
@@ -18,6 +19,11 @@ beforeEach(() => {
         .get("/api/node/configuration/crypto")
         .thrice()
         .reply(200, { data: Managers.configManager.getPreset("unitnet") });
+
+    nock("http://localhost:4003")
+        .get("/api/node/status")
+        .thrice()
+        .reply(200, nodeStatusResponse);
 
     jest.spyOn(httpie, "get");
     jest.spyOn(httpie, "post");

--- a/__tests__/integration/core-tester-cli/commands/send/htlc-refund.test.ts
+++ b/__tests__/integration/core-tester-cli/commands/send/htlc-refund.test.ts
@@ -5,6 +5,7 @@ import { Enums, Managers } from "@arkecosystem/crypto";
 import nock from "nock";
 import { HtlcRefundCommand } from "../../../../../packages/core-tester-cli/src/commands/send/htlc-refund";
 import { arkToSatoshi, captureTransactions, toFlags } from "../../shared";
+import { nodeStatusResponse } from "./fixtures";
 
 beforeEach(() => {
     // Just passthru. We'll test the Command class logic in its own test file more thoroughly
@@ -17,6 +18,11 @@ beforeEach(() => {
         .get("/api/node/configuration/crypto")
         .times(6)
         .reply(200, { data: Managers.configManager.getPreset("unitnet") });
+
+    nock("http://localhost:4003")
+        .get("/api/node/status")
+        .times(6)
+        .reply(200, nodeStatusResponse);
 
     jest.spyOn(httpie, "get");
     jest.spyOn(httpie, "post");

--- a/__tests__/integration/core-tester-cli/commands/send/ipfs.test.ts
+++ b/__tests__/integration/core-tester-cli/commands/send/ipfs.test.ts
@@ -5,6 +5,7 @@ import { Identities, Managers } from "@arkecosystem/crypto";
 import nock from "nock";
 import { IpfsCommand } from "../../../../../packages/core-tester-cli/src/commands/send/ipfs";
 import { arkToSatoshi, captureTransactions, toFlags } from "../../shared";
+import { nodeStatusResponse } from "./fixtures";
 
 beforeEach(() => {
     // Just passthru. We'll test the Command class logic in its own test file more thoroughly
@@ -17,6 +18,11 @@ beforeEach(() => {
         .get("/api/node/configuration/crypto")
         .thrice()
         .reply(200, { data: Managers.configManager.getPreset("unitnet") });
+
+    nock("http://localhost:4003")
+        .get("/api/node/status")
+        .thrice()
+        .reply(200, nodeStatusResponse);
 
     jest.spyOn(httpie, "get");
     jest.spyOn(httpie, "post");

--- a/__tests__/integration/core-tester-cli/commands/send/multi-payment.test.ts
+++ b/__tests__/integration/core-tester-cli/commands/send/multi-payment.test.ts
@@ -5,6 +5,7 @@ import { Managers, Utils } from "@arkecosystem/crypto";
 import nock from "nock";
 import { MultiPaymentCommand } from "../../../../../packages/core-tester-cli/src/commands/send/multi-payment";
 import { arkToSatoshi, captureTransactions, toFlags } from "../../shared";
+import { nodeStatusResponse } from "./fixtures";
 
 beforeEach(() => {
     // Just passthru. We'll test the Command class logic in its own test file more thoroughly
@@ -17,6 +18,11 @@ beforeEach(() => {
         .get("/api/node/configuration/crypto")
         .thrice()
         .reply(200, { data: Managers.configManager.getPreset("unitnet") });
+
+    nock("http://localhost:4003")
+        .get("/api/node/status")
+        .thrice()
+        .reply(200, nodeStatusResponse);
 
     jest.spyOn(httpie, "get");
     jest.spyOn(httpie, "post");

--- a/__tests__/integration/core-tester-cli/commands/send/multi-signature-registration.test.ts
+++ b/__tests__/integration/core-tester-cli/commands/send/multi-signature-registration.test.ts
@@ -5,6 +5,7 @@ import { Managers, Transactions } from "@arkecosystem/crypto";
 import nock from "nock";
 import { MultiSignatureRegistrationCommand } from "../../../../../packages/core-tester-cli/src/commands/send/multi-signature-registration";
 import { arkToSatoshi, captureTransactions, expectTransactions, toFlags } from "../../shared";
+import { nodeStatusResponse } from "./fixtures";
 
 beforeEach(() => {
     // Just passthru. We'll test the Command class logic in its own test file more thoroughly
@@ -17,6 +18,11 @@ beforeEach(() => {
         .get("/api/node/configuration/crypto")
         .thrice()
         .reply(200, { data: Managers.configManager.getPreset("unitnet") });
+
+    nock("http://localhost:4003")
+        .get("/api/node/status")
+        .thrice()
+        .reply(200, nodeStatusResponse);
 
     jest.spyOn(httpie, "get");
     jest.spyOn(httpie, "post");

--- a/__tests__/integration/core-tester-cli/commands/send/second-signature.test.ts
+++ b/__tests__/integration/core-tester-cli/commands/send/second-signature.test.ts
@@ -5,6 +5,7 @@ import { Managers } from "@arkecosystem/crypto";
 import nock from "nock";
 import { SecondSignatureRegistrationCommand } from "../../../../../packages/core-tester-cli/src/commands/send/second-signature-registration";
 import { arkToSatoshi, captureTransactions, expectTransactions, toFlags } from "../../shared";
+import { nodeStatusResponse } from "./fixtures";
 
 beforeEach(() => {
     // Just passthru. We'll test the Command class logic in its own test file more thoroughly
@@ -17,6 +18,11 @@ beforeEach(() => {
         .get("/api/node/configuration/crypto")
         .thrice()
         .reply(200, { data: Managers.configManager.getPreset("unitnet") });
+
+    nock("http://localhost:4003")
+        .get("/api/node/status")
+        .thrice()
+        .reply(200, nodeStatusResponse);
 
     jest.spyOn(httpie, "get");
     jest.spyOn(httpie, "post");

--- a/__tests__/integration/core-tester-cli/commands/send/transfer.test.ts
+++ b/__tests__/integration/core-tester-cli/commands/send/transfer.test.ts
@@ -5,6 +5,7 @@ import { Managers } from "@arkecosystem/crypto";
 import nock from "nock";
 import { TransferCommand } from "../../../../../packages/core-tester-cli/src/commands/send/transfer";
 import { arkToSatoshi, captureTransactions, expectTransactions, toFlags } from "../../shared";
+import { nodeStatusResponse } from "./fixtures";
 
 beforeEach(() => {
     // Just passthru. We'll test the Command class logic in its own test file more thoroughly
@@ -17,6 +18,11 @@ beforeEach(() => {
         .get("/api/node/configuration/crypto")
         .twice()
         .reply(200, { data: Managers.configManager.getPreset("unitnet") });
+
+    nock("http://localhost:4003")
+        .get("/api/node/status")
+        .twice()
+        .reply(200, nodeStatusResponse);
 
     jest.spyOn(httpie, "post");
 });

--- a/__tests__/integration/core-tester-cli/commands/send/vote.test.ts
+++ b/__tests__/integration/core-tester-cli/commands/send/vote.test.ts
@@ -5,6 +5,7 @@ import { Managers } from "@arkecosystem/crypto";
 import nock from "nock";
 import { VoteCommand } from "../../../../../packages/core-tester-cli/src/commands/send/vote";
 import { arkToSatoshi, captureTransactions, expectTransactions, toFlags } from "../../shared";
+import { nodeStatusResponse } from "./fixtures";
 
 beforeEach(() => {
     // Just passthru. We'll test the Command class logic in its own test file more thoroughly
@@ -17,6 +18,11 @@ beforeEach(() => {
         .get("/api/node/configuration/crypto")
         .thrice()
         .reply(200, { data: Managers.configManager.getPreset("unitnet") });
+
+    nock("http://localhost:4003")
+        .get("/api/node/status")
+        .thrice()
+        .reply(200, nodeStatusResponse);
 
     jest.spyOn(httpie, "get");
     jest.spyOn(httpie, "post");

--- a/packages/core-tester-cli/src/commands/command.ts
+++ b/packages/core-tester-cli/src/commands/command.ts
@@ -219,8 +219,10 @@ export abstract class BaseCommand extends Command {
     private async setupConfigurationForCrypto() {
         try {
             const { data: dataCrypto } = await this.api.get("node/configuration/crypto");
+            const { data: dataStatus } = await this.api.get("node/status");
 
             Managers.configManager.setConfig(dataCrypto);
+            Managers.configManager.setHeight(dataStatus.now);
         } catch (error) {
             this.error(error.message);
         }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
For core-tester-cli, set the network height on configManager in order to have it correctly configured (milestones depend on height).
<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
