### PR TITLE
fix(core-blockchain): allow transition to fork from idle

### DIFF
--- a/packages/core-blockchain/src/blockchain.ts
+++ b/packages/core-blockchain/src/blockchain.ts
@@ -63,6 +63,7 @@ export class Blockchain implements blockchain.IBlockchain {
     protected blockProcessor: BlockProcessor;
     private actions: any;
     private missedBlocks: number = 0;
+    private lastCheckNetworkHealthTs: number = 0;
 
     /**
      * Create a new blockchain manager instance.
@@ -576,6 +577,13 @@ export class Blockchain implements blockchain.IBlockchain {
             Math.random() <= 0.8
         ) {
             this.missedBlocks = 0;
+
+            // do not check network health here more than every 10 minutes
+            const nowTs = Date.now();
+            if (nowTs - this.lastCheckNetworkHealthTs < 10 * 60 * 1000) {
+                return;
+            }
+            this.lastCheckNetworkHealthTs = nowTs;
 
             const networkStatus = await this.p2p.getMonitor().checkNetworkHealth();
             if (networkStatus.forked) {

--- a/packages/core-blockchain/src/machines/blockchain.ts
+++ b/packages/core-blockchain/src/machines/blockchain.ts
@@ -36,6 +36,7 @@ export const blockchainMachine: any = Machine({
                 WAKEUP: "syncWithNetwork",
                 NEWBLOCK: "newBlock",
                 STOP: "stopped",
+                FORK: "fork",
             },
         },
         newBlock: {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
Allow transition to fork from idle state, as the ForgerMissing event can be triggered while being idle.

Also implement a 10min delay between each potential checkNetworkHealth as when downloading blocks we can trigger a lot of ForgerMissing events.

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
