### PR TITLE
fix(core-transaction-pool): use sorted array (instead of tree) for storing transactions by fee and nonce

### DIFF
--- a/__tests__/unit/core-transaction-pool/connection.test.ts
+++ b/__tests__/unit/core-transaction-pool/connection.test.ts
@@ -1087,16 +1087,19 @@ describe("Connection", () => {
                     expect(prevSender).toEqual(curSender);
                 }
 
-                if (prevSender !== curSender) {
-                    let j;
-                    for (j = i - 2; j >= 0 && sortedTransactions[j].data.senderPublicKey === prevSender; j--) {
-                        // Find the leftmost transaction in a sequence of transactions from the same
-                        // sender, ending at prevTransaction. That leftmost transaction's fee must
-                        // be greater or equal to the fee of curTransaction.
-                    }
-                    j++;
-                    expect(sortedTransactions[j].data.fee.isGreaterThanEqual(curTransaction.data.fee)).toBeTrue();
-                }
+                // This is not true anymore with current implementation, which is simpler and more performant
+                // than the previous one, but it does not do this fee optimization (which is a very specific
+                // case and is not worth it currently)
+                // if (prevSender !== curSender) {
+                //    let j;
+                //    for (j = i - 2; j >= 0 && sortedTransactions[j].data.senderPublicKey === prevSender; j--) {
+                //        // Find the leftmost transaction in a sequence of transactions from the same
+                //        // sender, ending at prevTransaction. That leftmost transaction's fee must
+                //        // be greater or equal to the fee of curTransaction.
+                //    }
+                //    j++;
+                //    expect(sortedTransactions[j].data.fee.isGreaterThanEqual(curTransaction.data.fee)).toBeTrue();
+                // }
 
                 if (lastNonceBySender[curSender] !== undefined) {
                     expect(lastNonceBySender[curSender].isLessThan(curTransaction.data.nonce)).toBeTrue();

--- a/__tests__/unit/core-transaction-pool/memory.test.ts
+++ b/__tests__/unit/core-transaction-pool/memory.test.ts
@@ -1,0 +1,87 @@
+import "./mocks/core-container";
+
+import { Managers, Transactions, Utils } from "@arkecosystem/crypto";
+import { Memory } from "../../../packages/core-transaction-pool/src/memory";
+
+Managers.configManager.setFromPreset("testnet");
+Managers.configManager.getMilestone().aip11 = true;
+
+describe("Memory", () => {
+    describe("getLowestFeeLastNonce", () => {
+        it("should get the lowest fee which also is the last nonce from the sender", () => {
+            const txs = [];
+            let lastNonceLowestFeeTx;
+            for (let i = 0; i < 20; i++) {
+                for (let nonce = 1; nonce <= 5; nonce++) {
+                    const passphrase = `random ${i}`;
+                    const address = "AWLzbT4z7KntQ3D9LTz7ukPHyXy6mNy2YQ";
+                    const transaction = Transactions.BuilderFactory.transfer()
+                        .nonce(nonce.toString())
+                        .recipientId(address)
+                        .amount("1")
+                        .fee(Math.floor(Math.random() * 100000).toString()) //
+                        .sign(passphrase)
+                        .build();
+
+                    txs.push(transaction);
+                }
+                const lastNonceTx = txs[txs.length - 1];
+                lastNonceLowestFeeTx = lastNonceLowestFeeTx
+                    ? lastNonceTx.data.fee.isLessThan(lastNonceLowestFeeTx.data.fee)
+                        ? lastNonceTx
+                        : lastNonceLowestFeeTx
+                    : lastNonceTx;
+            }
+
+            const memory = new Memory(120);
+            for (const tx of txs) {
+                memory.remember(tx);
+            }
+
+            expect(memory.getLowestFeeLastNonce()).toEqual(lastNonceLowestFeeTx);
+        });
+    });
+
+    describe("sortedByFee", () => {
+        it.each([[undefined], [100], [190], [565], [1550]])(
+            "should keep nonce order when sorting by fee and nonce - with limit %s",
+            limit => {
+                const txs = [];
+                for (let i = 0; i < 50; i++) {
+                    for (let nonce = 1; nonce <= 50; nonce++) {
+                        const passphrase = `random ${i}`;
+                        const address = "AWLzbT4z7KntQ3D9LTz7ukPHyXy6mNy2YQ";
+                        const transaction = Transactions.BuilderFactory.transfer()
+                            .nonce(nonce.toString())
+                            .recipientId(address)
+                            .amount("1")
+                            .fee(Math.floor(Math.random() * 100000).toString()) //
+                            .sign(passphrase)
+                            .build();
+
+                        txs.push(transaction);
+                    }
+                }
+
+                const memory = new Memory(120);
+                for (const tx of txs) {
+                    memory.remember(tx);
+                }
+
+                const byFee = [...memory.sortedByFee(limit)];
+
+                // checking that nonces are in order
+                const lastNonceBySender: { [id: string]: Utils.BigNumber } = {};
+                for (const tx of byFee) {
+                    const sender = tx.data.senderPublicKey;
+                    if (lastNonceBySender[sender]) {
+                        expect(tx.data.nonce).toEqual(lastNonceBySender[sender].plus(1));
+                    } else {
+                        expect(tx.data.nonce).toEqual(Utils.BigNumber.ONE);
+                    }
+                    lastNonceBySender[sender] = tx.data.nonce;
+                }
+            },
+        );
+    });
+});

--- a/__tests__/unit/core-transaction-pool/memory.test.ts
+++ b/__tests__/unit/core-transaction-pool/memory.test.ts
@@ -8,18 +8,51 @@ Managers.configManager.getMilestone().aip11 = true;
 
 describe("Memory", () => {
     describe("getLowestFeeLastNonce", () => {
-        it("should get the lowest fee which also is the last nonce from the sender", () => {
+        it("should get the lowest fee which also is the last nonce from the sender - when a 'last nonce tx' is among the 100 lowest fee txs", () => {
             const txs = [];
             let lastNonceLowestFeeTx;
-            for (let i = 0; i < 20; i++) {
-                for (let nonce = 1; nonce <= 5; nonce++) {
+            for (let i = 0; i < 100; i++) {
+                for (let nonce = 1; nonce <= 10; nonce++) {
                     const passphrase = `random ${i}`;
                     const address = "AWLzbT4z7KntQ3D9LTz7ukPHyXy6mNy2YQ";
                     const transaction = Transactions.BuilderFactory.transfer()
                         .nonce(nonce.toString())
                         .recipientId(address)
                         .amount("1")
-                        .fee(Math.floor(Math.random() * 100000).toString()) //
+                        .fee((1e6 - 1000 * nonce - i).toString()) // the last nonce tx will be the lowest fee
+                        .sign(passphrase)
+                        .build();
+
+                    txs.push(transaction);
+                }
+                const lastNonceTx = txs[txs.length - 1];
+                lastNonceLowestFeeTx = lastNonceLowestFeeTx
+                    ? lastNonceTx.data.fee.isLessThan(lastNonceLowestFeeTx.data.fee)
+                        ? lastNonceTx
+                        : lastNonceLowestFeeTx
+                    : lastNonceTx;
+            }
+
+            const memory = new Memory(120);
+            for (const tx of txs) {
+                memory.remember(tx);
+            }
+
+            expect(memory.getLowestFeeLastNonce()).toEqual(lastNonceLowestFeeTx);
+        });
+
+        it("should get the lowest fee which also is the last nonce from the sender - when the 100 lowest fees are not a 'last nonce tx'", () => {
+            const txs = [];
+            let lastNonceLowestFeeTx;
+            for (let i = 0; i < 100; i++) {
+                for (let nonce = 1; nonce <= 10; nonce++) {
+                    const passphrase = `random ${i}`;
+                    const address = "AWLzbT4z7KntQ3D9LTz7ukPHyXy6mNy2YQ";
+                    const transaction = Transactions.BuilderFactory.transfer()
+                        .nonce(nonce.toString())
+                        .recipientId(address)
+                        .amount("1")
+                        .fee((1000 * nonce + i).toString()) // the last nonce tx will be the biggest fee
                         .sign(passphrase)
                         .build();
 

--- a/__tests__/unit/core-utils/sorted-array.test.ts
+++ b/__tests__/unit/core-utils/sorted-array.test.ts
@@ -1,0 +1,170 @@
+import { SortedArray } from "@arkecosystem/core-utils/src/sorted-array";
+import { Utils } from "@arkecosystem/crypto";
+
+describe("SortedArray", () => {
+    // using Bignumbers for the tests
+    const compareFunction = (a: Utils.BigNumber, b: Utils.BigNumber) => {
+        if (a.isGreaterThan(b)) {
+            return 1;
+        }
+        if (a.isLessThan(b)) {
+            return -1;
+        }
+        return 0;
+    };
+
+    describe("insert", () => {
+        it("should insert sorted", () => {
+            const sortedArray = new SortedArray(compareFunction);
+
+            const bignums: Utils.BigNumber[] = [];
+            for (let i = 0; i < 1000; i++) {
+                const randomBignum = Utils.BigNumber.make(Math.floor(Math.random() * 1000000));
+                if (bignums.find(b => b.isEqualTo(randomBignum))) {
+                    continue;
+                }
+
+                sortedArray.insert(randomBignum);
+                bignums.push(randomBignum);
+            }
+
+            expect(sortedArray.getAll()).toEqual(bignums.sort(compareFunction));
+        });
+
+        it("should insert sorted - when some values are identical", () => {
+            const sortedArray = new SortedArray(compareFunction);
+
+            const bignums: Utils.BigNumber[] = [];
+            for (let i = 0; i < 1000; i++) {
+                const randomBignum = Utils.BigNumber.make(Math.floor(Math.random() * 100));
+                sortedArray.insert(randomBignum);
+                bignums.push(randomBignum);
+            }
+
+            expect(sortedArray.getAll()).toEqual(bignums.sort(compareFunction));
+        });
+    });
+
+    describe("findIndex", () => {
+        it("should find the index corresponding to the find function", () => {
+            const sortedArray = new SortedArray(compareFunction);
+
+            const bignums: Utils.BigNumber[] = [];
+            for (let i = 0; i < 1000; i++) {
+                const randomBignum = Utils.BigNumber.make(Math.floor(Math.random() * 1000000));
+                if (bignums.find(b => b.isEqualTo(randomBignum))) {
+                    continue;
+                }
+
+                sortedArray.insert(randomBignum);
+                bignums.push(randomBignum);
+            }
+
+            const findLastInserted = sortedArray.findIndex(bignum => bignum.isEqualTo(bignums[bignums.length - 1]));
+            const all = sortedArray.getAll();
+            expect(all[findLastInserted]).toEqual(bignums[bignums.length - 1]);
+        });
+    });
+
+    describe("removeAtIndex", () => {
+        it("should remove the item at the index specified", () => {
+            const sortedArray = new SortedArray(compareFunction);
+            const bignums = [
+                Utils.BigNumber.make(2),
+                Utils.BigNumber.make(5),
+                Utils.BigNumber.make(11),
+                Utils.BigNumber.make(34),
+                Utils.BigNumber.make(555),
+            ];
+            for (const bignum of bignums) {
+                sortedArray.insert(bignum);
+            }
+
+            sortedArray.removeAtIndex(0);
+            expect(sortedArray.getAll()).toEqual(bignums.slice(1));
+
+            sortedArray.removeAtIndex(2);
+            expect(sortedArray.getAll()).toEqual([
+                Utils.BigNumber.make(5),
+                Utils.BigNumber.make(11),
+                Utils.BigNumber.make(555),
+            ]);
+        });
+    });
+
+    describe("getStrictlyBelow", () => {
+        it("should get the items strictly below item specified", () => {
+            const sortedArray = new SortedArray(compareFunction);
+            const bignums = [
+                Utils.BigNumber.make(2),
+                Utils.BigNumber.make(5),
+                Utils.BigNumber.make(11),
+                Utils.BigNumber.make(34),
+                Utils.BigNumber.make(555),
+            ];
+            for (const bignum of bignums) {
+                sortedArray.insert(bignum);
+            }
+
+            expect(sortedArray.getStrictlyBelow(Utils.BigNumber.make(12))).toEqual([
+                Utils.BigNumber.make(2),
+                Utils.BigNumber.make(5),
+                Utils.BigNumber.make(11),
+            ]);
+
+            expect(sortedArray.getStrictlyBelow(Utils.BigNumber.make(11))).toEqual([
+                Utils.BigNumber.make(2),
+                Utils.BigNumber.make(5),
+            ]);
+
+            expect(sortedArray.getStrictlyBelow(Utils.BigNumber.make(2))).toEqual([]);
+
+            expect(sortedArray.getStrictlyBelow(Utils.BigNumber.make(1))).toEqual([]);
+
+            expect(sortedArray.getStrictlyBelow(Utils.BigNumber.make(556))).toEqual(bignums);
+        });
+    });
+
+    describe("getStrictlyBetween", () => {
+        it("should get the items strictly between items specified", () => {
+            const sortedArray = new SortedArray(compareFunction);
+            const bignums = [
+                Utils.BigNumber.make(2),
+                Utils.BigNumber.make(5),
+                Utils.BigNumber.make(11),
+                Utils.BigNumber.make(34),
+                Utils.BigNumber.make(555),
+            ];
+            for (const bignum of bignums) {
+                sortedArray.insert(bignum);
+            }
+
+            expect(sortedArray.getStrictlyBetween(Utils.BigNumber.make(1), Utils.BigNumber.make(12))).toEqual([
+                Utils.BigNumber.make(2),
+                Utils.BigNumber.make(5),
+                Utils.BigNumber.make(11),
+            ]);
+
+            expect(sortedArray.getStrictlyBetween(Utils.BigNumber.make(1), Utils.BigNumber.make(11))).toEqual([
+                Utils.BigNumber.make(2),
+                Utils.BigNumber.make(5),
+            ]);
+
+            expect(sortedArray.getStrictlyBetween(Utils.BigNumber.make(2), Utils.BigNumber.make(11))).toEqual([
+                Utils.BigNumber.make(5),
+            ]);
+
+            expect(sortedArray.getStrictlyBetween(Utils.BigNumber.make(2), Utils.BigNumber.make(4))).toEqual([]);
+
+            expect(sortedArray.getStrictlyBetween(Utils.BigNumber.make(5), Utils.BigNumber.make(2))).toEqual([]);
+
+            expect(sortedArray.getStrictlyBetween(Utils.BigNumber.make(35), Utils.BigNumber.make(556))).toEqual([
+                Utils.BigNumber.make(555),
+            ]);
+
+            expect(sortedArray.getStrictlyBetween(Utils.BigNumber.make(555), Utils.BigNumber.make(1222))).toEqual([]);
+
+            expect(sortedArray.getStrictlyBetween(Utils.BigNumber.make(1), Utils.BigNumber.make(556))).toEqual(bignums);
+        });
+    });
+});

--- a/__tests__/unit/core-utils/tree.test.ts
+++ b/__tests__/unit/core-utils/tree.test.ts
@@ -175,4 +175,25 @@ describe("Tree", () => {
             expect(tree.find(treeId, toRemove)).toBeUndefined();
         }
     });
+
+    describe("getValuesLastToFirst", () => {
+        it("should get the values last to first", () => {
+            const tree = new Tree(compareFunction);
+
+            const bignums: Utils.BigNumber[] = [];
+            for (let i = 0; i < 1000; i++) {
+                const randomBignum = Utils.BigNumber.make(Math.floor(Math.random() * 1000000));
+                if (bignums.find(b => b.isEqualTo(randomBignum))) {
+                    continue;
+                }
+
+                const treeId = randomBignum.toString();
+                tree.insert(treeId, randomBignum);
+                bignums.push(randomBignum);
+            }
+
+            // checking that getAll() returns the bignums sorted just like the classic array sort() function
+            expect(tree.getValuesLastToFirst(1000)).toEqual([...bignums].sort(compareFunction).reverse());
+        });
+    });
 });

--- a/packages/core-transaction-pool/src/defaults.ts
+++ b/packages/core-transaction-pool/src/defaults.ts
@@ -6,8 +6,8 @@ export const defaults = {
     // only accepted if its fee is higher than the transaction with the lowest
     // fee in the pool. In this case the transaction with the lowest fee is removed
     // from the pool in order to accommodate the new one.
-    maxTransactionsInPool: process.env.CORE_MAX_TRANSACTIONS_IN_POOL || 100000,
-    maxTransactionsPerSender: process.env.CORE_TRANSACTION_POOL_MAX_PER_SENDER || 300,
+    maxTransactionsInPool: process.env.CORE_MAX_TRANSACTIONS_IN_POOL || 15000,
+    maxTransactionsPerSender: process.env.CORE_TRANSACTION_POOL_MAX_PER_SENDER || 150,
     allowedSenders: [],
     maxTransactionsPerRequest: process.env.CORE_TRANSACTION_POOL_MAX_PER_REQUEST || 40,
     // Max transaction age in number of blocks produced since the transaction was created.

--- a/packages/core-transaction-pool/src/memory.ts
+++ b/packages/core-transaction-pool/src/memory.ts
@@ -162,7 +162,7 @@ export class Memory {
         if (this.bySender[sender] === undefined) {
             // First transaction from this sender, create a new Tree.
             this.bySender[sender] = new SortedArray((a: Interfaces.ITransaction, b: Interfaces.ITransaction) => {
-                // if no nonce (v1 transactions), default to BigNumber.ZERO to still be able to use the tree
+                // if no nonce (v1 transactions), default to BigNumber.ZERO to still be able to use the sorted array
                 const nonceA = a.data.nonce || Utils.BigNumber.ZERO;
                 const nonceB = b.data.nonce || Utils.BigNumber.ZERO;
                 if (nonceA.isGreaterThan(nonceB)) {

--- a/packages/core-utils/src/index.ts
+++ b/packages/core-utils/src/index.ts
@@ -10,6 +10,7 @@ import { calculateLockExpirationStatus } from "./lock-expiration-calculator";
 import { NSect } from "./nsect";
 import { OrderedCappedMap } from "./ordered-capped-map";
 import { calculateRound, isNewRound } from "./round-calculator";
+import { SortedArray } from "./sorted-array";
 import { calculate } from "./supply-calculator";
 import * as Plugins from "./transform-plugins";
 import { Tree } from "./tree";
@@ -31,4 +32,5 @@ export {
     OrderedCappedMap,
     Plugins,
     Tree,
+    SortedArray,
 };

--- a/packages/core-utils/src/sorted-array.ts
+++ b/packages/core-utils/src/sorted-array.ts
@@ -74,24 +74,4 @@ export class SortedArray<T> {
 
         return itemsBetween;
     }
-
-    /*
-     * Binary search, TODO remove?
-     */
-    /*private binarySearch(item: T) {
-        var m = 0;
-        var n = this.sortedArray.length - 1;
-        while (m <= n) {
-            var k = (n + m) >> 1;
-            var cmp = this.compareFunction(item, this.sortedArray[k]);
-            if (cmp > 0) {
-                m = k + 1;
-            } else if(cmp < 0) {
-                n = k - 1;
-            } else {
-                return k;
-            }
-        }
-        return -m - 1;
-    }*/
 }

--- a/packages/core-utils/src/sorted-array.ts
+++ b/packages/core-utils/src/sorted-array.ts
@@ -1,0 +1,97 @@
+type CompareFunction<T> = (a: T, b: T) => number;
+type FindFunction<T> = (value: T, index?: number) => boolean;
+
+export class SortedArray<T> {
+    private sortedArray: T[] = [];
+    private compareFunction: CompareFunction<T>;
+
+    constructor(compareFunction: CompareFunction<T>) {
+        this.compareFunction = compareFunction;
+    }
+
+    public size(): number {
+        return this.sortedArray.length;
+    }
+
+    public isEmpty(): boolean {
+        return this.sortedArray.length === 0;
+    }
+
+    public getCompareFunction(): CompareFunction<T> {
+        return this.compareFunction;
+    }
+
+    public insert(item: T): void {
+        const index = this.sortedArray.findIndex(current => this.compareFunction(current, item) > 0);
+        if (index === -1) {
+            // item is bigger than all the elements in the array
+            this.sortedArray.push(item);
+        } else {
+            this.sortedArray.splice(index, 0, item);
+        }
+    }
+
+    public removeAtIndex(index: number): void {
+        if (index < 0) {
+            return;
+        }
+        this.sortedArray.splice(index, 1);
+    }
+
+    public findIndex(findFunction: FindFunction<T>): number {
+        return this.sortedArray.findIndex(findFunction);
+    }
+
+    public getAll(): T[] {
+        return [...this.sortedArray]; // return a clone
+    }
+
+    public getStrictlyBelow(max: T): T[] {
+        const itemsBelow = [];
+        for (const item of this.sortedArray) {
+            if (this.compareFunction(item, max) < 0) {
+                itemsBelow.push(item);
+            } else {
+                // no need to go further as the array is sorted
+                return itemsBelow;
+            }
+        }
+        return itemsBelow;
+    }
+
+    public getStrictlyBetween(min: T, max: T): T[] {
+        const itemsBetween = [];
+        let i: number = 0;
+
+        for (; i < this.sortedArray.length && this.compareFunction(this.sortedArray[i], min) <= 0; i++) {
+            // tslint:disable:no-empty
+        }
+
+        // we are now either above min or at the end of the array
+        for (; i < this.sortedArray.length && this.compareFunction(this.sortedArray[i], max) < 0; i++) {
+            itemsBetween.push(this.sortedArray[i]);
+        }
+
+        return itemsBetween;
+    }
+
+    /*
+     * Binary search, TODO remove?
+     */
+    /*private binarySearch(item: T) {
+        var m = 0;
+        var n = this.sortedArray.length - 1;
+        while (m <= n) {
+            var k = (n + m) >> 1;
+            var cmp = this.compareFunction(item, this.sortedArray[k]);
+            if (cmp > 0) {
+                m = k + 1;
+            } else if(cmp < 0) {
+                n = k - 1;
+            } else {
+                return k;
+            }
+        }
+        return -m - 1;
+    }*/
+}

--- a/packages/core-utils/src/tree.ts
+++ b/packages/core-utils/src/tree.ts
@@ -130,7 +130,7 @@ export class Tree<T> {
     }
 
     public toJSON(node: Node<T> = this.root): string {
-        return JSON.stringify(node.getStruct(), null, 2);
+        return JSON.stringify(node.getStruct(), undefined, 2);
     }
 
     private findMin(node: Node<T>): Node<T> {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
Use sorted array instead of tree for storing transaction by fee and nonce, because tree has some issues like with recursion and max call stack. Sorted array is simpler and does the job for a lower max size of the transaction pool (now reduced to 15k transactions by default instead of 100k).

(tree memory structure is still available in core-utils and might be improved and used in the future : needs re-balancing while inserting to be usable)
<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
