### PR TITLE
feat(core-manager): implement `info.coreStatus` action

### DIFF
--- a/__tests__/unit/core-manager/actions/info-core-status.test.ts
+++ b/__tests__/unit/core-manager/actions/info-core-status.test.ts
@@ -1,0 +1,33 @@
+import "jest-extended";
+
+import { Sandbox } from "@packages/core-test-framework";
+import { Container } from "@packages/core-kernel";
+import { Action } from "@packages/core-manager/src/actions/info-core-status";
+
+let sandbox: Sandbox;
+let action: Action;
+
+beforeEach(() => {
+    sandbox = new Sandbox();
+
+    sandbox.app.bind(Container.Identifiers.ApplicationVersion).toConstantValue("dummyVersion");
+
+    action = sandbox.app.resolve(Action);
+});
+
+describe("Info:CoreStatus", () => {
+    it("should have name", () => {
+        expect(action.name).toEqual("info.coreStatus");
+    })
+
+    // it("should return current and latest version", async () => {
+    //     let promise = action.execute({});
+    //
+    //     await expect(promise).toResolve();
+    //
+    //     let result = await promise;
+    //
+    //     await expect(result.currentVersion).toBe("dummyVersion");
+    //     await expect(result.latestVersion).toBeString();
+    // });
+});

--- a/__tests__/unit/core-manager/actions/info-core-status.test.ts
+++ b/__tests__/unit/core-manager/actions/info-core-status.test.ts
@@ -1,33 +1,97 @@
 import "jest-extended";
 
 import { Sandbox } from "@packages/core-test-framework";
-import { Container } from "@packages/core-kernel";
+import { ProcessState } from "@packages/core-cli/src/contracts";
 import { Action } from "@packages/core-manager/src/actions/info-core-status";
+import { Identifiers } from "@packages/core-manager/src/ioc";
+import { HttpClient } from "@packages/core-manager/src/utils";
 
 let sandbox: Sandbox;
 let action: Action;
 
+let mockCli;
+
 beforeEach(() => {
+    mockCli = {
+        get: jest.fn().mockReturnValue({
+            status: jest.fn().mockReturnValue(ProcessState.Online)
+        })
+    }
+
+    HttpClient.prototype.get = jest.fn().mockReturnValue(
+        {
+            data: {
+                syncing: true
+            }
+        }
+    )
+
+
+
     sandbox = new Sandbox();
 
-    sandbox.app.bind(Container.Identifiers.ApplicationVersion).toConstantValue("dummyVersion");
+    sandbox.app.bind(Identifiers.CLI).toConstantValue(mockCli);
 
     action = sandbox.app.resolve(Action);
 });
+
+afterEach(() => {
+    delete process.env.CORE_API_DISABLED
+    jest.clearAllMocks();
+})
 
 describe("Info:CoreStatus", () => {
     it("should have name", () => {
         expect(action.name).toEqual("info.coreStatus");
     })
 
-    // it("should return current and latest version", async () => {
-    //     let promise = action.execute({});
-    //
-    //     await expect(promise).toResolve();
-    //
-    //     let result = await promise;
-    //
-    //     await expect(result.currentVersion).toBe("dummyVersion");
-    //     await expect(result.latestVersion).toBeString();
-    // });
+    it("should return status and syncing using HTTP", async () => {
+        let promise = action.execute({});
+
+        await expect(promise).toResolve();
+
+        let result = await promise;
+
+        expect(result).toEqual({ processStatus: "online", syncing: true })
+    });
+
+    it("should return status and syncing using HTTPS", async () => {
+        process.env.CORE_API_DISABLED = "true";
+
+        let promise = action.execute({});
+
+        await expect(promise).toResolve();
+
+        let result = await promise;
+
+        expect(result).toEqual({ processStatus: "online", syncing: true })
+    });
+
+    it("should return syncing = false if error on request", async () => {
+        HttpClient.prototype.get = jest.fn().mockImplementation(async () => {
+            throw new Error();
+        })
+
+        let promise = action.execute({});
+
+        await expect(promise).toResolve();
+
+        let result = await promise;
+
+        expect(result).toEqual({ processStatus: "online", syncing: undefined })
+    });
+
+    it("should return status undefined if process status is undefined", async () => {
+        mockCli.get = jest.fn().mockReturnValue({
+            status: jest.fn().mockReturnValue(undefined)
+        })
+
+        let promise = action.execute({});
+
+        await expect(promise).toResolve();
+
+        let result = await promise;
+
+        expect(result).toEqual({ processStatus: "undefined", syncing: true })
+    });
 });

--- a/__tests__/unit/core-manager/utils/__mocks__/axios.ts
+++ b/__tests__/unit/core-manager/utils/__mocks__/axios.ts
@@ -1,0 +1,2 @@
+import mockAxios from 'jest-mock-axios';
+export default mockAxios;

--- a/__tests__/unit/core-manager/utils/http-client.test.ts
+++ b/__tests__/unit/core-manager/utils/http-client.test.ts
@@ -1,0 +1,20 @@
+import "jest-extended";
+
+import mockAxios from 'jest-mock-axios';
+import { HttpClient } from "@packages/core-manager/src/utils";
+
+describe("HttpClient", () => {
+    describe("get", () => {
+        it("should be ok", async () => {
+            let httpClient = new HttpClient( "http", "0.0.0.0", 4003);
+
+            let promise = httpClient.get("/")
+            mockAxios.mockResponse({ data: { result: {} } });
+
+            let result = await promise;
+
+            expect(result).toEqual({ result: {} });
+        })
+    })
+})
+

--- a/__tests__/unit/core-manager/utils/http-client.test.ts
+++ b/__tests__/unit/core-manager/utils/http-client.test.ts
@@ -1,15 +1,16 @@
 import "jest-extended";
 
-import got from 'got';
+// import got from 'got';
+import nock from "nock";
 import { HttpClient } from "@packages/core-manager/src/utils";
 
 describe("HttpClient", () => {
     describe("get", () => {
         it("should be ok", async () => {
-            got.get = jest.fn().mockReturnValue({
-                json: jest.fn().mockResolvedValue(
-                {result: {}}
-                )
+            nock.cleanAll();
+
+            nock(/.*/).get("/").reply(200, {
+                result: {}
             });
 
             let httpClient = new HttpClient( "http", "0.0.0.0", 4003);

--- a/__tests__/unit/core-manager/utils/http-client.test.ts
+++ b/__tests__/unit/core-manager/utils/http-client.test.ts
@@ -1,15 +1,20 @@
 import "jest-extended";
 
-import mockAxios from 'jest-mock-axios';
+import got from 'got';
 import { HttpClient } from "@packages/core-manager/src/utils";
 
 describe("HttpClient", () => {
     describe("get", () => {
         it("should be ok", async () => {
+            got.get = jest.fn().mockReturnValue({
+                json: jest.fn().mockResolvedValue(
+                {result: {}}
+                )
+            });
+
             let httpClient = new HttpClient( "http", "0.0.0.0", 4003);
 
             let promise = httpClient.get("/")
-            mockAxios.mockResponse({ data: { result: {} } });
 
             let result = await promise;
 

--- a/packages/core-manager/package.json
+++ b/packages/core-manager/package.json
@@ -32,6 +32,9 @@
         "hapi-auth-bearer-token": "^6.1.6",
         "latest-version": "^5.1.0"
     },
+    "devDependencies": {
+        "nock": "^12.0.3"
+    },
     "engines": {
         "node": ">=10.x"
     },

--- a/packages/core-manager/package.json
+++ b/packages/core-manager/package.json
@@ -22,18 +22,15 @@
     },
     "dependencies": {
         "argon2": "^0.26.2",
-        "axios": "^0.19.2",
         "@arkecosystem/core-kernel": "^3.0.0-next.0",
         "@hapi/basic": "^6.0.0",
         "@hapi/boom": "^9.0.0",
         "@hapi/hapi": "^19.0.0",
         "@hapist/json-rpc": "^0.2.0",
         "@hapist/whitelist": "^0.1.0",
+        "got": "^11.1.3",
         "hapi-auth-bearer-token": "^6.1.6",
         "latest-version": "^5.1.0"
-    },
-    "devDependencies": {
-        "jest-mock-axios": "^4.0.0"
     },
     "engines": {
         "node": ">=10.x"

--- a/packages/core-manager/package.json
+++ b/packages/core-manager/package.json
@@ -32,6 +32,9 @@
         "hapi-auth-bearer-token": "^6.1.6",
         "latest-version": "^5.1.0"
     },
+    "devDependencies": {
+        "jest-mock-axios": "^4.0.0"
+    },
     "engines": {
         "node": ">=10.x"
     },

--- a/packages/core-manager/package.json
+++ b/packages/core-manager/package.json
@@ -22,6 +22,7 @@
     },
     "dependencies": {
         "argon2": "^0.26.2",
+        "axios": "^0.19.2",
         "@arkecosystem/core-kernel": "^3.0.0-next.0",
         "@hapi/basic": "^6.0.0",
         "@hapi/boom": "^9.0.0",

--- a/packages/core-manager/src/actions/info-core-status.ts
+++ b/packages/core-manager/src/actions/info-core-status.ts
@@ -37,7 +37,7 @@ export class Action implements Actions.Action {
         return processManager.status(`${token}-core`);
     }
 
-    private async getSyncingStatus(): Promise<boolean> {
+    private async getSyncingStatus(): Promise<boolean | undefined> {
         let connection  = this.getConnectionData();
 
         const httpClient = new HttpClient(connection.protocol, connection.host, connection.port);
@@ -46,8 +46,8 @@ export class Action implements Actions.Action {
             let result = await httpClient.get("/api/node/syncing");
 
             return result.data.syncing;
-        } catch {
-            return false;
+        } catch (err) {
+            return undefined;
         }
     }
 

--- a/packages/core-manager/src/actions/info-core-status.ts
+++ b/packages/core-manager/src/actions/info-core-status.ts
@@ -43,9 +43,9 @@ export class Action implements Actions.Action {
         const httpClient = new HttpClient(connection.protocol, connection.host, connection.port);
 
         try {
-            let result = await httpClient.get("/api/node/syncing");
+            let response = await httpClient.get("/api/node/syncing");
 
-            return result.data.syncing;
+            return response.data.syncing;
         } catch (err) {
             return undefined;
         }

--- a/packages/core-manager/src/actions/info-core-status.ts
+++ b/packages/core-manager/src/actions/info-core-status.ts
@@ -1,0 +1,60 @@
+
+import { Application, Container } from "@arkecosystem/core-kernel";
+import { Application as Cli, Container as CliContainer, Contracts, Services } from "@arkecosystem/core-cli";
+import { Actions } from "../contracts"
+import { Identifiers } from "../ioc"
+import { HttpClient } from "../utils"
+
+
+@Container.injectable()
+export class Action implements Actions.Action {
+    public name = "info.coreStatus";
+
+    @Container.inject(Container.Identifiers.Application)
+    private readonly app!: Application;
+
+    public async execute(params: object): Promise<any> {
+        return {
+            processStatus: this.getProcessStatus(),
+            syncing: await this.getSyncingStatus()
+        }
+    }
+
+    private getProcessStatus(): Contracts.ProcessState | undefined {
+        const cli = this.app.get<Cli>(Identifiers.CLI);
+
+        const processManager = cli.get<Services.ProcessManager>(CliContainer.Identifiers.ProcessManager);
+
+        return processManager.status("ark-core");
+    }
+
+    private async getSyncingStatus(): Promise<boolean> {
+        let connection  = this.getConnectionData();
+
+        const httpClient = new HttpClient(connection.protocol, connection.host, connection.port);
+
+        try {
+            let result = await httpClient.get("/api/node/syncing");
+
+            return result.data.syncing;
+        } catch {
+            return false;
+        }
+    }
+
+    private getConnectionData(): { host: string, port: number | string, protocol: string } {
+        if (!process.env.CORE_API_DISABLED) {
+            return {
+                host: process.env.CORE_API_HOST || "0.0.0.0",
+                port: process.env.CORE_API_PORT || 4003,
+                protocol: "http"
+            }
+        }
+
+        return {
+            host: process.env.CORE_API_SSL_HOST || "0.0.0.0",
+            port: process.env.CORE_API_SSL_PORT || 8443,
+            protocol: "https"
+        }
+    }
+}

--- a/packages/core-manager/src/actions/info-core-status.ts
+++ b/packages/core-manager/src/actions/info-core-status.ts
@@ -10,22 +10,31 @@ import { HttpClient } from "../utils"
 export class Action implements Actions.Action {
     public name = "info.coreStatus";
 
+    public schema = {
+        type: "object",
+        properties: {
+            token: {
+                type: "string"
+            }
+        }
+    }
+
     @Container.inject(Container.Identifiers.Application)
     private readonly app!: Application;
 
-    public async execute(params: object): Promise<any> {
+    public async execute(params: any): Promise<any> {
         return {
-            processStatus: this.getProcessStatus(),
+            processStatus: this.getProcessStatus(params.token) || "undefined",
             syncing: await this.getSyncingStatus()
         }
     }
 
-    private getProcessStatus(): Contracts.ProcessState | undefined {
+    private getProcessStatus(token: string = "ark"): Contracts.ProcessState | undefined {
         const cli = this.app.get<Cli>(Identifiers.CLI);
 
         const processManager = cli.get<Services.ProcessManager>(CliContainer.Identifiers.ProcessManager);
 
-        return processManager.status("ark-core");
+        return processManager.status(`${token}-core`);
     }
 
     private async getSyncingStatus(): Promise<boolean> {

--- a/packages/core-manager/src/ioc/identifiers.ts
+++ b/packages/core-manager/src/ioc/identifiers.ts
@@ -1,6 +1,7 @@
 export const Identifiers = {
     HTTP: Symbol.for("API<HTTP>"),
     HTTPS: Symbol.for("API<HTTPS>"),
+    CLI: Symbol.for("Application<Cli>"),
     ActionReader: Symbol.for("Discover<Action>"),
     PluginFactory: Symbol.for("Factory<Plugin>"),
     BasicCredentialsValidator: Symbol.for("Validator<BasicCreadentials>"),

--- a/packages/core-manager/src/service-provider.ts
+++ b/packages/core-manager/src/service-provider.ts
@@ -1,4 +1,5 @@
-import { Providers} from "@arkecosystem/core-kernel";
+import { Container, Providers, Types } from "@arkecosystem/core-kernel";
+import { ApplicationFactory } from "@arkecosystem/core-cli";
 import { Identifiers } from "./ioc";
 import { Server } from "./server/server";
 import { ActionReader } from "./action-reader";
@@ -11,6 +12,9 @@ export class ServiceProvider extends Providers.ServiceProvider {
         this.app.bind(Identifiers.PluginFactory).to(PluginFactory).inSingletonScope();
         this.app.bind(Identifiers.BasicCredentialsValidator).to(Argon2id).inSingletonScope();
         this.app.bind(Identifiers.TokenValidator).to(SimpleTokenValidator).inSingletonScope();
+
+        const pkg: Types.PackageJson = require("../package.json");
+        this.app.bind(Identifiers.CLI).toConstantValue(ApplicationFactory.make(new Container.Container(), pkg));
 
         if (this.config().get("server.http.enabled")) {
             await this.buildServer("http", Identifiers.HTTP);

--- a/packages/core-manager/src/utils/http-client.ts
+++ b/packages/core-manager/src/utils/http-client.ts
@@ -7,8 +7,6 @@ export class HttpClient {
     public async get(path: string): Promise<any> {
         let url = `${this.protocol}://${this.host}:${this.port}${path}`
 
-        console.log(url)
-
         return  (await axios.get(url)).data;
     }
 }

--- a/packages/core-manager/src/utils/http-client.ts
+++ b/packages/core-manager/src/utils/http-client.ts
@@ -1,0 +1,14 @@
+import axios from "axios"
+
+export class HttpClient {
+    public constructor(private protocol: string, private host: string, private port: string | number) {
+    }
+
+    public async get(path: string): Promise<any> {
+        let url = `${this.protocol}://${this.host}:${this.port}${path}`
+
+        console.log(url)
+
+        return  (await axios.get(url)).data;
+    }
+}

--- a/packages/core-manager/src/utils/http-client.ts
+++ b/packages/core-manager/src/utils/http-client.ts
@@ -1,4 +1,4 @@
-import axios from "axios"
+import got from "got"
 
 export class HttpClient {
     public constructor(private protocol: string, private host: string, private port: string | number) {
@@ -7,6 +7,6 @@ export class HttpClient {
     public async get(path: string): Promise<any> {
         let url = `${this.protocol}://${this.host}:${this.port}${path}`
 
-        return  (await axios.get(url)).data;
+        return got(url).json();
     }
 }

--- a/packages/core-manager/src/utils/http-client.ts
+++ b/packages/core-manager/src/utils/http-client.ts
@@ -7,6 +7,6 @@ export class HttpClient {
     public async get(path: string): Promise<any> {
         let url = `${this.protocol}://${this.host}:${this.port}${path}`
 
-        return got(url).json();
+        return got.get(url).json();
     }
 }

--- a/packages/core-manager/src/utils/index.ts
+++ b/packages/core-manager/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from "./http-client"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8632,6 +8632,13 @@ jest-message-util@^26.0.0:
     slash "^3.0.0"
     stack-utils "^2.0.2"
 
+jest-mock-axios@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jest-mock-axios/-/jest-mock-axios-4.0.0.tgz#f59ac5dcdb4ae51c4ec21203382bc4c001dd26f4"
+  integrity sha512-p5+G9eVeEg2wH46Hle8yvsyXikk8V7jSDrlaNDOXc6sA5jyD6JAIO4voZPdB0V1A9rCVFHExOU+JRyTc2blnjw==
+  dependencies:
+    synchronous-promise "^2.0.10"
+
 jest-mock@^26.0.0:
   version "26.0.0"
   resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-26.0.0.tgz#71b14f634e1f3ec6bd6da1372a1bc03d0126f6a7"
@@ -13197,6 +13204,11 @@ symbol-tree@^3.2.4:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
+
+synchronous-promise@^2.0.10:
+  version "2.0.11"
+  resolved "https://registry.yarnpkg.com/synchronous-promise/-/synchronous-promise-2.0.11.tgz#e92022b0754e916f556d3ace1626d24a24214b7e"
+  integrity sha512-8/L5FOCjnlK0FoAfj+NqdCaImMKvEyOEzGmdfcezKp5K9HIukm4akx72endvM87eS/gU8kOxiMQflpC/CdkQAg==
 
 table@^5.2.3:
   version "5.4.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4167,6 +4167,13 @@ axios@^0.19.0:
     follow-redirects "1.5.10"
     is-buffer "^2.0.2"
 
+axios@^0.19.2:
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
+  integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
+  dependencies:
+    follow-redirects "1.5.10"
+
 babel-jest@^26.0.0:
   version "26.0.0"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-26.0.0.tgz#fa2adcff5313bd89bdf200bfa674fa4babd4f602"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

This PR add new action for getting current application process status and syncing status if available.

---

### Action

**Name:** info.coreStatus

**Params:**
|Name|Type|Description|
|-|-|-|
|token|String|(Optional). Name of the token. Used for getting process by token name|

**Response:**
|Name|Type|Description|
|-|-|-|
|processStatus|String|Proces status|
|syncing|Boolean|(Optional) Is node in syncing mode? Returned only if running node returned successful response.|


**Possible process statuses:**
- undefined
- online
- stopped
- stopping
- waiting restart
- launching
- errored
- one-launch-status

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
