### PR TITLE
fix(core-p2p): disable permessage-deflate

### DIFF
--- a/packages/core-p2p/src/peer-connector.ts
+++ b/packages/core-p2p/src/peer-connector.ts
@@ -74,7 +74,7 @@ export class PeerConnector implements P2P.IPeerConnector {
             port: peer.port,
             hostname: peer.ip,
             ackTimeout: Math.max(app.resolveOptions("p2p").getBlocksTimeout, app.resolveOptions("p2p").verifyTimeout),
-            perMessageDeflate: true,
+            perMessageDeflate: false,
             codecEngine: codec,
         });
 

--- a/packages/core-p2p/src/socket-server/index.ts
+++ b/packages/core-p2p/src/socket-server/index.ts
@@ -31,7 +31,7 @@ export const startSocketServer = async (service: P2P.IPeerService, config: Recor
             // See https://github.com/SocketCluster/socketcluster/issues/506 about
             // details on how pingTimeout works.
             pingTimeout: Math.max(app.resolveOptions("p2p").getBlocksTimeout, app.resolveOptions("p2p").verifyTimeout),
-            perMessageDeflate: true,
+            perMessageDeflate: false,
             maxPayload: blockMaxPayload + 10 * 1024, // 10KB margin vs block maxPayload to allow few additional chars for p2p message
         },
         ...config.server,


### PR DESCRIPTION
## Summary

There is memory leak in `core-p2p` which also leads to workers not responding after a while. This is caused by enabling `permessage-deflate` (PMD) in the websockets. PMD was introduced in 2.5 but the problem only became apparent in 2.6 because PMD uses heuristics to determine whether to compress the data or send it uncompressed, for example, small packets are not compressed because the overhead would not be worth it. AIP11 introduced things like multipayments, which result in larger transaction payloads, triggering PMD compression whereas the smaller transaction payloads in Core 2.5 were below the threshold for PMD compression. This is why the problem only became apparent in 2.6 and also likely explains why 2.6 uses more CPU cycles as PMD is happening much more often, which requires more resources to compress/uncompress the data.

Due to the current p2p architecture, using PMD means the websocket can never be garbage collected (GC). Over time the number of websockets keeps rising and this causes a memory leak. Eventually, the leak stops the PMD compression queues from consuming their data, so any data to be compressed does not get sent to the destination websocket. This is what causes the workers to appear to stop responding, since their compressed output never gets consumed in the compression queue. It also explains why the `p2p.peer.postTransactions` endpoint still works -- it only returns an empty array, below the PMD compression threshold, whereas other endpoints return more data which would be compressed.

Due to the new optimised data transmission codec and serialisation, PMD is no longer required and will make for a leaner less resource-hungry Core.

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
