### PR TITLE
feat(core-manager): implement `info.currentDelegate` action

### DIFF
--- a/__tests__/unit/core-manager/__fixtures__/index.ts
+++ b/__tests__/unit/core-manager/__fixtures__/index.ts
@@ -1,1 +1,2 @@
 export * as Assets from "./assets";
+export * as TriggerResponses from "./trigger-responses";

--- a/__tests__/unit/core-manager/__fixtures__/trigger-responses.ts
+++ b/__tests__/unit/core-manager/__fixtures__/trigger-responses.ts
@@ -1,0 +1,5 @@
+export const forgetCurrentDelegateResponse =
+    '1 processes have received command forger.currentDelegate\n[ark-core:0:default]={"response":{"rank":16,"username":"genesis_25"}}';
+
+export const forgetCurrentDelegateError =
+    '1 processes have received command forger.currentDelegate\n[ark-core:0:default]={"error": "Dummy error"}';

--- a/__tests__/unit/core-manager/actions/info-current-delegate.test.ts
+++ b/__tests__/unit/core-manager/actions/info-current-delegate.test.ts
@@ -1,0 +1,60 @@
+import "jest-extended";
+
+import { Action } from "@packages/core-manager/src/actions/info-current-delegate";
+import { Identifiers } from "@packages/core-manager/src/ioc";
+import { Sandbox } from "@packages/core-test-framework";
+
+import { TriggerResponses } from "../__fixtures__";
+
+let sandbox: Sandbox;
+let action: Action;
+
+let mockCli;
+let mockTrigger;
+
+beforeEach(() => {
+    mockTrigger = jest.fn().mockReturnValue({
+        stdout: TriggerResponses.forgetCurrentDelegateResponse,
+    });
+
+    mockCli = {
+        get: jest.fn().mockReturnValue({
+            trigger: mockTrigger,
+        }),
+    };
+
+    sandbox = new Sandbox();
+
+    sandbox.app.bind(Identifiers.CLI).toConstantValue(mockCli);
+
+    action = sandbox.app.resolve(Action);
+});
+
+afterEach(() => {
+    delete process.env.CORE_API_DISABLED;
+    jest.clearAllMocks();
+});
+
+describe("Info:CurrentDelegate", () => {
+    it("should have name", () => {
+        expect(action.name).toEqual("info.currentDelegate");
+    });
+
+    it("should return current delegate", async () => {
+        const result = await action.execute({});
+
+        expect(result).toEqual({ rank: 16, username: "genesis_25" });
+    });
+
+    it("should throw error if trigger responded with error", async () => {
+        mockTrigger = jest.fn().mockReturnValue({
+            stdout: TriggerResponses.forgetCurrentDelegateError,
+        });
+
+        mockCli.get = jest.fn().mockReturnValue({
+            trigger: mockTrigger,
+        });
+
+        await expect(action.execute({})).rejects.toThrow("Trigger returned error");
+    });
+});

--- a/__tests__/unit/core-manager/utils/process-actions.test.ts
+++ b/__tests__/unit/core-manager/utils/process-actions.test.ts
@@ -1,0 +1,40 @@
+import "jest-extended";
+
+import { parseProcessActionResponse } from "@packages/core-manager/src/utils";
+
+import { TriggerResponses } from "../__fixtures__";
+
+describe("ParseProcessActionResponse", () => {
+    it("should parse valid response", async () => {
+        expect(
+            parseProcessActionResponse({
+                stdout: TriggerResponses.forgetCurrentDelegateResponse,
+            }),
+        ).toEqual({ response: { rank: 16, username: "genesis_25" } });
+    });
+
+    it("should parse errored response", async () => {
+        expect(
+            parseProcessActionResponse({
+                stdout: TriggerResponses.forgetCurrentDelegateError,
+            }),
+        ).toEqual({ error: "Dummy error" });
+    });
+
+    it("should throw error if number of line is not 2", async () => {
+        expect(() => {
+            parseProcessActionResponse({
+                stdout: "1 processes have received command forger.currentDelegate",
+            });
+        }).toThrow("Cannot parse process action response");
+    });
+
+    it("should throw error if trigger response is invalid", async () => {
+        expect(() => {
+            parseProcessActionResponse({
+                stdout:
+                    '1 processes have received command forger.currentDelegate\n[ark-core:0:default]={"rank":16,"username":"genesis_25"}', // Missing response
+            });
+        }).toThrow("Invalid process action response");
+    });
+});

--- a/packages/core-manager/src/actions/info-current-delegate.ts
+++ b/packages/core-manager/src/actions/info-current-delegate.ts
@@ -1,0 +1,34 @@
+import { Application as Cli, Container as CliContainer, Services } from "@arkecosystem/core-cli";
+import { Application, Container } from "@arkecosystem/core-kernel";
+
+import { Actions } from "../contracts";
+import { Identifiers } from "../ioc";
+import { parseProcessActionResponse } from "../utils";
+
+@Container.injectable()
+export class Action implements Actions.Action {
+    public name = "info.currentDelegate";
+
+    @Container.inject(Container.Identifiers.Application)
+    private readonly app!: Application;
+
+    public async execute(params: object): Promise<any> {
+        return await this.getCurrentDelegate();
+    }
+
+    private async getCurrentDelegate(): Promise<any> {
+        const cli = this.app.get<Cli>(Identifiers.CLI);
+
+        const processManager = cli.get<Services.ProcessManager>(CliContainer.Identifiers.ProcessManager);
+
+        const response = processManager.trigger("ark-core", "forger.currentDelegate");
+
+        const result = parseProcessActionResponse(response);
+
+        if (result.error) {
+            throw new Error("Trigger returned error.");
+        }
+
+        return result.response;
+    }
+}

--- a/packages/core-manager/src/utils/index.ts
+++ b/packages/core-manager/src/utils/index.ts
@@ -1,2 +1,3 @@
 export * from "./api-connection";
 export * from "./http-client";
+export * from "./process-actions";

--- a/packages/core-manager/src/utils/process-actions.ts
+++ b/packages/core-manager/src/utils/process-actions.ts
@@ -1,0 +1,20 @@
+import { Types } from "@arkecosystem/core-kernel";
+import { ExecaSyncReturnValue } from "execa";
+
+export const parseProcessActionResponse = (response: ExecaSyncReturnValue): Types.JsonObject => {
+    const responseLines = response.stdout.split("\n");
+
+    if (responseLines.length >= 2) {
+        const response = responseLines[1].substring(responseLines[1].indexOf("=") + 1);
+
+        const parsedResponse = JSON.parse(response);
+
+        if (!parsedResponse.response && !parsedResponse.error) {
+            throw new Error("Invalid process action response");
+        }
+
+        return parsedResponse;
+    }
+
+    throw new Error("Cannot parse process action response");
+};


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

This PR add new action which return current delegate username and rank if forger process is running. 

### Action

**Name:** info.currentDelegate

**Params:** none

**Response:** 
|Name|Type|Description|
|-|-|-|
|username|String|Delegate username.|
|rank|Number|Delegate rank.|


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->


- [x] Tests
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
