### PR TITLE
fix(crypto): multisig legacy allow signatures property

### DIFF
--- a/__tests__/unit/crypto/transactions/schemas.test.ts
+++ b/__tests__/unit/crypto/transactions/schemas.test.ts
@@ -6,9 +6,10 @@ import { IMultiSignatureAsset } from "../../../../packages/crypto/src/interfaces
 import { configManager } from "../../../../packages/crypto/src/managers";
 import { BuilderFactory } from "../../../../packages/crypto/src/transactions";
 import { TransactionTypeFactory } from "../../../../packages/crypto/src/transactions";
+import { schemas } from "../../../../packages/crypto/src/transactions/types";
 import { TransactionSchema } from "../../../../packages/crypto/src/transactions/types/schemas";
 import { validator as Ajv } from "../../../../packages/crypto/src/validation";
-import { htlcSecretHex, htlcSecretHashHex } from "../../../utils/fixtures"
+import { htlcSecretHashHex, htlcSecretHex } from "../../../utils/fixtures";
 
 let transaction;
 let transactionSchema: TransactionSchema;
@@ -697,7 +698,7 @@ describe("Multi Signature Registration Transaction", () => {
         expect(error).not.toBeUndefined();
     });
 
-    it("should validate legacy multisignature", () => {
+    it("should not validate legacy multisignature against current multisig schema", () => {
         const legacyMultiSignature = {
             version: 1,
             network: 23,
@@ -723,6 +724,35 @@ describe("Multi Signature Registration Transaction", () => {
         };
 
         const { error } = Ajv.validate(transactionSchema.$id, legacyMultiSignature);
+        expect(error).not.toBeUndefined();
+    });
+
+    it("should validate legacy multisignature against legacy schema", () => {
+        const legacyMultiSignature = {
+            version: 1,
+            network: 23,
+            type: 4,
+            timestamp: 53253482,
+            senderPublicKey: "0333421e69d3531a1c43c43cd4b9344e5a10640644a5fd35618b6306f3a4d7f208",
+            fee: "2000000000",
+            amount: "0",
+            asset: {
+                multiSignatureLegacy: {
+                    keysgroup: [
+                        "+034da006f958beba78ec54443df4a3f52237253f7ae8cbdb17dccf3feaa57f3126",
+                        "+0310c283aac7b35b4ae6fab201d36e8322c3408331149982e16013a5bcb917081c",
+                        "+0392a762e0123945455b7afe675e5ab98fb1586de43e5682514b9454d6edced724",
+                    ],
+                    lifetime: 24,
+                    min: 2,
+                },
+            },
+            signature:
+                "304402206009fbf8592e2e3485bc0aa84dbbc8c78326d59191daf870693bc3446b5eeeee02200b4ff5dd53b1e337fe6fbe090f42337dcfc4242c802c340815326e3858d13d6b",
+            id: "32aa60577531c190e6a29d28f434367c84c2f0a62eceba5c5483a3983639d51a",
+        };
+
+        const { error } = Ajv.validate(schemas.multiSignatureLegacy, legacyMultiSignature);
         expect(error).toBeUndefined();
     });
 });

--- a/packages/crypto/src/transactions/registry.ts
+++ b/packages/crypto/src/transactions/registry.ts
@@ -15,6 +15,7 @@ import {
     IpfsTransaction,
     MultiPaymentTransaction,
     MultiSignatureRegistrationTransaction,
+    schemas,
     SecondSignatureRegistrationTransaction,
     Transaction,
     TransactionTypeFactory,
@@ -42,6 +43,8 @@ class TransactionRegistry {
         this.registerTransactionType(HtlcLockTransaction);
         this.registerTransactionType(HtlcClaimTransaction);
         this.registerTransactionType(HtlcRefundTransaction);
+
+        validator.extendTransaction(schemas.multiSignatureLegacy, false);
     }
 
     public registerTransactionType(constructor: TransactionConstructor): void {

--- a/packages/crypto/src/transactions/registry.ts
+++ b/packages/crypto/src/transactions/registry.ts
@@ -44,6 +44,8 @@ class TransactionRegistry {
         this.registerTransactionType(HtlcClaimTransaction);
         this.registerTransactionType(HtlcRefundTransaction);
 
+        // registering multisignature legacy schema separate after splitting the main
+        // multisignature schema into current implementation and legacy
         validator.extendTransaction(schemas.multiSignatureLegacy, false);
     }
 

--- a/packages/crypto/src/transactions/types/schemas.ts
+++ b/packages/crypto/src/transactions/types/schemas.ts
@@ -145,38 +145,11 @@ export const vote = extend(transactionBaseSchema, {
     },
 });
 
-// For multisignature registration transaction, we have a different way of handling the
-// "signatures" property because of multisignature legacy transactions. Then we need to
-// delete the "signatures" property definition from the base schema to implement our own.
-const transactionBaseSchemaNoSignatures = extend(transactionBaseSchema, {});
-delete transactionBaseSchemaNoSignatures.properties.signatures;
-export const multiSignature = extend(transactionBaseSchemaNoSignatures, {
+export const multiSignature = extend(transactionBaseSchema, {
     $id: "multiSignature",
     if: { properties: { version: { anyOf: [{ type: "null" }, { const: 1 }] } } },
-    then: {
-        required: ["asset"],
-        properties: {
-            signatures: {
-                type: "array",
-                maxItems: 1,
-                additionalItems: false,
-                items: { $ref: "alphanumeric" },
-            },
-        },
-    },
-    else: {
-        required: ["asset", "signatures"],
-        properties: {
-            signatures: {
-                type: "array",
-                minItems: { $data: "1/asset/multiSignature/min" },
-                maxItems: { $data: "1/asset/multiSignature/publicKeys/length" },
-                additionalItems: false,
-                uniqueItems: true,
-                items: { allOf: [{ minLength: 130, maxLength: 130 }, { $ref: "alphanumeric" }] },
-            },
-        },
-    },
+    then: { required: ["asset"] },
+    else: { required: ["asset", "signatures"] },
     properties: {
         type: { transactionType: TransactionType.MultiSignature },
         amount: { bignumber: { minimum: 0, maximum: 0 } },
@@ -242,6 +215,14 @@ export const multiSignature = extend(transactionBaseSchemaNoSignatures, {
                     },
                 },
             ],
+        },
+        signatures: {
+            type: "array",
+            minItems: { $data: "1/asset/multiSignature/min" },
+            maxItems: { $data: "1/asset/multiSignature/publicKeys/length" },
+            additionalItems: false,
+            uniqueItems: true,
+            items: { allOf: [{ minLength: 130, maxLength: 130 }, { $ref: "alphanumeric" }] },
         },
     },
 });

--- a/packages/crypto/src/transactions/types/schemas.ts
+++ b/packages/crypto/src/transactions/types/schemas.ts
@@ -145,12 +145,7 @@ export const vote = extend(transactionBaseSchema, {
     },
 });
 
-// For multisignature registration transaction, we have a different way of handling the
-// "signatures" property because of multisignature legacy transactions. Then we need to
-// delete the "signatures" property definition from the base schema to implement our own.
-const transactionBaseSchemaNoSignatures = extend(transactionBaseSchema, {});
-delete transactionBaseSchemaNoSignatures.properties.signatures;
-export const multiSignature = extend(transactionBaseSchemaNoSignatures, {
+export const multiSignature = extend(transactionBaseSchema, {
     $id: "multiSignature",
     if: { properties: { version: { anyOf: [{ type: "null" }, { const: 1 }] } } },
     then: { required: ["asset"] },
@@ -221,26 +216,13 @@ export const multiSignature = extend(transactionBaseSchemaNoSignatures, {
                 },
             ],
         },
-        if: { version: { anyOf: [{ type: "null" }, { const: 1 }] } },
-        then: {
-            signatures: {
-                type: "array",
-                additionalItems: false,
-                uniqueItems: true,
-                items: { $ref: "alphanumeric" },
-                minItems: 1,
-                maxItems: 1,
-            },
-        },
-        else: {
-            signatures: {
-                type: "array",
-                additionalItems: false,
-                uniqueItems: true,
-                items: { allOf: [{ minLength: 130, maxLength: 130 }, { $ref: "alphanumeric" }] },
-                minItems: { $data: "1/asset/multiSignature/min" },
-                maxItems: { $data: "1/asset/multiSignature/publicKeys/length" },
-            },
+        signatures: {
+            type: "array",
+            minItems: { $data: "1/asset/multiSignature/min" },
+            maxItems: { $data: "1/asset/multiSignature/publicKeys/length" },
+            additionalItems: false,
+            uniqueItems: true,
+            items: { allOf: [{ minLength: 130, maxLength: 130 }, { $ref: "alphanumeric" }] },
         },
     },
 });

--- a/packages/crypto/src/transactions/types/schemas.ts
+++ b/packages/crypto/src/transactions/types/schemas.ts
@@ -145,7 +145,12 @@ export const vote = extend(transactionBaseSchema, {
     },
 });
 
-export const multiSignature = extend(transactionBaseSchema, {
+// For multisignature registration transaction, we have a different way of handling the
+// "signatures" property because of multisignature legacy transactions. Then we need to
+// delete the "signatures" property definition from the base schema to implement our own.
+const transactionBaseSchemaNoSignatures = extend(transactionBaseSchema, {});
+delete transactionBaseSchemaNoSignatures.properties.signatures;
+export const multiSignature = extend(transactionBaseSchemaNoSignatures, {
     $id: "multiSignature",
     if: { properties: { version: { anyOf: [{ type: "null" }, { const: 1 }] } } },
     then: { required: ["asset"] },
@@ -216,13 +221,26 @@ export const multiSignature = extend(transactionBaseSchema, {
                 },
             ],
         },
-        signatures: {
-            type: "array",
-            minItems: { $data: "1/asset/multiSignature/min" },
-            maxItems: { $data: "1/asset/multiSignature/publicKeys/length" },
-            additionalItems: false,
-            uniqueItems: true,
-            items: { allOf: [{ minLength: 130, maxLength: 130 }, { $ref: "alphanumeric" }] },
+        if: { version: { anyOf: [{ type: "null" }, { const: 1 }] } },
+        then: {
+            signatures: {
+                type: "array",
+                additionalItems: false,
+                uniqueItems: true,
+                items: { $ref: "alphanumeric" },
+                minItems: 1,
+                maxItems: 1,
+            },
+        },
+        else: {
+            signatures: {
+                type: "array",
+                additionalItems: false,
+                uniqueItems: true,
+                items: { allOf: [{ minLength: 130, maxLength: 130 }, { $ref: "alphanumeric" }] },
+                minItems: { $data: "1/asset/multiSignature/min" },
+                maxItems: { $data: "1/asset/multiSignature/publicKeys/length" },
+            },
         },
     },
 });

--- a/packages/crypto/src/transactions/types/schemas.ts
+++ b/packages/crypto/src/transactions/types/schemas.ts
@@ -145,11 +145,38 @@ export const vote = extend(transactionBaseSchema, {
     },
 });
 
-export const multiSignature = extend(transactionBaseSchema, {
+// For multisignature registration transaction, we have a different way of handling the
+// "signatures" property because of multisignature legacy transactions. Then we need to
+// delete the "signatures" property definition from the base schema to implement our own.
+const transactionBaseSchemaNoSignatures = extend(transactionBaseSchema, {});
+delete transactionBaseSchemaNoSignatures.properties.signatures;
+export const multiSignature = extend(transactionBaseSchemaNoSignatures, {
     $id: "multiSignature",
     if: { properties: { version: { anyOf: [{ type: "null" }, { const: 1 }] } } },
-    then: { required: ["asset"] },
-    else: { required: ["asset", "signatures"] },
+    then: {
+        required: ["asset"],
+        properties: {
+            signatures: {
+                type: "array",
+                maxItems: 1,
+                additionalItems: false,
+                items: { $ref: "alphanumeric" },
+            },
+        },
+    },
+    else: {
+        required: ["asset", "signatures"],
+        properties: {
+            signatures: {
+                type: "array",
+                minItems: { $data: "1/asset/multiSignature/min" },
+                maxItems: { $data: "1/asset/multiSignature/publicKeys/length" },
+                additionalItems: false,
+                uniqueItems: true,
+                items: { allOf: [{ minLength: 130, maxLength: 130 }, { $ref: "alphanumeric" }] },
+            },
+        },
+    },
     properties: {
         type: { transactionType: TransactionType.MultiSignature },
         amount: { bignumber: { minimum: 0, maximum: 0 } },
@@ -215,14 +242,6 @@ export const multiSignature = extend(transactionBaseSchema, {
                     },
                 },
             ],
-        },
-        signatures: {
-            type: "array",
-            minItems: { $data: "1/asset/multiSignature/min" },
-            maxItems: { $data: "1/asset/multiSignature/publicKeys/length" },
-            additionalItems: false,
-            uniqueItems: true,
-            items: { allOf: [{ minLength: 130, maxLength: 130 }, { $ref: "alphanumeric" }] },
         },
     },
 });


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

Resolves #3444 by allowing in json schema validation legacy multisig to have the "signatures" property (which is handled fine by core then).

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
