### PR TITLE
chore: support fedora

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -98,7 +98,7 @@ if [[ ! -z $DEB ]]; then
     sudo apt-get install -y git curl apt-transport-https update-notifier
 elif [[ ! -z $RPM ]]; then
     sudo yum update -y
-    sudo yum install git curl epel-release -y
+    sudo yum install git curl epel-release --skip-broken -y
 fi
 
 success "Installed system dependencies!"


### PR DESCRIPTION
## Summary

Following on from #3738 I wanted to use Fedora rather than CentOS so I made the required changes to the installer script to make it compatible with both RHEL/CentOS and Fedora. It was a lot less work than anticipated, just adding `--skip-broken` so it only installs `epel-release` if it's available and won't abort the installation if it's not (since it's required for RHEL/CentOS, thus will be installed, but is not present in Fedora since it is not necessary for that distro).

I confirmed that this makes Core installable and runnable on the latest Fedora and also continues to work fine on the latest CentOS.

If you only want to support RHEL/CentOS as far as RedHat distributions go then fair enough, feel free to close unmerged, but since I already wanted to fix it for myself so I could use my own server running Fedora I thought I'd share it with you in case you wanted to support Fedora out of the box as well as Debian/Ubuntu/RHEL/CentOS.

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
