### PR TITLE
Remove custom wallet repository

### DIFF
--- a/packages/core-transactions/src/handlers/transaction.ts
+++ b/packages/core-transactions/src/handlers/transaction.ts
@@ -31,15 +31,12 @@ export abstract class TransactionHandler {
     @Container.inject(Container.Identifiers.WalletRepository)
     protected readonly walletRepository!: Contracts.State.WalletRepository;
 
-    public async verify(
-        transaction: Interfaces.ITransaction,
-        customWalletRepository?: Contracts.State.WalletRepository,
-    ): Promise<boolean> {
-        const walletRepository: Contracts.State.WalletRepository = customWalletRepository ?? this.walletRepository;
-
+    public async verify(transaction: Interfaces.ITransaction): Promise<boolean> {
         AppUtils.assert.defined<string>(transaction.data.senderPublicKey);
 
-        const senderWallet: Contracts.State.Wallet = walletRepository.findByPublicKey(transaction.data.senderPublicKey);
+        const senderWallet: Contracts.State.Wallet = this.walletRepository.findByPublicKey(
+            transaction.data.senderPublicKey,
+        );
 
         if (senderWallet.hasMultiSignature()) {
             transaction.isVerified = this.verifySignatures(senderWallet, transaction.data);


### PR DESCRIPTION
## Summary

Segregated pool doesn't pass custom wallet repository as argument. It isn't needed anymore.

This is draft, so I can check that tests do run fine on CI. Because @sebastijankuzner is working on core-transactions test coverage, I will try to merge his changes here occasionally.

## Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged
