### PR TITLE
perf(core): use jemalloc as the memory allocator

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -149,10 +149,10 @@ success "Installed PM2!"
 heading "Installing program dependencies..."
 
 if [[ ! -z $DEB ]]; then
-    sudo apt-get install build-essential libcairo2-dev pkg-config libtool autoconf automake python libpq-dev jq -y
+    sudo apt-get install build-essential libcairo2-dev pkg-config libtool autoconf automake python libpq-dev jq libjemalloc-dev -y
 elif [[ ! -z $RPM ]]; then
     sudo yum groupinstall "Development Tools" -y -q
-    sudo yum install postgresql-devel jq -y -q
+    sudo yum install postgresql-devel jq jemalloc-devel -y -q
 fi
 
 success "Installed program dependencies!"

--- a/packages/core/bin/run
+++ b/packages/core/bin/run
@@ -4,7 +4,7 @@ if (process.env.LD_PRELOAD !== 'libjemalloc.so') {
     process.env.LD_PRELOAD = 'libjemalloc.so'
     let exitStatus = 0
     try {
-        require('child_process').execSync(process.argv.join(' '), { stdio: [0, 1, 2] })
+        require('child_process').execFileSync(process.argv0, process.argv.slice(1), { stdio: [0, 1, 2] })
     } catch (error) {
         exitStatus = error.status
     }

--- a/packages/core/bin/run
+++ b/packages/core/bin/run
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+process.env.LD_PRELOAD = 'libjemalloc.so'
+
 require('@oclif/command').run()
 .then(require('@oclif/command/flush'))
 .catch(require('@oclif/errors/handle'))

--- a/packages/core/bin/run
+++ b/packages/core/bin/run
@@ -1,14 +1,22 @@
 #!/usr/bin/env node
 
-if (process.env.LD_PRELOAD !== 'libjemalloc.so') {
-    process.env.LD_PRELOAD = 'libjemalloc.so'
-    let exitStatus = 0
-    try {
-        require('child_process').execFileSync(process.argv0, process.argv.slice(1), { stdio: [0, 1, 2] })
-    } catch (error) {
-        exitStatus = error.status
+const child_process = require('child_process')
+
+const jemallocPath = child_process.spawnSync('whereis libjemalloc | xargs -n1 | grep libjemalloc.so', { shell: true }).stdout.toString().trim()
+
+if (jemallocPath) {
+    if (process.env.LD_PRELOAD !== jemallocPath) {
+        process.env.LD_PRELOAD = jemallocPath
+        let exitStatus = 0
+        try {
+            child_process.execFileSync(process.argv0, process.argv.slice(1), { stdio: [0, 1, 2] })
+        } catch (error) {
+            exitStatus = error.status
+        }
+        process.exit(exitStatus)
     }
-    process.exit(exitStatus)
+} else {
+    console.error('The jemalloc library was not found on your system. It is recommended to install it for better memory management. Falling back to the system default...')
 }
 
 require('@oclif/command').run()

--- a/packages/core/bin/run
+++ b/packages/core/bin/run
@@ -1,22 +1,26 @@
 #!/usr/bin/env node
 
-const child_process = require('child_process')
+try {
+    const child_process = require('child_process')
 
-const jemallocPath = child_process.spawnSync('whereis libjemalloc | xargs -n1 | grep libjemalloc.so', { shell: true }).stdout.toString().trim()
+    const jemallocPath = child_process.spawnSync('whereis libjemalloc | xargs -n1 | grep libjemalloc.so', { shell: true }).stdout.toString().trim()
 
-if (jemallocPath) {
-    if (process.env.LD_PRELOAD !== jemallocPath) {
-        process.env.LD_PRELOAD = jemallocPath
-        let exitStatus = 0
-        try {
-            child_process.execFileSync(process.argv0, process.argv.slice(1), { stdio: [0, 1, 2] })
-        } catch (error) {
-            exitStatus = error.status
+    if (jemallocPath) {
+        if (process.env.LD_PRELOAD !== jemallocPath) {
+            process.env.LD_PRELOAD = jemallocPath
+            let exitStatus = 0
+            try {
+                child_process.execFileSync(process.argv0, process.argv.slice(1), { stdio: [0, 1, 2] })
+            } catch (error) {
+                exitStatus = error.status
+            }
+            process.exit(exitStatus)
         }
-        process.exit(exitStatus)
+    } else {
+        console.error('The jemalloc library was not found on your system. It is recommended to install it for better memory management. Falling back to the system default...')
     }
-} else {
-    console.error('The jemalloc library was not found on your system. It is recommended to install it for better memory management. Falling back to the system default...')
+} catch (error) {
+    //
 }
 
 require('@oclif/command').run()

--- a/packages/core/bin/run
+++ b/packages/core/bin/run
@@ -1,6 +1,15 @@
 #!/usr/bin/env node
 
-process.env.LD_PRELOAD = 'libjemalloc.so'
+if (process.env.LD_PRELOAD !== 'libjemalloc.so') {
+    process.env.LD_PRELOAD = 'libjemalloc.so'
+    let exitStatus = 0
+    try {
+        require('child_process').execSync(process.argv.join(' '), { stdio: [0, 1, 2] })
+    } catch (error) {
+        exitStatus = error.status
+    }
+    process.exit(exitStatus)
+}
 
 require('@oclif/command').run()
 .then(require('@oclif/command/flush'))


### PR DESCRIPTION
## Summary

This PR replaces the native memory allocator with jemalloc in Core to reduce memory fragmentation and results in a smaller memory footprint as confirmed by multiple Core nodes using the native memory allocator (glibc) vs jemalloc, where in all cases the jemalloc nodes consistently used less RAM. Furthermore, results from a sync from 0 test (using the same hardware with 2GB physical RAM to eliminate variability due to different specifications) demonstrate that jemalloc is more performant and uses far less memory by the end:

native memory allocator (glibc): Completed in 14h 54m 14s using 1.3GB RAM 30 minutes after completion.
jemalloc: Completed in 13h 37m 56s using 314.5MB RAM 30 minutes after completion.

Therefore a sync from 0 using jemalloc completed 1h 16m 18s faster than glibc on the same hardware and, upon finishing, was using ~1017MB less RAM.

On a different (much higher powered) machine with 32GB RAM, I rolled back 300,000 blocks on devnet and re-synced using glibc and jemalloc:

native memory allocator (glibc): Completed in 7 minutes and 20 seconds using 3.5GB RAM (!) 10 minutes after completion.
jemalloc: Completed in 6 minutes and 50 seconds using 410.9MB RAM 10 minutes after completion.

In that instance, jemalloc completed 30 seconds faster than glibc and used a staggering ~3173MB less RAM.

This PR does not change the default system memory allocator to jemalloc as this may not be desirable and we should not make such system-wide changes. It just makes the Core process use jemalloc and leaves everything else untouched.

**Special update instructions:**
Users should manually run `sudo apt-get install libjemalloc-dev` (Debian derivatives) or `sudo yum install libjemalloc-devel` (RedHat derivatives) before updating since they don't re-run the Core installer (which will automatically install it for new installations).

~Update with `ark update --no-restart` then `pm2 delete all` and restart the `relay`/`forger`/`core` process(es) via `ark {relay|forger|core}:start`. Merely executing `ark {relay|forger|core}:restart` or letting the updater restart the processes is insufficient as it will not inject the `LD_PRELOAD` variable, presumably due to pm2 caching.~ 
Now refactored so the normal `ark update` procedure is sufficient to restart Core as long as libjemalloc has been installed as above.

To confirm Core is now using jemalloc, run ``cat /proc/`pgrep -f "@arkecosystem/core/bin/run"`/smaps | grep jemalloc``. The output should show references to `libjemalloc.so` to confirm the process is running with jemalloc.

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
