### PR TITLE
fix(core-blockchain): set height 1 on config manager for processing genesis block (blockchain replay)

### DIFF
--- a/packages/core-blockchain/src/replay/replay-blockchain.ts
+++ b/packages/core-blockchain/src/replay/replay-blockchain.ts
@@ -100,6 +100,8 @@ export class ReplayBlockchain extends Blockchain {
     }
 
     private async processGenesisBlock(): Promise<void> {
+        Managers.configManager.setHeight(1);
+
         const genesisBlock: Interfaces.IBlock = Blocks.BlockFactory.fromJson(
             Managers.configManager.get("genesisBlock"),
         );
@@ -148,6 +150,8 @@ export class ReplayBlockchain extends Blockchain {
             roundInfo,
             delegates,
         );
+
+        this.memoryDatabase.restoreCurrentRound(1);
 
         this.logger.info("Finished loading genesis block.");
     }


### PR DESCRIPTION


<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
Resolves #3554 

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->
Set height=1 on config manager for processing genesis block + initialize memoryDatabase activeDelegates with restoreCurrentRound.

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
