### PR TITLE
feat(core-manager): implement `log.archived` action

### DIFF
--- a/__tests__/unit/core-manager/action-reader.test.ts
+++ b/__tests__/unit/core-manager/action-reader.test.ts
@@ -13,6 +13,7 @@ beforeEach(() => {
 
     sandbox.app.bind(Identifiers.ActionReader).to(ActionReader).inSingletonScope();
     sandbox.app.bind(Container.Identifiers.PluginConfiguration).toConstantValue({});
+    sandbox.app.bind(Container.Identifiers.FilesystemService).toConstantValue({});
 
     actionReader = sandbox.app.get<ActionReader>(Identifiers.ActionReader);
 });

--- a/__tests__/unit/core-manager/actions/log-archived.test.ts
+++ b/__tests__/unit/core-manager/actions/log-archived.test.ts
@@ -1,0 +1,43 @@
+import "jest-extended";
+
+import { Container } from "@packages/core-kernel";
+import { Action } from "@packages/core-manager/src/actions/log-archived";
+import { Sandbox } from "@packages/core-test-framework";
+
+let sandbox: Sandbox;
+let action: Action;
+
+const mockFilesystem = {
+    files: jest
+        .fn()
+        .mockResolvedValue([
+            `${process.env.HOME}/.pm2/logs/ark-core-out.log`,
+            `${process.env.HOME}/.pm2/logs/ark-core-error.log`,
+        ]),
+
+    size: jest.fn().mockResolvedValue(1024),
+};
+
+beforeEach(() => {
+    sandbox = new Sandbox();
+
+    sandbox.app.bind(Container.Identifiers.ApplicationVersion).toConstantValue("dummyVersion");
+    sandbox.app.bind(Container.Identifiers.FilesystemService).toConstantValue(mockFilesystem);
+
+    action = sandbox.app.resolve(Action);
+});
+
+describe("Info:CoreVersion", () => {
+    it("should have name", () => {
+        expect(action.name).toEqual("log.archived");
+    });
+
+    it("should return file info", async () => {
+        const result = await action.execute({});
+
+        expect(result).toBeArray();
+        expect(result[0].size).toBe(1);
+        expect(result[0].name).toBeString();
+        expect(result[0].downloadLink).toBeString();
+    });
+});

--- a/__tests__/unit/core-manager/server/routes/log-achived.test.ts
+++ b/__tests__/unit/core-manager/server/routes/log-achived.test.ts
@@ -1,0 +1,85 @@
+import "jest-extended";
+
+import { Container } from "@packages/core-kernel";
+import { ActionReader } from "@packages/core-manager/src/action-reader";
+import { Actions } from "@packages/core-manager/src/contracts";
+import { defaults } from "@packages/core-manager/src/defaults";
+import { Identifiers } from "@packages/core-manager/src/ioc";
+import Handlers from "@packages/core-manager/src/server/handlers";
+import { PluginFactory } from "@packages/core-manager/src/server/plugins/plugin-factory";
+import { Server } from "@packages/core-manager/src/server/server";
+import { Argon2id, SimpleTokenValidator } from "@packages/core-manager/src/server/validators";
+import { Sandbox } from "@packages/core-test-framework";
+
+let sandbox: Sandbox;
+let server: Server;
+
+const logger = {
+    info: jest.fn(),
+    notice: jest.fn(),
+    error: jest.fn(),
+};
+
+let pluginsConfiguration;
+
+const mockFilesystem = {
+    get: jest.fn().mockResolvedValue(Buffer.from("file_content")),
+};
+
+beforeEach(() => {
+    const actionReader: Partial<ActionReader> = {
+        discoverActions(): Actions.Method[] {
+            return [];
+        },
+    };
+
+    pluginsConfiguration = { ...defaults.plugins };
+
+    pluginsConfiguration.basicAuthentication.enabled = false;
+    pluginsConfiguration.tokenAuthentication.enabled = false;
+
+    sandbox = new Sandbox();
+
+    sandbox.app.bind(Identifiers.HTTP).to(Server).inSingletonScope();
+    sandbox.app.bind(Identifiers.ActionReader).toConstantValue(actionReader);
+    sandbox.app.bind(Identifiers.PluginFactory).to(PluginFactory).inSingletonScope();
+    sandbox.app.bind(Identifiers.BasicCredentialsValidator).to(Argon2id).inSingletonScope();
+    sandbox.app.bind(Identifiers.TokenValidator).to(SimpleTokenValidator).inSingletonScope();
+
+    sandbox.app.bind(Container.Identifiers.LogService).toConstantValue(logger);
+    sandbox.app.bind(Container.Identifiers.FilesystemService).toConstantValue(mockFilesystem);
+    sandbox.app.bind(Container.Identifiers.PluginConfiguration).toConstantValue({
+        get: jest.fn().mockReturnValue(pluginsConfiguration),
+    });
+
+    sandbox.app.terminate = jest.fn();
+
+    server = sandbox.app.get<Server>(Identifiers.HTTP);
+});
+
+afterEach(async () => {
+    await server.dispose();
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+});
+
+describe("LogArchived", () => {
+    it("should be ok", async () => {
+        await server.initialize("serverName", {});
+
+        await server.register({
+            plugin: Handlers,
+        });
+
+        await server.boot();
+
+        const injectOptions = {
+            method: "GET",
+            url: "/log/archived/ark-core-out.log",
+        };
+
+        const response = await server.inject(injectOptions);
+
+        expect(response.result).toEqual("file_content");
+    });
+});

--- a/__tests__/unit/core-manager/service-provider.test.ts
+++ b/__tests__/unit/core-manager/service-provider.test.ts
@@ -1,9 +1,9 @@
 import "jest-extended";
 
 import { Application, Container, Providers } from "@packages/core-kernel";
-import { ServiceProvider } from "@packages/core-manager/src/service-provider";
-import { Identifiers } from "@packages/core-manager/src/ioc";
 import { defaults } from "@packages/core-manager/src/defaults";
+import { Identifiers } from "@packages/core-manager/src/ioc";
+import { ServiceProvider } from "@packages/core-manager/src/service-provider";
 import path from "path";
 
 let app: Application;
@@ -26,6 +26,7 @@ beforeEach(() => {
 
     app.bind(Container.Identifiers.LogService).toConstantValue(logger);
     app.bind(Container.Identifiers.PluginConfiguration).to(Providers.PluginConfiguration).inSingletonScope();
+    app.bind(Container.Identifiers.FilesystemService).toConstantValue({});
 
     defaults.server.https.tls.key = path.resolve(__dirname, "./__fixtures__/key.pem");
     defaults.server.https.tls.cert = path.resolve(__dirname, "./__fixtures__/server.crt");
@@ -39,7 +40,7 @@ describe("ServiceProvider", () => {
     });
 
     it("should register", async () => {
-        let usedDefaults = { ...defaults };
+        const usedDefaults = { ...defaults };
 
         setPluginConfiguration(app, serviceProvider, usedDefaults);
 
@@ -47,7 +48,7 @@ describe("ServiceProvider", () => {
     });
 
     it("should boot and dispose HTTP server", async () => {
-        let usedDefaults = { ...defaults };
+        const usedDefaults = { ...defaults };
 
         usedDefaults.server.http.enabled = true;
 
@@ -64,7 +65,7 @@ describe("ServiceProvider", () => {
     });
 
     it("should boot and dispose HTTPS server", async () => {
-        let usedDefaults = { ...defaults };
+        const usedDefaults = { ...defaults };
 
         usedDefaults.server.http.enabled = false;
         usedDefaults.server.https.enabled = "enabled";
@@ -82,7 +83,7 @@ describe("ServiceProvider", () => {
     });
 
     it("should dispose with HTTP and HTTPS server", async () => {
-        let usedDefaults = { ...defaults };
+        const usedDefaults = { ...defaults };
 
         usedDefaults.server.http.enabled = true;
         usedDefaults.server.https.enabled = "enabled";

--- a/packages/core-manager/src/actions/log-archived.ts
+++ b/packages/core-manager/src/actions/log-archived.ts
@@ -1,0 +1,29 @@
+import { Container, Contracts } from "@arkecosystem/core-kernel";
+import { basename } from "path";
+
+import { Actions } from "../contracts";
+
+@Container.injectable()
+export class Action implements Actions.Action {
+    public name = "log.archived";
+
+    @Container.inject(Container.Identifiers.FilesystemService)
+    private readonly filesystem!: Contracts.Kernel.Filesystem;
+
+    public async execute(params: object): Promise<any> {
+        return Promise.all((await this.getArchivedLogs()).map((x) => this.getArchiveInfo(x)));
+    }
+
+    private async getArchiveInfo(path: string): Promise<any> {
+        return {
+            name: basename(path),
+            size: Math.round((await this.filesystem.size(path)) / 1024),
+            downloadLink: `/log/archived/${basename(path)}`,
+        };
+    }
+
+    private async getArchivedLogs(): Promise<string[]> {
+        const logsPath = `${process.env.HOME}/.pm2/logs`;
+        return this.filesystem.files(logsPath);
+    }
+}

--- a/packages/core-manager/src/server/controllers/log-archived.ts
+++ b/packages/core-manager/src/server/controllers/log-archived.ts
@@ -1,0 +1,21 @@
+import { Container, Contracts } from "@arkecosystem/core-kernel";
+import Hapi from "@hapi/hapi";
+import { join } from "path";
+
+@Container.injectable()
+export class LogArchivedController {
+    @Container.inject(Container.Identifiers.FilesystemService)
+    private readonly filesystem!: Contracts.Kernel.Filesystem;
+
+    public async file(request: Hapi.Request, h: Hapi.ResponseToolkit) {
+        const logsPath = `${process.env.HOME}/.pm2/logs`;
+        const fileName = request.params.id;
+
+        const file = await this.filesystem.get(join(logsPath, fileName));
+
+        return h
+            .response(file)
+            .header("Content-Type", "text/plain")
+            .header("Content-Disposition", "attachment; filename= " + fileName);
+    }
+}

--- a/packages/core-manager/src/server/handlers.ts
+++ b/packages/core-manager/src/server/handlers.ts
@@ -1,0 +1,15 @@
+import Hapi from "@hapi/hapi";
+
+import * as LogArchived from "./routes/log-archived";
+
+export = {
+    async register(server: Hapi.Server): Promise<void> {
+        const handlers = [LogArchived];
+
+        for (const handler of handlers) {
+            handler.register(server);
+        }
+    },
+    name: "Manager API",
+    version: "1.0.0",
+};

--- a/packages/core-manager/src/server/routes/log-archived.ts
+++ b/packages/core-manager/src/server/routes/log-archived.ts
@@ -1,0 +1,22 @@
+import Hapi from "@hapi/hapi";
+import Joi from "@hapi/joi";
+
+import { LogArchivedController } from "../controllers/log-archived";
+
+export const register = (server: Hapi.Server): void => {
+    const controller = server.app.app.resolve(LogArchivedController);
+    server.bind(controller);
+
+    server.route({
+        method: "GET",
+        path: "/log/archived/{id}",
+        handler: controller.file,
+        options: {
+            validate: {
+                params: Joi.object({
+                    id: Joi.string().required(),
+                }),
+            },
+        },
+    });
+};

--- a/packages/core-manager/src/server/server.ts
+++ b/packages/core-manager/src/server/server.ts
@@ -1,5 +1,5 @@
 import { Container, Contracts, Types } from "@arkecosystem/core-kernel";
-import { Server as HapiServer, ServerInjectOptions, ServerInjectResponse } from "@hapi/hapi";
+import { Server as HapiServer, ServerInjectOptions, ServerInjectResponse, ServerRoute } from "@hapi/hapi";
 import { readFileSync } from "fs";
 
 import { Plugins } from "../contracts";
@@ -23,8 +23,17 @@ export class Server {
     public async initialize(name: string, serverOptions: Types.JsonObject): Promise<void> {
         this.name = name;
         this.server = new HapiServer(this.getServerOptions(serverOptions));
+        this.server.app.app = this.app;
 
         await this.server.register(this.pluginFactory.preparePlugins());
+    }
+
+    public async register(plugins: any | any[]): Promise<void> {
+        return this.server.register(plugins);
+    }
+
+    public async route(routes: ServerRoute | ServerRoute[]): Promise<void> {
+        return this.server.route(routes);
     }
 
     public async inject(options: string | ServerInjectOptions): Promise<ServerInjectResponse> {

--- a/packages/core-manager/src/server/server.ts
+++ b/packages/core-manager/src/server/server.ts
@@ -1,5 +1,5 @@
 import { Container, Contracts, Types } from "@arkecosystem/core-kernel";
-import { Server as HapiServer, ServerInjectOptions, ServerInjectResponse, ServerRoute } from "@hapi/hapi";
+import { Server as HapiServer, ServerInjectOptions, ServerInjectResponse } from "@hapi/hapi";
 import { readFileSync } from "fs";
 
 import { Plugins } from "../contracts";
@@ -30,10 +30,6 @@ export class Server {
 
     public async register(plugins: any | any[]): Promise<void> {
         return this.server.register(plugins);
-    }
-
-    public async route(routes: ServerRoute | ServerRoute[]): Promise<void> {
-        return this.server.route(routes);
     }
 
     public async inject(options: string | ServerInjectOptions): Promise<ServerInjectResponse> {

--- a/packages/core-manager/src/service-provider.ts
+++ b/packages/core-manager/src/service-provider.ts
@@ -6,6 +6,7 @@ import { Identifiers } from "./ioc";
 import { PluginFactory } from "./server/plugins";
 import { Server } from "./server/server";
 import { Argon2id, SimpleTokenValidator } from "./server/validators";
+import Handlers from "./server/handlers";
 
 export class ServiceProvider extends Providers.ServiceProvider {
     public async register(): Promise<void> {
@@ -66,6 +67,10 @@ export class ServiceProvider extends Providers.ServiceProvider {
                     cors: true,
                 },
             },
+        });
+
+        await server.register({
+            plugin: Handlers,
         });
     }
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

This PR add new action which return list of available logs with size and download link. PR also implements new server route for downloading log files.

### Action

**Name:** log.archived

**Params:**: none

**Response:** List of log infos
|Name|Type|Description|
|-|-|-|
|name|String|Log file name.|
|size|Number|Log file size.|
|downloadLink|String|Link for downloading log.|

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
