### PR TITLE
feat(core-manager): implement `process.stop` action 

### DIFF
--- a/__tests__/unit/core-manager/actions/process.stop.test.ts
+++ b/__tests__/unit/core-manager/actions/process.stop.test.ts
@@ -1,0 +1,45 @@
+import "jest-extended";
+
+import { ProcessState } from "@packages/core-cli/src/contracts";
+import { Action } from "@packages/core-manager/src/actions/process.stop";
+import { Identifiers } from "@packages/core-manager/src/ioc";
+import { Sandbox } from "@packages/core-test-framework";
+
+let sandbox: Sandbox;
+let action: Action;
+
+let mockCli;
+
+beforeEach(() => {
+    mockCli = {
+        get: jest.fn().mockReturnValue({
+            status: jest.fn().mockReturnValue(ProcessState.Stopped),
+            stop: jest.fn(),
+        }),
+    };
+
+    sandbox = new Sandbox();
+
+    sandbox.app.bind(Identifiers.CLI).toConstantValue(mockCli);
+
+    action = sandbox.app.resolve(Action);
+});
+
+afterEach(() => {
+    jest.clearAllMocks();
+});
+
+describe("Process:Stop", () => {
+    it("should have name", () => {
+        expect(action.name).toEqual("process.stop");
+    });
+
+    it("should return stopped process status", async () => {
+        const result = await action.execute({ name: "ark-core" });
+
+        expect(result).toEqual({
+            name: "ark-core",
+            status: "stopped",
+        });
+    });
+});

--- a/packages/core-manager/src/actions/process.stop.ts
+++ b/packages/core-manager/src/actions/process.stop.ts
@@ -1,0 +1,40 @@
+import { Application as Cli, Container as CliContainer, Services } from "@arkecosystem/core-cli";
+import { Application, Container } from "@arkecosystem/core-kernel";
+
+import { Actions } from "../contracts";
+import { Identifiers } from "../ioc";
+
+@Container.injectable()
+export class Action implements Actions.Action {
+    public name = "process.stop";
+
+    public schema = {
+        type: "object",
+        properties: {
+            name: {
+                type: "string",
+            },
+        },
+        required: ["name"],
+    };
+
+    @Container.inject(Container.Identifiers.Application)
+    private readonly app!: Application;
+
+    public async execute(params: any): Promise<any> {
+        return {
+            name: params.name,
+            status: this.stopProcess(params.name),
+        };
+    }
+
+    private stopProcess(name: string): string {
+        const cli = this.app.get<Cli>(Identifiers.CLI);
+
+        const processManager = cli.get<Services.ProcessManager>(CliContainer.Identifiers.ProcessManager);
+
+        processManager.stop(name);
+
+        return processManager.status(name)?.toString() || "undefined";
+    }
+}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

This PR add new action which stop the named process and return stopped process status.

### Action

**Name:** process.stop

**Params:**
|Name|Type|Description|
|-|-|-|
|name|String|Process name.|

**Response:**
|Name|Type|Description|
|-|-|-|
|name|String|Process name.|
|status|String|Process status.|


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
