### PR TITLE
chore: remove core-utils package

### DIFF
--- a/packages/core-kernel/src/utils/expiration-calculator.ts
+++ b/packages/core-kernel/src/utils/expiration-calculator.ts
@@ -43,10 +43,6 @@ export const calculateTransactionExpiration = (
 export const calculateLockExpirationStatus = (
     lastBlock: Interfaces.IBlock,
     expiration: Interfaces.IHtlcExpiration,
-): boolean => {
-    return (
-        (expiration.type === Enums.HtlcLockExpirationType.EpochTimestamp &&
-            expiration.value <= lastBlock.data.timestamp) ||
-        (expiration.type === Enums.HtlcLockExpirationType.BlockHeight && expiration.value <= lastBlock.data.height)
-    );
-};
+): boolean =>
+    (expiration.type === Enums.HtlcLockExpirationType.EpochTimestamp && expiration.value <= lastBlock.data.timestamp) ||
+    (expiration.type === Enums.HtlcLockExpirationType.BlockHeight && expiration.value <= lastBlock.data.height);

--- a/packages/core-utils/src/lock-expiration-calculator.ts
+++ b/packages/core-utils/src/lock-expiration-calculator.ts
@@ -1,8 +1,0 @@
-import { Enums, Interfaces } from "@arkecosystem/crypto";
-
-export const calculateLockExpirationStatus = (
-    lastBlock: Interfaces.IBlock,
-    expiration: Interfaces.IHtlcExpiration,
-): boolean =>
-    (expiration.type === Enums.HtlcLockExpirationType.EpochTimestamp && expiration.value <= lastBlock.data.timestamp) ||
-    (expiration.type === Enums.HtlcLockExpirationType.BlockHeight && expiration.value <= lastBlock.data.height);


### PR DESCRIPTION
Must've slipped in during the merge of 2.6