### PR TITLE
fix(core-transaction-pool): always apply to sender wallet on acceptChainedBlock

### DIFF
--- a/__tests__/integration/core-transaction-pool/processor.test.ts
+++ b/__tests__/integration/core-transaction-pool/processor.test.ts
@@ -100,6 +100,7 @@ describe("Transaction Guard", () => {
 
             const transaction = TransactionFactory.transfer(walletGen.address, 2 * 100000000)
                 .withNetwork("unitnet")
+                .withNonce(wallet.nonce.plus(1))
                 .withPassphrase(walletGen.passphrase)
                 .build()[0];
 


### PR DESCRIPTION
Currently, when a node syncs from genesis, not all transactions are applied to the relevant sender wallets in the transaction pool's `acceptChainedBlock`.

This causes issues where the pool wallet state becomes inconsistent with the database wallet state.

By guaranteeing that the sender wallet is always set, the transactions are always properly applied to the relevant wallets on `acceptChainedBlock`, and the state & db wallets remain in sync.