### PR TITLE
fix(core-database): straight delete blocks during rollback

### DIFF
--- a/__tests__/functional/core-database/repositories/block-repository.test.ts
+++ b/__tests__/functional/core-database/repositories/block-repository.test.ts
@@ -284,3 +284,17 @@ describe("BlockRepository.listByExpression", () => {
         expect(listResult.rows).toStrictEqual([toBlockModel(block3), toBlockModel(block2)]);
     });
 });
+
+describe("BlockRepository.deleteTopBlocks", () => {
+    it("should delete blocks", async () => {
+        const blockRepository = getCustomRepository(BlockRepository);
+        await blockRepository.saveBlocks([block1, block2, block3]);
+        await blockRepository.deleteTopBlocks(2);
+        const block1ById = await blockRepository.findById(block1.data.id);
+        const block2ById = await blockRepository.findById(block2.data.id);
+        const block3ById = await blockRepository.findById(block3.data.id);
+        expect(block1ById).toStrictEqual(toBlockModel(block1));
+        expect(block2ById).toBeUndefined();
+        expect(block3ById).toBeUndefined();
+    });
+});

--- a/packages/core-blockchain/src/blockchain.ts
+++ b/packages/core-blockchain/src/blockchain.ts
@@ -344,22 +344,10 @@ export class Blockchain implements Contracts.Blockchain.Blockchain {
      * @return {void}
      */
     public async removeTopBlocks(count: number): Promise<void> {
-        const blocks: Interfaces.IBlockData[] = await this.database.getTopBlocks(count);
+        this.app.log.info(`Removing top ${Utils.pluralize("block", count, true)}`);
 
-        this.app.log.info(
-            `Removing ${Utils.pluralize(
-                "block",
-                blocks.length,
-                true,
-            )} from height ${(blocks[0] as any).height.toLocaleString()}`,
-        );
-
-        try {
-            await this.blockRepository.deleteBlocks(blocks);
-            await this.database.loadBlocksFromCurrentRound();
-        } catch (error) {
-            this.app.log.error(`Encountered error while removing blocks: ${error.message}`);
-        }
+        await this.blockRepository.deleteTopBlocks(count);
+        await this.database.loadBlocksFromCurrentRound();
     }
 
     /**

--- a/packages/core-database/src/repositories/block-repository.ts
+++ b/packages/core-database/src/repositories/block-repository.ts
@@ -216,4 +216,52 @@ export class BlockRepository extends AbstractRepository<Block> {
                 .execute();
         });
     }
+
+    public async deleteTopBlocks(count: number): Promise<void> {
+        await this.manager.transaction(async (manager) => {
+            const maxHeightRow = await manager
+                .createQueryBuilder()
+                .select("MAX(height) AS max_height")
+                .from(Block, "blocks")
+                .getRawOne();
+
+            const targetHeight = maxHeightRow["max_height"] - count;
+            const roundInfo = Utils.roundCalculator.calculateRound(targetHeight);
+            const targetRound = roundInfo.round;
+
+            const blockIdRows = await manager
+                .createQueryBuilder()
+                .select(["id"])
+                .from(Block, "blocks")
+                .where("height > :targetHeight", { targetHeight })
+                .getRawMany();
+
+            const blockIds = blockIdRows.map((row) => row["id"]);
+
+            if (blockIds.length !== count) {
+                throw new Error("Corrupt database");
+            }
+
+            await manager
+                .createQueryBuilder()
+                .delete()
+                .from(Transaction)
+                .where("block_id IN (:...blockIds)", { blockIds })
+                .execute();
+
+            await manager
+                .createQueryBuilder()
+                .delete()
+                .from(Block)
+                .where("id IN (:...blockIds)", { blockIds })
+                .execute();
+
+            await manager
+                .createQueryBuilder()
+                .delete()
+                .from(Round)
+                .where("round > :targetRound", { targetRound })
+                .execute();
+        });
+    }
 }


### PR DESCRIPTION
## Summary

`Blockchain.removeTopBlocks` now calls `BlockRepository.deleteTopBlocks` instead of loading them first through `DatabaseService.getTopBlocks` and then deleting through `BlockRepository.deleteBlocks`.

Note that previously `Blockchain.removeTopBlocks` was eating error, only logging it instead of re-throwing.

There are two use-cases when blocks have to be deleted:

1. During rollback top 1000 blocks (up to 10000) are removed.
   Improved by this PR.
1. When reverting, reverted blocks are deleted at the end.
   I plan to refactor revertion to use new `BlockRepository.delgetTopBlock` that pops single block from database rendering `BlockRepository.deleteBlocks` obsolete.

## Checklist

- [x] Tests
- [x] Ready to be merged
