### PR TITLE
refactor(core-blockchain): reset missedBlocks before await call

### DIFF
--- a/packages/core-blockchain/src/blockchain.ts
+++ b/packages/core-blockchain/src/blockchain.ts
@@ -575,13 +575,13 @@ export class Blockchain implements blockchain.IBlockchain {
             this.missedBlocks >= Managers.configManager.getMilestone().activeDelegates / 3 - 1 &&
             Math.random() <= 0.8
         ) {
+            this.missedBlocks = 0;
+
             const networkStatus = await this.p2p.getMonitor().checkNetworkHealth();
             if (networkStatus.forked) {
                 this.state.numberOfBlocksToRollback = networkStatus.blocksToRollback;
                 this.dispatch("FORK");
             }
-
-            this.missedBlocks = 0;
         }
     }
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
Reset missedBlocks before await call in checkMissingBlocks.
<!-- Why are these changes necessary? -->
Reason for that is the await call takes a bit of time, during which checkMissingBlocks can be called various times. If missedBlocks is not reset before it, we can end up calling this await checkNetworkHealth() a lot of times for nothing.
<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
