### PR TITLE
refactor(core-state): merge index and reindex into one function inside WalletRepository

### DIFF
--- a/__tests__/functional/transaction-forging/delegate-resignation.test.ts
+++ b/__tests__/functional/transaction-forging/delegate-resignation.test.ts
@@ -167,7 +167,7 @@ describe("Transaction Forging - Delegate Resignation", () => {
             await expect(transactionsResign.id).not.toBeForged();
 
             for (const delegate of takenDelegates) {
-                walletRepository.reindex(delegate);
+                walletRepository.index(delegate);
             }
         });
     });

--- a/__tests__/integration/core-api/__support__/setup.ts
+++ b/__tests__/integration/core-api/__support__/setup.ts
@@ -124,6 +124,6 @@ export const calculateRanks = async () => {
         const wallet = walletRepository.findByPublicKey(delegate.publicKey!);
         wallet.setAttribute("delegate.rank", i + 1);
 
-        walletRepository.reindex(wallet);
+        walletRepository.index(wallet);
     });
 };

--- a/__tests__/integration/core-api/handlers/delegates.test.ts
+++ b/__tests__/integration/core-api/handlers/delegates.test.ts
@@ -49,7 +49,7 @@ beforeEach(() => {
     wallet.setAttribute("delegate.producedBlocks", 75);
     wallet.setAttribute("delegate.voteBalance", AppUtils.BigNumber.make(delegate.voteBalance));
 
-    walletRepository.reindex(wallet);
+    walletRepository.index(wallet);
 });
 
 const createWallet = (address: string): Contracts.State.Wallet =>
@@ -89,7 +89,7 @@ describe("API 2.0 - Delegates", () => {
                 const delegate = reverseDelegates[i];
                 delegate.setAttribute("delegate.voteBalance", AppUtils.BigNumber.make(i * 1e8));
 
-                walletRepository.reindex(delegate);
+                walletRepository.index(delegate);
             }
 
             const response = await api.request("GET", "delegates", { orderBy: "votes:asc" });
@@ -104,7 +104,7 @@ describe("API 2.0 - Delegates", () => {
                 const delegate = originalDelegates[i];
                 delegate.setAttribute("delegate.voteBalance", AppUtils.BigNumber.ZERO);
 
-                walletRepository.reindex(delegate);
+                walletRepository.index(delegate);
             }
         });
 
@@ -116,7 +116,7 @@ describe("API 2.0 - Delegates", () => {
             );
             const wallet: Contracts.State.Wallet = walletRepository.findByUsername("genesis_1");
             wallet.setAttribute("delegate.voteBalance", AppUtils.BigNumber.make(12500000000000000));
-            walletRepository.reindex(wallet);
+            walletRepository.index(wallet);
 
             const response = await api.request("GET", "delegates", { orderBy: "votes:desc" });
             expect(response).toBeSuccessfulResponse();
@@ -274,17 +274,17 @@ describe("API 2.0 - Delegates", () => {
             for (let i = 0; i < delegates.length; i++) {
                 const delegate = delegates[i];
                 delegate.setAttribute("delegate.voteBalance", AppUtils.BigNumber.ZERO);
-                walletRepository.reindex(delegate);
+                walletRepository.index(delegate);
             }
 
             // Give 2 delegates a vote weight
             const delegate1 = walletRepository.findByUsername("genesis_1");
             delegate1.setAttribute("delegate.voteBalance", AppUtils.BigNumber.make(10000000 * 1e8));
-            walletRepository.reindex(delegate1);
+            walletRepository.index(delegate1);
 
             const delegate2 = walletRepository.findByUsername("genesis_2");
             delegate2.setAttribute("delegate.voteBalance", AppUtils.BigNumber.make(10000000 * 1e8));
-            walletRepository.reindex(delegate2);
+            walletRepository.index(delegate2);
 
             const response = await api.request("POST", "delegates/search", {
                 approval: {
@@ -305,7 +305,7 @@ describe("API 2.0 - Delegates", () => {
             // Make sure all vote balances are at 0
             for (const delegate of walletRepository.allByUsername()) {
                 delegate.setAttribute("delegate.voteBalance", AppUtils.BigNumber.ZERO);
-                walletRepository.reindex(delegate);
+                walletRepository.index(delegate);
             }
         });
 
@@ -321,17 +321,17 @@ describe("API 2.0 - Delegates", () => {
             for (let i = 0; i < delegates.length; i++) {
                 const delegate = delegates[i];
                 delegate.setAttribute("delegate.voteBalance", AppUtils.BigNumber.ZERO);
-                walletRepository.reindex(delegate);
+                walletRepository.index(delegate);
             }
 
             // Give 2 delegates a vote weight
             const delegate1 = walletRepository.findByUsername("genesis_1");
             delegate1.setAttribute("delegate.voteBalance", AppUtils.BigNumber.make(10000000 * 1e8));
-            walletRepository.reindex(delegate1);
+            walletRepository.index(delegate1);
 
             const delegate2 = walletRepository.findByUsername("genesis_2");
             delegate2.setAttribute("delegate.voteBalance", AppUtils.BigNumber.make(5000000 * 1e8));
-            walletRepository.reindex(delegate2);
+            walletRepository.index(delegate2);
 
             const response = await api.request("POST", "delegates/search", {
                 approval: {
@@ -492,13 +492,13 @@ describe("API 2.0 - Delegates", () => {
             for (let i = 0; i < delegates.length; i++) {
                 const delegate = delegates[i];
                 delegate.setAttribute("delegate.producedBlocks", 0);
-                walletRepository.reindex(delegate);
+                walletRepository.index(delegate);
             }
 
             // Give 2 delegates a vote weight
             const delegate1 = walletRepository.findByUsername("genesis_1");
             delegate1.setAttribute("delegate.producedBlocks", delegate.producedBlocks);
-            walletRepository.reindex(delegate1);
+            walletRepository.index(delegate1);
 
             const response = await api.request("POST", "delegates/search", {
                 producedBlocks: {
@@ -548,13 +548,13 @@ describe("API 2.0 - Delegates", () => {
             for (let i = 0; i < delegates.length; i++) {
                 const delegate = delegates[i];
                 delegate.setAttribute("delegate.voteBalance", 0);
-                walletRepository.reindex(delegate);
+                walletRepository.index(delegate);
             }
 
             // Give 2 delegates a vote weight
             const delegate1 = walletRepository.findByUsername("genesis_1");
             delegate1.setAttribute("delegate.voteBalance", AppUtils.BigNumber.make(delegate.voteBalance));
-            walletRepository.reindex(delegate1);
+            walletRepository.index(delegate1);
 
             const response = await api.request("POST", "delegates/search", {
                 voteBalance: {

--- a/__tests__/integration/core-api/handlers/locks.test.ts
+++ b/__tests__/integration/core-api/handlers/locks.test.ts
@@ -56,7 +56,7 @@ describe("API 2.0 - Locks", () => {
 
             wallet.setAttribute("htlc.locks", locks);
 
-            walletRepository.reindex(wallet);
+            walletRepository.index(wallet);
         }
     });
 
@@ -201,7 +201,7 @@ describe("API 2.0 - Locks", () => {
 
         it("should POST a search for locks with the exact vendorField", async () => {
             const wallet = createWallet("secret", { vendorField: "HTLC" });
-            walletRepository.reindex(wallet);
+            walletRepository.index(wallet);
 
             const response = await api.request("POST", "locks/search", {
                 vendorField: "HTLC",
@@ -219,7 +219,7 @@ describe("API 2.0 - Locks", () => {
 
         it("should POST a search for locks within the timestamp range", async () => {
             const wallet = createWallet("secret", { timestamp: 5000 });
-            walletRepository.reindex(wallet);
+            walletRepository.index(wallet);
 
             const response = await api.request("POST", "locks/search", {
                 timestamp: {

--- a/__tests__/integration/core-api/handlers/wallets.test.ts
+++ b/__tests__/integration/core-api/handlers/wallets.test.ts
@@ -389,13 +389,13 @@ describe("API 2.0 - Wallets", () => {
             for (let i = 0; i < delegates.length; i++) {
                 const delegate = delegates[i];
                 delegate.setAttribute("delegate.voteBalance", Utils.BigNumber.ZERO);
-                walletRepository.reindex(delegate);
+                walletRepository.index(delegate);
             }
 
             // Give 2 delegates a vote weight
             const delegate1 = walletRepository.findByUsername("genesis_1");
             delegate1.setAttribute("delegate.voteBalance", Utils.BigNumber.make(balance));
-            walletRepository.reindex(delegate1);
+            walletRepository.index(delegate1);
 
             const response = await api.request("POST", "wallets/search", {
                 address,

--- a/__tests__/unit/core-transactions/handlers/one/multi-signature-registration.test.ts
+++ b/__tests__/unit/core-transactions/handlers/one/multi-signature-registration.test.ts
@@ -63,10 +63,10 @@ beforeEach(() => {
     multiSignatureWallet = buildMultiSignatureWallet();
     recipientWallet = buildRecipientWallet(factoryBuilder);
 
-    walletRepository.reindex(senderWallet);
-    walletRepository.reindex(secondSignatureWallet);
-    walletRepository.reindex(multiSignatureWallet);
-    walletRepository.reindex(recipientWallet);
+    walletRepository.index(senderWallet);
+    walletRepository.index(secondSignatureWallet);
+    walletRepository.index(multiSignatureWallet);
+    walletRepository.index(recipientWallet);
 });
 
 describe("MultiSignatureRegistrationTransaction", () => {
@@ -92,7 +92,7 @@ describe("MultiSignatureRegistrationTransaction", () => {
 
         recipientWallet = new Wallets.Wallet(Identities.Address.fromMultiSignatureAsset(multiSignatureAsset), new Services.Attributes.AttributeMap(getWalletAttributeSet()));
 
-        walletRepository.reindex(recipientWallet);
+        walletRepository.index(recipientWallet);
 
         multiSignatureTransaction = BuilderFactory.multiSignature()
             .version(1)

--- a/__tests__/unit/core-transactions/handlers/two/delegate-registration.test.ts
+++ b/__tests__/unit/core-transactions/handlers/two/delegate-registration.test.ts
@@ -64,10 +64,10 @@ beforeEach(() => {
     multiSignatureWallet = buildMultiSignatureWallet();
     recipientWallet = buildRecipientWallet(factoryBuilder);
 
-    walletRepository.reindex(senderWallet);
-    walletRepository.reindex(secondSignatureWallet);
-    walletRepository.reindex(multiSignatureWallet);
-    walletRepository.reindex(recipientWallet);
+    walletRepository.index(senderWallet);
+    walletRepository.index(secondSignatureWallet);
+    walletRepository.index(multiSignatureWallet);
+    walletRepository.index(recipientWallet);
 });
 
 describe("DelegateRegistrationTransaction", () => {
@@ -199,7 +199,7 @@ describe("DelegateRegistrationTransaction", () => {
 
             delegateWallet.setAttribute("delegate", { username: "dummy" });
 
-            walletRepository.reindex(delegateWallet);
+            walletRepository.index(delegateWallet);
 
             await expect(handler.throwIfCannotBeApplied(delegateRegistrationTransaction, senderWallet, walletRepository)).rejects.toThrow(
                 WalletUsernameAlreadyRegisteredError,
@@ -237,7 +237,7 @@ describe("DelegateRegistrationTransaction", () => {
 
             anotherWallet.balance = Utils.BigNumber.make(7527654310);
 
-            walletRepository.reindex(anotherWallet);
+            walletRepository.index(anotherWallet);
 
             let anotherDelegateRegistrationTransaction = BuilderFactory.delegateRegistration()
                 .usernameAsset("dummy")

--- a/__tests__/unit/core-transactions/handlers/two/delegate-resignation.test.ts
+++ b/__tests__/unit/core-transactions/handlers/two/delegate-resignation.test.ts
@@ -64,10 +64,10 @@ beforeEach(() => {
     multiSignatureWallet = buildMultiSignatureWallet();
     recipientWallet = buildRecipientWallet(factoryBuilder);
 
-    walletRepository.reindex(senderWallet);
-    walletRepository.reindex(secondSignatureWallet);
-    walletRepository.reindex(multiSignatureWallet);
-    walletRepository.reindex(recipientWallet);
+    walletRepository.index(senderWallet);
+    walletRepository.index(secondSignatureWallet);
+    walletRepository.index(multiSignatureWallet);
+    walletRepository.index(recipientWallet);
 });
 
 describe("DelegateResignationTransaction", () => {
@@ -97,7 +97,7 @@ describe("DelegateResignationTransaction", () => {
 
             delegateWallet.setAttribute("delegate", { username: "username" +  i } );
 
-            walletRepository.reindex(delegateWallet);
+            walletRepository.index(delegateWallet);
             allDelegates.push(delegateWallet);
         }
 
@@ -111,7 +111,7 @@ describe("DelegateResignationTransaction", () => {
 
         delegateWallet.balance = Utils.BigNumber.make(66 * 1e8);
         delegateWallet.setAttribute("delegate", {username: "dummy"});
-        walletRepository.reindex(delegateWallet);
+        walletRepository.index(delegateWallet);
 
         delegateResignationTransaction = BuilderFactory.delegateResignation()
             .nonce("1")
@@ -134,7 +134,7 @@ describe("DelegateResignationTransaction", () => {
         it("should resolve - simulate genesis wallet", async () => {
             allDelegates[0].forgetAttribute("delegate");
 
-            walletRepository.reindex(allDelegates[0]);
+            walletRepository.index(allDelegates[0]);
 
             setMockTransaction(delegateResignationTransaction);
             await expect(handler.bootstrap()).toResolve();
@@ -160,7 +160,7 @@ describe("DelegateResignationTransaction", () => {
 
         it("should not throw if wallet is a delegate - second sign", async () => {
             secondSignatureWallet.setAttribute("delegate", {username: "dummy"});
-            walletRepository.reindex(secondSignatureWallet);
+            walletRepository.index(secondSignatureWallet);
             await expect(handler.throwIfCannotBeApplied(secondSignatureDelegateResignationTransaction, secondSignatureWallet, walletRepository)).toResolve();
         });
 
@@ -174,7 +174,7 @@ describe("DelegateResignationTransaction", () => {
                 .make();
 
             anotherDelegate.setAttribute("delegate", {username: "another"});
-            walletRepository.reindex(anotherDelegate);
+            walletRepository.index(anotherDelegate);
 
             await expect(handler.throwIfCannotBeApplied(delegateResignationTransaction, delegateWallet, walletRepository)).toResolve();
         });

--- a/__tests__/unit/core-transactions/handlers/two/general.test.ts
+++ b/__tests__/unit/core-transactions/handlers/two/general.test.ts
@@ -62,10 +62,10 @@ beforeEach(() => {
     multiSignatureWallet = buildMultiSignatureWallet();
     recipientWallet = buildRecipientWallet(factoryBuilder);
 
-    walletRepository.reindex(senderWallet);
-    walletRepository.reindex(secondSignatureWallet);
-    walletRepository.reindex(multiSignatureWallet);
-    walletRepository.reindex(recipientWallet);
+    walletRepository.index(senderWallet);
+    walletRepository.index(secondSignatureWallet);
+    walletRepository.index(multiSignatureWallet);
+    walletRepository.index(recipientWallet);
 });
 
 describe("General Tests", () => {

--- a/__tests__/unit/core-transactions/handlers/two/htlc-claim.test.ts
+++ b/__tests__/unit/core-transactions/handlers/two/htlc-claim.test.ts
@@ -71,10 +71,10 @@ beforeEach(() => {
     multiSignatureWallet = buildMultiSignatureWallet();
     recipientWallet = buildRecipientWallet(factoryBuilder);
 
-    walletRepository.reindex(senderWallet);
-    walletRepository.reindex(secondSignatureWallet);
-    walletRepository.reindex(multiSignatureWallet);
-    walletRepository.reindex(recipientWallet);
+    walletRepository.index(senderWallet);
+    walletRepository.index(secondSignatureWallet);
+    walletRepository.index(multiSignatureWallet);
+    walletRepository.index(recipientWallet);
 });
 
 describe("Htlc claim", () => {
@@ -116,8 +116,8 @@ describe("Htlc claim", () => {
                 })
                 .make();
 
-            walletRepository.reindex(lockWallet);
-            walletRepository.reindex(claimWallet);
+            walletRepository.index(lockWallet);
+            walletRepository.index(claimWallet);
 
             let expiration = {
                 type: expirationType,
@@ -145,7 +145,7 @@ describe("Htlc claim", () => {
                 },
             });
 
-            walletRepository.reindex(lockWallet);
+            walletRepository.index(lockWallet);
 
             htlcClaimTransaction = BuilderFactory.htlcClaim()
                 .htlcClaimAsset({
@@ -238,7 +238,7 @@ describe("Htlc claim", () => {
                     })
                     .make();
 
-                walletRepository.reindex(dummyWallet);
+                walletRepository.index(dummyWallet);
 
                 htlcClaimTransaction = BuilderFactory.htlcClaim()
                     .htlcClaimAsset({
@@ -282,7 +282,7 @@ describe("Htlc claim", () => {
                     },
                 });
 
-                walletRepository.reindex(lockWallet);
+                walletRepository.index(lockWallet);
 
                 htlcClaimTransaction = BuilderFactory.htlcClaim()
                     .htlcClaimAsset({
@@ -390,7 +390,7 @@ describe("Htlc claim", () => {
                     })
                     .make();
 
-                walletRepository.reindex(dummyWallet);
+                walletRepository.index(dummyWallet);
 
                 htlcClaimTransaction = BuilderFactory.htlcClaim()
                     .htlcClaimAsset({

--- a/__tests__/unit/core-transactions/handlers/two/htlc-lock.test.ts
+++ b/__tests__/unit/core-transactions/handlers/two/htlc-lock.test.ts
@@ -64,10 +64,10 @@ beforeEach(() => {
     multiSignatureWallet = buildMultiSignatureWallet();
     recipientWallet = buildRecipientWallet(factoryBuilder);
 
-    walletRepository.reindex(senderWallet);
-    walletRepository.reindex(secondSignatureWallet);
-    walletRepository.reindex(multiSignatureWallet);
-    walletRepository.reindex(recipientWallet);
+    walletRepository.index(senderWallet);
+    walletRepository.index(secondSignatureWallet);
+    walletRepository.index(multiSignatureWallet);
+    walletRepository.index(recipientWallet);
 });
 
 describe("Htlc lock", () => {

--- a/__tests__/unit/core-transactions/handlers/two/htlc-refund.test.ts
+++ b/__tests__/unit/core-transactions/handlers/two/htlc-refund.test.ts
@@ -67,10 +67,10 @@ beforeEach(() => {
     multiSignatureWallet = buildMultiSignatureWallet();
     recipientWallet = buildRecipientWallet(factoryBuilder);
 
-    walletRepository.reindex(senderWallet);
-    walletRepository.reindex(secondSignatureWallet);
-    walletRepository.reindex(multiSignatureWallet);
-    walletRepository.reindex(recipientWallet);
+    walletRepository.index(senderWallet);
+    walletRepository.index(secondSignatureWallet);
+    walletRepository.index(multiSignatureWallet);
+    walletRepository.index(recipientWallet);
 });
 
 describe("Htlc refund", () => {
@@ -99,7 +99,7 @@ describe("Htlc refund", () => {
                 })
                 .make();
 
-            walletRepository.reindex(lockWallet);
+            walletRepository.index(lockWallet);
 
             const amount = 6 * 1e8;
             let expiration = {
@@ -129,7 +129,7 @@ describe("Htlc refund", () => {
                 },
             });
 
-            walletRepository.reindex(lockWallet);
+            walletRepository.index(lockWallet);
 
             htlcRefundTransaction = BuilderFactory.htlcRefund()
                 .htlcRefundAsset({
@@ -204,7 +204,7 @@ describe("Htlc refund", () => {
                     })
                     .make();
 
-                walletRepository.reindex(dummyWallet);
+                walletRepository.index(dummyWallet);
 
                 htlcRefundTransaction = BuilderFactory.htlcRefund()
                     .htlcRefundAsset({
@@ -245,7 +245,7 @@ describe("Htlc refund", () => {
                     },
                 });
 
-                walletRepository.reindex(lockWallet);
+                walletRepository.index(lockWallet);
 
                 htlcRefundTransaction = BuilderFactory.htlcRefund()
                     .htlcRefundAsset({
@@ -299,7 +299,7 @@ describe("Htlc refund", () => {
                     },
                 });
 
-                walletRepository.reindex(lockWallet);
+                walletRepository.index(lockWallet);
 
                 await expect(handler.throwIfCannotEnterPool(htlcRefundTransaction)).rejects.toThrow(Contracts.TransactionPool.PoolError);
             });
@@ -350,7 +350,7 @@ describe("Htlc refund", () => {
                     })
                     .make();
 
-                walletRepository.reindex(dummyWallet);
+                walletRepository.index(dummyWallet);
 
                 htlcRefundTransaction = BuilderFactory.htlcRefund()
                     .htlcRefundAsset({

--- a/__tests__/unit/core-transactions/handlers/two/ipfs.test.ts
+++ b/__tests__/unit/core-transactions/handlers/two/ipfs.test.ts
@@ -59,10 +59,10 @@ beforeEach(() => {
     multiSignatureWallet = buildMultiSignatureWallet();
     recipientWallet = buildRecipientWallet(factoryBuilder);
 
-    walletRepository.reindex(senderWallet);
-    walletRepository.reindex(secondSignatureWallet);
-    walletRepository.reindex(multiSignatureWallet);
-    walletRepository.reindex(recipientWallet);
+    walletRepository.index(senderWallet);
+    walletRepository.index(secondSignatureWallet);
+    walletRepository.index(multiSignatureWallet);
+    walletRepository.index(recipientWallet);
 });
 
 describe("Ipfs", () => {

--- a/__tests__/unit/core-transactions/handlers/two/multi-payment.test.ts
+++ b/__tests__/unit/core-transactions/handlers/two/multi-payment.test.ts
@@ -58,10 +58,10 @@ beforeEach(() => {
     multiSignatureWallet = buildMultiSignatureWallet();
     recipientWallet = buildRecipientWallet(factoryBuilder);
 
-    walletRepository.reindex(senderWallet);
-    walletRepository.reindex(secondSignatureWallet);
-    walletRepository.reindex(multiSignatureWallet);
-    walletRepository.reindex(recipientWallet);
+    walletRepository.index(senderWallet);
+    walletRepository.index(secondSignatureWallet);
+    walletRepository.index(multiSignatureWallet);
+    walletRepository.index(recipientWallet);
 });
 
 describe("MultiPaymentTransaction", () => {

--- a/__tests__/unit/core-transactions/handlers/two/multi-signature-registration.test.ts
+++ b/__tests__/unit/core-transactions/handlers/two/multi-signature-registration.test.ts
@@ -63,9 +63,9 @@ beforeEach(() => {
     secondSignatureWallet = buildSecondSignatureWallet(factoryBuilder);
     recipientWallet = buildRecipientWallet(factoryBuilder);
 
-    walletRepository.reindex(senderWallet);
-    walletRepository.reindex(secondSignatureWallet);
-    walletRepository.reindex(recipientWallet);
+    walletRepository.index(senderWallet);
+    walletRepository.index(secondSignatureWallet);
+    walletRepository.index(recipientWallet);
 });
 
 describe("MultiSignatureRegistrationTransaction", () => {
@@ -91,7 +91,7 @@ describe("MultiSignatureRegistrationTransaction", () => {
 
         recipientWallet = new Wallets.Wallet(Identities.Address.fromMultiSignatureAsset(multiSignatureAsset), new Services.Attributes.AttributeMap(getWalletAttributeSet()));
 
-        walletRepository.reindex(recipientWallet);
+        walletRepository.index(recipientWallet);
 
         multiSignatureTransaction = BuilderFactory.multiSignature()
             .multiSignatureAsset(multiSignatureAsset)

--- a/__tests__/unit/core-transactions/handlers/two/second-signature-registration.test.ts
+++ b/__tests__/unit/core-transactions/handlers/two/second-signature-registration.test.ts
@@ -62,10 +62,10 @@ beforeEach(() => {
     multiSignatureWallet = buildMultiSignatureWallet();
     recipientWallet = buildRecipientWallet(factoryBuilder);
 
-    walletRepository.reindex(senderWallet);
-    walletRepository.reindex(secondSignatureWallet);
-    walletRepository.reindex(multiSignatureWallet);
-    walletRepository.reindex(recipientWallet);
+    walletRepository.index(senderWallet);
+    walletRepository.index(secondSignatureWallet);
+    walletRepository.index(multiSignatureWallet);
+    walletRepository.index(recipientWallet);
 });
 
 describe("SecondSignatureRegistrationTransaction", () => {

--- a/__tests__/unit/core-transactions/handlers/two/transfer.test.ts
+++ b/__tests__/unit/core-transactions/handlers/two/transfer.test.ts
@@ -62,10 +62,10 @@ beforeEach(() => {
     multiSignatureWallet = buildMultiSignatureWallet();
     recipientWallet = buildRecipientWallet(factoryBuilder);
 
-    walletRepository.reindex(senderWallet);
-    walletRepository.reindex(secondSignatureWallet);
-    walletRepository.reindex(multiSignatureWallet);
-    walletRepository.reindex(recipientWallet);
+    walletRepository.index(senderWallet);
+    walletRepository.index(secondSignatureWallet);
+    walletRepository.index(multiSignatureWallet);
+    walletRepository.index(recipientWallet);
 });
 
 describe("TransferTransaction", () => {

--- a/__tests__/unit/core-transactions/handlers/two/vote.test.ts
+++ b/__tests__/unit/core-transactions/handlers/two/vote.test.ts
@@ -62,10 +62,10 @@ beforeEach(() => {
     multiSignatureWallet = buildMultiSignatureWallet();
     recipientWallet = buildRecipientWallet(factoryBuilder);
 
-    walletRepository.reindex(senderWallet);
-    walletRepository.reindex(secondSignatureWallet);
-    walletRepository.reindex(multiSignatureWallet);
-    walletRepository.reindex(recipientWallet);
+    walletRepository.index(senderWallet);
+    walletRepository.index(secondSignatureWallet);
+    walletRepository.index(multiSignatureWallet);
+    walletRepository.index(recipientWallet);
 });
 
 describe("VoteTransaction", () => {
@@ -92,7 +92,7 @@ describe("VoteTransaction", () => {
 
         delegateWallet.setAttribute("delegate", { username: "test" });
 
-        walletRepository.reindex(delegateWallet);
+        walletRepository.index(delegateWallet);
 
         voteTransaction = BuilderFactory.vote()
             .votesAsset(["+" + delegateWallet.publicKey!])
@@ -219,7 +219,7 @@ describe("VoteTransaction", () => {
 
         it("should throw if vote for non delegate wallet", async () => {
             delegateWallet.forgetAttribute("delegate");
-            walletRepository.reindex(delegateWallet);
+            walletRepository.index(delegateWallet);
             await expect(handler.throwIfCannotBeApplied(voteTransaction, senderWallet, walletRepository)).rejects.toThrow(
                 VotedForNonDelegateError,
             );

--- a/packages/core-kernel/src/contracts/state/wallets.ts
+++ b/packages/core-kernel/src/contracts/state/wallets.ts
@@ -176,9 +176,7 @@ export interface WalletRepository {
 
     getNonce(publicKey: string): Utils.BigNumber;
 
-    index(wallets: ReadonlyArray<Wallet>): void;
-
-    reindex(wallet: Wallet): void;
+    index(wallets: Wallet | ReadonlyArray<Wallet>): void;
 
     forgetByAddress(address: string): void;
 

--- a/packages/core-magistrate-transactions/src/handlers/bridgechain-registration.ts
+++ b/packages/core-magistrate-transactions/src/handlers/bridgechain-registration.ts
@@ -54,7 +54,7 @@ export class BridgechainRegistrationTransactionHandler extends MagistrateTransac
             };
 
             wallet.setAttribute<IBusinessWalletAttributes>("business", businessAttributes);
-            this.walletRepository.reindex(wallet);
+            this.walletRepository.index(wallet);
         }
     }
 
@@ -159,7 +159,7 @@ export class BridgechainRegistrationTransactionHandler extends MagistrateTransac
         };
 
         sender.setAttribute<IBusinessWalletAttributes>("business", businessAttributes);
-        walletRepository.reindex(sender);
+        walletRepository.index(sender);
     }
 
     public async revertForSender(
@@ -186,7 +186,7 @@ export class BridgechainRegistrationTransactionHandler extends MagistrateTransac
 
         delete businessAttributes.bridgechains[bridgechainId];
 
-        walletRepository.reindex(sender);
+        walletRepository.index(sender);
     }
 
     public async applyToRecipient(

--- a/packages/core-magistrate-transactions/src/handlers/bridgechain-resignation.ts
+++ b/packages/core-magistrate-transactions/src/handlers/bridgechain-resignation.ts
@@ -49,7 +49,7 @@ export class BridgechainResignationTransactionHandler extends MagistrateTransact
             bridgechainAsset.resigned = true;
 
             wallet.setAttribute<IBusinessWalletAttributes>("business", businessAttributes);
-            this.walletRepository.reindex(wallet);
+            this.walletRepository.index(wallet);
         }
     }
 

--- a/packages/core-magistrate-transactions/src/handlers/bridgechain-update.ts
+++ b/packages/core-magistrate-transactions/src/handlers/bridgechain-update.ts
@@ -57,7 +57,7 @@ export class BridgechainUpdateTransactionHandler extends MagistrateTransactionHa
                 ...shallowCloneBridgechainUpdate,
             };
 
-            this.walletRepository.reindex(wallet);
+            this.walletRepository.index(wallet);
         }
     }
 
@@ -165,7 +165,7 @@ export class BridgechainUpdateTransactionHandler extends MagistrateTransactionHa
             ...shallowCloneBridgechainUpdate,
         };
 
-        walletRepository.reindex(wallet);
+        walletRepository.index(wallet);
     }
 
     public async revertForSender(
@@ -265,7 +265,7 @@ export class BridgechainUpdateTransactionHandler extends MagistrateTransactionHa
         Utils.assert.defined<object>(businessAttributes.bridgechains);
         businessAttributes.bridgechains[bridgechainId] = { bridgechainAsset };
 
-        walletRepository.reindex(sender);
+        walletRepository.index(sender);
     }
 
     public async applyToRecipient(

--- a/packages/core-magistrate-transactions/src/handlers/business-registration.ts
+++ b/packages/core-magistrate-transactions/src/handlers/business-registration.ts
@@ -47,7 +47,7 @@ export class BusinessRegistrationTransactionHandler extends MagistrateTransactio
             };
 
             wallet.setAttribute<IBusinessWalletAttributes>("business", asset);
-            this.walletRepository.reindex(wallet);
+            this.walletRepository.index(wallet);
         }
     }
 
@@ -104,7 +104,7 @@ export class BusinessRegistrationTransactionHandler extends MagistrateTransactio
             businessAsset: transaction.data.asset.businessRegistration,
         });
 
-        walletRepository.reindex(sender);
+        walletRepository.index(sender);
     }
 
     public async revertForSender(

--- a/packages/core-magistrate-transactions/src/handlers/business-resignation.ts
+++ b/packages/core-magistrate-transactions/src/handlers/business-resignation.ts
@@ -34,7 +34,7 @@ export class BusinessResignationTransactionHandler extends MagistrateTransaction
         for (const transaction of transactions) {
             const wallet: Contracts.State.Wallet = this.walletRepository.findByPublicKey(transaction.senderPublicKey);
             wallet.setAttribute("business.resigned", true);
-            this.walletRepository.reindex(wallet);
+            this.walletRepository.index(wallet);
         }
     }
 
@@ -88,7 +88,7 @@ export class BusinessResignationTransactionHandler extends MagistrateTransaction
         const sender: Contracts.State.Wallet = walletRepository.findByPublicKey(transaction.data.senderPublicKey);
 
         sender.setAttribute("business.resigned", true);
-        walletRepository.reindex(sender);
+        walletRepository.index(sender);
     }
 
     public async revertForSender(
@@ -104,7 +104,7 @@ export class BusinessResignationTransactionHandler extends MagistrateTransaction
         const sender: Contracts.State.Wallet = walletRepository.findByPublicKey(transaction.data.senderPublicKey);
 
         sender.forgetAttribute("business.resigned");
-        walletRepository.reindex(sender);
+        walletRepository.index(sender);
     }
 
     public async applyToRecipient(

--- a/packages/core-state/src/block-state.ts
+++ b/packages/core-state/src/block-state.ts
@@ -370,6 +370,6 @@ export class BlockState {
         const generatorAddress = Identities.Address.fromPublicKey(generatorPublicKey);
         const generatorWallet = this.walletRepository.createWallet(generatorAddress);
         generatorWallet.publicKey = generatorPublicKey;
-        this.walletRepository.reindex(generatorWallet);
+        this.walletRepository.index(generatorWallet);
     }
 }

--- a/packages/core-state/src/wallets/wallet-repository-clone.ts
+++ b/packages/core-state/src/wallets/wallet-repository-clone.ts
@@ -15,7 +15,7 @@ export class WalletRepositoryClone extends WalletRepository {
         }
     }
 
-    public reindex(wallet: Contracts.State.Wallet): void {
-        super.reindex(wallet.clone());
+    public index(wallet: Contracts.State.Wallet): void {
+        super.index(wallet.clone());
     }
 }

--- a/packages/core-state/src/wallets/wallet-repository-copy-on-write.ts
+++ b/packages/core-state/src/wallets/wallet-repository-copy-on-write.ts
@@ -15,7 +15,7 @@ export class WalletRepositoryCopyOnWrite extends WalletRepository {
     public findByAddress(address: string): Contracts.State.Wallet {
         if (address && !this.hasByAddress(address)) {
             const walletClone = this.blockchainWalletRepository.findByAddress(address).clone();
-            this.reindex(walletClone);
+            this.index(walletClone);
         }
         return this.findByIndex(Contracts.State.WalletIndexes.Addresses, address)!;
     }
@@ -28,14 +28,14 @@ export class WalletRepositoryCopyOnWrite extends WalletRepository {
             return false;
         }
         const walletClone = this.blockchainWalletRepository.findByIndex(index, key).clone();
-        this.reindex(walletClone);
+        this.index(walletClone);
         return true;
     }
 
     public allByUsername(): ReadonlyArray<Contracts.State.Wallet> {
         for (const wallet of this.blockchainWalletRepository.allByUsername()) {
             if (super.hasByAddress(wallet.address) === false) {
-                this.reindex(wallet.clone());
+                this.index(wallet.clone());
             }
         }
         return super.allByUsername();

--- a/packages/core-state/src/wallets/wallet-repository.ts
+++ b/packages/core-state/src/wallets/wallet-repository.ts
@@ -142,15 +142,13 @@ export class WalletRepository implements Contracts.State.WalletRepository {
         this.getIndex(indexName).forget(key);
     }
 
-    public index(wallets: ReadonlyArray<Contracts.State.Wallet>): void {
-        for (const wallet of wallets) {
-            this.reindex(wallet);
-        }
-    }
-
-    public reindex(wallet: Contracts.State.Wallet): void {
-        for (const walletIndex of Object.values(this.indexes)) {
-            walletIndex.index(wallet);
+    public index(wallets: Contracts.State.Wallet | ReadonlyArray<Contracts.State.Wallet>): void {
+        if (!Array.isArray(wallets)) {
+            this.indexWallet(wallets as Contracts.State.Wallet);
+        } else {
+            for (const wallet of wallets) {
+                this.indexWallet(wallet);
+            }
         }
     }
 
@@ -228,6 +226,12 @@ export class WalletRepository implements Contracts.State.WalletRepository {
         params: Record<string, any> = {},
     ): Contracts.State.RowsPaginated<Contracts.State.Wallet> {
         return this.search(scope, { ...params, ...{ orderBy: "balance:desc" } });
+    }
+
+    private indexWallet(wallet: Contracts.State.Wallet): void {
+        for (const walletIndex of Object.values(this.indexes)) {
+            walletIndex.index(wallet);
+        }
     }
 
     private searchWallets(

--- a/packages/core-transactions/src/handlers/one/delegate-registration.ts
+++ b/packages/core-transactions/src/handlers/one/delegate-registration.ts
@@ -137,7 +137,7 @@ export class DelegateRegistrationTransactionHandler extends TransactionHandler {
             round: 0,
         });
 
-        walletRepository.reindex(sender);
+        walletRepository.index(sender);
     }
 
     public async revertForSender(

--- a/packages/core-transactions/src/handlers/one/multi-signature-registration.ts
+++ b/packages/core-transactions/src/handlers/one/multi-signature-registration.ts
@@ -36,7 +36,7 @@ export class MultiSignatureRegistrationTransactionHandler extends TransactionHan
             }
 
             wallet.setAttribute("multiSignature", multiSignature);
-            this.walletRepository.reindex(wallet);
+            this.walletRepository.index(wallet);
         }
     }
 

--- a/packages/core-transactions/src/handlers/two/delegate-registration.ts
+++ b/packages/core-transactions/src/handlers/two/delegate-registration.ts
@@ -27,7 +27,7 @@ export class DelegateRegistrationTransactionHandler extends One.DelegateRegistra
                 rank: undefined,
             });
 
-            this.walletRepository.reindex(wallet);
+            this.walletRepository.index(wallet);
         }
 
         const forgedBlocks = await this.blockRepository.getDelegatesForgedBlocks();

--- a/packages/core-transactions/src/handlers/two/delegate-resignation.ts
+++ b/packages/core-transactions/src/handlers/two/delegate-resignation.ts
@@ -32,7 +32,7 @@ export class DelegateResignationTransactionHandler extends TransactionHandler {
         for (const transaction of transactions) {
             const wallet: Contracts.State.Wallet = this.walletRepository.findByPublicKey(transaction.senderPublicKey);
             wallet.setAttribute("delegate.resigned", true);
-            this.walletRepository.reindex(wallet);
+            this.walletRepository.index(wallet);
         }
     }
     public async isActivated(): Promise<boolean> {
@@ -101,7 +101,7 @@ export class DelegateResignationTransactionHandler extends TransactionHandler {
         const senderWallet: Contracts.State.Wallet = walletRepository.findByPublicKey(transaction.data.senderPublicKey);
 
         senderWallet.setAttribute("delegate.resigned", true);
-        walletRepository.reindex(senderWallet);
+        walletRepository.index(senderWallet);
     }
 
     public async revertForSender(

--- a/packages/core-transactions/src/handlers/two/htlc-claim.ts
+++ b/packages/core-transactions/src/handlers/two/htlc-claim.ts
@@ -165,9 +165,9 @@ export class HtlcClaimTransactionHandler extends TransactionHandler {
 
         delete locks[lockId];
 
-        walletRepository.reindex(sender);
-        walletRepository.reindex(lockWallet);
-        walletRepository.reindex(recipientWallet);
+        walletRepository.index(sender);
+        walletRepository.index(lockWallet);
+        walletRepository.index(recipientWallet);
     }
 
     public async revertForSender(
@@ -220,9 +220,9 @@ export class HtlcClaimTransactionHandler extends TransactionHandler {
             ...lockTransaction.asset.lock,
         };
 
-        walletRepository.reindex(sender);
-        walletRepository.reindex(lockWallet);
-        walletRepository.reindex(recipientWallet);
+        walletRepository.index(sender);
+        walletRepository.index(lockWallet);
+        walletRepository.index(recipientWallet);
     }
 
     public async applyToRecipient(

--- a/packages/core-transactions/src/handlers/two/htlc-lock.ts
+++ b/packages/core-transactions/src/handlers/two/htlc-lock.ts
@@ -105,7 +105,7 @@ export class HtlcLockTransactionHandler extends TransactionHandler {
         const lockedBalance = sender.getAttribute<Utils.BigNumber>("htlc.lockedBalance", Utils.BigNumber.ZERO);
         sender.setAttribute("htlc.lockedBalance", lockedBalance.plus(transaction.data.amount));
 
-        walletRepository.reindex(sender);
+        walletRepository.index(sender);
     }
 
     public async revertForSender(
@@ -121,7 +121,7 @@ export class HtlcLockTransactionHandler extends TransactionHandler {
         const lockedBalance = sender.getAttribute<Utils.BigNumber>("htlc.lockedBalance", Utils.BigNumber.ZERO);
         sender.setAttribute("htlc.lockedBalance", lockedBalance.minus(transaction.data.amount));
 
-        walletRepository.reindex(sender);
+        walletRepository.index(sender);
     }
 
     public async applyToRecipient(
@@ -149,7 +149,7 @@ export class HtlcLockTransactionHandler extends TransactionHandler {
         };
         sender.setAttribute("htlc.locks", locks);
 
-        walletRepository.reindex(sender);
+        walletRepository.index(sender);
     }
 
     public async revertForRecipient(
@@ -165,6 +165,6 @@ export class HtlcLockTransactionHandler extends TransactionHandler {
         delete locks[transaction.id];
         sender.setAttribute("htlc.locks", locks);
 
-        walletRepository.reindex(sender);
+        walletRepository.index(sender);
     }
 }

--- a/packages/core-transactions/src/handlers/two/htlc-refund.ts
+++ b/packages/core-transactions/src/handlers/two/htlc-refund.ts
@@ -158,7 +158,7 @@ export class HtlcRefundTransactionHandler extends TransactionHandler {
 
         delete locks[lockId];
 
-        walletRepository.reindex(lockWallet);
+        walletRepository.index(lockWallet);
     }
 
     public async revertForSender(
@@ -208,7 +208,7 @@ export class HtlcRefundTransactionHandler extends TransactionHandler {
             };
         }
 
-        walletRepository.reindex(lockWallet);
+        walletRepository.index(lockWallet);
     }
 
     public async applyToRecipient(

--- a/packages/core-transactions/src/handlers/two/ipfs.ts
+++ b/packages/core-transactions/src/handlers/two/ipfs.ts
@@ -33,7 +33,7 @@ export class IpfsTransactionHandler extends TransactionHandler {
 
             const ipfsHashes: Contracts.State.WalletIpfsAttributes = wallet.getAttribute("ipfs.hashes");
             ipfsHashes[transaction.asset.ipfs!] = true;
-            this.walletRepository.reindex(wallet);
+            this.walletRepository.index(wallet);
         }
     }
 
@@ -78,7 +78,7 @@ export class IpfsTransactionHandler extends TransactionHandler {
 
         sender.getAttribute("ipfs.hashes", {})[transaction.data.asset.ipfs] = true;
 
-        walletRepository.reindex(sender);
+        walletRepository.index(sender);
     }
 
     public async revertForSender(
@@ -102,7 +102,7 @@ export class IpfsTransactionHandler extends TransactionHandler {
             sender.forgetAttribute("ipfs");
         }
 
-        walletRepository.reindex(sender);
+        walletRepository.index(sender);
     }
 
     public async applyToRecipient(

--- a/packages/core-transactions/src/handlers/two/multi-signature-registration.ts
+++ b/packages/core-transactions/src/handlers/two/multi-signature-registration.ts
@@ -42,7 +42,7 @@ export class MultiSignatureRegistrationTransactionHandler extends TransactionHan
             }
 
             wallet.setAttribute("multiSignature", multiSignature);
-            this.walletRepository.reindex(wallet);
+            this.walletRepository.index(wallet);
         }
     }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

Condense `index` and `reindex` into one method.

<!-- Why are these changes necessary? -->

Only one index method means the naming is better. Smaller API (public methods on class) = simpler code.

<!-- How were these changes implemented? -->

The index and reindex methods were condensed into one method - index, which accepts either a wallet or an array of wallets.

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
