### PR TITLE
feat(core-manager): implement `configuration.updatePlugins` action

### DIFF
--- a/__tests__/unit/core-manager/action-reader.test.ts
+++ b/__tests__/unit/core-manager/action-reader.test.ts
@@ -13,6 +13,7 @@ beforeEach(() => {
 
     sandbox.app.bind(Identifiers.ActionReader).to(ActionReader).inSingletonScope();
     sandbox.app.bind(Container.Identifiers.PluginConfiguration).toConstantValue({});
+    sandbox.app.bind(Container.Identifiers.FilesystemService).toConstantValue({});
 
     actionReader = sandbox.app.get<ActionReader>(Identifiers.ActionReader);
 });

--- a/__tests__/unit/core-manager/actions/configuration-update-plugins.test.ts
+++ b/__tests__/unit/core-manager/actions/configuration-update-plugins.test.ts
@@ -1,0 +1,52 @@
+import "jest-extended";
+
+import { Container } from "@packages/core-kernel";
+import { Action } from "@packages/core-manager/src/actions/configuration-update-plugins";
+import { Sandbox } from "@packages/core-test-framework";
+
+let sandbox: Sandbox;
+let action: Action;
+
+const mockFilesystem = {
+    put: jest.fn(),
+};
+
+beforeEach(() => {
+    sandbox = new Sandbox();
+
+    sandbox.app.bind(Container.Identifiers.FilesystemService).toConstantValue(mockFilesystem);
+
+    action = sandbox.app.resolve(Action);
+
+    sandbox.app.configPath = jest.fn().mockReturnValue("/path/to/file");
+});
+
+describe("Configuration:UpdatePlugins", () => {
+    it("should have name", () => {
+        expect(action.name).toEqual("configuration.updatePlugins");
+    });
+
+    it("should validate and save configuration", async () => {
+        const content = "module.exports = { '@arkecosystem/core-kernel': {} }";
+
+        const result = await action.execute({ content: content });
+
+        expect(result).toEqual({});
+        expect(mockFilesystem.put).toHaveBeenCalledTimes(1);
+    });
+
+    it("should throw error - content cannot be resolved", async () => {
+        const content = "invalid_file";
+        await expect(action.execute({ content: content })).rejects.toThrow("Content cannot be resolved");
+    });
+
+    it("should throw error - plugins keys are missing", async () => {
+        const content = "module.exports = {}";
+        await expect(action.execute({ content: content })).rejects.toThrow("Missing plugin keys");
+    });
+
+    it("should throw error - plugin is not an abject", async () => {
+        const content = "module.exports = { '@arkecosystem/core-kernel': 1 }";
+        await expect(action.execute({ content: content })).rejects.toThrow("Plugin is not an object");
+    });
+});

--- a/packages/core-manager/package.json
+++ b/packages/core-manager/package.json
@@ -34,6 +34,7 @@
         "got": "^11.1.3",
         "hapi-auth-bearer-token": "^6.1.6",
         "latest-version": "^5.1.0",
+        "require-from-string": "^2.0.2",
         "typeorm": "^0.2.21"
     },
     "devDependencies": {

--- a/packages/core-manager/src/actions/configuration-update-plugins.ts
+++ b/packages/core-manager/src/actions/configuration-update-plugins.ts
@@ -1,0 +1,56 @@
+import { Application, Container, Contracts } from "@arkecosystem/core-kernel";
+import requireFromString from "require-from-string";
+
+import { Actions } from "../contracts";
+
+@Container.injectable()
+export class Action implements Actions.Action {
+    public name = "configuration.updatePlugins";
+
+    public schema = {
+        type: "object",
+        properties: {
+            content: {
+                type: "string",
+            },
+        },
+        required: ["content"],
+    };
+
+    @Container.inject(Container.Identifiers.Application)
+    private readonly app!: Application;
+
+    @Container.inject(Container.Identifiers.FilesystemService)
+    private readonly filesystem!: Contracts.Kernel.Filesystem;
+
+    public async execute(params: { content: string }): Promise<any> {
+        await this.updatePlugins(params.content);
+
+        return {};
+    }
+
+    private validatePlugins(content: string): void {
+        let pluginsResolved: any = undefined;
+        try {
+            pluginsResolved = requireFromString(content);
+        } catch {}
+
+        if (!(pluginsResolved instanceof Object)) {
+            throw new Error("Content cannot be resolved");
+        }
+
+        if (!Object.keys(pluginsResolved).some((key) => key.includes("@arkecosystem/"))) {
+            throw new Error("Missing plugin keys");
+        }
+
+        if (!Object.keys(pluginsResolved).every((key) => typeof pluginsResolved[key] === "object")) {
+            throw new Error(`Plugin is not an object`);
+        }
+    }
+
+    private async updatePlugins(content: string): Promise<void> {
+        this.validatePlugins(content);
+
+        await this.filesystem.put(this.app.configPath("plugins.js"), content);
+    }
+}

--- a/packages/core-manager/src/actions/configuration-update-plugins.ts
+++ b/packages/core-manager/src/actions/configuration-update-plugins.ts
@@ -35,7 +35,7 @@ export class Action implements Actions.Action {
             pluginsResolved = requireFromString(content);
         } catch {}
 
-        if (!(pluginsResolved instanceof Object)) {
+        if (typeof pluginsResolved !== "object") {
             throw new Error("Content cannot be resolved");
         }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary


This PR add new action which validate and save plugins.js file for current network (selected on core-manager start) if validation pass.

### Action

**Name:** configuration.updatePlugins

**Params:**: 
|Name|Type|Description|
|-|-|-|
|content|String|plugins.js file content.|

**Response:** Empty if action executed without errors. 

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
