### PR TITLE
feat(core-forger): implements `forger.lastForgedBlock` process actions 

### DIFF
--- a/__tests__/unit/core-forger/forger-service.test.ts
+++ b/__tests__/unit/core-forger/forger-service.test.ts
@@ -127,6 +127,14 @@ describe("ForgerService", () => {
         });
     });
 
+    describe("GetLastForgedBlock", () => {
+        it("should return undefined", async () => {
+            forgerService.register({ hosts: [mockHost] });
+
+            expect(forgerService.getLastForgedBlock()).toBeUndefined();
+        });
+    });
+
     describe("Register", () => {
         it("should register an associated client", async () => {
             forgerService.register({ hosts: [mockHost] });

--- a/__tests__/unit/core-forger/process-actions/last-forged-block.test.ts
+++ b/__tests__/unit/core-forger/process-actions/last-forged-block.test.ts
@@ -1,0 +1,30 @@
+import "jest-extended";
+
+import { Container } from "@arkecosystem/core-kernel";
+import { Sandbox } from "@arkecosystem/core-test-framework/src";
+import { LastForgedBlockRemoteAction } from "@packages/core-forger/src/process-actions/last-forged-block";
+
+let sandbox: Sandbox;
+let action: LastForgedBlockRemoteAction;
+
+const mockBlock = {
+    id: "123",
+};
+
+const mockForgerService = {
+    getLastForgedBlock: jest.fn().mockReturnValue(mockBlock),
+};
+
+beforeEach(() => {
+    sandbox = new Sandbox();
+
+    sandbox.app.bind(Container.Identifiers.ForgerService).toConstantValue(mockForgerService);
+
+    action = sandbox.app.resolve(LastForgedBlockRemoteAction);
+});
+
+describe("LastForgedBlockProcessAction", () => {
+    it("should return last forged block", async () => {
+        await expect(action.handler()).resolves.toEqual(mockBlock);
+    });
+});

--- a/packages/core-forger/src/forger-service.ts
+++ b/packages/core-forger/src/forger-service.ts
@@ -62,6 +62,13 @@ export class ForgerService {
 
     /**
      * @private
+     * @type {(Interfaces.IBlock | undefined)}
+     * @memberof ForgerService
+     */
+    private lastForgedBlock: Interfaces.IBlock | undefined;
+
+    /**
+     * @private
      * @type {boolean}
      * @memberof ForgerService
      */
@@ -69,6 +76,10 @@ export class ForgerService {
 
     public getRound(): Contracts.P2P.CurrentRound | undefined {
         return this.round;
+    }
+
+    public getLastForgedBlock(): Interfaces.IBlock | undefined {
+        return this.lastForgedBlock;
     }
 
     /**
@@ -269,6 +280,7 @@ export class ForgerService {
 
             await this.client.broadcastBlock(block);
 
+            this.lastForgedBlock = block;
             this.client.emitEvent(Enums.BlockEvent.Forged, block.data);
 
             for (const transaction of transactions) {

--- a/packages/core-forger/src/process-actions/index.ts
+++ b/packages/core-forger/src/process-actions/index.ts
@@ -1,1 +1,2 @@
 export * from "./current-delegate";
+export * from "./last-forged-block";

--- a/packages/core-forger/src/process-actions/last-forged-block.ts
+++ b/packages/core-forger/src/process-actions/last-forged-block.ts
@@ -1,0 +1,19 @@
+import { Container, Contracts, Utils } from "@arkecosystem/core-kernel";
+
+import { ForgerService } from "../forger-service";
+
+@Container.injectable()
+export class LastForgedBlockRemoteAction implements Contracts.Kernel.ProcessAction {
+    public name = "forger.lastForgedBlock";
+
+    @Container.inject(Container.Identifiers.ForgerService)
+    private readonly forger!: ForgerService;
+
+    public async handler() {
+        const lastForgedBlock = this.forger.getLastForgedBlock();
+
+        Utils.assert.defined(lastForgedBlock);
+
+        return lastForgedBlock;
+    }
+}

--- a/packages/core-forger/src/service-provider.ts
+++ b/packages/core-forger/src/service-provider.ts
@@ -5,7 +5,7 @@ import { DelegateFactory } from "./delegate-factory";
 import { DelegateTracker } from "./delegate-tracker";
 import { ForgerService } from "./forger-service";
 import { Delegate } from "./interfaces";
-import { CurrentDelegateProcessAction } from "./process-actions";
+import { CurrentDelegateProcessAction, LastForgedBlockRemoteAction } from "./process-actions";
 
 /**
  * @export
@@ -79,6 +79,10 @@ export class ServiceProvider extends Providers.ServiceProvider {
         this.app
             .get<Contracts.Kernel.ProcessActionsService>(Container.Identifiers.ProcessActionsService)
             .register(this.app.resolve(CurrentDelegateProcessAction));
+
+        this.app
+            .get<Contracts.Kernel.ProcessActionsService>(Container.Identifiers.ProcessActionsService)
+            .register(this.app.resolve(LastForgedBlockRemoteAction));
     }
 
     /**


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

This PR implements new `forger.lastForgedBlock` process action in core-forger package. Action returns last forged block, forged by local forger.

### Process Action:

**Name:** forger.lastForgedBlock

**Description:** Returns last block created from local forger.

**Params:** None

**Result:** Last forged block. 

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [x] Tests
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
