### PR TITLE
feat(core-manager): implement `info.nextForgingSlot` action

### DIFF
--- a/__tests__/unit/core-manager/__fixtures__/trigger-responses.ts
+++ b/__tests__/unit/core-manager/__fixtures__/trigger-responses.ts
@@ -3,3 +3,9 @@ export const forgetCurrentDelegateResponse =
 
 export const forgetCurrentDelegateError =
     '1 processes have received command forger.currentDelegate\n[ark-core:0:default]={"error": "Dummy error"}';
+
+export const forgetNextForgingSlotResponse =
+    '1 processes have received command forger.nextSlot\n[ark-core:0:default]={"response":{"remainingTime":6000}}';
+
+export const forgetNextForgingSlotError =
+    '1 processes have received command forger.nextSlot\n[ark-core:0:default]={"error": "Dummy error"}';

--- a/__tests__/unit/core-manager/actions/info-next-forging-slot.test.ts
+++ b/__tests__/unit/core-manager/actions/info-next-forging-slot.test.ts
@@ -1,0 +1,60 @@
+import "jest-extended";
+
+import { Action } from "@packages/core-manager/src/actions/info-next-forging-slot";
+import { Identifiers } from "@packages/core-manager/src/ioc";
+import { Sandbox } from "@packages/core-test-framework";
+
+import { TriggerResponses } from "../__fixtures__";
+
+let sandbox: Sandbox;
+let action: Action;
+
+let mockCli;
+let mockTrigger;
+
+beforeEach(() => {
+    mockTrigger = jest.fn().mockReturnValue({
+        stdout: TriggerResponses.forgetNextForgingSlotResponse,
+    });
+
+    mockCli = {
+        get: jest.fn().mockReturnValue({
+            trigger: mockTrigger,
+        }),
+    };
+
+    sandbox = new Sandbox();
+
+    sandbox.app.bind(Identifiers.CLI).toConstantValue(mockCli);
+
+    action = sandbox.app.resolve(Action);
+});
+
+afterEach(() => {
+    delete process.env.CORE_API_DISABLED;
+    jest.clearAllMocks();
+});
+
+describe("Info:NextForgingSlot", () => {
+    it("should have name", () => {
+        expect(action.name).toEqual("info.nextForgingSlot");
+    });
+
+    it("should return remainingTime", async () => {
+        const result = await action.execute({});
+
+        expect(result).toEqual({ remainingTime: 6000 });
+    });
+
+    it("should throw error if trigger responded with error", async () => {
+        mockTrigger = jest.fn().mockReturnValue({
+            stdout: TriggerResponses.forgetNextForgingSlotError,
+        });
+
+        mockCli.get = jest.fn().mockReturnValue({
+            trigger: mockTrigger,
+        });
+
+        await expect(action.execute({})).rejects.toThrow("Trigger returned error");
+    });
+});

--- a/packages/core-manager/src/actions/info-next-forging-slot.ts
+++ b/packages/core-manager/src/actions/info-next-forging-slot.ts
@@ -1,0 +1,34 @@
+import { Application as Cli, Container as CliContainer, Services } from "@arkecosystem/core-cli";
+import { Application, Container } from "@arkecosystem/core-kernel";
+
+import { Actions } from "../contracts";
+import { Identifiers } from "../ioc";
+import { parseProcessActionResponse } from "../utils";
+
+@Container.injectable()
+export class Action implements Actions.Action {
+    public name = "info.nextForgingSlot";
+
+    @Container.inject(Container.Identifiers.Application)
+    private readonly app!: Application;
+
+    public async execute(params: object): Promise<any> {
+        return await this.getNextForgingSlot();
+    }
+
+    private async getNextForgingSlot(): Promise<any> {
+        const cli = this.app.get<Cli>(Identifiers.CLI);
+
+        const processManager = cli.get<Services.ProcessManager>(CliContainer.Identifiers.ProcessManager);
+
+        const response = processManager.trigger("ark-core", "forger.nextSlot");
+
+        const result = parseProcessActionResponse(response);
+
+        if (result.error) {
+            throw new Error("Trigger returned error.");
+        }
+
+        return result.response;
+    }
+}

--- a/packages/core-manager/src/actions/info-next-forging-slot.ts
+++ b/packages/core-manager/src/actions/info-next-forging-slot.ts
@@ -26,7 +26,7 @@ export class Action implements Actions.Action {
         const result = parseProcessActionResponse(response);
 
         if (result.error) {
-            throw new Error("Trigger returned error.");
+            throw new Error("Trigger returned error");
         }
 
         return result.response;


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

This PR add new action which return time till the next forging slot if forger process is running.

### Action

**Name:** info.nextForgingSlot

**Params:** none

**Response:**
|Name|Type|Description|
|-|-|-|
|remainingTime|Number|Time till next forging slot in ms.|


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [x] Tests
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
