### PR TITLE
fix(core-transaction-pool): throw ERR_HIGH_FEE when fee is too high

### DIFF
--- a/__tests__/unit/core-transaction-pool/processor.test.ts
+++ b/__tests__/unit/core-transaction-pool/processor.test.ts
@@ -1,7 +1,7 @@
-import { Container, Contracts } from "@arkecosystem/core-kernel";
-import { Identities, Managers, Transactions } from "@arkecosystem/crypto";
-
-import { Processor } from "../../../packages/core-transaction-pool/src/processor";
+import { Container, Contracts } from "@packages/core-kernel";
+import { TransactionFeeToLowError } from "@packages/core-transaction-pool/src/errors";
+import { Processor } from "@packages/core-transaction-pool/src/processor";
+import { Identities, Managers, Transactions } from "@packages/crypto";
 
 Managers.configManager.getMilestone().aip11 = true;
 const transaction1 = Transactions.BuilderFactory.transfer()
@@ -21,7 +21,7 @@ const transaction2 = Transactions.BuilderFactory.transfer()
 
 const logger = { warning: jest.fn(), error: jest.fn() };
 const pool = { addTransaction: jest.fn() };
-const dynamicFeeMatcher = { canEnterPool: jest.fn(), canBroadcast: jest.fn() };
+const dynamicFeeMatcher = { throwIfCannotEnterPool: jest.fn(), throwIfCannotBroadcast: jest.fn() };
 const transactionBroadcaster = { broadcastTransactions: jest.fn() };
 
 const container = new Container.Container();
@@ -33,25 +33,29 @@ container.bind(Container.Identifiers.PeerTransactionBroadcaster).toConstantValue
 beforeEach(() => {
     logger.warning.mockReset();
     pool.addTransaction.mockReset();
-    dynamicFeeMatcher.canEnterPool.mockReset();
-    dynamicFeeMatcher.canBroadcast.mockReset();
+    dynamicFeeMatcher.throwIfCannotEnterPool.mockReset();
+    dynamicFeeMatcher.throwIfCannotBroadcast.mockReset();
     transactionBroadcaster.broadcastTransactions.mockReset();
 });
 
 describe("Processor.process", () => {
     it("should add eligible transactions to pool", async () => {
-        dynamicFeeMatcher.canEnterPool.mockReturnValueOnce(true).mockReturnValueOnce(false);
+        dynamicFeeMatcher.throwIfCannotEnterPool
+            .mockImplementationOnce(async (transaction) => {})
+            .mockImplementationOnce(async (transaction) => {
+                throw new TransactionFeeToLowError(transaction);
+            });
 
         const processor = container.resolve(Processor);
         await processor.process([transaction1.data, transaction2.data]);
 
-        expect(dynamicFeeMatcher.canEnterPool).toBeCalledTimes(2);
+        expect(dynamicFeeMatcher.throwIfCannotEnterPool).toBeCalledTimes(2);
         expect(pool.addTransaction).toBeCalledTimes(1);
-        expect(dynamicFeeMatcher.canBroadcast).toBeCalledTimes(1);
-        expect(transactionBroadcaster.broadcastTransactions).not.toBeCalled();
+        expect(dynamicFeeMatcher.throwIfCannotBroadcast).toBeCalledTimes(1);
+        expect(transactionBroadcaster.broadcastTransactions).toBeCalledTimes(1);
 
         expect(processor.accept).toEqual([transaction1.id]);
-        expect(processor.broadcast).toEqual([]);
+        expect(processor.broadcast).toEqual([transaction1.id]);
         expect(processor.invalid).toEqual([transaction2.id]);
         expect(processor.excess).toEqual([]);
         expect(processor.errors[transaction2.id]).toBeTruthy();
@@ -59,15 +63,18 @@ describe("Processor.process", () => {
     });
 
     it("should add broadcast eligible transaction", async () => {
-        dynamicFeeMatcher.canEnterPool.mockReturnValueOnce(true).mockReturnValueOnce(true);
-        dynamicFeeMatcher.canBroadcast.mockReturnValueOnce(true).mockReturnValueOnce(false);
+        dynamicFeeMatcher.throwIfCannotBroadcast
+            .mockImplementationOnce(async (transaction) => {})
+            .mockImplementationOnce(async (transaction) => {
+                throw new TransactionFeeToLowError(transaction);
+            });
 
         const processor = container.resolve(Processor);
         await processor.process([transaction1.data, transaction2.data]);
 
-        expect(dynamicFeeMatcher.canEnterPool).toBeCalledTimes(2);
+        expect(dynamicFeeMatcher.throwIfCannotEnterPool).toBeCalledTimes(2);
         expect(pool.addTransaction).toBeCalledTimes(2);
-        expect(dynamicFeeMatcher.canBroadcast).toBeCalledTimes(2);
+        expect(dynamicFeeMatcher.throwIfCannotBroadcast).toBeCalledTimes(2);
         expect(transactionBroadcaster.broadcastTransactions).toBeCalled();
 
         expect(processor.accept).toEqual([transaction1.id, transaction2.id]);
@@ -78,7 +85,6 @@ describe("Processor.process", () => {
     });
 
     it("should rethrow unexpected error", async () => {
-        dynamicFeeMatcher.canEnterPool.mockReturnValueOnce(true);
         pool.addTransaction.mockRejectedValueOnce(new Error("Unexpected error"));
 
         const processor = container.resolve(Processor);
@@ -86,9 +92,9 @@ describe("Processor.process", () => {
 
         await expect(promise).rejects.toThrow();
 
-        expect(dynamicFeeMatcher.canEnterPool).toBeCalledTimes(1);
+        expect(dynamicFeeMatcher.throwIfCannotEnterPool).toBeCalledTimes(1);
         expect(pool.addTransaction).toBeCalledTimes(1);
-        expect(dynamicFeeMatcher.canBroadcast).toBeCalledTimes(0);
+        expect(dynamicFeeMatcher.throwIfCannotBroadcast).toBeCalledTimes(0);
         expect(transactionBroadcaster.broadcastTransactions).not.toBeCalled();
 
         expect(processor.accept).toEqual([]);
@@ -101,15 +107,14 @@ describe("Processor.process", () => {
     it("should track excess transactions", async () => {
         const exceedsError = new Contracts.TransactionPool.PoolError("Exceeds", "ERR_EXCEEDS_MAX_COUNT", transaction1);
 
-        dynamicFeeMatcher.canEnterPool.mockReturnValueOnce(true);
         pool.addTransaction.mockRejectedValueOnce(exceedsError);
 
         const processor = container.resolve(Processor);
         await processor.process([transaction1.data]);
 
-        expect(dynamicFeeMatcher.canEnterPool).toBeCalledTimes(1);
+        expect(dynamicFeeMatcher.throwIfCannotEnterPool).toBeCalledTimes(1);
         expect(pool.addTransaction).toBeCalledTimes(1);
-        expect(dynamicFeeMatcher.canBroadcast).toBeCalledTimes(0);
+        expect(dynamicFeeMatcher.throwIfCannotBroadcast).toBeCalledTimes(0);
         expect(transactionBroadcaster.broadcastTransactions).not.toBeCalled();
 
         expect(processor.accept).toEqual([]);

--- a/packages/core-kernel/src/contracts/transaction-pool/dynamic-fee-matcher.ts
+++ b/packages/core-kernel/src/contracts/transaction-pool/dynamic-fee-matcher.ts
@@ -1,6 +1,6 @@
 import { Interfaces } from "@arkecosystem/crypto";
 
 export interface DynamicFeeMatcher {
-    canEnterPool(transaction: Interfaces.ITransaction): Promise<boolean>;
-    canBroadcast(transaction: Interfaces.ITransaction): Promise<boolean>;
+    throwIfCannotEnterPool(transaction: Interfaces.ITransaction): Promise<void>;
+    throwIfCannotBroadcast(transaction: Interfaces.ITransaction): Promise<void>;
 }

--- a/packages/core-transaction-pool/src/errors.ts
+++ b/packages/core-transaction-pool/src/errors.ts
@@ -41,6 +41,12 @@ export class TransactionFeeToLowError extends Contracts.TransactionPool.PoolErro
     }
 }
 
+export class TransactionFeeToHighError extends Contracts.TransactionPool.PoolError {
+    public constructor(transaction: Interfaces.ITransaction) {
+        super(`${transaction} fee is to high to enter the pool`, "ERR_HIGH_FEE", transaction);
+    }
+}
+
 export class SenderExceededMaximumTransactionCountError extends Contracts.TransactionPool.PoolError {
     public readonly maxCount: number;
 

--- a/packages/core-transaction-pool/src/processor.ts
+++ b/packages/core-transaction-pool/src/processor.ts
@@ -1,8 +1,6 @@
 import { Container, Contracts, Utils as AppUtils } from "@arkecosystem/core-kernel";
 import { Interfaces, Transactions } from "@arkecosystem/crypto";
 
-import { TransactionFeeToLowError } from "./errors";
-
 @Container.injectable()
 export class Processor implements Contracts.TransactionPool.Processor {
     public accept: string[] = [];
@@ -33,15 +31,14 @@ export class Processor implements Contracts.TransactionPool.Processor {
                 AppUtils.assert.defined<string>(transaction.id);
 
                 try {
-                    if (await this.dynamicFeeMatcher.canEnterPool(transaction)) {
-                        await this.pool.addTransaction(transaction);
-                        this.accept.push(transaction.id);
-                        if (await this.dynamicFeeMatcher.canBroadcast(transaction)) {
-                            broadcastableTransactions.push(transaction);
-                        }
-                    } else {
-                        throw new TransactionFeeToLowError(transaction);
-                    }
+                    await this.dynamicFeeMatcher.throwIfCannotEnterPool(transaction);
+                    await this.pool.addTransaction(transaction);
+                    this.accept.push(transaction.id);
+
+                    try {
+                        await this.dynamicFeeMatcher.throwIfCannotBroadcast(transaction);
+                        broadcastableTransactions.push(transaction);
+                    } catch {}
                 } catch (error) {
                     this.invalid.push(transaction.id);
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

This PR fixes #3712 bug. Additional fee checks are added and DynamicFeeMatcher is now reponsible for throwing error if fee is too high or too low. 

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
