### PR TITLE
perf(core-transaction-pool): use tree memory structure to sort by fee and by sender nonce

### DIFF
--- a/__tests__/unit/core-utils/tree.test.ts
+++ b/__tests__/unit/core-utils/tree.test.ts
@@ -1,0 +1,178 @@
+import { Tree } from "@arkecosystem/core-utils/src/tree";
+import { Utils } from "@arkecosystem/crypto";
+
+describe("Tree", () => {
+    // using Bignumbers for the tests
+    const compareFunction = (a: Utils.BigNumber, b: Utils.BigNumber) => {
+        if (a.isGreaterThan(b)) {
+            return 1;
+        }
+        if (a.isLessThan(b)) {
+            return -1;
+        }
+        return 0;
+    };
+
+    describe("when tree is empty", () => {
+        it("should insert the first value in the root node of the tree", () => {
+            const tree = new Tree(compareFunction);
+            expect(tree.isEmpty()).toBeTrue();
+
+            const valueToInsert = Utils.BigNumber.make(33);
+            tree.insert(valueToInsert.toString(), valueToInsert);
+
+            expect(tree.isEmpty()).toBeFalse();
+
+            const expectedTree = {
+                values: { [valueToInsert.toString()]: valueToInsert },
+                lastValueAdded: valueToInsert,
+            };
+            expect(tree.toJSON()).toEqual(JSON.stringify(expectedTree, null, 2));
+        });
+
+        it("should do nothing when removing any value", () => {
+            const tree = new Tree(compareFunction);
+            const expectedTree = {
+                values: {},
+            };
+            expect(tree.toJSON()).toEqual(JSON.stringify(expectedTree, null, 2));
+
+            tree.remove("2", Utils.BigNumber.make(2));
+
+            expect(tree.toJSON()).toEqual(JSON.stringify(expectedTree, null, 2));
+        });
+    });
+
+    describe("when tree has one value", () => {
+        it("should get back to empty state when removing the only value", () => {
+            const tree = new Tree(compareFunction);
+            const expectedEmptyTree = {
+                values: {},
+            };
+            expect(tree.toJSON()).toEqual(JSON.stringify(expectedEmptyTree, null, 2));
+
+            const valueToAddAndRemove = Utils.BigNumber.make(2);
+            tree.insert(valueToAddAndRemove.toString(), valueToAddAndRemove);
+            const expectedTreeOneValue = {
+                values: { [valueToAddAndRemove.toString()]: valueToAddAndRemove },
+                lastValueAdded: valueToAddAndRemove,
+            };
+            expect(tree.toJSON()).toEqual(JSON.stringify(expectedTreeOneValue, null, 2));
+
+            tree.remove(valueToAddAndRemove.toString(), valueToAddAndRemove);
+
+            expect(tree.toJSON()).toEqual(JSON.stringify(expectedEmptyTree, null, 2));
+        });
+
+        it("should insert in the right node when the compare function returns more than zero", () => {
+            const tree = new Tree(compareFunction);
+
+            const rootValue = Utils.BigNumber.make(43);
+            tree.insert(rootValue.toString(), rootValue);
+            const expectedTreeOneValue = {
+                values: { [rootValue.toString()]: rootValue },
+                lastValueAdded: rootValue,
+            };
+            expect(tree.toJSON()).toEqual(JSON.stringify(expectedTreeOneValue, null, 2));
+
+            const valueGreaterThanRoot = Utils.BigNumber.make(44);
+            tree.insert(valueGreaterThanRoot.toString(), valueGreaterThanRoot);
+            const expectedTreeTwoValues = {
+                values: { [rootValue.toString()]: rootValue },
+                lastValueAdded: rootValue,
+                right: {
+                    values: { [valueGreaterThanRoot.toString()]: valueGreaterThanRoot },
+                    lastValueAdded: valueGreaterThanRoot,
+                    parent: rootValue.toString(),
+                },
+            };
+            expect(tree.toJSON()).toEqual(JSON.stringify(expectedTreeTwoValues, null, 2));
+        });
+
+        it("should insert in the left node when the compare function returns less than zero", () => {
+            const tree = new Tree(compareFunction);
+
+            const rootValue = Utils.BigNumber.make(43);
+            tree.insert(rootValue.toString(), rootValue);
+            const expectedTreeOneValue = {
+                values: { [rootValue.toString()]: rootValue },
+                lastValueAdded: rootValue,
+            };
+            expect(tree.toJSON()).toEqual(JSON.stringify(expectedTreeOneValue, null, 2));
+
+            const valueLessThanRoot = Utils.BigNumber.make(42);
+            tree.insert(valueLessThanRoot.toString(), valueLessThanRoot);
+            const expectedTreeTwoValues = {
+                values: { [rootValue.toString()]: rootValue },
+                lastValueAdded: rootValue,
+                left: {
+                    values: { [valueLessThanRoot.toString()]: valueLessThanRoot },
+                    lastValueAdded: valueLessThanRoot,
+                    parent: rootValue.toString(),
+                },
+            };
+            expect(tree.toJSON()).toEqual(JSON.stringify(expectedTreeTwoValues, null, 2));
+        });
+
+        it("should insert in the same node when the compare function returns zero", () => {
+            const tree = new Tree(compareFunction);
+
+            const rootValue = Utils.BigNumber.make(43);
+            tree.insert(rootValue.toString(), rootValue);
+            const expectedTreeOneValue = {
+                values: { [rootValue.toString()]: rootValue },
+                lastValueAdded: rootValue,
+            };
+            expect(tree.toJSON()).toEqual(JSON.stringify(expectedTreeOneValue, null, 2));
+
+            const valueEqualsRoot = Utils.BigNumber.make(43);
+            const id = "customId";
+            // inserting with a different id so that the value is added to the root values
+            // it looks weird right now but it makes sense when storing transactions by fee for example, we can
+            // have multiple transactions with the same fee, so stored in the same node
+            tree.insert(id, valueEqualsRoot);
+            const expectedTreeTwoValues = {
+                values: { [rootValue.toString()]: rootValue, [id]: valueEqualsRoot },
+                lastValueAdded: valueEqualsRoot,
+            };
+            expect(tree.toJSON()).toEqual(JSON.stringify(expectedTreeTwoValues, null, 2));
+        });
+    });
+
+    it("should insert, find, remove, and retrieve all data sorted - test on a 1000 item sample", () => {
+        const tree = new Tree(compareFunction);
+
+        const bignums: Utils.BigNumber[] = [];
+        for (let i = 0; i < 1000; i++) {
+            const randomBignum = Utils.BigNumber.make(Math.floor(Math.random() * 1000000));
+            if (bignums.find(b => b.isEqualTo(randomBignum))) {
+                continue;
+            }
+
+            const treeId = randomBignum.toString();
+            tree.insert(treeId, randomBignum);
+            bignums.push(randomBignum);
+        }
+
+        // checking that getAll() returns the bignums sorted just like the classic array sort() function
+        expect(tree.getAll()).toEqual([...bignums].sort(compareFunction));
+
+        for (let i = 0; i < bignums.length; i += 10) {
+            const treeId = bignums[i].toString();
+            const foundFromTree = tree.find(treeId, bignums[i]);
+            expect(foundFromTree).toEqual(bignums[i]);
+        }
+
+        while (bignums.length) {
+            const toRemove = bignums.pop();
+            const treeId = toRemove.toString();
+
+            expect(tree.find(treeId, toRemove)).toEqual(toRemove);
+
+            tree.remove(treeId, toRemove);
+
+            expect(tree.getAll()).toEqual([...bignums].sort(compareFunction));
+            expect(tree.find(treeId, toRemove)).toBeUndefined();
+        }
+    });
+});

--- a/packages/core-transaction-pool/src/connection.ts
+++ b/packages/core-transaction-pool/src/connection.ts
@@ -440,7 +440,7 @@ export class Connection implements TransactionPool.IConnection {
 
             if (lowest && lowest.data.fee.isLessThan(transaction.data.fee)) {
                 await this.walletManager.revertTransactionForSender(lowest);
-                this.memory.forget(lowest.id, lowest.data.senderPublicKey);
+                this.memory.forget(lowest.data.id, lowest.data.senderPublicKey);
             } else {
                 return {
                     transaction,

--- a/packages/core-transaction-pool/src/connection.ts
+++ b/packages/core-transaction-pool/src/connection.ts
@@ -5,7 +5,7 @@ import { ApplicationEvents } from "@arkecosystem/core-event-emitter";
 import { Database, EventEmitter, Logger, State, TransactionPool } from "@arkecosystem/core-interfaces";
 import { Wallets } from "@arkecosystem/core-state";
 import { Handlers } from "@arkecosystem/core-transactions";
-import { Enums, Interfaces, Transactions, Utils } from "@arkecosystem/crypto";
+import { Enums, Interfaces, Transactions } from "@arkecosystem/crypto";
 import differencewith from "lodash.differencewith";
 import { ITransactionsProcessed } from "./interfaces";
 import { Memory } from "./memory";
@@ -76,7 +76,7 @@ export class Connection implements TransactionPool.IConnection {
     }
 
     public getAllTransactions(): Interfaces.ITransaction[] {
-        return this.memory.allSortedByFee();
+        return this.memory.sortedByFee();
     }
 
     public async getTransactionsByType(type: number, typeGroup?: number): Promise<Set<Interfaces.ITransaction>> {
@@ -385,7 +385,9 @@ export class Connection implements TransactionPool.IConnection {
 
         let i = 0;
         // Copy the returned array because validateTransactions() in the loop body we may remove entries.
-        const allTransactions: Interfaces.ITransaction[] = [...this.memory.allSortedByFee()];
+        const allTransactions: Interfaces.ITransaction[] = [
+            ...this.memory.sortedByFee(start + size), // fetch only what we need
+        ];
         for (const transaction of allTransactions) {
             if (data.length === size) {
                 return data;
@@ -434,13 +436,9 @@ export class Connection implements TransactionPool.IConnection {
         if (this.options.maxTransactionsInPool <= poolSize) {
             // The pool can't accommodate more transactions. Either decline the newcomer or remove
             // an existing transaction from the pool in order to free up space.
-            const all: Interfaces.ITransaction[] = this.memory.allSortedByFee();
-            const lowest: Interfaces.ITransaction = all[all.length - 1];
+            const lowest: Interfaces.ITransaction = this.memory.getLowestFeeLastNonce();
 
-            const fee: Utils.BigNumber = transaction.data.fee;
-            const lowestFee: Utils.BigNumber = lowest.data.fee;
-
-            if (lowestFee.isLessThan(fee)) {
+            if (lowest && lowest.data.fee.isLessThan(transaction.data.fee)) {
                 await this.walletManager.revertTransactionForSender(lowest);
                 this.memory.forget(lowest.id, lowest.data.senderPublicKey);
             } else {
@@ -449,8 +447,8 @@ export class Connection implements TransactionPool.IConnection {
                     type: "ERR_POOL_FULL",
                     message:
                         `Pool is full (has ${poolSize} transactions) and this transaction's fee ` +
-                        `${fee.toFixed()} is not higher than the lowest fee already in pool ` +
-                        `${lowestFee.toFixed()}`,
+                        `${transaction.data.fee.toFixed()} is not higher than the lowest fee already in pool ` +
+                        `${lowest ? lowest.data.fee.toFixed() : ""}`,
                 };
             }
         }

--- a/packages/core-transaction-pool/src/memory.ts
+++ b/packages/core-transaction-pool/src/memory.ts
@@ -1,7 +1,7 @@
 import { app } from "@arkecosystem/core-container";
 import { State } from "@arkecosystem/core-interfaces";
-import { expirationCalculator } from "@arkecosystem/core-utils";
-import { Crypto, Interfaces, Managers, Transactions, Utils } from "@arkecosystem/crypto";
+import { expirationCalculator, Tree } from "@arkecosystem/core-utils";
+import { Crypto, Interfaces, Managers, Transactions } from "@arkecosystem/crypto";
 import assert from "assert";
 
 export class Memory {
@@ -15,8 +15,20 @@ export class Memory {
     private all: Interfaces.ITransaction[] = [];
     private allIsSorted: boolean = true;
     private byId: { [key: string]: Interfaces.ITransaction } = {};
-    private bySender: { [key: string]: Set<Interfaces.ITransaction> } = {};
+    private bySender: { [key: string]: Tree<Interfaces.ITransaction> } = {};
     private byType: Map<Transactions.InternalTransactionType, Set<Interfaces.ITransaction>> = new Map();
+
+    private byFee: Tree<Interfaces.ITransaction> = new Tree(
+        (a: Interfaces.ITransaction, b: Interfaces.ITransaction) => {
+            if (a.data.fee.isGreaterThan(b.data.fee)) {
+                return -1;
+            }
+            if (a.data.fee.isLessThan(b.data.fee)) {
+                return 1;
+            }
+            return 0;
+        },
+    );
 
     /**
      * Contains only transactions that expire, possibly sorted by height (lower first).
@@ -30,9 +42,12 @@ export class Memory {
 
     constructor(private readonly maxTransactionAge: number) {}
 
-    public allSortedByFee(): Interfaces.ITransaction[] {
+    public sortedByFee(limit?: number): Interfaces.ITransaction[] {
         if (!this.allIsSorted) {
-            this.sortAll();
+            if (limit) {
+                return this.sort(limit);
+            }
+            this.sort();
             this.allIsSorted = true;
         }
 
@@ -60,10 +75,9 @@ export class Memory {
         const transactions: Interfaces.ITransaction[] = [];
 
         for (const transaction of this.byExpiration) {
-            if (expirationCalculator.calculateTransactionExpiration(
-                transaction.data,
-                expirationContext,
-            ) > currentHeight) {
+            if (
+                expirationCalculator.calculateTransactionExpiration(transaction.data, expirationContext) > currentHeight
+            ) {
                 break;
             }
 
@@ -110,16 +124,30 @@ export class Memory {
 
     public getBySender(senderPublicKey: string): Set<Interfaces.ITransaction> {
         if (this.bySender[senderPublicKey] !== undefined) {
-            return this.bySender[senderPublicKey];
+            return new Set(this.bySender[senderPublicKey].getAll());
         }
 
         return new Set();
     }
 
+    public getLowestFeeLastNonce(): Interfaces.ITransaction | undefined {
+        // Algorithm : get the lowest fees transactions : if one of them happen to be the last nonce
+        // of the sender, then return it (try that for the 1000 lowest fee transactions)
+        const sortedByFee = this.byFee.getAll();
+        for (let i = sortedByFee.length - 1; i > Math.max(sortedByFee.length - 1000, 0); i--) {
+            const transaction = sortedByFee[i];
+            const lastByNonceSameSender = this.bySender[transaction.data.senderPublicKey].getLast();
+            if (lastByNonceSameSender && lastByNonceSameSender[0].data.id === transaction.data.id) {
+                return transaction;
+            }
+        }
+        return undefined;
+    }
+
     public remember(transaction: Interfaces.ITransaction, databaseReady?: boolean): void {
         assert.strictEqual(this.byId[transaction.id], undefined);
 
-        this.all.push(transaction);
+        this.byFee.insert(transaction.data.id, transaction);
         this.allIsSorted = false;
 
         this.byId[transaction.id] = transaction;
@@ -128,12 +156,19 @@ export class Memory {
         const { type, typeGroup } = transaction;
 
         if (this.bySender[sender] === undefined) {
-            // First transaction from this sender, create a new Set.
-            this.bySender[sender] = new Set([transaction]);
-        } else {
-            // Append to existing transaction ids for this sender.
-            this.bySender[sender].add(transaction);
+            // First transaction from this sender, create a new Tree.
+            this.bySender[sender] = new Tree((a: Interfaces.ITransaction, b: Interfaces.ITransaction) => {
+                if (a.data.nonce.isGreaterThan(b.data.fee)) {
+                    return 1;
+                }
+                if (a.data.nonce.isLessThan(b.data.fee)) {
+                    return -1;
+                }
+                return 0;
+            });
         }
+        // Append to existing transaction ids for this sender.
+        this.bySender[sender].insert(transaction.data.id, transaction);
 
         const internalType: Transactions.InternalTransactionType = Transactions.InternalTransactionType.from(
             type,
@@ -187,14 +222,16 @@ export class Memory {
         const transaction: Interfaces.ITransaction = this.byId[id];
         const { type, typeGroup } = this.byId[id];
 
+        this.byFee.remove(id, transaction);
+
         // XXX worst case: O(n)
         let i: number = this.byExpiration.findIndex(e => e.id === id);
         if (i !== -1) {
             this.byExpiration.splice(i, 1);
         }
 
-        this.bySender[senderPublicKey].delete(transaction);
-        if (this.bySender[senderPublicKey].size === 0) {
+        this.bySender[senderPublicKey].remove(transaction.data.id, transaction);
+        if (this.bySender[senderPublicKey].isEmpty()) {
             delete this.bySender[senderPublicKey];
         }
 
@@ -271,46 +308,13 @@ export class Memory {
      * Sort `this.all` by fee (highest fee first) with the exception that transactions
      * from the same sender must be ordered lowest `nonce` first.
      */
-    private sortAll(): void {
-        const currentHeight: number = this.currentHeight();
-        const expirationContext = {
-            blockTime: Managers.configManager.getMilestone(currentHeight).blocktime,
-            currentHeight,
-            now: Crypto.Slots.getTime(),
-            maxTransactionAge: this.maxTransactionAge,
-        };
+    private sort(limit?: number): Interfaces.ITransaction[] {
+        const sortedByFee = this.byFee.getAll();
 
-        this.all.sort((a, b) => {
-            const feeA: Utils.BigNumber = a.data.fee;
-            const feeB: Utils.BigNumber = b.data.fee;
-
-            if (feeA.isGreaterThan(feeB)) {
-                return -1;
-            }
-
-            if (feeA.isLessThan(feeB)) {
-                return 1;
-            }
-
-            const expirationA: number = expirationCalculator.calculateTransactionExpiration(
-                a.data,
-                expirationContext,
-            );
-            const expirationB: number = expirationCalculator.calculateTransactionExpiration(
-                b.data,
-                expirationContext,
-            );
-
-            if (expirationA !== null && expirationB !== null) {
-                return expirationA - expirationB;
-            }
-
-            return 0;
-        });
-
+        let allMoved = 0;
         const indexBySender = {};
-        for (let i = 0; i < this.all.length; i++) {
-            const transaction: Interfaces.ITransaction = this.all[i];
+        for (let i = 0; i < sortedByFee.length; i++) {
+            const transaction: Interfaces.ITransaction = sortedByFee[i];
 
             if (transaction.data.version < 2) {
                 continue;
@@ -326,10 +330,10 @@ export class Memory {
 
             for (let j = 0; j < indexBySender[sender].length - 1; j++) {
                 const prevIndex: number = indexBySender[sender][j];
-                if (this.all[i].data.nonce.isLessThan(this.all[prevIndex].data.nonce)) {
+                if (sortedByFee[i].data.nonce.isLessThan(sortedByFee[prevIndex].data.nonce)) {
                     const newIndex = i + 1 + nMoved;
-                    this.all.splice(newIndex, 0, this.all[prevIndex]);
-                    this.all[prevIndex] = undefined;
+                    sortedByFee.splice(newIndex, 0, sortedByFee[prevIndex]);
+                    sortedByFee[prevIndex] = undefined;
 
                     indexBySender[sender][j] = newIndex;
 
@@ -342,9 +346,18 @@ export class Memory {
             }
 
             i += nMoved;
+            allMoved += nMoved;
+
+            if (limit && i > limit) {
+                break;
+            }
         }
 
-        this.all = this.all.filter(t => t !== undefined);
+        if (limit) {
+            return sortedByFee.slice(0, limit + allMoved).filter(t => t !== undefined);
+        }
+
+        return sortedByFee.filter(t => t !== undefined);
     }
 
     private currentHeight(): number {

--- a/packages/core-transaction-pool/src/memory.ts
+++ b/packages/core-transaction-pool/src/memory.ts
@@ -354,7 +354,7 @@ export class Memory {
             i += nMoved;
             allMoved += nMoved;
 
-            if (limit && i > limit) {
+            if (limit && i > limit + allMoved) {
                 break;
             }
         }

--- a/packages/core-transaction-pool/src/memory.ts
+++ b/packages/core-transaction-pool/src/memory.ts
@@ -47,7 +47,7 @@ export class Memory {
             if (limit) {
                 return this.sort(limit);
             }
-            this.sort();
+            this.all = this.sort();
             this.allIsSorted = true;
         }
 

--- a/packages/core-transaction-pool/src/memory.ts
+++ b/packages/core-transaction-pool/src/memory.ts
@@ -134,7 +134,7 @@ export class Memory {
         // Algorithm : get the lowest fees transactions : if one of them happen to be the last nonce
         // of the sender, then return it (try that for the 1000 lowest fee transactions)
         const sortedByFee = this.byFee.getAll();
-        for (let i = sortedByFee.length - 1; i > Math.max(sortedByFee.length - 1000, 0); i--) {
+        for (let i = sortedByFee.length - 1; i >= Math.max(sortedByFee.length - 1000, 0); i--) {
             const transaction = sortedByFee[i];
             const lastByNonceSameSender = this.bySender[transaction.data.senderPublicKey].getLast();
             if (lastByNonceSameSender && lastByNonceSameSender[0].data.id === transaction.data.id) {

--- a/packages/core-utils/src/index.ts
+++ b/packages/core-utils/src/index.ts
@@ -12,6 +12,7 @@ import { OrderedCappedMap } from "./ordered-capped-map";
 import { calculateRound, isNewRound } from "./round-calculator";
 import { calculate } from "./supply-calculator";
 import * as Plugins from "./transform-plugins";
+import { Tree } from "./tree";
 
 export const delegateCalculator = { calculateApproval, calculateForgedTotal };
 export const expirationCalculator = { calculateTransactionExpiration, calculateLockExpirationStatus };
@@ -29,4 +30,5 @@ export {
     NSect,
     OrderedCappedMap,
     Plugins,
+    Tree,
 };

--- a/packages/core-utils/src/tree.ts
+++ b/packages/core-utils/src/tree.ts
@@ -74,27 +74,13 @@ export class Tree<T> {
         }
     }
 
-    public find(id: string, value: T): Node<T> {
-        let currentNode = this.root;
-        for (;;) {
-            if (!currentNode || !currentNode.lastValueAdded) {
-                return undefined;
-            }
-
-            const cmp = this.compareFunction(value, currentNode.lastValueAdded);
-            if (cmp > 0) {
-                currentNode = currentNode.right;
-            } else if (cmp < 0) {
-                currentNode = currentNode.left;
-            } else {
-                // found
-                return currentNode;
-            }
-        }
+    public find(id: string, value: T): T | undefined {
+        const node = this.findNode(value);
+        return node ? node.values[id] : undefined;
     }
 
     public remove(id: string, value: T): void {
-        const node = this.find(id, value);
+        const node = this.findNode(value);
         if (!node) {
             return;
         }
@@ -134,6 +120,25 @@ export class Tree<T> {
 
     public toJSON(node: Node<T> = this.root): string {
         return JSON.stringify(node.getStruct(), null, 2);
+    }
+
+    private findNode(value: T): Node<T> | undefined {
+        let currentNode = this.root;
+        for (;;) {
+            if (!currentNode || !currentNode.lastValueAdded) {
+                return undefined;
+            }
+
+            const cmp = this.compareFunction(value, currentNode.lastValueAdded);
+            if (cmp > 0) {
+                currentNode = currentNode.right;
+            } else if (cmp < 0) {
+                currentNode = currentNode.left;
+            } else {
+                // found
+                return currentNode;
+            }
+        }
     }
 
     private removeNode(node: Node<T>): void {

--- a/packages/core-utils/src/tree.ts
+++ b/packages/core-utils/src/tree.ts
@@ -53,14 +53,13 @@ export class Tree<T> {
         let node = this.root;
         for (;;) {
             // node = this.insertChildNode(node, id, value);\
-            const valuesForNode = Object.values(node.values);
-            if (valuesForNode.length === 0) {
+            if (!node.lastValueAdded) {
                 node.values[id] = value;
                 node.lastValueAdded = value;
                 return;
             }
 
-            const cmp = this.compareFunction(value, valuesForNode[0]);
+            const cmp = this.compareFunction(value, node.lastValueAdded);
             if (cmp > 0) {
                 node = this.getOrCreateRightNode(node);
             } else if (cmp < 0) {
@@ -116,6 +115,10 @@ export class Tree<T> {
             return false;
         }
         return true;
+    }
+
+    public getCompareFunction(): CompareFunction<T> {
+        return this.compareFunction;
     }
 
     public toJSON(node: Node<T> = this.root): string {

--- a/packages/core-utils/src/tree.ts
+++ b/packages/core-utils/src/tree.ts
@@ -52,7 +52,6 @@ export class Tree<T> {
     public insert(id: string, value: T): void {
         let node = this.root;
         for (;;) {
-            // node = this.insertChildNode(node, id, value);\
             if (!node.lastValueAdded) {
                 node.values[id] = value;
                 node.lastValueAdded = value;
@@ -73,6 +72,8 @@ export class Tree<T> {
         }
     }
 
+    // This method is a bit dumb (to be properly implemented it would need to be like
+    // the array sort method), but it helps for testing.
     public find(id: string, value: T): T | undefined {
         const node = this.findNode(value);
         return node ? node.values[id] : undefined;
@@ -99,17 +100,6 @@ export class Tree<T> {
         this.removeNode(node);
     }
 
-    public findMin(node: Node<T>): Node<T> {
-        let currentNode = node;
-        for (;;) {
-            if (!currentNode.left) {
-                break;
-            } // currentNode is the leftest node
-            currentNode = currentNode.left;
-        }
-        return currentNode;
-    }
-
     public isEmpty(): boolean {
         if (this.root.lastValueAdded) {
             return false;
@@ -123,6 +113,17 @@ export class Tree<T> {
 
     public toJSON(node: Node<T> = this.root): string {
         return JSON.stringify(node.getStruct(), null, 2);
+    }
+
+    private findMin(node: Node<T>): Node<T> {
+        let currentNode = node;
+        for (;;) {
+            if (!currentNode.left) {
+                break;
+            } // currentNode is the leftest node
+            currentNode = currentNode.left;
+        }
+        return currentNode;
     }
 
     private findNode(value: T): Node<T> | undefined {

--- a/packages/core-utils/src/tree.ts
+++ b/packages/core-utils/src/tree.ts
@@ -157,16 +157,19 @@ export class Tree<T> {
             // and replace current value node with that next biggest value.
             const nextBiggerNode = this.findMin(node.right);
             if (this.compareFunction(nextBiggerNode.lastValueAdded, node.right.lastValueAdded) !== 0) {
+                this.removeNode(nextBiggerNode);
+
                 node.values = { ...nextBiggerNode.values };
                 node.lastValueAdded = nextBiggerNode.lastValueAdded;
-
-                this.removeNode(nextBiggerNode);
             } else {
                 // In case if next right value is the next bigger one and it doesn't have left child
                 // then just replace node that is going to be deleted with the right node.
                 node.values = node.right.values;
                 node.lastValueAdded = node.right.lastValueAdded;
                 node.right = node.right.right;
+                if (node.right) {
+                    node.right.parent = node;
+                }
             }
         } else {
             // Node has only one child.


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
Plus other perf improvements.

Now inserting txs is slower (expect around 10k per second, still okay).

But fetching is way faster, which is important when getting transactions for forging, considering default tx pool limit is 100k.

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
