### PR TITLE
feat(core-manager): implement `configuration.getEnv` action 

### DIFF
--- a/__tests__/unit/core-manager/action-reader.test.ts
+++ b/__tests__/unit/core-manager/action-reader.test.ts
@@ -13,6 +13,7 @@ beforeEach(() => {
 
     sandbox.app.bind(Identifiers.ActionReader).to(ActionReader).inSingletonScope();
     sandbox.app.bind(Container.Identifiers.PluginConfiguration).toConstantValue({});
+    sandbox.app.bind(Container.Identifiers.FilesystemService).toConstantValue({});
 
     actionReader = sandbox.app.get<ActionReader>(Identifiers.ActionReader);
 });

--- a/__tests__/unit/core-manager/actions/configuration-env-get.test.ts
+++ b/__tests__/unit/core-manager/actions/configuration-env-get.test.ts
@@ -1,0 +1,34 @@
+import "jest-extended";
+
+import { Container } from "@packages/core-kernel";
+import { Action } from "@packages/core-manager/src/actions/configuration-env-get";
+import { Sandbox } from "@packages/core-test-framework";
+
+let sandbox: Sandbox;
+let action: Action;
+
+const mockFilesystem = {
+    get: jest.fn().mockResolvedValue("file_content"),
+};
+
+beforeEach(() => {
+    sandbox = new Sandbox();
+
+    sandbox.app.bind(Container.Identifiers.FilesystemService).toConstantValue(mockFilesystem);
+
+    action = sandbox.app.resolve(Action);
+});
+
+describe("Configuration:EnvGet", () => {
+    it("should have name", () => {
+        expect(action.name).toEqual("configuration.getEnv");
+    });
+
+    it("should return .env content", async () => {
+        sandbox.app.environmentFile = jest.fn().mockReturnValue("path/to/env/file");
+
+        const result = await action.execute({});
+
+        await expect(result).toBe("file_content");
+    });
+});

--- a/packages/core-manager/src/actions/configuration-env-get.ts
+++ b/packages/core-manager/src/actions/configuration-env-get.ts
@@ -1,0 +1,21 @@
+import { Application, Container, Contracts } from "@arkecosystem/core-kernel";
+import { Actions } from "../contracts";
+
+@Container.injectable()
+export class Action implements Actions.Action {
+    public name = "configuration.getEnv";
+
+    @Container.inject(Container.Identifiers.Application)
+    private readonly app!: Application;
+
+    @Container.inject(Container.Identifiers.FilesystemService)
+    private readonly filesystem!: Contracts.Kernel.Filesystem;
+
+    public async execute(params: object): Promise<any> {
+        return await this.getEnvFile();
+    }
+
+    public async getEnvFile(): Promise<string> {
+        return (await this.filesystem.get(this.app.environmentFile())).toString();
+    }
+}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

This PR add new action which returns content of the .env file for current network (selected on core-manager start).

### Action

**Name:** configuration.getEnv

**Params:**: none

**Response:** .env file content

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
