### PR TITLE
fix(core-forger): log warning when active delegates are under the required delegate count

### DIFF
--- a/__tests__/unit/core-forger/setup.ts
+++ b/__tests__/unit/core-forger/setup.ts
@@ -15,10 +15,12 @@ export const setup = async activeDelegates => {
 
     const error: jest.SpyInstance = jest.fn();
     const debug: jest.SpyInstance = jest.fn();
+    const warning: jest.SpyInstance = jest.fn();
 
     const logger = {
         error,
         debug,
+        warning,
     };
 
     sandbox.app.bind(Container.Identifiers.LogService).toConstantValue(logger);

--- a/packages/core-forger/src/delegate-tracker.ts
+++ b/packages/core-forger/src/delegate-tracker.ts
@@ -89,7 +89,11 @@ export class DelegateTracker {
 
         if (activeDelegates.length < delegatesCount) {
             return this.logger.warning(
-                `Tracker only has ${activeDelegates.length} active delegates from a required ${delegatesCount}`,
+                `Tracker only has ${Utils.pluralize(
+                    "active delegate",
+                    activeDelegates.length,
+                    true,
+                )} from a required ${delegatesCount}`,
             );
         }
 

--- a/packages/core-forger/src/delegate-tracker.ts
+++ b/packages/core-forger/src/delegate-tracker.ts
@@ -87,6 +87,12 @@ export class DelegateTracker {
             }
         }
 
+        if (activeDelegates.length < delegatesCount) {
+            return this.logger.warning(
+                `Tracker only has ${activeDelegates.length} active delegates from a required ${delegatesCount}`,
+            );
+        }
+
         // Determine Next Forger Usernames...
         this.logger.debug(
             `Next Forgers: ${JSON.stringify(


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

Log a warning in the `DelegateTracker`'s `handle` method when the number of active delegates is below the required delegate count.

<!-- Why are these changes necessary? -->

Without the total number of required delegates we are not able to accurately compute the next forgers.

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
