### PR TITLE
feat(core-manager): implement `configuration.updateEnv` action

### DIFF
--- a/__tests__/unit/core-manager/action-reader.test.ts
+++ b/__tests__/unit/core-manager/action-reader.test.ts
@@ -13,6 +13,7 @@ beforeEach(() => {
 
     sandbox.app.bind(Identifiers.ActionReader).to(ActionReader).inSingletonScope();
     sandbox.app.bind(Container.Identifiers.PluginConfiguration).toConstantValue({});
+    sandbox.app.bind(Container.Identifiers.FilesystemService).toConstantValue({});
 
     actionReader = sandbox.app.get<ActionReader>(Identifiers.ActionReader);
 });

--- a/__tests__/unit/core-manager/actions/configuration-update-env.test.ts
+++ b/__tests__/unit/core-manager/actions/configuration-update-env.test.ts
@@ -1,0 +1,56 @@
+import "jest-extended";
+
+import { Container } from "@packages/core-kernel";
+import { Action } from "@packages/core-manager/src/actions/configuration-update-env";
+import { Sandbox } from "@packages/core-test-framework";
+
+let sandbox: Sandbox;
+let action: Action;
+
+const mockFilesystem = {
+    put: jest.fn(),
+};
+
+beforeEach(() => {
+    sandbox = new Sandbox();
+
+    sandbox.app.bind(Container.Identifiers.FilesystemService).toConstantValue(mockFilesystem);
+
+    action = sandbox.app.resolve(Action);
+
+    sandbox.app.environmentFile = jest.fn().mockReturnValue("/path/to/file");
+});
+
+describe("Configuration:UpdateEnv", () => {
+    it("should have name", () => {
+        expect(action.name).toEqual("configuration.updateEnv");
+    });
+
+    it("should validate and save configuration", async () => {
+        const content = "ABC=1\n\nABD=2";
+
+        const result = await action.execute({ content: content });
+
+        expect(result).toEqual({});
+    });
+
+    it("should throw validation error - variable is lowercase", async () => {
+        const content = "abc=1";
+        await expect(action.execute({ content: content })).rejects.toThrow();
+    });
+
+    it("should throw validation error - variable contains invalid chars", async () => {
+        const content = "ABC.D=1";
+        await expect(action.execute({ content: content })).rejects.toThrow();
+    });
+
+    it("should throw validation error - invalid characters (space) after expression", async () => {
+        const content = "ABC=1 ";
+        await expect(action.execute({ content: content })).rejects.toThrow();
+    });
+
+    it("should throw validation error - value is not set", async () => {
+        const content = "ABC=";
+        await expect(action.execute({ content: content })).rejects.toThrow();
+    });
+});

--- a/packages/core-manager/src/actions/configuration-update-env.ts
+++ b/packages/core-manager/src/actions/configuration-update-env.ts
@@ -1,0 +1,52 @@
+import { Application, Container, Contracts } from "@arkecosystem/core-kernel";
+
+import { Actions } from "../contracts";
+
+@Container.injectable()
+export class Action implements Actions.Action {
+    public name = "configuration.updateEnv";
+
+    public schema = {
+        type: "object",
+        properties: {
+            content: {
+                type: "string",
+            },
+        },
+        required: ["content"],
+    };
+
+    @Container.inject(Container.Identifiers.Application)
+    // @ts-ignore
+    private readonly app!: Application;
+
+    @Container.inject(Container.Identifiers.FilesystemService)
+    private readonly filesystem!: Contracts.Kernel.Filesystem;
+
+    public async execute(params: { content: string }): Promise<any> {
+        await this.updateEnv(params.content);
+
+        return {};
+    }
+
+    private validateEnv(content: string): void {
+        let count = 0;
+        for (const line of content.toString().split("\n")) {
+            count++;
+            if (line === "") {
+                continue;
+            }
+            const matches: RegExpExecArray | null = new RegExp(/^[A-Z][A-Z0-9_]*=\S*$/).exec(line);
+
+            if (!matches) {
+                throw new Error(`Invalid line [${count}]: ${line}`);
+            }
+        }
+    }
+
+    private async updateEnv(content: string): Promise<void> {
+        this.validateEnv(content);
+
+        await this.filesystem.put(this.app.environmentFile(), content);
+    }
+}

--- a/packages/core-manager/src/actions/configuration-update-env.ts
+++ b/packages/core-manager/src/actions/configuration-update-env.ts
@@ -17,7 +17,6 @@ export class Action implements Actions.Action {
     };
 
     @Container.inject(Container.Identifiers.Application)
-    // @ts-ignore
     private readonly app!: Application;
 
     @Container.inject(Container.Identifiers.FilesystemService)
@@ -36,7 +35,7 @@ export class Action implements Actions.Action {
             if (line === "") {
                 continue;
             }
-            const matches: RegExpExecArray | null = new RegExp(/^[A-Z][A-Z0-9_]*=\S*$/).exec(line);
+            const matches: RegExpExecArray | null = new RegExp(/^[A-Z][A-Z0-9_]*=\S\S*$/).exec(line);
 
             if (!matches) {
                 throw new Error(`Invalid line [${count}]: ${line}`);


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

This PR add new action which validate and save .env file for current network (selected on core-manager start) if validation pass.

### Action

**Name:** configuration.updateEnv

**Params:**: 
|Name|Type|Description|
|-|-|-|
|content|String|.env file content.|

**Response:** Empty if action executed without errors. 

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
