### PR TITLE
fix(core): make app.js optional as initially intended

### DIFF
--- a/packages/core/bin/config/testnet/app.js
+++ b/packages/core/bin/config/testnet/app.js
@@ -36,4 +36,4 @@ module.exports = {
             },
         },
     },
-}
+};

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -33,16 +33,26 @@ export const updateEnvironmentVariables = (envFile: string, variables: Environme
 };
 
 export const getCliConfig = (
-    options: Record<string, any>,
+    flags: Record<string, any>,
     paths: envPaths.Paths,
     defaultValue = {},
 ): Record<string, any> => {
-    const configPath: string = `${paths.config}/app.js`;
-    if (!existsSync(configPath)) {
+    const configPaths: string[] = [`${paths.config}/app.js`, resolve(__dirname, `../bin/config/${flags.network}/app.js`)];
+
+    let configPath: string;
+    for (const path of configPaths) {
+        if (existsSync(path)) {
+            configPath = path;
+
+            break;
+        }
+    }
+
+    if (!configPath) {
         return defaultValue;
     }
 
-    const key: string = `cli.${options.suffix}.run.plugins`;
+    const key: string = `cli.${flags.suffix}.run.plugins`;
     const configuration = require(resolve(configPath));
     if (!dottie.exists(configuration, key)) {
         return defaultValue;


### PR DESCRIPTION
## Summary

Adds the `app.js` file to testnet and fixes the wrongly behaviour that the `app.js` file is required to be published. It was intended to be optional and fallback to the default `app.js` that core ships if it doesn't exist in the published configuration folder.

Can be tested with `yarn global add @arkecosystem/core@2.6.0-alpha.1`.

## Checklist

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged
