### PR TITLE
fix(core): handle multiple installations of jemalloc

### DIFF
--- a/packages/core/bin/run
+++ b/packages/core/bin/run
@@ -3,7 +3,7 @@
 try {
     const child_process = require('child_process')
 
-    const jemallocPath = child_process.spawnSync('whereis libjemalloc | xargs -n1 | grep libjemalloc.so', { shell: true }).stdout.toString().trim()
+    const jemallocPath = child_process.spawnSync('whereis libjemalloc | xargs -n1 | grep libjemalloc.so', { shell: true }).stdout.toString().split('\n').shift().trim()
 
     if (jemallocPath) {
         if (process.env.LD_PRELOAD !== jemallocPath) {


### PR DESCRIPTION
## Summary

This handles an edge case if there are multiple installations of jemalloc (e.g. a system-wide installation via a package manager in `/usr/lib` and also another version built from source in `/usr/local/lib`).

Previously it would fail because the `jemallocPath` would contain a concatenation of both installation paths separated by a newline. Now we just take the first path that we find.

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
