### PR TITLE
fix(core-transaction-pool): introduce CORE_RESET_POOL env variable

### DIFF
--- a/packages/core-transaction-pool/src/service.ts
+++ b/packages/core-transaction-pool/src/service.ts
@@ -25,7 +25,7 @@ export class Service implements Contracts.TransactionPool.Service {
     private readonly expirationService!: Contracts.TransactionPool.ExpirationService;
 
     public async boot(): Promise<void> {
-        if (process.env.CORE_RESET_DATABASE) {
+        if (process.env.CORE_RESET_DATABASE || process.env.CORE_RESET_POOL) {
             this.flush();
         } else {
             await this.readdTransactions();


### PR DESCRIPTION
## Summary

Introduced new environment variable `CORE_RESET_POOL` which only resets pool. Unlike `CORE_RESET_DATABASE` that resets both main and pool databases.

## Checklist

- [x] Ready to be merged
