### PR TITLE
feat(core-manager): implement `process.list` action

### DIFF
--- a/__tests__/unit/core-manager/actions/info-core-status.test.ts
+++ b/__tests__/unit/core-manager/actions/info-core-status.test.ts
@@ -1,10 +1,10 @@
 import "jest-extended";
 
-import { Sandbox } from "@packages/core-test-framework";
 import { ProcessState } from "@packages/core-cli/src/contracts";
 import { Action } from "@packages/core-manager/src/actions/info-core-status";
 import { Identifiers } from "@packages/core-manager/src/ioc";
 import { HttpClient } from "@packages/core-manager/src/utils";
+import { Sandbox } from "@packages/core-test-framework";
 
 let sandbox: Sandbox;
 let action: Action;
@@ -14,19 +14,15 @@ let mockCli;
 beforeEach(() => {
     mockCli = {
         get: jest.fn().mockReturnValue({
-            status: jest.fn().mockReturnValue(ProcessState.Online)
-        })
-    }
+            status: jest.fn().mockReturnValue(ProcessState.Online),
+        }),
+    };
 
-    HttpClient.prototype.get = jest.fn().mockReturnValue(
-        {
-            data: {
-                syncing: true
-            }
-        }
-    )
-
-
+    HttpClient.prototype.get = jest.fn().mockReturnValue({
+        data: {
+            syncing: true,
+        },
+    });
 
     sandbox = new Sandbox();
 
@@ -36,62 +32,62 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-    delete process.env.CORE_API_DISABLED
+    delete process.env.CORE_API_DISABLED;
     jest.clearAllMocks();
-})
+});
 
 describe("Info:CoreStatus", () => {
     it("should have name", () => {
         expect(action.name).toEqual("info.coreStatus");
-    })
+    });
 
     it("should return status and syncing using HTTP", async () => {
-        let promise = action.execute({});
+        const promise = action.execute({});
 
         await expect(promise).toResolve();
 
-        let result = await promise;
+        const result = await promise;
 
-        expect(result).toEqual({ processStatus: "online", syncing: true })
+        expect(result).toEqual({ processStatus: "online", syncing: true });
     });
 
     it("should return status and syncing using HTTPS", async () => {
         process.env.CORE_API_DISABLED = "true";
 
-        let promise = action.execute({});
+        const promise = action.execute({});
 
         await expect(promise).toResolve();
 
-        let result = await promise;
+        const result = await promise;
 
-        expect(result).toEqual({ processStatus: "online", syncing: true })
+        expect(result).toEqual({ processStatus: "online", syncing: true });
     });
 
     it("should return syncing = false if error on request", async () => {
         HttpClient.prototype.get = jest.fn().mockImplementation(async () => {
             throw new Error();
-        })
+        });
 
-        let promise = action.execute({});
+        const promise = action.execute({});
 
         await expect(promise).toResolve();
 
-        let result = await promise;
+        const result = await promise;
 
-        expect(result).toEqual({ processStatus: "online", syncing: undefined })
+        expect(result).toEqual({ processStatus: "online", syncing: undefined });
     });
 
     it("should return status undefined if process status is undefined", async () => {
         mockCli.get = jest.fn().mockReturnValue({
-            status: jest.fn().mockReturnValue(undefined)
-        })
+            status: jest.fn().mockReturnValue(undefined),
+        });
 
-        let promise = action.execute({});
+        const promise = action.execute({});
 
         await expect(promise).toResolve();
 
-        let result = await promise;
+        const result = await promise;
 
-        expect(result).toEqual({ processStatus: "undefined", syncing: true })
+        expect(result).toEqual({ processStatus: "undefined", syncing: true });
     });
 });

--- a/__tests__/unit/core-manager/actions/process-list.test.ts
+++ b/__tests__/unit/core-manager/actions/process-list.test.ts
@@ -59,7 +59,7 @@ describe("Process:List", () => {
                 name: "ark-manager",
                 pm_id: 0,
                 monit: {
-                    memory: 98283520,
+                    memory: 95980,
                     cpu: 0.1,
                 },
                 status: "online",

--- a/__tests__/unit/core-manager/actions/process-list.test.ts
+++ b/__tests__/unit/core-manager/actions/process-list.test.ts
@@ -1,0 +1,69 @@
+import "jest-extended";
+
+import { ProcessState } from "@packages/core-cli/src/contracts";
+import { Action } from "@packages/core-manager/src/actions/process-list";
+import { Identifiers } from "@packages/core-manager/src/ioc";
+import { Sandbox } from "@packages/core-test-framework";
+
+let sandbox: Sandbox;
+let action: Action;
+
+let mockCli;
+
+beforeEach(() => {
+    mockCli = {
+        get: jest.fn().mockReturnValue({
+            list: jest.fn().mockReturnValue([
+                {
+                    pid: 13477,
+                    name: "ark-manager",
+                    pm_id: 0,
+                    pm2_env: {},
+                    monit: {
+                        memory: 98283520,
+                        cpu: 0.1,
+                    },
+                },
+            ]),
+            status: jest.fn().mockReturnValue(ProcessState.Online),
+        }),
+    };
+
+    sandbox = new Sandbox();
+
+    sandbox.app.bind(Identifiers.CLI).toConstantValue(mockCli);
+
+    action = sandbox.app.resolve(Action);
+});
+
+afterEach(() => {
+    delete process.env.CORE_API_DISABLED;
+    jest.clearAllMocks();
+});
+
+describe("Process:List", () => {
+    it("should have name", () => {
+        expect(action.name).toEqual("process.list");
+    });
+
+    it("should return process list", async () => {
+        const promise = action.execute({});
+
+        await expect(promise).toResolve();
+
+        const result = await promise;
+
+        expect(result).toEqual([
+            {
+                pid: 13477,
+                name: "ark-manager",
+                pm_id: 0,
+                monit: {
+                    memory: 98283520,
+                    cpu: 0.1,
+                },
+                status: "online",
+            },
+        ]);
+    });
+});

--- a/__tests__/unit/core/commands/manager-start.test.ts
+++ b/__tests__/unit/core/commands/manager-start.test.ts
@@ -1,0 +1,42 @@
+import { Container } from "@arkecosystem/core-cli";
+import { Console } from "@arkecosystem/core-test-framework";
+import { Command } from "@packages/core/src/commands/manager-start";
+import os from "os";
+import { resolve } from "path";
+import { dirSync, setGracefulCleanup } from "tmp";
+
+let cli;
+let processManager;
+beforeEach(() => {
+    process.env.CORE_PATH_CONFIG = dirSync().name;
+
+    cli = new Console();
+    processManager = cli.app.get(Container.Identifiers.ProcessManager);
+});
+
+afterAll(() => setGracefulCleanup());
+
+describe("StartCommand", () => {
+    it("should throw if the process does not exist", async () => {
+        jest.spyOn(os, "freemem").mockReturnValue(99999999999);
+        jest.spyOn(os, "totalmem").mockReturnValue(99999999999);
+
+        const spyStart = jest.spyOn(processManager, "start").mockImplementation(undefined);
+
+        await cli.execute(Command);
+
+        expect(spyStart).toHaveBeenCalledWith(
+            {
+                args: "manager:run --token=ark --network=testnet --v=0 --env=production",
+                env: {
+                    CORE_ENV: "production",
+                    NODE_ENV: "production",
+                },
+                name: "ark-manager",
+                node_args: undefined,
+                script: resolve(__dirname, "../../../../packages/core/bin/run"),
+            },
+            { "kill-timeout": 30000, "max-restarts": 5, name: "ark-manager" },
+        );
+    });
+});

--- a/__tests__/unit/core/commands/manager-stop.test.ts
+++ b/__tests__/unit/core/commands/manager-stop.test.ts
@@ -1,0 +1,82 @@
+import { Container } from "@arkecosystem/core-cli";
+import { Console } from "@arkecosystem/core-test-framework";
+import { Command } from "@packages/core/src/commands/manager-stop";
+
+let cli;
+let processManager;
+beforeEach(() => {
+    cli = new Console();
+    processManager = cli.app.get(Container.Identifiers.ProcessManager);
+});
+
+describe("StopCommand", () => {
+    it("should throw if the process does not exist", async () => {
+        const missing = jest.spyOn(processManager, "missing").mockReturnValue(true);
+        const isUnknown = jest.spyOn(processManager, "isUnknown").mockReturnValue(false);
+        const isStopped = jest.spyOn(processManager, "isStopped").mockReturnValue(false);
+
+        await expect(cli.execute(Command)).rejects.toThrowError('[ERROR] The "ark-manager" process does not exist.');
+
+        missing.mockReset();
+        isUnknown.mockReset();
+        isStopped.mockReset();
+    });
+
+    it("should throw if the process entered an unknown state", async () => {
+        const missing = jest.spyOn(processManager, "missing").mockReturnValue(false);
+        const isUnknown = jest.spyOn(processManager, "isUnknown").mockReturnValue(true);
+        const isStopped = jest.spyOn(processManager, "isStopped").mockReturnValue(false);
+
+        await expect(cli.execute(Command)).rejects.toThrowError(
+            '[ERROR] The "ark-manager" process has entered an unknown state.',
+        );
+
+        missing.mockReset();
+        isUnknown.mockReset();
+        isStopped.mockReset();
+    });
+
+    it("should throw if the process is stopped", async () => {
+        const missing = jest.spyOn(processManager, "missing").mockReturnValue(false);
+        const isUnknown = jest.spyOn(processManager, "isUnknown").mockReturnValue(false);
+        const isStopped = jest.spyOn(processManager, "isStopped").mockReturnValue(true);
+
+        await expect(cli.execute(Command)).rejects.toThrowError('[ERROR] The "ark-manager" process is not running.');
+
+        missing.mockReset();
+        isUnknown.mockReset();
+        isStopped.mockReset();
+    });
+
+    it("should stop the process if the [--daemon] flag is not present", async () => {
+        const missing = jest.spyOn(processManager, "missing").mockReturnValue(false);
+        const isUnknown = jest.spyOn(processManager, "isUnknown").mockReturnValue(false);
+        const isStopped = jest.spyOn(processManager, "isStopped").mockReturnValue(false);
+        const deleteSpy = jest.spyOn(processManager, "delete").mockImplementation();
+
+        await cli.withFlags({ daemon: true }).execute(Command);
+
+        expect(deleteSpy).toHaveBeenCalled();
+
+        missing.mockReset();
+        isUnknown.mockReset();
+        isStopped.mockReset();
+        deleteSpy.mockReset();
+    });
+
+    it("should delete the process if the [--daemon] flag is present", async () => {
+        const missing = jest.spyOn(processManager, "missing").mockReturnValue(false);
+        const isUnknown = jest.spyOn(processManager, "isUnknown").mockReturnValue(false);
+        const isStopped = jest.spyOn(processManager, "isStopped").mockReturnValue(false);
+        const stop = jest.spyOn(processManager, "stop").mockImplementation();
+
+        await cli.execute(Command);
+
+        expect(stop).toHaveBeenCalled();
+
+        missing.mockReset();
+        isUnknown.mockReset();
+        isStopped.mockReset();
+        stop.mockReset();
+    });
+});

--- a/packages/core-manager/src/actions/process-list.ts
+++ b/packages/core-manager/src/actions/process-list.ts
@@ -1,0 +1,33 @@
+import { Application as Cli, Container as CliContainer, Services } from "@arkecosystem/core-cli";
+import { Application, Container } from "@arkecosystem/core-kernel";
+
+import { Actions } from "../contracts";
+import { Identifiers } from "../ioc";
+
+@Container.injectable()
+export class Action implements Actions.Action {
+    public name = "process.list";
+
+    @Container.inject(Container.Identifiers.Application)
+    private readonly app!: Application;
+
+    public async execute(params: any): Promise<any> {
+        return this.getProcessList();
+    }
+
+    private getProcessList(): any[] {
+        const cli = this.app.get<Cli>(Identifiers.CLI);
+
+        const processManager = cli.get<Services.ProcessManager>(CliContainer.Identifiers.ProcessManager);
+
+        const processList = processManager.list();
+
+        for (const processInfo of processList) {
+            delete processInfo.pm2_env;
+
+            processInfo.status = processManager.status(processInfo.name) || "undefined";
+        }
+
+        return processList;
+    }
+}

--- a/packages/core-manager/src/actions/process-list.ts
+++ b/packages/core-manager/src/actions/process-list.ts
@@ -25,6 +25,8 @@ export class Action implements Actions.Action {
         for (const processInfo of processList) {
             delete processInfo.pm2_env;
 
+            processInfo.monit.memory = Math.round(processInfo.monit.memory / 1024);
+
             processInfo.status = processManager.status(processInfo.name) || "undefined";
         }
 

--- a/packages/core/src/commands/manager-stop.ts
+++ b/packages/core/src/commands/manager-stop.ts
@@ -1,5 +1,4 @@
-import { Commands, Container, Utils } from "@arkecosystem/core-cli";
-import { Networks } from "@arkecosystem/crypto";
+import { Commands, Container } from "@arkecosystem/core-cli";
 import Joi from "@hapi/joi";
 
 /**
@@ -15,7 +14,7 @@ export class Command extends Commands.Command {
      * @type {string}
      * @memberof Command
      */
-    public signature: string = "manager:run";
+    public signature: string = "manager:stop";
 
     /**
      * The console command description.
@@ -23,8 +22,7 @@ export class Command extends Commands.Command {
      * @type {string}
      * @memberof Command
      */
-    public description: string =
-        "Run the Manager process in background. Exiting the process will stop it from running.";
+    public description: string = "Stop the Manager process.";
 
     /**
      * Configure the console command.
@@ -35,8 +33,7 @@ export class Command extends Commands.Command {
     public configure(): void {
         this.definition
             .setFlag("token", "The name of the token.", Joi.string().default("ark"))
-            .setFlag("network", "The name of the network.", Joi.string().valid(...Object.keys(Networks)))
-            .setFlag("env", "", Joi.string().default("production"));
+            .setFlag("daemon", "Stop the Core process or daemon.", Joi.boolean());
     }
 
     /**
@@ -46,11 +43,8 @@ export class Command extends Commands.Command {
      * @memberof Command
      */
     public async execute(): Promise<void> {
-        const flags = { ...this.getFlags() };
-        flags.processType = "manager";
-
-        await Utils.buildApplication({
-            flags,
-        });
+        this.app
+            .get<any>(Container.Identifiers.ProcessFactory)(this.getFlag("token"), "manager")
+            .stop(this.getFlag("daemon"));
     }
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

This PR add new action which returns list of all pm2 processes. PR also implements additional CLI commands:
- manager:start
- manager:stop

### Action

**Name:** process.list

**Params:** none

**Response:**: Array of process informations.
|Name|Type|Description|
|-|-|-|
|pid|Number|Process ID.|
|name|String|Process name.|
|pm_id|Number|PM2 process id.|
|status|String|Process status.|
|monit.memory|Number|Process memory consumption in KB|
|monit.cpu|Number|Process cpu consumption in percent.|

**Possible process statuses:**
- undefined
- online
- stopped
- stopping
- waiting restart
- launching
- errored
- one-launch-status


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
