### PR TITLE
refactor(core-transactions): use findByPublicKey to set both publickey and address on the multisig wallet

### DIFF
--- a/__tests__/integration/core-transactions/handlers/multi-signature.test.ts
+++ b/__tests__/integration/core-transactions/handlers/multi-signature.test.ts
@@ -57,8 +57,11 @@ describe("Multi signature handler bootstrap", () => {
         await stateBuilder.run();
 
         const multiSigAddress = Identities.Address.fromMultiSignatureAsset(transaction.asset.multiSignature);
-        const senderWallet = walletManager.findByAddress(multiSigAddress);
-        expect(senderWallet.balance).toEqual(Utils.BigNumber.ZERO);
-        expect(senderWallet.getAttribute("multiSignature")).toEqual(transaction.asset.multiSignature);
+        const multiSigPublicKey = Identities.PublicKey.fromMultiSignatureAsset(transaction.asset.multiSignature);
+        const multisigWallet = walletManager.findByAddress(multiSigAddress);
+
+        expect(multisigWallet.balance).toEqual(Utils.BigNumber.ZERO);
+        expect(multisigWallet.publicKey).toEqual(multiSigPublicKey);
+        expect(multisigWallet.getAttribute("multiSignature")).toEqual(transaction.asset.multiSignature);
     });
 });

--- a/packages/core-transactions/src/handlers/multi-signature.ts
+++ b/packages/core-transactions/src/handlers/multi-signature.ts
@@ -38,7 +38,9 @@ export class MultiSignatureTransactionHandler extends TransactionHandler {
                     multiSignature.legacy = true;
                 } else {
                     multiSignature = transaction.asset.multiSignature;
-                    wallet = walletManager.findByAddress(Identities.Address.fromMultiSignatureAsset(multiSignature));
+                    wallet = walletManager.findByPublicKey(
+                        Identities.PublicKey.fromMultiSignatureAsset(multiSignature),
+                    );
                 }
                 if (wallet.hasMultiSignature()) {
                     throw new MultiSignatureAlreadyRegisteredError();
@@ -77,8 +79,8 @@ export class MultiSignatureTransactionHandler extends TransactionHandler {
             throw new MultiSignatureKeyCountMismatchError();
         }
 
-        const multiSigAddress: string = Identities.Address.fromMultiSignatureAsset(data.asset.multiSignature);
-        const recipientWallet: State.IWallet = walletManager.findByAddress(multiSigAddress);
+        const multiSigPublicKey: string = Identities.PublicKey.fromMultiSignatureAsset(data.asset.multiSignature);
+        const recipientWallet: State.IWallet = walletManager.findByPublicKey(multiSigPublicKey);
 
         if (recipientWallet.hasMultiSignature()) {
             throw new MultiSignatureAlreadyRegisteredError();
@@ -95,7 +97,7 @@ export class MultiSignatureTransactionHandler extends TransactionHandler {
         data: Interfaces.ITransactionData,
         pool: TransactionPool.IConnection,
         processor: TransactionPool.IProcessor,
-    ): Promise<{ type: string, message: string } | null> {
+    ): Promise<{ type: string; message: string } | null> {
         return this.typeFromSenderAlreadyInPool(data, pool);
     }
 
@@ -108,7 +110,7 @@ export class MultiSignatureTransactionHandler extends TransactionHandler {
         // Create the multi sig wallet
         if (transaction.data.version >= 2) {
             walletManager
-                .findByAddress(Identities.Address.fromMultiSignatureAsset(transaction.data.asset.multiSignature))
+                .findByPublicKey(Identities.PublicKey.fromMultiSignatureAsset(transaction.data.asset.multiSignature))
                 .setAttribute("multiSignature", transaction.data.asset.multiSignature);
         }
     }
@@ -129,8 +131,8 @@ export class MultiSignatureTransactionHandler extends TransactionHandler {
         const { data }: Interfaces.ITransaction = transaction;
 
         if (data.version >= 2) {
-            const recipientWallet: State.IWallet = walletManager.findByAddress(
-                Identities.Address.fromMultiSignatureAsset(data.asset.multiSignature),
+            const recipientWallet: State.IWallet = walletManager.findByPublicKey(
+                Identities.PublicKey.fromMultiSignatureAsset(data.asset.multiSignature),
             );
             recipientWallet.setAttribute("multiSignature", transaction.data.asset.multiSignature);
         }
@@ -143,8 +145,8 @@ export class MultiSignatureTransactionHandler extends TransactionHandler {
         const { data }: Interfaces.ITransaction = transaction;
 
         if (data.version >= 2) {
-            const recipientWallet: State.IWallet = walletManager.findByAddress(
-                Identities.Address.fromMultiSignatureAsset(data.asset.multiSignature),
+            const recipientWallet: State.IWallet = walletManager.findByPublicKey(
+                Identities.PublicKey.fromMultiSignatureAsset(data.asset.multiSignature),
             );
 
             recipientWallet.forgetAttribute("multiSignature");


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

Set the public key on the wallet when applying multisignature registration transaction. Before using findByAddress, it would only set the address, now using findByPublicKey it sets both address and public key.

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
