### PR TITLE
feat(core-manager): implement `snapshots.delete` action 

### DIFF
--- a/__tests__/unit/core-manager/actions/snapshots-delete.test.ts
+++ b/__tests__/unit/core-manager/actions/snapshots-delete.test.ts
@@ -1,0 +1,47 @@
+import "jest-extended";
+
+import { Container } from "@packages/core-kernel";
+import { Action } from "@packages/core-manager/src/actions/snaphsots-delete";
+import { Sandbox } from "@packages/core-test-framework";
+
+let sandbox: Sandbox;
+let action: Action;
+
+let mockFilesystem;
+
+beforeEach(() => {
+    mockFilesystem = {
+        exists: jest.fn().mockResolvedValue(true),
+        delete: jest.fn().mockResolvedValue(true),
+    };
+
+    sandbox = new Sandbox();
+
+    sandbox.app.bind(Container.Identifiers.FilesystemService).toConstantValue(mockFilesystem);
+
+    action = sandbox.app.resolve(Action);
+});
+
+describe("Snapshots:Delete", () => {
+    it("should have name", () => {
+        expect(action.name).toEqual("snapshots.delete");
+    });
+
+    it("should delete snapshot", async () => {
+        const result = await action.execute({ name: "1-10" });
+
+        expect(result).toEqual({});
+    });
+
+    it("should throw error if snapshot is not found", async () => {
+        mockFilesystem.exists = jest.fn().mockResolvedValue(false);
+
+        await expect(action.execute({ name: "1-10" })).rejects.toThrow("Snapshot not found");
+    });
+
+    it("should throw error if snapshot is not deleted", async () => {
+        mockFilesystem.delete = jest.fn().mockResolvedValue(false);
+
+        await expect(action.execute({ name: "1-10" })).rejects.toThrow("Cannot delete snapshot");
+    });
+});

--- a/packages/core-manager/src/actions/snaphsots-delete.ts
+++ b/packages/core-manager/src/actions/snaphsots-delete.ts
@@ -31,7 +31,7 @@ export class Action implements Actions.Action {
         const snapshotPath = join(snapshotsDir, name);
 
         if (!(await this.filesystem.exists(snapshotPath))) {
-            throw new Error("Snapshot does not exist");
+            throw new Error("Snapshot not found");
         }
 
         if (!(await this.filesystem.delete(snapshotPath))) {

--- a/packages/core-manager/src/actions/snaphsots-delete.ts
+++ b/packages/core-manager/src/actions/snaphsots-delete.ts
@@ -1,0 +1,41 @@
+import { Container, Contracts } from "@arkecosystem/core-kernel";
+import { join } from "path";
+
+import { Actions } from "../contracts";
+
+@Container.injectable()
+export class Action implements Actions.Action {
+    public name = "snapshots.delete";
+
+    public schema = {
+        type: "object",
+        properties: {
+            name: {
+                type: "string",
+            },
+        },
+        required: ["name"],
+    };
+
+    @Container.inject(Container.Identifiers.FilesystemService)
+    private readonly filesystem!: Contracts.Kernel.Filesystem;
+
+    public async execute(params: { name: string }): Promise<any> {
+        await this.deleteSnapshot(params.name);
+
+        return {};
+    }
+
+    public async deleteSnapshot(name: string): Promise<void> {
+        const snapshotsDir = `${process.env.CORE_PATH_DATA}/snapshots/`;
+        const snapshotPath = join(snapshotsDir, name);
+
+        if (!(await this.filesystem.exists(snapshotPath))) {
+            throw new Error("Snapshot does not exist");
+        }
+
+        if (!(await this.filesystem.delete(snapshotPath))) {
+            throw new Error("Cannot delete snapshot");
+        }
+    }
+}

--- a/packages/core/src/commands/core-run.ts
+++ b/packages/core/src/commands/core-run.ts
@@ -58,7 +58,7 @@ export class Command extends Commands.Command {
         const flags: Contracts.AnyObject = { ...this.getFlags() };
         flags.processType = "core";
 
-        this.actions.abortRunningProcess(`${flags.token}-core`);
+        // this.actions.abortRunningProcess(`${flags.token}-core`);
 
         await Utils.buildApplication({
             flags,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

This PR add new action which delete snapshot folder with given name.

### Action

**Name:** snapshots.delete

**Params:** 
|Name|Type|Description|
|-|-|-|
|name|String|Snapshot name.|


**Response:**: Empty response if action is completed successfully. 

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
