### PR TITLE
feat(core-manager): implement `process.start` action

### DIFF
--- a/__tests__/unit/core-manager/actions/process-start.test.ts
+++ b/__tests__/unit/core-manager/actions/process-start.test.ts
@@ -1,0 +1,54 @@
+import "jest-extended";
+
+import { Action } from "@packages/core-manager/src/actions/process-start";
+import { Identifiers } from "@packages/core-manager/src/ioc";
+import { Sandbox } from "@packages/core-test-framework";
+
+let sandbox: Sandbox;
+let action: Action;
+
+let mockCli;
+
+const mockCoreStart = {
+    register: jest.fn(),
+    run: jest.fn(),
+};
+
+const mockCommands = {
+    ["core:start"]: mockCoreStart,
+};
+
+beforeEach(() => {
+    mockCli = {
+        resolve: jest.fn().mockReturnValue({
+            within: jest.fn().mockReturnValue(mockCommands),
+        }),
+    };
+
+    sandbox = new Sandbox();
+
+    sandbox.app.bind(Identifiers.CLI).toConstantValue(mockCli);
+
+    action = sandbox.app.resolve(Action);
+});
+
+afterEach(() => {
+    delete process.env.CORE_API_DISABLED;
+    jest.clearAllMocks();
+});
+
+describe("Process:Start", () => {
+    it("should have name", () => {
+        expect(action.name).toEqual("process.start");
+    });
+
+    it("should start ", async () => {
+        const result = await action.execute({ name: "core", args: "--network=testnet --env=test" });
+
+        expect(result).toEqual({});
+    });
+
+    it("should throw error if name is invalid ", async () => {
+        await expect(action.execute({ name: "invalid", args: "--network=testnet --env=test" })).rejects.toThrowError();
+    });
+});

--- a/packages/core-manager/src/actions/process-start.ts
+++ b/packages/core-manager/src/actions/process-start.ts
@@ -1,0 +1,68 @@
+import * as Cli from "@arkecosystem/core-cli";
+import { Application, Container } from "@arkecosystem/core-kernel";
+import { resolve } from "path";
+
+import { Actions } from "../contracts";
+import { Identifiers } from "../ioc";
+
+@Container.injectable()
+export class Action implements Actions.Action {
+    public name = "process.start";
+
+    public schema = {
+        type: "object",
+        properties: {
+            name: {
+                type: "string",
+            },
+            args: {
+                type: "string",
+            },
+        },
+        required: ["name", "args"],
+    };
+
+    @Container.inject(Container.Identifiers.Application)
+    private readonly app!: Application;
+
+    public async execute(params: any): Promise<any> {
+        return await this.startProcess(params.name, params.args);
+    }
+
+    private async startProcess(name: string, args: string): Promise<any> {
+        const commands = this.discoverCommands();
+
+        const command: Cli.Commands.Command = commands[`${name}:start`];
+
+        if (!command) {
+            throw new Error(`Command ${name}:start does not exists.`);
+        }
+
+        const splitArgs = args.replace(/\s+/g, " ").split(" ");
+
+        const argv = [`${name}:start`, ...splitArgs];
+
+        command.register(argv);
+
+        await command.run();
+
+        return {};
+    }
+
+    private discoverCommands(): Cli.Contracts.CommandList {
+        const cli = this.app.get<Cli.Application>(Identifiers.CLI);
+
+        const discoverer = cli.resolve(Cli.Commands.DiscoverCommands);
+        const commands = discoverer.within(resolve("./dist/commands"));
+
+        const startCommands = {};
+
+        for (const command of Object.keys(commands)) {
+            if (command.includes(":start")) {
+                startCommands[command] = commands[command];
+            }
+        }
+
+        return startCommands;
+    }
+}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

This PR add new action which starts named process via CLI command with passed arguments.


### Action

**Name:** process.start

**Params:**
|Name|Type|Description|
|-|-|-|
|name|String|Cli command name without :start. Examples: core, forger, manager, relay|
|args|String|Additional command arguments: Example: --network=devnet --token=dark|

**Response:** none


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
