### PR TITLE
feat(core-manager): implement `snapshots.create` action 

### DIFF
--- a/__tests__/unit/core-manager/action-reader.test.ts
+++ b/__tests__/unit/core-manager/action-reader.test.ts
@@ -12,6 +12,7 @@ beforeEach(() => {
     sandbox = new Sandbox();
 
     sandbox.app.bind(Identifiers.ActionReader).to(ActionReader).inSingletonScope();
+    sandbox.app.bind(Identifiers.SnapshotsManager).toConstantValue({});
     sandbox.app.bind(Container.Identifiers.PluginConfiguration).toConstantValue({});
     sandbox.app.bind(Container.Identifiers.FilesystemService).toConstantValue({});
 

--- a/__tests__/unit/core-manager/actions/snapshots-create.test.ts
+++ b/__tests__/unit/core-manager/actions/snapshots-create.test.ts
@@ -1,0 +1,42 @@
+import "jest-extended";
+
+import { Action } from "@packages/core-manager/src/actions/snapshots-create";
+import { Identifiers } from "@packages/core-manager/src/ioc";
+import { Sandbox } from "@packages/core-test-framework";
+
+let sandbox: Sandbox;
+let action: Action;
+
+const mockSnapshotManager = {
+    start: jest.fn(),
+};
+
+beforeEach(() => {
+    sandbox = new Sandbox();
+
+    sandbox.app.bind(Identifiers.SnapshotsManager).toConstantValue(mockSnapshotManager);
+
+    sandbox.app.network = jest.fn().mockReturnValue("testnet");
+
+    action = sandbox.app.resolve(Action);
+});
+
+describe("Snapshots:Create", () => {
+    it("should have name", () => {
+        expect(action.name).toEqual("snapshots.create");
+    });
+
+    it("should return empty object if ok", async () => {
+        const result = await action.execute({});
+
+        expect(result).toEqual({});
+    });
+
+    it("should return error if manager throws error", async () => {
+        mockSnapshotManager.start.mockImplementation(async () => {
+            throw new Error();
+        });
+
+        await expect(action.execute({})).rejects.toThrow();
+    });
+});

--- a/__tests__/unit/core-manager/snapshots/snapshot-manager.test.ts
+++ b/__tests__/unit/core-manager/snapshots/snapshot-manager.test.ts
@@ -1,0 +1,48 @@
+import "jest-extended";
+
+import { Container } from "@packages/core-kernel";
+import { Identifiers } from "@packages/core-manager/src/ioc";
+import { SnapshotsManager } from "@packages/core-manager/src/snapshots/snapshots-manager";
+import { Sandbox } from "@packages/core-test-framework";
+
+let sandbox: Sandbox;
+let snapshotsManager: SnapshotsManager;
+
+const mockSnapshotService = {
+    dump: () => {
+        return new Promise((resolve) => {
+            setTimeout(() => {
+                resolve();
+            }, 500);
+        });
+    },
+};
+
+beforeEach(() => {
+    sandbox = new Sandbox();
+
+    sandbox.app.bind(Identifiers.SnapshotsManager).to(SnapshotsManager);
+    sandbox.app.bind(Container.Identifiers.SnapshotService).toConstantValue(mockSnapshotService);
+
+    snapshotsManager = sandbox.app.get(Identifiers.SnapshotsManager);
+});
+
+describe("Snapshots:Create", () => {
+    it("should resolve if no actions is running", async () => {
+        await expect(snapshotsManager.start("dummy_name", {})).toResolve();
+
+        // Delay
+        await new Promise((resolve) => {
+            setTimeout(() => {
+                resolve();
+            }, 800);
+        });
+
+        await expect(snapshotsManager.start("dummy_name", {})).toResolve();
+    });
+
+    it("should throw if another action is running", async () => {
+        await expect(snapshotsManager.start("dummy_name", {})).toResolve();
+        await expect(snapshotsManager.start("dummy_name", {})).rejects.toThrow();
+    });
+});

--- a/packages/core-manager/src/actions/snapshots-create.ts
+++ b/packages/core-manager/src/actions/snapshots-create.ts
@@ -1,0 +1,43 @@
+import { Application, Container } from "@arkecosystem/core-kernel";
+
+import { Actions } from "../contracts";
+import { Identifiers } from "../ioc";
+import { SnapshotsManager } from "../snapshots/snapshots-manager";
+
+@Container.injectable()
+export class Action implements Actions.Action {
+    public name = "snapshots.create";
+
+    public schema = {
+        type: "object",
+        properties: {
+            codec: {
+                type: "string",
+            },
+            skipCompression: {
+                type: "boolean",
+            },
+            start: {
+                type: "number",
+            },
+            end: {
+                type: "number",
+            },
+        },
+    };
+
+    @Container.inject(Container.Identifiers.Application)
+    private readonly app!: Application;
+
+    @Container.inject(Identifiers.SnapshotsManager)
+    private readonly snapshotManager!: SnapshotsManager;
+
+    public async execute(params: any): Promise<any> {
+        await this.snapshotManager.start("snapshot:create", {
+            network: this.app.network(),
+            ...params,
+        });
+
+        return {};
+    }
+}

--- a/packages/core-manager/src/ioc/identifiers.ts
+++ b/packages/core-manager/src/ioc/identifiers.ts
@@ -6,4 +6,5 @@ export const Identifiers = {
     PluginFactory: Symbol.for("Factory<Plugin>"),
     BasicCredentialsValidator: Symbol.for("Validator<BasicCreadentials>"),
     TokenValidator: Symbol.for("Validator<Token>"),
+    SnapshotsManager: Symbol.for("Manager<Snapshots>"),
 };

--- a/packages/core-manager/src/service-provider.ts
+++ b/packages/core-manager/src/service-provider.ts
@@ -3,10 +3,11 @@ import { Container, Providers, Types } from "@arkecosystem/core-kernel";
 
 import { ActionReader } from "./action-reader";
 import { Identifiers } from "./ioc";
+import Handlers from "./server/handlers";
 import { PluginFactory } from "./server/plugins";
 import { Server } from "./server/server";
 import { Argon2id, SimpleTokenValidator } from "./server/validators";
-import Handlers from "./server/handlers";
+import { SnapshotsManager } from "./snapshots/snapshots-manager";
 
 export class ServiceProvider extends Providers.ServiceProvider {
     public async register(): Promise<void> {
@@ -14,6 +15,7 @@ export class ServiceProvider extends Providers.ServiceProvider {
         this.app.bind(Identifiers.PluginFactory).to(PluginFactory).inSingletonScope();
         this.app.bind(Identifiers.BasicCredentialsValidator).to(Argon2id).inSingletonScope();
         this.app.bind(Identifiers.TokenValidator).to(SimpleTokenValidator).inSingletonScope();
+        this.app.bind(Identifiers.SnapshotsManager).to(SnapshotsManager).inSingletonScope();
 
         const pkg: Types.PackageJson = require("../package.json");
         this.app.bind(Identifiers.CLI).toConstantValue(ApplicationFactory.make(new Container.Container(), pkg));

--- a/packages/core-manager/src/snapshots/snapshots-manager.ts
+++ b/packages/core-manager/src/snapshots/snapshots-manager.ts
@@ -1,0 +1,22 @@
+import { Container, Contracts } from "@arkecosystem/core-kernel";
+
+@Container.injectable()
+export class SnapshotsManager {
+    @Container.inject(Container.Identifiers.SnapshotService)
+    private readonly snapshotService!: Contracts.Snapshot.SnapshotService;
+
+    private processInAction?: string;
+
+    // TODO: Contracts.Snapshot.DumpOptions
+    public async start(name: string, options: any): Promise<void> {
+        if (this.processInAction) {
+            throw new Error(`Process ${this.processInAction} is executing`);
+        }
+
+        this.processInAction = name;
+
+        this.snapshotService.dump(options).finally(() => {
+            this.processInAction = undefined;
+        });
+    }
+}

--- a/packages/core/bin/config/devnet/app.json
+++ b/packages/core/bin/config/devnet/app.json
@@ -93,6 +93,9 @@
             },
             {
                 "package": "@arkecosystem/core-snapshots"
+            },
+            {
+                "package": "@arkecosystem/core-snapshots"
             }
         ]
     }

--- a/packages/core/bin/config/mainnet/app.json
+++ b/packages/core/bin/config/mainnet/app.json
@@ -93,6 +93,9 @@
             },
             {
                 "package": "@arkecosystem/core-snapshots"
+            },
+            {
+                "package": "@arkecosystem/core-snapshots"
             }
         ]
     }

--- a/packages/core/bin/config/testnet/app.json
+++ b/packages/core/bin/config/testnet/app.json
@@ -102,6 +102,9 @@
                 "package": "@arkecosystem/core-logger-pino"
             },
             {
+                "package": "@arkecosystem/core-snapshots"
+            },
+            {
                 "package": "@arkecosystem/core-manager"
             }
         ]


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

This PR add new action which creates snapshot with given parameters. PR also implements snapshot-manager which prevents snapshot action to run in parallel and can be later extended to keep record of the process status (eg: percentage of restored blocks). 

### Action

**Name:** snapshots.create

**Params:** 
|Name|Type|Description|
|-|-|-|
|codec|String|(Optional; Default: default) Codec name eg: default, json|
|skipCompression|Boolean|(Optional: Default: false) Skip zlib snapshot compression?|
|start|Number|(Optional) Number of first block included in snaphsot * |
|start|Number|(Optional) Number of last block included in snaphsot * |

**Response:**: Empty response if snapshot process is started successfully. It doesn't guarantee that snapshot process completed successfully. 

(*) Block height is later re-calculated to match nearest round start.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [x] Tests
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
