### PR TITLE
feat(core-webhooks): dispatch webhook events

### DIFF
--- a/__tests__/unit/core-webhooks/listener.test.ts
+++ b/__tests__/unit/core-webhooks/listener.test.ts
@@ -1,17 +1,19 @@
 import "jest-extended";
 
-import { Application } from "@packages/core-kernel/src/application";
 import { Container, Utils } from "@packages/core-kernel";
+import { HttpOptions, HttpResponse } from "@packages/core-kernel/src/utils";
+import { Sandbox } from "@packages/core-test-framework";
+import * as coditions from "@packages/core-webhooks/src/conditions";
 import { Database } from "@packages/core-webhooks/src/database";
 import { Identifiers } from "@packages/core-webhooks/src/identifiers";
-import { Listener } from "@packages/core-webhooks/src/listener";
 import { Webhook } from "@packages/core-webhooks/src/interfaces";
+import { WebhookEvent } from "@packages/core-webhooks/src/events";
+import { Listener } from "@packages/core-webhooks/src/listener";
 import { dirSync, setGracefulCleanup } from "tmp";
-import { HttpOptions, HttpResponse } from "@packages/core-kernel/src/utils";
-import { dummyWebhook } from "./__fixtures__/assets";
-import * as coditions from "@packages/core-webhooks/src/conditions";
 
-let app: Application;
+import { dummyWebhook } from "./__fixtures__/assets";
+
+let sandbox: Sandbox;
 let database: Database;
 let listener: Listener;
 let webhook: Webhook;
@@ -21,20 +23,42 @@ const logger = {
     error: jest.fn(),
 };
 
+const mockEventDispatcher = {
+    dispatch: jest.fn(),
+};
+
 let spyOnPost: jest.SpyInstance;
 
+const expectFinishedEventData = () => {
+    return expect.objectContaining({
+        executionTime: expect.toBeNumber(),
+        webhook: expect.toBeObject(),
+        payload: expect.anything(),
+    });
+};
+
+const expectFailedEventData = () => {
+    return expect.objectContaining({
+        executionTime: expect.toBeNumber(),
+        webhook: expect.toBeObject(),
+        payload: expect.anything(),
+        error: expect.toBeObject(),
+    });
+};
+
 beforeEach(() => {
-    app = new Application(new Container.Container());
-    app.bind("path.cache").toConstantValue(dirSync().name);
+    sandbox = new Sandbox();
+    sandbox.app.bind("path.cache").toConstantValue(dirSync().name);
 
-    app.bind<Database>(Identifiers.Database).to(Database).inSingletonScope();
+    sandbox.app.bind(Container.Identifiers.EventDispatcherService).toConstantValue(mockEventDispatcher);
+    sandbox.app.bind<Database>(Identifiers.Database).to(Database).inSingletonScope();
 
-    app.bind(Container.Identifiers.LogService).toConstantValue(logger);
+    sandbox.app.bind(Container.Identifiers.LogService).toConstantValue(logger);
 
-    database = app.get<Database>(Identifiers.Database);
+    database = sandbox.app.get<Database>(Identifiers.Database);
     database.boot();
 
-    listener = app.resolve<Listener>(Listener);
+    listener = sandbox.app.resolve<Listener>(Listener);
 
     webhook = Object.assign({}, dummyWebhook);
 
@@ -48,6 +72,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+    jest.clearAllMocks();
     jest.resetAllMocks();
 });
 
@@ -62,6 +87,9 @@ describe("Listener", () => {
 
             expect(spyOnPost).toHaveBeenCalled();
             expect(logger.debug).toHaveBeenCalled();
+
+            expect(mockEventDispatcher.dispatch).toHaveBeenCalledTimes(1);
+            expect(mockEventDispatcher.dispatch).toHaveBeenCalledWith(WebhookEvent.Broadcasted, expectFinishedEventData());
         });
 
         it("should log error if broadcast is not successful", async () => {
@@ -77,6 +105,9 @@ describe("Listener", () => {
 
             expect(spyOnPost).toHaveBeenCalled();
             expect(logger.error).toHaveBeenCalled();
+
+            expect(mockEventDispatcher.dispatch).toHaveBeenCalledTimes(1);
+            expect(mockEventDispatcher.dispatch).toHaveBeenCalledWith(WebhookEvent.Failed, expectFailedEventData());
         });
     });
 
@@ -86,6 +117,14 @@ describe("Listener", () => {
             database.create(webhook);
 
             await listener.handle({ name: "event", data: "dummy_data" });
+
+            expect(spyOnPost).toHaveBeenCalledTimes(0);
+        });
+
+        it("should not broadcast if event is webhook event", async () => {
+            database.create(webhook);
+
+            await listener.handle({ name: WebhookEvent.Broadcasted, data: "dummy_data" });
 
             expect(spyOnPost).toHaveBeenCalledTimes(0);
         });
@@ -103,6 +142,9 @@ describe("Listener", () => {
             await listener.handle({ name: "event", data: { test: 1 } });
 
             expect(spyOnPost).toHaveBeenCalledTimes(1);
+
+            expect(mockEventDispatcher.dispatch).toHaveBeenCalledTimes(1);
+            expect(mockEventDispatcher.dispatch).toHaveBeenCalledWith(WebhookEvent.Broadcasted, expectFinishedEventData());
         });
 
         it("should not broadcast if webhook condition is not satisfied", async () => {
@@ -121,7 +163,7 @@ describe("Listener", () => {
         });
 
         it("should not broadcast if webhook condition throws error", async () => {
-            let spyOnEq = jest.spyOn(coditions, "eq").mockImplementation((actual, expected) => {
+            const spyOnEq = jest.spyOn(coditions, "eq").mockImplementation((actual, expected) => {
                 throw new Error();
             });
 

--- a/__tests__/unit/core-webhooks/listener.test.ts
+++ b/__tests__/unit/core-webhooks/listener.test.ts
@@ -5,9 +5,9 @@ import { HttpOptions, HttpResponse } from "@packages/core-kernel/src/utils";
 import { Sandbox } from "@packages/core-test-framework";
 import * as coditions from "@packages/core-webhooks/src/conditions";
 import { Database } from "@packages/core-webhooks/src/database";
+import { WebhookEvent } from "@packages/core-webhooks/src/events";
 import { Identifiers } from "@packages/core-webhooks/src/identifiers";
 import { Webhook } from "@packages/core-webhooks/src/interfaces";
-import { WebhookEvent } from "@packages/core-webhooks/src/events";
 import { Listener } from "@packages/core-webhooks/src/listener";
 import { dirSync, setGracefulCleanup } from "tmp";
 
@@ -89,7 +89,10 @@ describe("Listener", () => {
             expect(logger.debug).toHaveBeenCalled();
 
             expect(mockEventDispatcher.dispatch).toHaveBeenCalledTimes(1);
-            expect(mockEventDispatcher.dispatch).toHaveBeenCalledWith(WebhookEvent.Broadcasted, expectFinishedEventData());
+            expect(mockEventDispatcher.dispatch).toHaveBeenCalledWith(
+                WebhookEvent.Broadcasted,
+                expectFinishedEventData(),
+            );
         });
 
         it("should log error if broadcast is not successful", async () => {
@@ -144,7 +147,10 @@ describe("Listener", () => {
             expect(spyOnPost).toHaveBeenCalledTimes(1);
 
             expect(mockEventDispatcher.dispatch).toHaveBeenCalledTimes(1);
-            expect(mockEventDispatcher.dispatch).toHaveBeenCalledWith(WebhookEvent.Broadcasted, expectFinishedEventData());
+            expect(mockEventDispatcher.dispatch).toHaveBeenCalledWith(
+                WebhookEvent.Broadcasted,
+                expectFinishedEventData(),
+            );
         });
 
         it("should not broadcast if webhook condition is not satisfied", async () => {

--- a/packages/core-webhooks/src/events.ts
+++ b/packages/core-webhooks/src/events.ts
@@ -1,0 +1,4 @@
+export enum WebhookEvent {
+    Broadcasted = "webhooks.broadcasted",
+    Failed = "webhooks.failed",
+}

--- a/packages/core-webhooks/src/listener.ts
+++ b/packages/core-webhooks/src/listener.ts
@@ -1,7 +1,9 @@
 import { Container, Contracts, Utils } from "@arkecosystem/core-kernel";
+import { performance } from "perf_hooks";
 
 import * as conditions from "./conditions";
 import { Database } from "./database";
+import { WebhookEvent } from "./events";
 import { Identifiers } from "./identifiers";
 import { Webhook } from "./interfaces";
 
@@ -31,6 +33,11 @@ export class Listener {
      * @memberof Listener
      */
     public async handle({ name, data }): Promise<void> {
+        // Skip own events to prevent cycling
+        if (name.toString().includes("webhooks")) {
+            return;
+        }
+
         const webhooks: Webhook[] = this.getWebhooks(name, data);
 
         for (const webhook of webhooks) {
@@ -45,6 +52,8 @@ export class Listener {
      * @memberof Broadcaster
      */
     public async broadcast(webhook: Webhook, payload: object, timeout: number = 1500): Promise<void> {
+        const start = performance.now();
+
         try {
             const { statusCode } = await Utils.http.post(webhook.target, {
                 body: {
@@ -61,9 +70,30 @@ export class Listener {
             this.logger.debug(
                 `Webhooks Job ${webhook.id} completed! Event [${webhook.event}] has been transmitted to [${webhook.target}] with a status of [${statusCode}].`,
             );
+
+            await this.dispatchWebhookEvent(start, webhook, payload);
         } catch (error) {
             this.logger.error(`Webhooks Job ${webhook.id} failed: ${error.message}`);
+
+            await this.dispatchWebhookEvent(start, webhook, payload, error);
         }
+    }
+
+    private async dispatchWebhookEvent(start: number, webhook: Webhook, payload: object, err?: Error) {
+        if (err) {
+            this.app.events.dispatch(WebhookEvent.Failed, {
+                executionTime: performance.now() - start,
+                webhook: webhook,
+                payload: payload,
+                errorMessage: err.message,
+            });
+        }
+
+        this.app.events.dispatch(WebhookEvent.Broadcasted, {
+            executionTime: performance.now() - start,
+            webhook: webhook,
+            payload: payload,
+        });
     }
 
     /**

--- a/packages/core-webhooks/src/listener.ts
+++ b/packages/core-webhooks/src/listener.ts
@@ -85,15 +85,15 @@ export class Listener {
                 executionTime: performance.now() - start,
                 webhook: webhook,
                 payload: payload,
-                errorMessage: err.message,
+                error: err,
+            });
+        } else {
+            this.app.events.dispatch(WebhookEvent.Broadcasted, {
+                executionTime: performance.now() - start,
+                webhook: webhook,
+                payload: payload,
             });
         }
-
-        this.app.events.dispatch(WebhookEvent.Broadcasted, {
-            executionTime: performance.now() - start,
-            webhook: webhook,
-            payload: payload,
-        });
     }
 
     /**


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

This PR adds functionality into webhook listener, that will emit webhook event every time event has been broasted. PR is part of: #3753.

Included data are:
- executionTime
- webhook
- payload
- error (if present)

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
