### PR TITLE
fix(core-transaction-pool): re-add transactions to pool when milestone changes

### DIFF
--- a/packages/core-kernel/src/contracts/transaction-pool/storage.ts
+++ b/packages/core-kernel/src/contracts/transaction-pool/storage.ts
@@ -1,9 +1,7 @@
-import { Interfaces } from "@arkecosystem/crypto";
-
 export interface Storage {
     hasTransaction(id: string): boolean;
-    getAllTransactions(): Iterable<Interfaces.ITransaction>;
-    addTransaction(transaction: Interfaces.ITransaction): void;
+    getAllTransactions(): Iterable<{ id: string; serialized: Buffer }>;
+    addTransaction(id: string, serialized: Buffer): void;
     removeTransaction(id: string): void;
     flush(): void;
 }

--- a/packages/core-transaction-pool/src/service.ts
+++ b/packages/core-transaction-pool/src/service.ts
@@ -1,5 +1,4 @@
 import { Container, Contracts, Enums as AppEnums, Providers, Utils as AppUtils } from "@arkecosystem/core-kernel";
-import { postConstruct } from "@arkecosystem/core-kernel/dist/ioc";
 import { Interfaces } from "@arkecosystem/crypto";
 
 import { TransactionAlreadyInPoolError, TransactionPoolFullError } from "./errors";
@@ -28,14 +27,11 @@ export class Service implements Contracts.TransactionPool.Service {
     @Container.inject(Container.Identifiers.TransactionPoolExpirationService)
     private readonly expirationService!: Contracts.TransactionPool.ExpirationService;
 
-    @postConstruct()
-    public initialize() {
+    public async boot(): Promise<void> {
         this.emitter.listen(AppEnums.CryptoEvent.MilestoneChanged, {
             handle: () => this.readdTransactions(),
         });
-    }
 
-    public async boot(): Promise<void> {
         if (process.env.CORE_RESET_DATABASE) {
             this.flush();
         } else {


### PR DESCRIPTION
## Summary

When milestone changes previously valid transactions may become invalid, so they have to be deserialized and re-added into pool again.

## Checklist

- [x] Ready to be merged
