### PR TITLE
refactor(crypto): remove long dependency

### DIFF
--- a/__tests__/unit/core-transaction-pool/connection.forging.test.ts
+++ b/__tests__/unit/core-transaction-pool/connection.forging.test.ts
@@ -7,7 +7,6 @@ import ByteBuffer from "bytebuffer";
 import { Wallets } from "@arkecosystem/core-state";
 import { Handlers } from "@arkecosystem/core-transactions";
 import { Constants, Crypto, Enums, Identities, Interfaces, Managers, Transactions, Utils } from "@arkecosystem/crypto";
-import Long from "long";
 import { Connection } from "../../../packages/core-transaction-pool/src/connection";
 import { defaults } from "../../../packages/core-transaction-pool/src/defaults";
 import { Memory } from "../../../packages/core-transaction-pool/src/memory";
@@ -115,7 +114,8 @@ describe("Connection", () => {
         const writeUint32 = (txField, value) =>
             options[txField] ? options[txField](buffer) : buffer.writeUint32(value);
         const writeUint64 = (txField, value) =>
-            options[txField] ? options[txField](buffer) : buffer.writeUint64(Long.fromString(value.toFixed()));
+            // @ts-ignore - The ByteBuffer types say we can't use strings but the code actually handles them.
+            options[txField] ? options[txField](buffer) : buffer.writeUint64(value.toFixed());
         const append = (txField, value, encoding = "utf8") =>
             options[txField] ? options[txField](buffer) : buffer.append(value, encoding);
 

--- a/__tests__/unit/core-transaction-pool/connection.forging.test.ts
+++ b/__tests__/unit/core-transaction-pool/connection.forging.test.ts
@@ -7,6 +7,7 @@ import ByteBuffer from "bytebuffer";
 import { Wallets } from "@arkecosystem/core-state";
 import { Handlers } from "@arkecosystem/core-transactions";
 import { Constants, Crypto, Enums, Identities, Interfaces, Managers, Transactions, Utils } from "@arkecosystem/crypto";
+import Long from "long";
 import { Connection } from "../../../packages/core-transaction-pool/src/connection";
 import { defaults } from "../../../packages/core-transaction-pool/src/defaults";
 import { Memory } from "../../../packages/core-transaction-pool/src/memory";
@@ -114,7 +115,7 @@ describe("Connection", () => {
         const writeUint32 = (txField, value) =>
             options[txField] ? options[txField](buffer) : buffer.writeUint32(value);
         const writeUint64 = (txField, value) =>
-            options[txField] ? options[txField](buffer) : buffer.writeUint64(value.toFixed());
+            options[txField] ? options[txField](buffer) : buffer.writeUint64(Long.fromString(value.toFixed()));
         const append = (txField, value, encoding = "utf8") =>
             options[txField] ? options[txField](buffer) : buffer.append(value, encoding);
 

--- a/__tests__/unit/core-transaction-pool/connection.forging.test.ts
+++ b/__tests__/unit/core-transaction-pool/connection.forging.test.ts
@@ -7,7 +7,6 @@ import ByteBuffer from "bytebuffer";
 import { Wallets } from "@arkecosystem/core-state";
 import { Handlers } from "@arkecosystem/core-transactions";
 import { Constants, Crypto, Enums, Identities, Interfaces, Managers, Transactions, Utils } from "@arkecosystem/crypto";
-import Long from "long";
 import { Connection } from "../../../packages/core-transaction-pool/src/connection";
 import { defaults } from "../../../packages/core-transaction-pool/src/defaults";
 import { Memory } from "../../../packages/core-transaction-pool/src/memory";
@@ -115,7 +114,7 @@ describe("Connection", () => {
         const writeUint32 = (txField, value) =>
             options[txField] ? options[txField](buffer) : buffer.writeUint32(value);
         const writeUint64 = (txField, value) =>
-            options[txField] ? options[txField](buffer) : buffer.writeUint64(Long.fromString(value.toFixed()));
+            options[txField] ? options[txField](buffer) : buffer.writeUint64(value.toFixed());
         const append = (txField, value, encoding = "utf8") =>
             options[txField] ? options[txField](buffer) : buffer.append(value, encoding);
 

--- a/__tests__/unit/core-transactions/handler-registry.test.ts
+++ b/__tests__/unit/core-transactions/handler-registry.test.ts
@@ -7,7 +7,6 @@ import { Registry, TransactionHandler } from "../../../packages/core-transaction
 import { TransactionHandlerConstructor } from "../../../packages/core-transactions/src/handlers/transaction";
 import { TransferTransactionHandler } from "../../../packages/core-transactions/src/handlers/transfer";
 
-import Long from "long";
 import { DeactivatedTransactionHandlerError } from "../../../packages/core-transactions/src/errors";
 import { testnet } from "../../../packages/crypto/src/networks";
 
@@ -45,7 +44,8 @@ class TestTransaction extends Transactions.Transaction {
     public serialize(): ByteBuffer {
         const { data } = this;
         const buffer = new ByteBuffer(24, true);
-        buffer.writeUint64(Long.fromString(data.amount.toFixed()));
+        // @ts-ignore - The ByteBuffer types say we can't use strings but the code actually handles them.
+        buffer.writeUint64(data.amount.toFixed());
         buffer.writeUint32(data.expiration || 0);
         buffer.append(Utils.Base58.decodeCheck(data.recipientId));
         buffer.writeInt32(data.asset.test);

--- a/__tests__/unit/core-transactions/handler-registry.test.ts
+++ b/__tests__/unit/core-transactions/handler-registry.test.ts
@@ -7,7 +7,6 @@ import { Registry, TransactionHandler } from "../../../packages/core-transaction
 import { TransactionHandlerConstructor } from "../../../packages/core-transactions/src/handlers/transaction";
 import { TransferTransactionHandler } from "../../../packages/core-transactions/src/handlers/transfer";
 
-import Long from "long";
 import { DeactivatedTransactionHandlerError } from "../../../packages/core-transactions/src/errors";
 import { testnet } from "../../../packages/crypto/src/networks";
 
@@ -45,7 +44,7 @@ class TestTransaction extends Transactions.Transaction {
     public serialize(): ByteBuffer {
         const { data } = this;
         const buffer = new ByteBuffer(24, true);
-        buffer.writeUint64(Long.fromString(data.amount.toFixed()));
+        buffer.writeUint64(data.amount.toFixed());
         buffer.writeUint32(data.expiration || 0);
         buffer.append(Utils.Base58.decodeCheck(data.recipientId));
         buffer.writeInt32(data.asset.test);

--- a/__tests__/unit/core-transactions/handler-registry.test.ts
+++ b/__tests__/unit/core-transactions/handler-registry.test.ts
@@ -7,6 +7,7 @@ import { Registry, TransactionHandler } from "../../../packages/core-transaction
 import { TransactionHandlerConstructor } from "../../../packages/core-transactions/src/handlers/transaction";
 import { TransferTransactionHandler } from "../../../packages/core-transactions/src/handlers/transfer";
 
+import Long from "long";
 import { DeactivatedTransactionHandlerError } from "../../../packages/core-transactions/src/errors";
 import { testnet } from "../../../packages/crypto/src/networks";
 
@@ -44,7 +45,7 @@ class TestTransaction extends Transactions.Transaction {
     public serialize(): ByteBuffer {
         const { data } = this;
         const buffer = new ByteBuffer(24, true);
-        buffer.writeUint64(data.amount.toFixed());
+        buffer.writeUint64(Long.fromString(data.amount.toFixed()));
         buffer.writeUint32(data.expiration || 0);
         buffer.append(Utils.Base58.decodeCheck(data.recipientId));
         buffer.writeInt32(data.asset.test);

--- a/__tests__/unit/crypto/transactions/deserializer.test.ts
+++ b/__tests__/unit/crypto/transactions/deserializer.test.ts
@@ -501,10 +501,10 @@ describe("Transaction serializer / Deserializer", () => {
                 buffer.writeUint32(Enums.TransactionTypeGroup.Core);
                 buffer.writeUint16(transaction.type);
                 // @ts-ignore - The ByteBuffer types say we can't use strings but the code actually handles them.
-                buffer.writeUint64(transaction.nonce.toFixed());
+                buffer.writeUint64(transaction.nonce.toString());
                 buffer.append(transaction.senderPublicKey, "hex");
                 // @ts-ignore - The ByteBuffer types say we can't use strings but the code actually handles them.
-                buffer.writeUint64(Utils.BigNumber.make(transaction.fee).toFixed());
+                buffer.writeUint64(Utils.BigNumber.make(transaction.fee).toString());
                 buffer.writeByte(0x00);
 
                 return Buffer.from(buffer.flip().toBuffer());

--- a/__tests__/unit/crypto/transactions/deserializer.test.ts
+++ b/__tests__/unit/crypto/transactions/deserializer.test.ts
@@ -1,7 +1,6 @@
 import "jest-extended";
 
 import ByteBuffer from "bytebuffer";
-import Long from "long";
 import { Enums, Errors, Utils } from "../../../../packages/crypto/src";
 import { Hash } from "../../../../packages/crypto/src/crypto";
 import {
@@ -501,9 +500,9 @@ describe("Transaction serializer / Deserializer", () => {
                 buffer.writeByte(transaction.network);
                 buffer.writeUint32(Enums.TransactionTypeGroup.Core);
                 buffer.writeUint16(transaction.type);
-                buffer.writeUint64(Long.fromString(transaction.nonce.toFixed()));
+                buffer.writeUint64(transaction.nonce.toFixed());
                 buffer.append(transaction.senderPublicKey, "hex");
-                buffer.writeUint64(Long.fromString(Utils.BigNumber.make(transaction.fee).toFixed()));
+                buffer.writeUint64(Utils.BigNumber.make(transaction.fee).toFixed());
                 buffer.writeByte(0x00);
 
                 return Buffer.from(buffer.flip().toBuffer());

--- a/__tests__/unit/crypto/transactions/deserializer.test.ts
+++ b/__tests__/unit/crypto/transactions/deserializer.test.ts
@@ -1,6 +1,7 @@
 import "jest-extended";
 
 import ByteBuffer from "bytebuffer";
+import Long from "long";
 import { Enums, Errors, Utils } from "../../../../packages/crypto/src";
 import { Hash } from "../../../../packages/crypto/src/crypto";
 import {
@@ -500,9 +501,9 @@ describe("Transaction serializer / Deserializer", () => {
                 buffer.writeByte(transaction.network);
                 buffer.writeUint32(Enums.TransactionTypeGroup.Core);
                 buffer.writeUint16(transaction.type);
-                buffer.writeUint64(transaction.nonce.toFixed());
+                buffer.writeUint64(Long.fromString(transaction.nonce.toFixed()));
                 buffer.append(transaction.senderPublicKey, "hex");
-                buffer.writeUint64(Utils.BigNumber.make(transaction.fee).toFixed());
+                buffer.writeUint64(Long.fromString(Utils.BigNumber.make(transaction.fee).toFixed()));
                 buffer.writeByte(0x00);
 
                 return Buffer.from(buffer.flip().toBuffer());

--- a/__tests__/unit/crypto/transactions/deserializer.test.ts
+++ b/__tests__/unit/crypto/transactions/deserializer.test.ts
@@ -1,7 +1,6 @@
 import "jest-extended";
 
 import ByteBuffer from "bytebuffer";
-import Long from "long";
 import { Enums, Errors, Utils } from "../../../../packages/crypto/src";
 import { Hash } from "../../../../packages/crypto/src/crypto";
 import {
@@ -17,8 +16,8 @@ import { TransactionFactory, Utils as TransactionUtils, Verifier } from "../../.
 import { BuilderFactory } from "../../../../packages/crypto/src/transactions/builders";
 import { Deserializer } from "../../../../packages/crypto/src/transactions/deserializer";
 import { Serializer } from "../../../../packages/crypto/src/transactions/serializer";
+import { htlcSecretHashHex, htlcSecretHex } from "../../../utils/fixtures";
 import { legacyMultiSignatureRegistration } from "./__fixtures__/transaction";
-import { htlcSecretHex, htlcSecretHashHex } from "../../../utils/fixtures";
 
 configManager.setHeight(2); // aip11 (v2 transactions) is true from height 2 on testnet
 
@@ -501,9 +500,11 @@ describe("Transaction serializer / Deserializer", () => {
                 buffer.writeByte(transaction.network);
                 buffer.writeUint32(Enums.TransactionTypeGroup.Core);
                 buffer.writeUint16(transaction.type);
-                buffer.writeUint64(Long.fromString(transaction.nonce.toFixed()));
+                // @ts-ignore - The ByteBuffer types say we can't use strings but the code actually handles them.
+                buffer.writeUint64(transaction.nonce.toFixed());
                 buffer.append(transaction.senderPublicKey, "hex");
-                buffer.writeUint64(Long.fromString(Utils.BigNumber.make(transaction.fee).toFixed()));
+                // @ts-ignore - The ByteBuffer types say we can't use strings but the code actually handles them.
+                buffer.writeUint64(Utils.BigNumber.make(transaction.fee).toFixed());
                 buffer.writeByte(0x00);
 
                 return Buffer.from(buffer.flip().toBuffer());

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -44,7 +44,6 @@
         "lodash.get": "^4.4.2",
         "lodash.set": "^4.3.2",
         "lodash.sumby": "^4.6.0",
-        "long": "~3",
         "tiny-glob": "^0.2.6",
         "wif": "^2.0.6"
     },

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -44,6 +44,7 @@
         "lodash.get": "^4.4.2",
         "lodash.set": "^4.3.2",
         "lodash.sumby": "^4.6.0",
+        "long": "~3",
         "tiny-glob": "^0.2.6",
         "wif": "^2.0.6"
     },

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -44,7 +44,6 @@
         "lodash.get": "^4.4.2",
         "lodash.set": "^4.3.2",
         "lodash.sumby": "^4.6.0",
-        "long": "~3",
         "tiny-glob": "^0.2.6",
         "wif": "^2.0.6"
     },
@@ -52,7 +51,6 @@
         "@types/bip32": "^1.0.2",
         "@types/bip39": "^2.4.2",
         "@types/buffer-xor": "^2.0.0",
-        "@types/bytebuffer": "^5.0.40",
         "@types/lodash.get": "^4.4.6",
         "@types/lodash.set": "^4.3.6",
         "@types/lodash.sumby": "^4.6.6",

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -28,6 +28,7 @@
     },
     "dependencies": {
         "@arkecosystem/utils": "0.8.3",
+        "@types/bytebuffer": "^5.0.40",
         "ajv": "^6.10.2",
         "ajv-keywords": "^3.4.1",
         "bcrypto": "^4.1.0",

--- a/packages/crypto/src/blocks/serializer.ts
+++ b/packages/crypto/src/blocks/serializer.ts
@@ -1,5 +1,6 @@
 import assert from "assert";
 import ByteBuffer from "bytebuffer";
+import Long from "long";
 import { PreviousBlockIdFormatError } from "../errors";
 import { IBlock, IBlockData, ITransactionData } from "../interfaces";
 import { configManager } from "../managers/config";
@@ -82,9 +83,9 @@ export class Serializer {
         buffer.writeUint32(block.height);
         buffer.append(block.previousBlockHex, "hex");
         buffer.writeUint32(block.numberOfTransactions);
-        buffer.writeUint64(block.totalAmount.toFixed());
-        buffer.writeUint64(block.totalFee.toFixed());
-        buffer.writeUint64(block.reward.toFixed());
+        buffer.writeUint64(Long.fromString(block.totalAmount.toString()));
+        buffer.writeUint64(Long.fromString(block.totalFee.toString()));
+        buffer.writeUint64(Long.fromString(block.reward.toString()));
         buffer.writeUint32(block.payloadLength);
         buffer.append(block.payloadHash, "hex");
         buffer.append(block.generatorPublicKey, "hex");

--- a/packages/crypto/src/blocks/serializer.ts
+++ b/packages/crypto/src/blocks/serializer.ts
@@ -1,6 +1,5 @@
 import assert from "assert";
 import ByteBuffer from "bytebuffer";
-import Long from "long";
 import { PreviousBlockIdFormatError } from "../errors";
 import { IBlock, IBlockData, ITransactionData } from "../interfaces";
 import { configManager } from "../managers/config";
@@ -83,9 +82,12 @@ export class Serializer {
         buffer.writeUint32(block.height);
         buffer.append(block.previousBlockHex, "hex");
         buffer.writeUint32(block.numberOfTransactions);
-        buffer.writeUint64(Long.fromString(block.totalAmount.toString()));
-        buffer.writeUint64(Long.fromString(block.totalFee.toString()));
-        buffer.writeUint64(Long.fromString(block.reward.toString()));
+        // @ts-ignore - The ByteBuffer types say we can't use strings but the code actually handles them.
+        buffer.writeUint64(block.totalAmount.toFixed());
+        // @ts-ignore - The ByteBuffer types say we can't use strings but the code actually handles them.
+        buffer.writeUint64(block.totalFee.toFixed());
+        // @ts-ignore - The ByteBuffer types say we can't use strings but the code actually handles them.
+        buffer.writeUint64(block.reward.toFixed());
         buffer.writeUint32(block.payloadLength);
         buffer.append(block.payloadHash, "hex");
         buffer.append(block.generatorPublicKey, "hex");

--- a/packages/crypto/src/blocks/serializer.ts
+++ b/packages/crypto/src/blocks/serializer.ts
@@ -1,6 +1,5 @@
 import assert from "assert";
 import ByteBuffer from "bytebuffer";
-import Long from "long";
 import { PreviousBlockIdFormatError } from "../errors";
 import { IBlock, IBlockData, ITransactionData } from "../interfaces";
 import { configManager } from "../managers/config";
@@ -83,9 +82,9 @@ export class Serializer {
         buffer.writeUint32(block.height);
         buffer.append(block.previousBlockHex, "hex");
         buffer.writeUint32(block.numberOfTransactions);
-        buffer.writeUint64(Long.fromString(block.totalAmount.toString()));
-        buffer.writeUint64(Long.fromString(block.totalFee.toString()));
-        buffer.writeUint64(Long.fromString(block.reward.toString()));
+        buffer.writeUint64(block.totalAmount.toFixed());
+        buffer.writeUint64(block.totalFee.toFixed());
+        buffer.writeUint64(block.reward.toFixed());
         buffer.writeUint32(block.payloadLength);
         buffer.append(block.payloadHash, "hex");
         buffer.append(block.generatorPublicKey, "hex");

--- a/packages/crypto/src/blocks/serializer.ts
+++ b/packages/crypto/src/blocks/serializer.ts
@@ -83,11 +83,11 @@ export class Serializer {
         buffer.append(block.previousBlockHex, "hex");
         buffer.writeUint32(block.numberOfTransactions);
         // @ts-ignore - The ByteBuffer types say we can't use strings but the code actually handles them.
-        buffer.writeUint64(block.totalAmount.toFixed());
+        buffer.writeUint64(block.totalAmount.toString());
         // @ts-ignore - The ByteBuffer types say we can't use strings but the code actually handles them.
-        buffer.writeUint64(block.totalFee.toFixed());
+        buffer.writeUint64(block.totalFee.toString());
         // @ts-ignore - The ByteBuffer types say we can't use strings but the code actually handles them.
-        buffer.writeUint64(block.reward.toFixed());
+        buffer.writeUint64(block.reward.toString());
         buffer.writeUint32(block.payloadLength);
         buffer.append(block.payloadHash, "hex");
         buffer.append(block.generatorPublicKey, "hex");

--- a/packages/crypto/src/transactions/serializer.ts
+++ b/packages/crypto/src/transactions/serializer.ts
@@ -1,6 +1,5 @@
 /* tslint:disable:no-shadowed-variable */
 import ByteBuffer from "bytebuffer";
-import Long from "long";
 import { Utils } from "..";
 import { TransactionType, TransactionTypeGroup } from "../enums";
 import { TransactionVersionError } from "../errors";
@@ -149,8 +148,8 @@ export class Serializer {
             }
         }
 
-        bb.writeInt64(Long.fromString(transaction.amount.toString()));
-        bb.writeInt64(Long.fromString(transaction.fee.toString()));
+        bb.writeInt64(transaction.amount.toFixed());
+        bb.writeInt64(transaction.fee.toFixed());
 
         if (assetSize > 0) {
             for (let i = 0; i < assetSize; i++) {
@@ -199,11 +198,11 @@ export class Serializer {
         } else {
             buffer.writeUint32(transaction.typeGroup);
             buffer.writeUint16(transaction.type);
-            buffer.writeUint64(Long.fromString(transaction.nonce.toString()));
+            buffer.writeUint64(transaction.nonce.toFixed());
         }
 
         buffer.append(transaction.senderPublicKey, "hex");
-        buffer.writeUint64(Long.fromString(transaction.fee.toString()));
+        buffer.writeUint64(transaction.fee.toFixed());
     }
 
     private static serializeVendorField(transaction: ITransaction, buffer: ByteBuffer): void {

--- a/packages/crypto/src/transactions/serializer.ts
+++ b/packages/crypto/src/transactions/serializer.ts
@@ -149,9 +149,9 @@ export class Serializer {
         }
 
         // @ts-ignore - The ByteBuffer types say we can't use strings but the code actually handles them.
-        bb.writeInt64(transaction.amount.toFixed());
+        bb.writeInt64(transaction.amount.toString());
         // @ts-ignore - The ByteBuffer types say we can't use strings but the code actually handles them.
-        bb.writeInt64(transaction.fee.toFixed());
+        bb.writeInt64(transaction.fee.toString());
 
         if (assetSize > 0) {
             for (let i = 0; i < assetSize; i++) {

--- a/packages/crypto/src/transactions/serializer.ts
+++ b/packages/crypto/src/transactions/serializer.ts
@@ -1,5 +1,6 @@
 /* tslint:disable:no-shadowed-variable */
 import ByteBuffer from "bytebuffer";
+import Long from "long";
 import { Utils } from "..";
 import { TransactionType, TransactionTypeGroup } from "../enums";
 import { TransactionVersionError } from "../errors";
@@ -148,8 +149,8 @@ export class Serializer {
             }
         }
 
-        bb.writeInt64(transaction.amount.toFixed());
-        bb.writeInt64(transaction.fee.toFixed());
+        bb.writeInt64(Long.fromString(transaction.amount.toString()));
+        bb.writeInt64(Long.fromString(transaction.fee.toString()));
 
         if (assetSize > 0) {
             for (let i = 0; i < assetSize; i++) {
@@ -198,11 +199,11 @@ export class Serializer {
         } else {
             buffer.writeUint32(transaction.typeGroup);
             buffer.writeUint16(transaction.type);
-            buffer.writeUint64(transaction.nonce.toFixed());
+            buffer.writeUint64(Long.fromString(transaction.nonce.toString()));
         }
 
         buffer.append(transaction.senderPublicKey, "hex");
-        buffer.writeUint64(transaction.fee.toFixed());
+        buffer.writeUint64(Long.fromString(transaction.fee.toString()));
     }
 
     private static serializeVendorField(transaction: ITransaction, buffer: ByteBuffer): void {

--- a/packages/crypto/src/transactions/serializer.ts
+++ b/packages/crypto/src/transactions/serializer.ts
@@ -1,6 +1,5 @@
 /* tslint:disable:no-shadowed-variable */
 import ByteBuffer from "bytebuffer";
-import Long from "long";
 import { Utils } from "..";
 import { TransactionType, TransactionTypeGroup } from "../enums";
 import { TransactionVersionError } from "../errors";
@@ -149,8 +148,10 @@ export class Serializer {
             }
         }
 
-        bb.writeInt64(Long.fromString(transaction.amount.toString()));
-        bb.writeInt64(Long.fromString(transaction.fee.toString()));
+        // @ts-ignore - The ByteBuffer types say we can't use strings but the code actually handles them.
+        bb.writeInt64(transaction.amount.toFixed());
+        // @ts-ignore - The ByteBuffer types say we can't use strings but the code actually handles them.
+        bb.writeInt64(transaction.fee.toFixed());
 
         if (assetSize > 0) {
             for (let i = 0; i < assetSize; i++) {
@@ -199,11 +200,13 @@ export class Serializer {
         } else {
             buffer.writeUint32(transaction.typeGroup);
             buffer.writeUint16(transaction.type);
-            buffer.writeUint64(Long.fromString(transaction.nonce.toString()));
+            // @ts-ignore - The ByteBuffer types say we can't use strings but the code actually handles them.
+            buffer.writeUint64(transaction.nonce.toString());
         }
 
         buffer.append(transaction.senderPublicKey, "hex");
-        buffer.writeUint64(Long.fromString(transaction.fee.toString()));
+        // @ts-ignore - The ByteBuffer types say we can't use strings but the code actually handles them.
+        buffer.writeUint64(transaction.fee.toString());
     }
 
     private static serializeVendorField(transaction: ITransaction, buffer: ByteBuffer): void {

--- a/packages/crypto/src/transactions/types/htlc-lock.ts
+++ b/packages/crypto/src/transactions/types/htlc-lock.ts
@@ -1,5 +1,4 @@
 import ByteBuffer from "bytebuffer";
-import Long from "long";
 import { TransactionType, TransactionTypeGroup } from "../../enums";
 import { Address } from "../../identities";
 import { ISerializeOptions } from "../../interfaces";
@@ -33,7 +32,8 @@ export class HtlcLockTransaction extends Transaction {
 
         const buffer: ByteBuffer = new ByteBuffer(8 + 32 + 1 + 4 + 21, true);
 
-        buffer.writeUint64(Long.fromString(data.amount.toString()));
+        // @ts-ignore - The ByteBuffer types say we can't use strings but the code actually handles them.
+        buffer.writeUint64(data.amount.toString());
         buffer.append(Buffer.from(data.asset.lock.secretHash, "hex"));
         buffer.writeUint8(data.asset.lock.expiration.type);
         buffer.writeUint32(data.asset.lock.expiration.value);

--- a/packages/crypto/src/transactions/types/htlc-lock.ts
+++ b/packages/crypto/src/transactions/types/htlc-lock.ts
@@ -1,4 +1,5 @@
 import ByteBuffer from "bytebuffer";
+import Long from "long";
 import { TransactionType, TransactionTypeGroup } from "../../enums";
 import { Address } from "../../identities";
 import { ISerializeOptions } from "../../interfaces";
@@ -32,7 +33,7 @@ export class HtlcLockTransaction extends Transaction {
 
         const buffer: ByteBuffer = new ByteBuffer(8 + 32 + 1 + 4 + 21, true);
 
-        buffer.writeUint64(data.amount.toFixed());
+        buffer.writeUint64(Long.fromString(data.amount.toString()));
         buffer.append(Buffer.from(data.asset.lock.secretHash, "hex"));
         buffer.writeUint8(data.asset.lock.expiration.type);
         buffer.writeUint32(data.asset.lock.expiration.value);

--- a/packages/crypto/src/transactions/types/htlc-lock.ts
+++ b/packages/crypto/src/transactions/types/htlc-lock.ts
@@ -1,5 +1,4 @@
 import ByteBuffer from "bytebuffer";
-import Long from "long";
 import { TransactionType, TransactionTypeGroup } from "../../enums";
 import { Address } from "../../identities";
 import { ISerializeOptions } from "../../interfaces";
@@ -33,7 +32,7 @@ export class HtlcLockTransaction extends Transaction {
 
         const buffer: ByteBuffer = new ByteBuffer(8 + 32 + 1 + 4 + 21, true);
 
-        buffer.writeUint64(Long.fromString(data.amount.toString()));
+        buffer.writeUint64(data.amount.toFixed());
         buffer.append(Buffer.from(data.asset.lock.secretHash, "hex"));
         buffer.writeUint8(data.asset.lock.expiration.type);
         buffer.writeUint32(data.asset.lock.expiration.value);

--- a/packages/crypto/src/transactions/types/multi-payment.ts
+++ b/packages/crypto/src/transactions/types/multi-payment.ts
@@ -1,5 +1,4 @@
 import ByteBuffer from "bytebuffer";
-import Long from "long";
 import { TransactionType, TransactionTypeGroup } from "../../enums";
 import { Address } from "../../identities";
 import { IMultiPaymentItem, ISerializeOptions } from "../../interfaces";
@@ -34,7 +33,8 @@ export class MultiPaymentTransaction extends Transaction {
         buffer.writeUint16(data.asset.payments.length);
 
         for (const payment of data.asset.payments) {
-            buffer.writeUint64(Long.fromString(payment.amount.toString()));
+            // @ts-ignore - The ByteBuffer types say we can't use strings but the code actually handles them.
+            buffer.writeUint64(payment.amount.toString());
 
             const { addressBuffer, addressError } = Address.toBuffer(payment.recipientId);
             options.addressError = addressError || options.addressError;

--- a/packages/crypto/src/transactions/types/multi-payment.ts
+++ b/packages/crypto/src/transactions/types/multi-payment.ts
@@ -1,5 +1,4 @@
 import ByteBuffer from "bytebuffer";
-import Long from "long";
 import { TransactionType, TransactionTypeGroup } from "../../enums";
 import { Address } from "../../identities";
 import { IMultiPaymentItem, ISerializeOptions } from "../../interfaces";
@@ -34,7 +33,7 @@ export class MultiPaymentTransaction extends Transaction {
         buffer.writeUint16(data.asset.payments.length);
 
         for (const payment of data.asset.payments) {
-            buffer.writeUint64(Long.fromString(payment.amount.toString()));
+            buffer.writeUint64(payment.amount.toFixed());
 
             const { addressBuffer, addressError } = Address.toBuffer(payment.recipientId);
             options.addressError = addressError || options.addressError;

--- a/packages/crypto/src/transactions/types/multi-payment.ts
+++ b/packages/crypto/src/transactions/types/multi-payment.ts
@@ -1,4 +1,5 @@
 import ByteBuffer from "bytebuffer";
+import Long from "long";
 import { TransactionType, TransactionTypeGroup } from "../../enums";
 import { Address } from "../../identities";
 import { IMultiPaymentItem, ISerializeOptions } from "../../interfaces";
@@ -33,7 +34,7 @@ export class MultiPaymentTransaction extends Transaction {
         buffer.writeUint16(data.asset.payments.length);
 
         for (const payment of data.asset.payments) {
-            buffer.writeUint64(payment.amount.toFixed());
+            buffer.writeUint64(Long.fromString(payment.amount.toString()));
 
             const { addressBuffer, addressError } = Address.toBuffer(payment.recipientId);
             options.addressError = addressError || options.addressError;

--- a/packages/crypto/src/transactions/types/transfer.ts
+++ b/packages/crypto/src/transactions/types/transfer.ts
@@ -1,5 +1,4 @@
 import ByteBuffer from "bytebuffer";
-import Long from "long";
 import { TransactionType, TransactionTypeGroup } from "../../enums";
 import { Address } from "../../identities";
 import { ISerializeOptions } from "../../interfaces";
@@ -25,7 +24,8 @@ export class TransferTransaction extends Transaction {
     public serialize(options?: ISerializeOptions): ByteBuffer {
         const { data } = this;
         const buffer: ByteBuffer = new ByteBuffer(24, true);
-        buffer.writeUint64(Long.fromString(data.amount.toString()));
+        // @ts-ignore - The ByteBuffer types say we can't use strings but the code actually handles them.
+        buffer.writeUint64(data.amount.toString());
         buffer.writeUint32(data.expiration || 0);
 
         const { addressBuffer, addressError } = Address.toBuffer(data.recipientId);

--- a/packages/crypto/src/transactions/types/transfer.ts
+++ b/packages/crypto/src/transactions/types/transfer.ts
@@ -1,5 +1,4 @@
 import ByteBuffer from "bytebuffer";
-import Long from "long";
 import { TransactionType, TransactionTypeGroup } from "../../enums";
 import { Address } from "../../identities";
 import { ISerializeOptions } from "../../interfaces";
@@ -25,7 +24,7 @@ export class TransferTransaction extends Transaction {
     public serialize(options?: ISerializeOptions): ByteBuffer {
         const { data } = this;
         const buffer: ByteBuffer = new ByteBuffer(24, true);
-        buffer.writeUint64(Long.fromString(data.amount.toString()));
+        buffer.writeUint64(data.amount.toFixed());
         buffer.writeUint32(data.expiration || 0);
 
         const { addressBuffer, addressError } = Address.toBuffer(data.recipientId);

--- a/packages/crypto/src/transactions/types/transfer.ts
+++ b/packages/crypto/src/transactions/types/transfer.ts
@@ -1,4 +1,5 @@
 import ByteBuffer from "bytebuffer";
+import Long from "long";
 import { TransactionType, TransactionTypeGroup } from "../../enums";
 import { Address } from "../../identities";
 import { ISerializeOptions } from "../../interfaces";
@@ -24,7 +25,7 @@ export class TransferTransaction extends Transaction {
     public serialize(options?: ISerializeOptions): ByteBuffer {
         const { data } = this;
         const buffer: ByteBuffer = new ByteBuffer(24, true);
-        buffer.writeUint64(data.amount.toFixed());
+        buffer.writeUint64(Long.fromString(data.amount.toString()));
         buffer.writeUint32(data.expiration || 0);
 
         const { addressBuffer, addressError } = Address.toBuffer(data.recipientId);


### PR DESCRIPTION
The `long@3` dependency can cause problems if people also have `long@4` installed because node.js will think it should use `long@4` even though we don't have it as a dependency. This will cause the `value instanceof Long` check in the `bytebuffer` dependency to fail because its own dependency is `long@3` but node.js will force it to use `long@4` if it is installed, which will throw an exception because the instance signatures will differ.

The `bytebuffer` types have been removed because they don't reflect their JavaScript code. The types state that you can only pass in a `number` or `Long` but their code will actually perform assertions and use `Long` internally to create an instance. This means that whatever long version is installed will be used.

```js
ByteBufferPrototype.writeUint64 = function(value, offset) {
    var relative = typeof offset === 'undefined';
    if (relative) offset = this.offset;
    if (!this.noAssert) {
        if (typeof value === 'number')
            value = Long.fromNumber(value);
        else if (typeof value === 'string')
            value = Long.fromString(value);
        else if (!(value && value instanceof Long))
            throw TypeError("Illegal value: "+value+" (not an integer or Long)");
        if (typeof offset !== 'number' || offset % 1 !== 0)
            throw TypeError("Illegal offset: "+offset+" (not an integer)");
        offset >>>= 0;
        if (offset < 0 || offset + 0 > this.buffer.length)
            throw RangeError("Illegal offset: 0 <= "+offset+" (+"+0+") <= "+this.buffer.length);
    }
    if (typeof value === 'number')
        value = Long.fromNumber(value);
    else if (typeof value === 'string')
        value = Long.fromString(value);
```