### PR TITLE
fix(core-state): update vote balance with htlc locked balance on vote transactions

### DIFF
--- a/packages/core-jest-matchers/src/functional/index.ts
+++ b/packages/core-jest-matchers/src/functional/index.ts
@@ -2,3 +2,4 @@ import "./accepted";
 import "./forged";
 import "./rejected";
 import "./unconfirmed";
+import "./vote-balance";

--- a/packages/core-jest-matchers/src/functional/vote-balance.ts
+++ b/packages/core-jest-matchers/src/functional/vote-balance.ts
@@ -1,0 +1,35 @@
+import got from "got";
+
+export {};
+
+declare global {
+    namespace jest {
+        // tslint:disable-next-line:interface-name
+        interface Matchers<R> {
+            toHaveVoteBalance(voteBalance: string): Promise<R>;
+        }
+    }
+}
+
+expect.extend({
+    toHaveVoteBalance: async (publicKey: string, voteBalance: string) => {
+        let pass: boolean = false;
+        let fetchedVoteBalance: string;
+        try {
+            const { body } = await got.get(`http://localhost:4003/api/v2/delegates/${publicKey}`);
+
+            const parsedBody = JSON.parse(body);
+
+            fetchedVoteBalance = parsedBody.data.votes;
+            pass = fetchedVoteBalance === voteBalance;
+        } catch (e) {} // tslint:disable-line
+
+        return {
+            pass,
+            message: () =>
+                `expected delegate ${publicKey} ${
+                    this.isNot ? "not" : ""
+                } to have vote balance = ${voteBalance}, got ${fetchedVoteBalance}`,
+        };
+    },
+});

--- a/packages/core-state/src/wallets/wallet-manager.ts
+++ b/packages/core-state/src/wallets/wallet-manager.ts
@@ -481,15 +481,19 @@ export class WalletManager implements State.IWalletManager {
             const vote: string = transaction.asset.votes[0];
             const delegate: State.IWallet = this.findByPublicKey(vote.substr(1));
             let voteBalance: Utils.BigNumber = delegate.getAttribute("delegate.voteBalance", Utils.BigNumber.ZERO);
+            const senderLockedBalance: Utils.BigNumber = sender.getAttribute(
+                "htlc.lockedBalance",
+                Utils.BigNumber.ZERO,
+            );
 
             if (vote.startsWith("+")) {
                 voteBalance = revert
-                    ? voteBalance.minus(sender.balance.minus(transaction.fee))
-                    : voteBalance.plus(sender.balance);
+                    ? voteBalance.minus(sender.balance.minus(transaction.fee)).minus(senderLockedBalance)
+                    : voteBalance.plus(sender.balance).plus(senderLockedBalance);
             } else {
                 voteBalance = revert
-                    ? voteBalance.plus(sender.balance)
-                    : voteBalance.minus(sender.balance.plus(transaction.fee));
+                    ? voteBalance.plus(sender.balance).plus(senderLockedBalance)
+                    : voteBalance.minus(sender.balance.plus(transaction.fee)).minus(senderLockedBalance);
             }
 
             delegate.setAttribute("delegate.voteBalance", voteBalance);


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
When updating the vote balance on a vote/unvote transaction, we were not taking the potential sender locked balance.
This fixes it.
<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
