### PR TITLE
feat(core-manager): implement `info.databaseSize` action

### DIFF
--- a/__tests__/unit/core-manager/action-reader.test.ts
+++ b/__tests__/unit/core-manager/action-reader.test.ts
@@ -1,8 +1,9 @@
 import "jest-extended";
 
-import { Sandbox } from "@packages/core-test-framework";
-import { Identifiers } from "@packages/core-manager/src/ioc";
+import { Container } from "@arkecosystem/core-kernel";
 import { ActionReader } from "@packages/core-manager";
+import { Identifiers } from "@packages/core-manager/src/ioc";
+import { Sandbox } from "@packages/core-test-framework";
 
 let sandbox: Sandbox;
 let actionReader: ActionReader;
@@ -11,13 +12,14 @@ beforeEach(() => {
     sandbox = new Sandbox();
 
     sandbox.app.bind(Identifiers.ActionReader).to(ActionReader).inSingletonScope();
+    sandbox.app.bind(Container.Identifiers.PluginConfiguration).toConstantValue({});
 
     actionReader = sandbox.app.get<ActionReader>(Identifiers.ActionReader);
 });
 
 describe("ActionReader", () => {
     it("should discover actions", async () => {
-        let actions = actionReader.discoverActions();
+        const actions = actionReader.discoverActions();
 
         expect(actions).toBeArray();
         expect(actions.length).toBeGreaterThanOrEqual(1);

--- a/__tests__/unit/core-manager/actions/info-database-size.test.ts
+++ b/__tests__/unit/core-manager/actions/info-database-size.test.ts
@@ -1,8 +1,6 @@
 import "jest-extended";
 
-import { Container } from "@packages/core-kernel";
 import { Action } from "@packages/core-manager/src/actions/info-database-size";
-import { defaults } from "@packages/core-manager/src/defaults";
 import { Sandbox } from "@packages/core-test-framework";
 import * as typeorm from "typeorm";
 
@@ -23,10 +21,6 @@ jest.spyOn(typeorm, "createConnection").mockImplementation(async () => {
 
 beforeEach(() => {
     sandbox = new Sandbox();
-
-    sandbox.app.bind(Container.Identifiers.PluginConfiguration).toConstantValue({
-        get: jest.fn().mockReturnValue({ ...defaults.connection }),
-    });
 
     action = sandbox.app.resolve(Action);
 });

--- a/__tests__/unit/core-manager/actions/info-database-size.test.ts
+++ b/__tests__/unit/core-manager/actions/info-database-size.test.ts
@@ -1,0 +1,44 @@
+import "jest-extended";
+
+import { Container } from "@packages/core-kernel";
+import { Action } from "@packages/core-manager/src/actions/info-database-size";
+import { defaults } from "@packages/core-manager/src/defaults";
+import { Sandbox } from "@packages/core-test-framework";
+import * as typeorm from "typeorm";
+
+let sandbox: Sandbox;
+let action: Action;
+
+// @ts-ignore
+jest.spyOn(typeorm, "createConnection").mockImplementation(async () => {
+    return {
+        query: jest.fn().mockResolvedValue([
+            {
+                pg_size_pretty: "100 MB",
+            },
+        ]),
+        close: jest.fn(),
+    };
+});
+
+beforeEach(() => {
+    sandbox = new Sandbox();
+
+    sandbox.app.bind(Container.Identifiers.PluginConfiguration).toConstantValue({
+        get: jest.fn().mockReturnValue({ ...defaults.connection }),
+    });
+
+    action = sandbox.app.resolve(Action);
+});
+
+describe("Info:DatabaseSize", () => {
+    it("should have name", () => {
+        expect(action.name).toEqual("info.databaseSize");
+    });
+
+    it("should return database size", async () => {
+        const result = await action.execute();
+
+        await expect(result.size).toBe("100 MB");
+    });
+});

--- a/__tests__/unit/core-manager/actions/info-database-size.test.ts
+++ b/__tests__/unit/core-manager/actions/info-database-size.test.ts
@@ -12,7 +12,7 @@ jest.spyOn(typeorm, "createConnection").mockImplementation(async () => {
     return {
         query: jest.fn().mockResolvedValue([
             {
-                pg_size_pretty: "100 MB",
+                pg_database_size: 1024,
             },
         ]),
         close: jest.fn(),
@@ -33,6 +33,6 @@ describe("Info:DatabaseSize", () => {
     it("should return database size", async () => {
         const result = await action.execute();
 
-        await expect(result.size).toBe("100 MB");
+        await expect(result.size).toBe(1);
     });
 });

--- a/__tests__/unit/core-manager/actions/info-disk-space.test.ts
+++ b/__tests__/unit/core-manager/actions/info-disk-space.test.ts
@@ -33,7 +33,7 @@ beforeEach(() => {
     action = sandbox.app.resolve(Action);
 });
 
-describe("Info:CoreVersion", () => {
+describe("Info:DiskSpace", () => {
     it("should have name", () => {
         expect(action.name).toEqual("info.diskSpace");
     });

--- a/packages/core-manager/package.json
+++ b/packages/core-manager/package.json
@@ -31,7 +31,8 @@
         "@hapist/whitelist": "^0.1.0",
         "got": "^11.1.3",
         "hapi-auth-bearer-token": "^6.1.6",
-        "latest-version": "^5.1.0"
+        "latest-version": "^5.1.0",
+        "typeorm": "^0.2.21"
     },
     "devDependencies": {
         "nock": "^12.0.3"

--- a/packages/core-manager/package.json
+++ b/packages/core-manager/package.json
@@ -23,6 +23,7 @@
     "dependencies": {
         "argon2": "^0.26.2",
         "@arkecosystem/core-kernel": "^3.0.0-next.0",
+        "@arkecosystem/core-database": "^3.0.0-next.0",
         "@arkecosystem/core-cli": "^3.0.0-next.0",
         "@hapi/basic": "^6.0.0",
         "@hapi/boom": "^9.0.0",

--- a/packages/core-manager/src/actions/info-database-size.ts
+++ b/packages/core-manager/src/actions/info-database-size.ts
@@ -21,14 +21,15 @@ export class Action implements Actions.Action {
         return this.getDatabaseDefaults().connection.database;
     }
 
-    private async getDatabaseSize(): Promise<string> {
+    private async getDatabaseSize(): Promise<number> {
         const connection = await this.connect();
 
         try {
             const result = await connection.query(
-                `SELECT pg_size_pretty( pg_database_size('${this.getDatabaseName()}'));`,
+                `SELECT pg_database_size('${this.getDatabaseName()}');`,
             );
-            return result[0].pg_size_pretty;
+
+            return Math.round(result[0].pg_database_size / 1024);
         } finally {
             await connection.close();
         }

--- a/packages/core-manager/src/actions/info-database-size.ts
+++ b/packages/core-manager/src/actions/info-database-size.ts
@@ -1,4 +1,4 @@
-import { Container, Providers } from "@arkecosystem/core-kernel";
+import { Container } from "@arkecosystem/core-kernel";
 import { Connection, ConnectionOptions, createConnection } from "typeorm";
 
 import { Actions } from "../contracts";
@@ -7,19 +7,18 @@ import { Actions } from "../contracts";
 export class Action implements Actions.Action {
     public name = "info.databaseSize";
 
-    @Container.inject(Container.Identifiers.PluginConfiguration)
-    @Container.tagged("plugin", "@arkecosystem/core-manager")
-    private readonly configuration!: Providers.PluginConfiguration;
-
     public async execute(): Promise<any> {
         return {
             size: await this.getDatabaseSize(),
         };
     }
 
+    private getDatabaseDefaults() {
+        return require("@arkecosystem/core-database/dist/defaults").defaults;
+    }
+
     private getDatabaseName(): string {
-        // @ts-ignore
-        return this.configuration.get("connection").database;
+        return this.getDatabaseDefaults().connection.database;
     }
 
     private async getDatabaseSize(): Promise<string> {
@@ -36,6 +35,6 @@ export class Action implements Actions.Action {
     }
 
     private async connect(): Promise<Connection> {
-        return createConnection(this.configuration.get("connection") as ConnectionOptions);
+        return createConnection(this.getDatabaseDefaults().connection as ConnectionOptions);
     }
 }

--- a/packages/core-manager/src/actions/info-database-size.ts
+++ b/packages/core-manager/src/actions/info-database-size.ts
@@ -14,6 +14,7 @@ export class Action implements Actions.Action {
     }
 
     private getDatabaseDefaults() {
+        // todo: this has to be grabbed from the container for the alias `database` or the manager will only work with official plugins
         return require("@arkecosystem/core-database/dist/defaults").defaults;
     }
 

--- a/packages/core-manager/src/actions/info-database-size.ts
+++ b/packages/core-manager/src/actions/info-database-size.ts
@@ -1,0 +1,41 @@
+import { Container, Providers } from "@arkecosystem/core-kernel";
+import { Connection, ConnectionOptions, createConnection } from "typeorm";
+
+import { Actions } from "../contracts";
+
+@Container.injectable()
+export class Action implements Actions.Action {
+    public name = "info.databaseSize";
+
+    @Container.inject(Container.Identifiers.PluginConfiguration)
+    @Container.tagged("plugin", "@arkecosystem/core-manager")
+    private readonly configuration!: Providers.PluginConfiguration;
+
+    public async execute(): Promise<any> {
+        return {
+            size: await this.getDatabaseSize(),
+        };
+    }
+
+    private getDatabaseName(): string {
+        // @ts-ignore
+        return this.configuration.get("connection").database;
+    }
+
+    private async getDatabaseSize(): Promise<string> {
+        const connection = await this.connect();
+
+        try {
+            const result = await connection.query(
+                `SELECT pg_size_pretty( pg_database_size('${this.getDatabaseName()}'));`,
+            );
+            return result[0].pg_size_pretty;
+        } finally {
+            await connection.close();
+        }
+    }
+
+    private async connect(): Promise<Connection> {
+        return createConnection(this.configuration.get("connection") as ConnectionOptions);
+    }
+}

--- a/packages/core-manager/src/defaults.ts
+++ b/packages/core-manager/src/defaults.ts
@@ -16,17 +16,6 @@ export const defaults = {
             },
         },
     },
-    connection: {
-        type: "postgres",
-        host: process.env.CORE_DB_HOST || "localhost",
-        port: process.env.CORE_DB_PORT || 5432,
-        database: process.env.CORE_DB_DATABASE || `${process.env.CORE_TOKEN}_${process.env.CORE_NETWORK_NAME}`,
-        username: process.env.CORE_DB_USERNAME || process.env.CORE_TOKEN,
-        password: process.env.CORE_DB_PASSWORD || "password",
-        entityPrefix: "public.",
-        synchronize: false,
-        logging: false,
-    },
     plugins: {
         whitelist: ["*"],
         tokenAuthentication: {

--- a/packages/core-manager/src/defaults.ts
+++ b/packages/core-manager/src/defaults.ts
@@ -16,6 +16,17 @@ export const defaults = {
             },
         },
     },
+    connection: {
+        type: "postgres",
+        host: process.env.CORE_DB_HOST || "localhost",
+        port: process.env.CORE_DB_PORT || 5432,
+        database: process.env.CORE_DB_DATABASE || `${process.env.CORE_TOKEN}_${process.env.CORE_NETWORK_NAME}`,
+        username: process.env.CORE_DB_USERNAME || process.env.CORE_TOKEN,
+        password: process.env.CORE_DB_PASSWORD || "password",
+        entityPrefix: "public.",
+        synchronize: false,
+        logging: false,
+    },
     plugins: {
         whitelist: ["*"],
         tokenAuthentication: {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

This PR add new action for getting database space using pg_database_size SQL method. 

### Action

**Name:** info.databaseSize

**Params:** none

**Response:**
|Name|Type|Description|
|-|-|-|
|size|Number|Size of the database in KB.|

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
