### PR TITLE
feat(core): add flag to skip export of rolled back transactions

### DIFF
--- a/packages/core-snapshots/src/manager.ts
+++ b/packages/core-snapshots/src/manager.ts
@@ -86,7 +86,7 @@ export class SnapshotManager {
         this.database.close();
     }
 
-    public async rollbackByHeight(height: number) {
+    public async rollbackByHeight(height: number, backupTransactions: boolean = true) {
         if (!height || height <= 0) {
             app.forceExit(`Rollback height ${height.toLocaleString()} is invalid.`);
         }
@@ -104,11 +104,13 @@ export class SnapshotManager {
         const rollbackBlock = await this.database.getBlockByHeight(height);
         const queryTransactionBackup = await this.database.getTransactionsBackupQuery(rollbackBlock.timestamp);
 
-        await backupTransactionsToJSON(
-            `rollbackTransactionBackup.${+height + 1}.${currentHeight}.json`,
-            queryTransactionBackup,
-            this.database,
-        );
+        if (backupTransactions) {
+            await backupTransactionsToJSON(
+                `rollbackTransactionBackup.${+height + 1}.${currentHeight}.json`,
+                queryTransactionBackup,
+                this.database,
+            );
+        }
 
         const newLastBlock = await this.database.rollbackChain(roundInfo);
         logger.info(
@@ -118,10 +120,10 @@ export class SnapshotManager {
         this.database.close();
     }
 
-    public async rollbackByNumber(amount: number) {
+    public async rollbackByNumber(amount: number, backupTransactions: boolean = true) {
         const { height } = await this.database.getLastBlock();
 
-        return this.rollbackByHeight(height - amount);
+        return this.rollbackByHeight(height - amount, backupTransactions);
     }
 
     private async init(options, exportAction: boolean = false) {

--- a/packages/core/src/commands/snapshot/rollback.ts
+++ b/packages/core/src/commands/snapshot/rollback.ts
@@ -16,6 +16,11 @@ export class RollbackCommand extends BaseCommand {
         number: flags.integer({
             description: "the number of blocks to roll back",
         }),
+        export: flags.boolean({
+            description: "export the rolled back transactions",
+            default: true,
+            allowNo: true,
+        })
     };
 
     public async run(): Promise<void> {
@@ -32,9 +37,9 @@ export class RollbackCommand extends BaseCommand {
         }
 
         if (flags.height) {
-            await app.resolvePlugin<SnapshotManager>("snapshots").rollbackByHeight(flags.height);
+            await app.resolvePlugin<SnapshotManager>("snapshots").rollbackByHeight(flags.height, flags.export);
         } else if (flags.number) {
-            await app.resolvePlugin<SnapshotManager>("snapshots").rollbackByNumber(flags.number);
+            await app.resolvePlugin<SnapshotManager>("snapshots").rollbackByNumber(flags.number, flags.export);
         } else {
             this.error("Please specify either a height or number of blocks to roll back.");
         }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

This PR adds an additional flag (`--export` / `--no-export`) to the `snapshot:rollback` command which allows to skip the export of rolled back transactions.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
