### PR TITLE
feat(core-api): filter peers by version range

### DIFF
--- a/__tests__/integration/core-api/handlers/peers.test.ts
+++ b/__tests__/integration/core-api/handlers/peers.test.ts
@@ -89,7 +89,7 @@ describe("API 2.0 - Peers", () => {
             expect(response).toBeSuccessfulResponse();
 
             const expectedMeta = {
-                count: 2,
+                count: 5,
                 first: "/peers?page=1&limit=100",
                 last: "/peers?page=1&limit=100",
                 next: null,
@@ -108,7 +108,7 @@ describe("API 2.0 - Peers", () => {
             expect(response.data.data).toBeArrayOfSize(peers.length);
             expect(response.data.data[0]).toBeObject();
 
-            expect(response.data.data.sort((a, b) => semver.compare(a, b))).toEqual(response.data.data);
+            expect(response.data.data.sort((a, b) => semver.compare(a.version, b.version))).toEqual(response.data.data);
         });
 
         it("should GET all the peers sorted by version,desc", async () => {
@@ -117,7 +117,9 @@ describe("API 2.0 - Peers", () => {
             expect(response.data.data).toBeArrayOfSize(peers.length);
             expect(response.data.data[0]).toBeObject();
 
-            expect(response.data.data.sort((a, b) => semver.rcompare(a, b))).toEqual(response.data.data);
+            expect(response.data.data.sort((a, b) => semver.rcompare(a.version, b.version))).toEqual(
+                response.data.data,
+            );
         });
 
         it("should GET all the peers sorted by height,asc", async () => {
@@ -171,7 +173,7 @@ describe("API 2.0 - Peers", () => {
             expect(response.data.data[0]).toBeObject();
             expect(response.data.data[0].ip).toBe(peers[2].ip);
             expect(response.data.data[1].ip).toBe(peers[3].ip);
-            expect(response.data.data[1].ip).toBe(peers[4].ip);
+            expect(response.data.data[2].ip).toBe(peers[4].ip);
         });
 
         it("should GET the peers filtered by version range", async () => {

--- a/__tests__/integration/core-api/handlers/peers.test.ts
+++ b/__tests__/integration/core-api/handlers/peers.test.ts
@@ -2,6 +2,7 @@ import "../../../utils";
 
 import { app } from "@arkecosystem/core-container";
 import { Peer } from "@arkecosystem/core-p2p/src/peer";
+import semver from "semver";
 import { setUp, tearDown } from "../__support__/setup";
 import { utils } from "../utils";
 
@@ -23,6 +24,33 @@ const peers = [
             height: 1,
         },
         latency: 1,
+    },
+    {
+        ip: "1.0.0.97",
+        port: 4002,
+        version: "2.5.0",
+        state: {
+            height: 3,
+        },
+        latency: 1,
+    },
+    {
+        ip: "1.0.0.96",
+        port: 4002,
+        version: "2.5.1",
+        state: {
+            height: 4,
+        },
+        latency: 2,
+    },
+    {
+        ip: "1.0.0.95",
+        port: 4002,
+        version: "2.5.2",
+        state: {
+            height: 4,
+        },
+        latency: 3,
     },
 ];
 
@@ -68,7 +96,7 @@ describe("API 2.0 - Peers", () => {
                 pageCount: 1,
                 previous: null,
                 self: "/peers?page=1&limit=100",
-                totalCount: 2,
+                totalCount: 5,
                 totalCountIsEstimate: undefined,
             };
             expect(response.data.meta).toEqual(expectedMeta);
@@ -79,8 +107,8 @@ describe("API 2.0 - Peers", () => {
             expect(response).toBeSuccessfulResponse();
             expect(response.data.data).toBeArrayOfSize(peers.length);
             expect(response.data.data[0]).toBeObject();
-            expect(response.data.data[0].ip).toBe(peers[1].ip);
-            expect(response.data.data[1].ip).toBe(peers[0].ip);
+
+            expect(response.data.data.sort((a, b) => semver.compare(a, b))).toEqual(response.data.data);
         });
 
         it("should GET all the peers sorted by version,desc", async () => {
@@ -88,8 +116,8 @@ describe("API 2.0 - Peers", () => {
             expect(response).toBeSuccessfulResponse();
             expect(response.data.data).toBeArrayOfSize(peers.length);
             expect(response.data.data[0]).toBeObject();
-            expect(response.data.data[0].ip).toBe(peers[0].ip);
-            expect(response.data.data[1].ip).toBe(peers[1].ip);
+
+            expect(response.data.data.sort((a, b) => semver.rcompare(a, b))).toEqual(response.data.data);
         });
 
         it("should GET all the peers sorted by height,asc", async () => {
@@ -97,8 +125,8 @@ describe("API 2.0 - Peers", () => {
             expect(response).toBeSuccessfulResponse();
             expect(response.data.data).toBeArrayOfSize(peers.length);
             expect(response.data.data[0]).toBeObject();
-            expect(response.data.data[0].ip).toBe(peers[1].ip);
-            expect(response.data.data[1].ip).toBe(peers[0].ip);
+
+            expect(response.data.data.sort((a, b) => a.height < b.height)).toEqual(response.data.data);
         });
 
         it("should GET all the peers sorted by height,desc", async () => {
@@ -106,8 +134,8 @@ describe("API 2.0 - Peers", () => {
             expect(response).toBeSuccessfulResponse();
             expect(response.data.data).toBeArrayOfSize(peers.length);
             expect(response.data.data[0]).toBeObject();
-            expect(response.data.data[0].ip).toBe(peers[0].ip);
-            expect(response.data.data[1].ip).toBe(peers[1].ip);
+
+            expect(response.data.data.sort((a, b) => a.height > b.height)).toEqual(response.data.data);
         });
 
         it("should GET all the peers sorted by latency,asc", async () => {
@@ -115,8 +143,8 @@ describe("API 2.0 - Peers", () => {
             expect(response).toBeSuccessfulResponse();
             expect(response.data.data).toBeArrayOfSize(peers.length);
             expect(response.data.data[0]).toBeObject();
-            expect(response.data.data[0].ip).toBe(peers[1].ip);
-            expect(response.data.data[1].ip).toBe(peers[0].ip);
+
+            expect(response.data.data.sort((a, b) => a.latency < b.latency)).toEqual(response.data.data);
         });
 
         it("should GET all the peers sorted by latency,desc", async () => {
@@ -124,8 +152,35 @@ describe("API 2.0 - Peers", () => {
             expect(response).toBeSuccessfulResponse();
             expect(response.data.data).toBeArrayOfSize(peers.length);
             expect(response.data.data[0]).toBeObject();
-            expect(response.data.data[0].ip).toBe(peers[0].ip);
-            expect(response.data.data[1].ip).toBe(peers[1].ip);
+
+            expect(response.data.data.sort((a, b) => a.latency > b.latency)).toEqual(response.data.data);
+        });
+
+        it("should GET the peers filtered by exact version", async () => {
+            const response = await utils.request("GET", "peers", { version: "2.5.0" });
+            expect(response).toBeSuccessfulResponse();
+            expect(response.data.data).toBeArrayOfSize(1);
+            expect(response.data.data[0]).toBeObject();
+            expect(response.data.data[0].ip).toBe(peers[2].ip);
+        });
+
+        it("should GET the peers filtered by version including wildcard", async () => {
+            const response = await utils.request("GET", "peers", { version: "2.5.*" });
+            expect(response).toBeSuccessfulResponse();
+            expect(response.data.data).toBeArrayOfSize(3);
+            expect(response.data.data[0]).toBeObject();
+            expect(response.data.data[0].ip).toBe(peers[2].ip);
+            expect(response.data.data[1].ip).toBe(peers[3].ip);
+            expect(response.data.data[1].ip).toBe(peers[4].ip);
+        });
+
+        it("should GET the peers filtered by version range", async () => {
+            const response = await utils.request("GET", "peers", { version: "2.5.1 - 2.5.2" });
+            expect(response).toBeSuccessfulResponse();
+            expect(response.data.data).toBeArrayOfSize(2);
+            expect(response.data.data[0]).toBeObject();
+            expect(response.data.data[0].ip).toBe(peers[3].ip);
+            expect(response.data.data[1].ip).toBe(peers[4].ip);
         });
     });
 

--- a/packages/core-api/src/handlers/peers/controller.ts
+++ b/packages/core-api/src/handlers/peers/controller.ts
@@ -10,9 +10,17 @@ export class PeersController extends Controller {
     public async index(request: Hapi.Request, h: Hapi.ResponseToolkit) {
         const allPeers: P2P.IPeer[] = [...this.blockchain.p2p.getStorage().getPeers()];
 
-        let result = request.query.version
-            ? allPeers.filter(peer => peer.version === (request.query as any).version)
-            : allPeers;
+        let result = allPeers;
+
+        if (request.query.version) {
+            const versionRange = semver.validRange(request.query.version);
+
+            if (versionRange) {
+                result = result.filter(peer => semver.satisfies(peer.version, versionRange));
+            } else {
+                return Boom.notFound("Invalid version range provided");
+            }
+        }
 
         const count: number = result.length;
 

--- a/packages/core-api/src/handlers/peers/controller.ts
+++ b/packages/core-api/src/handlers/peers/controller.ts
@@ -13,7 +13,7 @@ export class PeersController extends Controller {
         let result = allPeers;
 
         if (request.query.version) {
-            const versionRange = semver.validRange(request.query.version);
+            const versionRange = semver.validRange(decodeURIComponent((request.query as any).version));
 
             if (versionRange) {
                 result = result.filter(peer => semver.satisfies(peer.version, versionRange));


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Changes the peers API endpoint so that it can also accept a version range for retrieval of multiple versions at once.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
