### PR TITLE
fix(core-database): check for missed blocks before applying round

### DIFF
--- a/packages/core-database/src/database-service.ts
+++ b/packages/core-database/src/database-service.ts
@@ -81,13 +81,13 @@ export class DatabaseService implements Database.IDatabaseService {
             this.blocksInCurrentRound.push(block);
         }
 
+        this.detectMissedBlocks(block);
+
         await this.applyRound(block.data.height);
 
         for (const transaction of block.transactions) {
             await this.emitTransactionEvents(transaction);
         }
-
-        this.detectMissedBlocks(block);
 
         this.emitter.emit(ApplicationEvents.BlockApplied, block.data);
     }


### PR DESCRIPTION
## Summary

Fixes #3491 by detecting missed blocks before applying the round, since applying the round will repopulate `forgingDelegates` with the order of the new round, but we need to check against the current (old) round to detect the correct delegate if the last delegate in a round misses its block. Otherwise it incorrectly fires for a different delegate in the new round.

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
