### PR TITLE
feat(core-manager): implement `log.log` action 

### DIFF
--- a/__tests__/unit/core-manager/action-reader.test.ts
+++ b/__tests__/unit/core-manager/action-reader.test.ts
@@ -13,6 +13,7 @@ beforeEach(() => {
 
     sandbox.app.bind(Identifiers.ActionReader).to(ActionReader).inSingletonScope();
     sandbox.app.bind(Container.Identifiers.PluginConfiguration).toConstantValue({});
+    sandbox.app.bind(Container.Identifiers.FilesystemService).toConstantValue({});
 
     actionReader = sandbox.app.get<ActionReader>(Identifiers.ActionReader);
 });

--- a/__tests__/unit/core-manager/actions/log-log.test.ts
+++ b/__tests__/unit/core-manager/actions/log-log.test.ts
@@ -1,0 +1,62 @@
+import "jest-extended";
+
+import { Container } from "@packages/core-kernel";
+import { Action } from "@packages/core-manager/src/actions/log-log";
+import { Sandbox } from "@packages/core-test-framework";
+
+let sandbox: Sandbox;
+let action: Action;
+
+const mockFilesystem = {
+    exists: jest.fn().mockReturnValue(true),
+};
+
+jest.mock("execa", () => {
+    return {
+        sync: jest.fn().mockImplementation((command: string) => {
+            if (command.includes("wc")) {
+                return {
+                    stdout: "     100 path/to/file",
+                };
+            }
+
+            return {
+                stdout: "file lines",
+            };
+        }),
+    };
+});
+
+beforeEach(() => {
+    sandbox = new Sandbox();
+
+    sandbox.app.bind(Container.Identifiers.FilesystemService).toConstantValue(mockFilesystem);
+
+    action = sandbox.app.resolve(Action);
+});
+
+describe("Log:Log", () => {
+    it("should have name", () => {
+        expect(action.name).toEqual("log.log");
+    });
+
+    it("should return totalLines and lines", async () => {
+        const result = await action.execute({ name: "ark-core" });
+
+        await expect(result.totalLines).toBe(100);
+        await expect(result.lines).toBeString();
+    });
+
+    it("should return totalLines and lines if showError is set", async () => {
+        const result = await action.execute({ name: "ark-core", showError: true });
+
+        await expect(result.totalLines).toBe(100);
+        await expect(result.lines).toBeString();
+    });
+
+    it("should throw error if file not exists", async () => {
+        mockFilesystem.exists = jest.fn().mockReturnValue(false);
+
+        await expect(action.execute({ name: "ark-core" })).rejects.toThrowError("Cannot find log file");
+    });
+});

--- a/packages/core-manager/src/actions/log-log.ts
+++ b/packages/core-manager/src/actions/log-log.ts
@@ -1,0 +1,77 @@
+import { Container, Contracts } from "@arkecosystem/core-kernel";
+import { ExecaSyncReturnValue, sync } from "execa";
+import { join } from "path";
+
+import { Actions } from "../contracts";
+
+@Container.injectable()
+export class Action implements Actions.Action {
+    public name = "log.log";
+
+    public schema = {
+        type: "object",
+        properties: {
+            name: {
+                type: "string",
+            },
+            showError: {
+                type: "boolean",
+            },
+            fromLine: {
+                type: "integer",
+                minimum: 1,
+            },
+            range: {
+                type: "integer",
+                minimum: 1,
+                maximum: 10000,
+            },
+        },
+        required: ["name"],
+    };
+
+    @Container.inject(Container.Identifiers.FilesystemService)
+    private readonly filesystem!: Contracts.Kernel.Filesystem;
+
+    public async execute(params: {
+        name: string;
+        fromLine?: number;
+        range?: number;
+        showError?: boolean;
+    }): Promise<any> {
+        return await this.getLog(params.name, params.fromLine, params.range, params.showError);
+    }
+
+    private getTotalLines(path: string): number {
+        const response: ExecaSyncReturnValue = sync(`wc -l ${path}`, { shell: true });
+
+        return parseInt(response.stdout);
+    }
+
+    private getLines(path: string, fromLine: number, range: number): number {
+        const response: ExecaSyncReturnValue = sync(`sed -n '${fromLine},${fromLine + range}p' ${path}`, {
+            shell: true,
+        });
+
+        return response.stdout;
+    }
+
+    private async getLog(
+        name: string,
+        fromLine: number = 1,
+        range: number = 100,
+        showError: boolean = false,
+    ): Promise<any> {
+        const logsPath = `${process.env.HOME}/.pm2/logs`;
+        const filePath = join(logsPath, `${name}-${showError ? "error" : "out"}.log`);
+
+        if (this.filesystem.exists(filePath)) {
+            return {
+                totalLines: this.getTotalLines(filePath),
+                lines: this.getLines(filePath, fromLine, range),
+            };
+        }
+
+        throw new Error("Cannot find log file");
+    }
+}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary


This PR add new action which return total count of log file lines and return those lines in selected range. 

### Action

**Name:** log.log

**Params:**
|Name|Type|Description|
|-|-|-|
|name|String|Process name. Example: "ark-core", "ark-forger".|
|fromLine|Number|(Optional; Default: 1) Starting line of returned range.|
|range|Number|(Optional; Default: 100) Range size.|
|showError|Boolean|(Optional; Default: false) Show logs from error file.|

**Response:**
|Name|Type|Description|
|-|-|-|
|totalLines|Number|Number of lines in log file.|
|lines|String|Content of the file within given range.|

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
