### PR TITLE
feat(core-transaction-pool): disaptch additional transaction-pool events

### DIFF
--- a/__tests__/unit/core-transaction-pool/sender-state.test.ts
+++ b/__tests__/unit/core-transaction-pool/sender-state.test.ts
@@ -17,6 +17,7 @@ const configuration = { getRequired: jest.fn(), getOptional: jest.fn() };
 const handler = { verify: jest.fn(), throwIfCannotEnterPool: jest.fn(), apply: jest.fn(), revert: jest.fn() };
 const handlerRegistry = { getActivatedHandlerForData: jest.fn() };
 const expirationService = { isExpired: jest.fn(), getExpirationHeight: jest.fn() };
+const eventDispatcherService = { dispatch: jest.fn() };
 
 let sandbox: Sandbox;
 
@@ -26,6 +27,7 @@ beforeEach(() => {
     sandbox.app.bind(Container.Identifiers.PluginConfiguration).toConstantValue(configuration);
     sandbox.app.bind(Container.Identifiers.TransactionHandlerRegistry).toConstantValue(handlerRegistry);
     sandbox.app.bind(Container.Identifiers.TransactionPoolExpirationService).toConstantValue(expirationService);
+    sandbox.app.bind(Container.Identifiers.EventDispatcherService).toConstantValue(eventDispatcherService);
     sandbox.app.bind(Container.Identifiers.TriggerService).to(Services.Triggers.Triggers).inSingletonScope();
 
     sandbox.app
@@ -112,6 +114,8 @@ describe("SenderState.apply", () => {
 
         await expect(promise).rejects.toBeInstanceOf(Contracts.TransactionPool.PoolError);
         await expect(promise).rejects.toHaveProperty("type", "ERR_EXPIRED");
+
+        expect(eventDispatcherService.dispatch).toHaveBeenCalledTimes(1);
     });
 
     it("should throw when transaction fails to verify", async () => {

--- a/__tests__/unit/core-transaction-pool/sender-state.test.ts
+++ b/__tests__/unit/core-transaction-pool/sender-state.test.ts
@@ -1,15 +1,14 @@
-import { Container, Contracts } from "@packages/core-kernel";
-import { Crypto, Interfaces, Managers } from "@packages/crypto";
-
-import { SenderState } from "@packages/core-transaction-pool/src/sender-state";
-import { Sandbox } from "@packages/core-test-framework";
+import { Container, Contracts, Enums } from "@packages/core-kernel";
 import { Services } from "@packages/core-kernel/dist";
+import { Sandbox } from "@packages/core-test-framework";
 import {
     ApplyTransactionAction,
     RevertTransactionAction,
     ThrowIfCannotEnterPoolAction,
     VerifyTransactionAction,
 } from "@packages/core-transaction-pool/src/actions";
+import { SenderState } from "@packages/core-transaction-pool/src/sender-state";
+import { Crypto, Interfaces, Managers } from "@packages/crypto";
 
 jest.mock("@packages/crypto");
 
@@ -116,6 +115,7 @@ describe("SenderState.apply", () => {
         await expect(promise).rejects.toHaveProperty("type", "ERR_EXPIRED");
 
         expect(eventDispatcherService.dispatch).toHaveBeenCalledTimes(1);
+        expect(eventDispatcherService.dispatch).toHaveBeenCalledWith(Enums.TransactionEvent.Expired, expect.anything());
     });
 
     it("should throw when transaction fails to verify", async () => {

--- a/packages/core-transaction-pool/src/sender-state.ts
+++ b/packages/core-transaction-pool/src/sender-state.ts
@@ -1,4 +1,4 @@
-import { Container, Contracts, Providers, Services } from "@arkecosystem/core-kernel";
+import { Container, Contracts, Enums, Providers, Services } from "@arkecosystem/core-kernel";
 import { Handlers } from "@arkecosystem/core-transactions";
 import { Crypto, Interfaces, Managers } from "@arkecosystem/crypto";
 
@@ -48,6 +48,8 @@ export class SenderState implements Contracts.TransactionPool.SenderState {
         }
 
         if (await this.expirationService.isExpired(transaction)) {
+            this.app.events.dispatch(Enums.TransactionEvent.Expired, transaction.data);
+
             const expirationHeight: number = await this.expirationService.getExpirationHeight(transaction);
             throw new TransactionHasExpiredError(transaction, expirationHeight);
         }

--- a/packages/core-transaction-pool/src/service.ts
+++ b/packages/core-transaction-pool/src/service.ts
@@ -1,10 +1,13 @@
-import { Container, Contracts, Providers, Utils as AppUtils } from "@arkecosystem/core-kernel";
+import { Container, Contracts, Enums, Providers, Utils as AppUtils } from "@arkecosystem/core-kernel";
 import { Interfaces } from "@arkecosystem/crypto";
 
 import { TransactionAlreadyInPoolError, TransactionPoolFullError } from "./errors";
 
 @Container.injectable()
 export class Service implements Contracts.TransactionPool.Service {
+    @Container.inject(Container.Identifiers.Application)
+    public readonly app!: Contracts.Kernel.Application;
+
     @Container.inject(Container.Identifiers.LogService)
     private readonly logger!: Contracts.Kernel.Logger;
 
@@ -160,6 +163,8 @@ export class Service implements Contracts.TransactionPool.Service {
             if (await this.expirationService.isExpired(transaction)) {
                 this.logger.warning(`${transaction} expired`);
                 await this.removeTransaction(transaction);
+
+                this.app.events.dispatch(Enums.TransactionEvent.Expired, transaction.data);
             }
         }
     }

--- a/packages/core-transaction-pool/src/service.ts
+++ b/packages/core-transaction-pool/src/service.ts
@@ -49,8 +49,12 @@ export class Service implements Contracts.TransactionPool.Service {
         try {
             await this.addTransactionToMempool(transaction);
             this.logger.debug(`${transaction} added to pool`);
+
+            this.app.events.dispatch(Enums.TransactionEvent.AddedToPool, transaction.data);
         } catch (error) {
             this.storage.removeTransaction(transaction.id);
+
+            this.app.events.dispatch(Enums.TransactionEvent.RejectedByPool, transaction.data);
             throw error;
         }
     }
@@ -73,6 +77,8 @@ export class Service implements Contracts.TransactionPool.Service {
             this.storage.removeTransaction(transaction.id);
             this.logger.error(`${transaction} removed from pool (wasn't in mempool)`);
         }
+
+        this.app.events.dispatch(Enums.TransactionEvent.RemovedFromPool, transaction.data);
     }
 
     public async acceptForgedTransaction(transaction: Interfaces.ITransaction): Promise<void> {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

PR included additional transaction-pool events, required by  #3753:
- [x] AddedToPool = "transaction.pool.added"
- [x] RejectedByPool = "transaction.pool.rejected"
- [x] RemovedFromPool = "transaction.pool.removed"
- [x] Expired = "transaction.expired"



<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->


- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
