### PR TITLE
feat(core-forger): implements `forger.nextSlot` process actions

### DIFF
--- a/__tests__/unit/core-forger/forger-service.test.ts
+++ b/__tests__/unit/core-forger/forger-service.test.ts
@@ -127,6 +127,18 @@ describe("ForgerService", () => {
         });
     });
 
+    describe("GetRemainingSlotTime", () => {
+        it("should return undefined", async () => {
+            forgerService.register({ hosts: [mockHost] });
+
+            // @ts-ignore
+            const spyGetNetworkState = jest.spyOn(forgerService.client, "getNetworkState");
+            spyGetNetworkState.mockResolvedValue(mockNetworkState);
+
+            await expect(forgerService.getRemainingSlotTime()).resolves.toBeNumber();
+        });
+    });
+
     describe("Register", () => {
         it("should register an associated client", async () => {
             forgerService.register({ hosts: [mockHost] });

--- a/__tests__/unit/core-forger/process-actions/next-slot.test.ts
+++ b/__tests__/unit/core-forger/process-actions/next-slot.test.ts
@@ -1,0 +1,28 @@
+import "jest-extended";
+
+import { Container } from "@arkecosystem/core-kernel";
+import { Sandbox } from "@arkecosystem/core-test-framework/src";
+import { NextSlotProcessAction } from "@packages/core-forger/src/process-actions/next-slot";
+
+let sandbox: Sandbox;
+let action: NextSlotProcessAction;
+
+const mockForgerService = {
+    getRemainingSlotTime: jest.fn().mockReturnValue(1000),
+};
+
+beforeEach(() => {
+    sandbox = new Sandbox();
+
+    sandbox.app.bind(Container.Identifiers.ForgerService).toConstantValue(mockForgerService);
+
+    action = sandbox.app.resolve(NextSlotProcessAction);
+});
+
+describe("NextSlotProcessAction", () => {
+    it("should return remaining time", async () => {
+        await expect(action.handler()).resolves.toEqual({
+            remainingTime: 1000,
+        });
+    });
+});

--- a/packages/core-forger/src/forger-service.ts
+++ b/packages/core-forger/src/forger-service.ts
@@ -71,6 +71,17 @@ export class ForgerService {
         return this.round;
     }
 
+    public async getRemainingSlotTime(): Promise<number> {
+        const networkState: Contracts.P2P.NetworkState = await this.client.getNetworkState();
+
+        const blockTimeLookup = await AppUtils.forgingInfoCalculator.getBlockTimeLookup(
+            this.app,
+            networkState.nodeHeight!,
+        );
+
+        return Crypto.Slots.getTimeInMsUntilNextSlot(blockTimeLookup);
+    }
+
     /**
      * @param {*} options
      * @memberof ForgerService

--- a/packages/core-forger/src/process-actions/index.ts
+++ b/packages/core-forger/src/process-actions/index.ts
@@ -1,1 +1,2 @@
 export * from "./current-delegate";
+export * from "./next-slot";

--- a/packages/core-forger/src/process-actions/next-slot.ts
+++ b/packages/core-forger/src/process-actions/next-slot.ts
@@ -1,0 +1,17 @@
+import { Container, Contracts } from "@arkecosystem/core-kernel";
+
+import { ForgerService } from "../forger-service";
+
+@Container.injectable()
+export class NextSlotProcessAction implements Contracts.Kernel.ProcessAction {
+    public name = "forger.nextSlot";
+
+    @Container.inject(Container.Identifiers.ForgerService)
+    private readonly forger!: ForgerService;
+
+    public async handler() {
+        return {
+            remainingTime: await this.forger.getRemainingSlotTime(),
+        };
+    }
+}

--- a/packages/core-forger/src/service-provider.ts
+++ b/packages/core-forger/src/service-provider.ts
@@ -5,7 +5,7 @@ import { DelegateFactory } from "./delegate-factory";
 import { DelegateTracker } from "./delegate-tracker";
 import { ForgerService } from "./forger-service";
 import { Delegate } from "./interfaces";
-import { CurrentDelegateProcessAction } from "./process-actions";
+import { CurrentDelegateProcessAction, NextSlotProcessAction } from "./process-actions";
 
 /**
  * @export
@@ -79,6 +79,10 @@ export class ServiceProvider extends Providers.ServiceProvider {
         this.app
             .get<Contracts.Kernel.ProcessActionsService>(Container.Identifiers.ProcessActionsService)
             .register(this.app.resolve(CurrentDelegateProcessAction));
+
+        this.app
+            .get<Contracts.Kernel.ProcessActionsService>(Container.Identifiers.ProcessActionsService)
+            .register(this.app.resolve(NextSlotProcessAction));
     }
 
     /**


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

This PR implements new forger.nextSlot process action in core-forger package. Action returns time till next slot.


### Process Action:

**Name:** forger.nextSlot

**Description:** Returns remaining time till next slot in ms. 

**Params:** None

**Result:**
|Field|Type|Description|
|-|-|-|
|remainingTime|Number|Remaining time in ms.| 

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [x] Tests
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
