### PR TITLE
feat(core-cli): implement trigger method in ProcessManager

### DIFF
--- a/__tests__/unit/core-cli/services/process-manager.test.ts
+++ b/__tests__/unit/core-cli/services/process-manager.test.ts
@@ -468,6 +468,24 @@ describe("ProcessManager", () => {
         });
     });
 
+    describe("#trigger", () => {
+        it(".trigger()", () => {
+            // Arrange...
+            const spySync: jest.SpyInstance = jest.spyOn(execa, "sync").mockReturnValue({
+                stdout: null,
+                stderr: undefined,
+                failed: false,
+            });
+
+            // Act...
+            const { failed } = processManager.trigger("ark-core", "module.name", "params");
+
+            // Assert...
+            expect(failed).toBeFalse();
+            expect(spySync).toHaveBeenCalledWith("pm2 trigger ark-core module.name params", { shell: true });
+        });
+    });
+
     describe("#status", () => {
         it("should return the status if the process exists", () => {
             // Arrange...

--- a/packages/core-cli/src/services/process-manager.ts
+++ b/packages/core-cli/src/services/process-manager.ts
@@ -165,6 +165,14 @@ export class ProcessManager {
     }
 
     /**
+     * @returns {ExecaSyncReturnValue}
+     * @memberof ProcessManager
+     */
+    public trigger(id: ProcessIdentifier, processActionName: string, param?: string): ExecaSyncReturnValue {
+        return this.shellSync(`pm2 trigger ${id} ${processActionName} ${param}`);
+    }
+
+    /**
      * @param {ProcessIdentifier} id
      * @returns {(ProcessState | undefined)}
      * @memberof ProcessManager


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

This PR adds support for triggering pm2 trigger actions from ProcessManager. Functionality is added to trigger Process Actions directly from core via shell.  

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->
- [x] Tests 
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
