### PR TITLE
fix(core): jemalloc compatibility for ubuntu 16.04

### DIFF
--- a/packages/core/bin/run
+++ b/packages/core/bin/run
@@ -3,7 +3,7 @@
 try {
     const child_process = require('child_process')
 
-    const jemallocPath = child_process.spawnSync('whereis libjemalloc | xargs -n1 | grep libjemalloc.so', { shell: true }).stdout.toString().split('\n').shift().trim()
+    const jemallocPath = child_process.spawnSync(`ls -d1H $(gcc -print-search-dirs | grep libraries: | awk '{print $2}' | sed -e 's/:/* /g' -e 's/$/*/' -e 's/^.//') | grep libjemalloc.so`, { shell: true }).stdout.toString().split('\n').shift().trim()
 
     if (jemallocPath) {
         if (process.env.LD_PRELOAD !== jemallocPath) {


### PR DESCRIPTION
## Summary

@geopsllc reported that Core couldn't find libjemalloc on Ubuntu 16.04.

I reproduced this and it seems `whereis` in Ubuntu 16.04 doesn't traverse `/usr/lib/{architecture}/` to find binaries, whereas 18.04's version does. Since the package manager installs libjemalloc to that directory, Core doesn't find it on 16.04 even when it is properly installed.

Replaced `whereis` with output from `gcc --print-search-dirs` which now also works on 16.04 as well as the others (since `gcc` is always installed as part of the Core installation).

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
