### PR TITLE
fix(core-transaction-pool): rebuild vs update race

### DIFF
--- a/__tests__/functional/transaction-forging/entity-register.test.ts
+++ b/__tests__/functional/transaction-forging/entity-register.test.ts
@@ -17,7 +17,6 @@ describe("Transaction Forging - Entity registration", () => {
     describe("Signed with 1 Passphrase", () => {
         it("should broadcast, accept and forge it [Signed with 1 Passphrase]", async () => {
             // Registering a desktop wallet plugin
-            await snoozeForBlock(1);
             const entityRegistration = TransactionFactory.initialize(app)
                 .entity({
                     type: Enums.EntityType.Plugin,
@@ -29,10 +28,12 @@ describe("Transaction Forging - Entity registration", () => {
                 })
                 .withPassphrase(secrets[0])
                 .createOne();
+
             await expect(entityRegistration).toBeAccepted();
             await snoozeForBlock(1);
-            // await expect(entityRegistration.id).toBeForged();
-            // await expect(entityRegistration).entityRegistered();
+            await expect(entityRegistration.id).toBeForged();
+
+            await expect(entityRegistration).entityRegistered();
         });
 
         it("should reject entity registration, because entity name contains unicode control characters [Signed with 1 Passphrase]", async () => {

--- a/__tests__/unit/core-api/__support__/index.ts
+++ b/__tests__/unit/core-api/__support__/index.ts
@@ -53,6 +53,9 @@ export const buildSenderWallet = (app: Application, passphrase: string | null = 
 
 export const initApp = (): Application => {
     const app = new Application(new Container.Container());
+    const logger = { error: jest.fn() };
+
+    app.bind(Container.Identifiers.LogService).toConstantValue(logger);
 
     app.bind(Container.Identifiers.PluginConfiguration).to(Providers.PluginConfiguration).inSingletonScope();
 

--- a/__tests__/unit/core-magistrate-api/service-provider.test.ts
+++ b/__tests__/unit/core-magistrate-api/service-provider.test.ts
@@ -37,6 +37,8 @@ beforeEach(() => {
     app.bind(Container.Identifiers.TransactionHistoryService).toConstantValue({});
 
     app.bind(Container.Identifiers.TransactionHandlerRegistry).toConstantValue({});
+
+    app.bind(Container.Identifiers.LogService).toConstantValue({});
 });
 
 describe("ServiceProvider", () => {

--- a/__tests__/unit/core-state/block-state.test.ts
+++ b/__tests__/unit/core-state/block-state.test.ts
@@ -310,9 +310,9 @@ describe("BlockState", () => {
         expect(forgingWallet.balance).toEqual(balanceBefore);
     });
 
-    it("should throw if there is no forger wallet", () => {
+    it("should throw if there is no forger wallet", async () => {
         walletRepo.forgetByPublicKey(forgingWallet.publicKey);
-        expect(async () => await blockState.applyBlock(blocks[0])).toReject();
+        await expect(blockState.applyBlock(blocks[0])).toReject();
     });
 
     it("should update sender's and recipient's delegate's vote balance when applying transaction", async () => {

--- a/__tests__/unit/core-state/setup.ts
+++ b/__tests__/unit/core-state/setup.ts
@@ -23,6 +23,7 @@ export interface Spies {
     logger: {
         error: jest.SpyInstance;
         info: jest.SpyInstance;
+        notice: jest.SpyInstance;
         debug: jest.SpyInstance;
         warning: jest.SpyInstance;
     };
@@ -71,6 +72,7 @@ export const setUp = async (setUpOptions = setUpDefaults, skipBoot = false): Pro
     const logger = {
         error: jest.fn(),
         info: jest.fn(),
+        notice: jest.fn(),
         debug: jest.fn(),
         warning: jest.fn(),
     };

--- a/__tests__/unit/core-state/setup.ts
+++ b/__tests__/unit/core-state/setup.ts
@@ -68,6 +68,15 @@ export const setUpDefaults = {
 export const setUp = async (setUpOptions = setUpDefaults, skipBoot = false): Promise<Setup> => {
     const sandbox = new Sandbox();
 
+    const logger = {
+        error: jest.fn(),
+        info: jest.fn(),
+        debug: jest.fn(),
+        warning: jest.fn(),
+    };
+
+    sandbox.app.bind(Container.Identifiers.LogService).toConstantValue(logger);
+
     sandbox.app.bind(Container.Identifiers.WalletAttributes).to(Services.Attributes.AttributeSet).inSingletonScope();
 
     sandbox.app.get<Services.Attributes.AttributeSet>(Container.Identifiers.WalletAttributes).set("delegate");
@@ -193,19 +202,6 @@ export const setUp = async (setUpOptions = setUpDefaults, skipBoot = false): Pro
 
     const applySpy: jest.SpyInstance = jest.fn();
     const revertSpy: jest.SpyInstance = jest.fn();
-    const error: jest.SpyInstance = jest.fn();
-    const info: jest.SpyInstance = jest.fn();
-    const debug: jest.SpyInstance = jest.fn();
-    const warning: jest.SpyInstance = jest.fn();
-
-    const logger = {
-        error,
-        info,
-        debug,
-        warning,
-    };
-
-    sandbox.app.bind(Container.Identifiers.LogService).toConstantValue(logger);
 
     const getRegisteredHandlersSpy = jest.fn();
 

--- a/__tests__/unit/core-transaction-pool/expiration-service.test.ts
+++ b/__tests__/unit/core-transaction-pool/expiration-service.test.ts
@@ -137,10 +137,10 @@ describe("ExpirationService.getExpirationHeight", () => {
         const expirationService = container.resolve(ExpirationService);
         const check = async () => await expirationService.getExpirationHeight(transaction);
 
-        expect(await check).toReject();
+        await expect(check()).rejects.toThrowError();
     });
 
-    it("should return value stored in expiration field when checking v2 transaciton with expiration field", async () => {
+    it("should return value stored in expiration field when checking v2 transaction with expiration field", async () => {
         const transaction = { data: { version: 2, expiration: 100 } } as Interfaces.ITransaction;
         const expirationService = container.resolve(ExpirationService);
         const expirationHeight = await expirationService.getExpirationHeight(transaction);

--- a/__tests__/unit/core-transaction-pool/sender-state.test.ts
+++ b/__tests__/unit/core-transaction-pool/sender-state.test.ts
@@ -1,64 +1,46 @@
-import { Container, Contracts, Enums } from "@packages/core-kernel";
-import { Services } from "@packages/core-kernel/dist";
-import { Sandbox } from "@packages/core-test-framework";
-import {
-    ApplyTransactionAction,
-    RevertTransactionAction,
-    ThrowIfCannotEnterPoolAction,
-    VerifyTransactionAction,
-} from "@packages/core-transaction-pool/src/actions";
-import { SenderState } from "@packages/core-transaction-pool/src/sender-state";
-import { Crypto, Interfaces, Managers } from "@packages/crypto";
+import { Container, Contracts, Enums } from "@arkecosystem/core-kernel";
+import { Crypto, Interfaces, Managers } from "@arkecosystem/crypto";
+
+import { SenderState } from "../../../packages/core-transaction-pool/src/sender-state";
 
 jest.mock("@packages/crypto");
 
-const configuration = { getRequired: jest.fn(), getOptional: jest.fn() };
-const handler = { verify: jest.fn(), throwIfCannotEnterPool: jest.fn(), apply: jest.fn(), revert: jest.fn() };
-const handlerRegistry = { getActivatedHandlerForData: jest.fn() };
-const expirationService = { isExpired: jest.fn(), getExpirationHeight: jest.fn() };
-const eventDispatcherService = { dispatch: jest.fn() };
+const configuration = {
+    getRequired: jest.fn(),
+    getOptional: jest.fn(),
+};
+const handlerRegistry = {
+    getActivatedHandlerForData: jest.fn(),
+};
+const expirationService = {
+    isExpired: jest.fn(),
+    getExpirationHeight: jest.fn(),
+};
+const triggers = {
+    call: jest.fn(),
+};
+const emitter = {
+    dispatch: jest.fn(),
+};
 
-let sandbox: Sandbox;
+const container = new Container.Container();
+container.bind(Container.Identifiers.PluginConfiguration).toConstantValue(configuration);
+container.bind(Container.Identifiers.TransactionHandlerRegistry).toConstantValue(handlerRegistry);
+container.bind(Container.Identifiers.TransactionPoolExpirationService).toConstantValue(expirationService);
+container.bind(Container.Identifiers.TriggerService).toConstantValue(triggers);
+container.bind(Container.Identifiers.EventDispatcherService).toConstantValue(emitter);
 
 beforeEach(() => {
-    sandbox = new Sandbox();
-
-    sandbox.app.bind(Container.Identifiers.PluginConfiguration).toConstantValue(configuration);
-    sandbox.app.bind(Container.Identifiers.TransactionHandlerRegistry).toConstantValue(handlerRegistry);
-    sandbox.app.bind(Container.Identifiers.TransactionPoolExpirationService).toConstantValue(expirationService);
-    sandbox.app.bind(Container.Identifiers.EventDispatcherService).toConstantValue(eventDispatcherService);
-    sandbox.app.bind(Container.Identifiers.TriggerService).to(Services.Triggers.Triggers).inSingletonScope();
-
-    sandbox.app
-        .get<Services.Triggers.Triggers>(Container.Identifiers.TriggerService)
-        .bind("applyTransaction", new ApplyTransactionAction());
-
-    sandbox.app
-        .get<Services.Triggers.Triggers>(Container.Identifiers.TriggerService)
-        .bind("revertTransaction", new RevertTransactionAction());
-
-    sandbox.app
-        .get<Services.Triggers.Triggers>(Container.Identifiers.TriggerService)
-        .bind("throwIfCannotEnterPool", new ThrowIfCannotEnterPoolAction());
-
-    sandbox.app
-        .get<Services.Triggers.Triggers>(Container.Identifiers.TriggerService)
-        .bind("verifyTransaction", new VerifyTransactionAction());
-
     (Managers.configManager.get as jest.Mock).mockReset();
     (Crypto.Slots.getTime as jest.Mock).mockReset();
 
     configuration.getRequired.mockReset();
     configuration.getOptional.mockReset();
-    handler.verify.mockReset();
-    handler.throwIfCannotEnterPool.mockReset();
-    handler.apply.mockReset();
-    handler.revert.mockReset();
     handlerRegistry.getActivatedHandlerForData.mockReset();
     expirationService.isExpired.mockReset();
     expirationService.getExpirationHeight.mockReset();
-
-    handlerRegistry.getActivatedHandlerForData.mockReturnValue(Promise.resolve(handler));
+    triggers.call.mockReset();
+    emitter.dispatch.mockReset();
 });
 
 const transaction = {
@@ -69,9 +51,10 @@ const transaction = {
 
 describe("SenderState.apply", () => {
     it("should throw when transaction exceeds maximum byte size", async () => {
+        const senderState = container.resolve(SenderState);
+
         configuration.getRequired.mockReturnValueOnce(0); // maxTransactionBytes
 
-        const senderState = sandbox.app.resolve(SenderState);
         const promise = senderState.apply(transaction);
 
         await expect(promise).rejects.toBeInstanceOf(Contracts.TransactionPool.PoolError);
@@ -79,10 +62,11 @@ describe("SenderState.apply", () => {
     });
 
     it("should throw when transaction is from wrong network", async () => {
+        const senderState = container.resolve(SenderState);
+
         (Managers.configManager.get as jest.Mock).mockReturnValue(321); // network.pubKeyHash
         configuration.getRequired.mockReturnValueOnce(1024); // maxTransactionBytes
 
-        const senderState = sandbox.app.resolve(SenderState);
         const promise = senderState.apply(transaction);
 
         await expect(promise).rejects.toBeInstanceOf(Contracts.TransactionPool.PoolError);
@@ -90,11 +74,12 @@ describe("SenderState.apply", () => {
     });
 
     it("should throw when transaction is from future", async () => {
+        const senderState = container.resolve(SenderState);
+
         (Managers.configManager.get as jest.Mock).mockReturnValue(123); // network.pubKeyHash
         (Crypto.Slots.getTime as jest.Mock).mockReturnValue(9999);
         configuration.getRequired.mockReturnValueOnce(1024); // maxTransactionBytes
 
-        const senderState = sandbox.app.resolve(SenderState);
         const promise = senderState.apply(transaction);
 
         await expect(promise).rejects.toBeInstanceOf(Contracts.TransactionPool.PoolError);
@@ -102,88 +87,130 @@ describe("SenderState.apply", () => {
     });
 
     it("should throw when transaction expired", async () => {
+        const senderState = container.resolve(SenderState);
+
         (Managers.configManager.get as jest.Mock).mockReturnValue(123); // network.pubKeyHash
         (Crypto.Slots.getTime as jest.Mock).mockReturnValue(13600);
         configuration.getRequired.mockReturnValueOnce(1024); // maxTransactionBytes
         expirationService.isExpired.mockReturnValueOnce(true);
         expirationService.getExpirationHeight.mockReturnValueOnce(10);
 
-        const senderState = sandbox.app.resolve(SenderState);
         const promise = senderState.apply(transaction);
 
         await expect(promise).rejects.toBeInstanceOf(Contracts.TransactionPool.PoolError);
         await expect(promise).rejects.toHaveProperty("type", "ERR_EXPIRED");
 
-        expect(eventDispatcherService.dispatch).toHaveBeenCalledTimes(1);
-        expect(eventDispatcherService.dispatch).toHaveBeenCalledWith(Enums.TransactionEvent.Expired, expect.anything());
+        expect(emitter.dispatch).toHaveBeenCalledTimes(1);
+        expect(emitter.dispatch).toHaveBeenCalledWith(Enums.TransactionEvent.Expired, expect.anything());
     });
 
     it("should throw when transaction fails to verify", async () => {
+        const senderState = container.resolve(SenderState);
+        const handler = {};
+
         (Managers.configManager.get as jest.Mock).mockReturnValue(123); // network.pubKeyHash
         (Crypto.Slots.getTime as jest.Mock).mockReturnValue(13600);
         configuration.getRequired.mockReturnValueOnce(1024); // maxTransactionBytes
         expirationService.isExpired.mockReturnValueOnce(false);
-        handler.verify.mockResolvedValue(false);
+        handlerRegistry.getActivatedHandlerForData.mockResolvedValueOnce(handler);
+        triggers.call.mockResolvedValueOnce(false); // verifyTransaction
 
-        const senderState = sandbox.app.resolve(SenderState);
         const promise = senderState.apply(transaction);
 
         await expect(promise).rejects.toBeInstanceOf(Contracts.TransactionPool.PoolError);
         await expect(promise).rejects.toHaveProperty("type", "ERR_BAD_DATA");
+
+        expect(handlerRegistry.getActivatedHandlerForData).toBeCalledWith(transaction.data);
+        expect(triggers.call).toBeCalledWith("verifyTransaction", { handler, transaction });
     });
 
     it("should throw when state is corrupted", async () => {
-        handler.revert.mockRejectedValueOnce(new Error("Corrupt it"));
+        const senderState = container.resolve(SenderState);
+        const handler = {};
 
         (Managers.configManager.get as jest.Mock).mockReturnValue(123); // network.pubKeyHash
         (Crypto.Slots.getTime as jest.Mock).mockReturnValue(13600);
         configuration.getRequired.mockReturnValueOnce(1024); // maxTransactionBytes
         expirationService.isExpired.mockReturnValueOnce(false);
-        handler.verify.mockResolvedValue(true);
 
-        const senderState = sandbox.app.resolve(SenderState);
+        // revert
+        handlerRegistry.getActivatedHandlerForData.mockResolvedValueOnce(handler);
+        triggers.call.mockRejectedValueOnce(new Error("Corrupt it!")); // revertTransaction
+
+        // apply
+        handlerRegistry.getActivatedHandlerForData.mockResolvedValueOnce(handler);
+        triggers.call.mockResolvedValueOnce(true); // verifyTransaction
+
         await senderState.revert(transaction).catch(() => undefined);
         const promise = senderState.apply(transaction);
 
         await expect(promise).rejects.toBeInstanceOf(Contracts.TransactionPool.PoolError);
         await expect(promise).rejects.toHaveProperty("type", "ERR_RETRY");
+
+        expect(handlerRegistry.getActivatedHandlerForData).toBeCalledWith(transaction.data);
+        expect(triggers.call).toBeCalledWith("revertTransaction", { handler, transaction });
+
+        expect(handlerRegistry.getActivatedHandlerForData).toBeCalledWith(transaction.data);
+        expect(triggers.call).toBeCalledWith("verifyTransaction", { handler, transaction });
     });
 
     it("should throw when transaction fails to apply", async () => {
+        const senderState = container.resolve(SenderState);
+        const handler = {};
+
         (Managers.configManager.get as jest.Mock).mockReturnValue(123); // network.pubKeyHash
         (Crypto.Slots.getTime as jest.Mock).mockReturnValue(13600);
         configuration.getRequired.mockReturnValueOnce(1024); // maxTransactionBytes
         expirationService.isExpired.mockReturnValueOnce(false);
-        handler.verify.mockResolvedValue(true);
-        handler.throwIfCannotEnterPool.mockRejectedValueOnce(new Error("Something terrible"));
+        handlerRegistry.getActivatedHandlerForData.mockResolvedValueOnce(handler);
+        triggers.call.mockResolvedValueOnce(true); // verifyTransaction
+        triggers.call.mockResolvedValueOnce(undefined); // throwIfCannotEnterPool
+        triggers.call.mockRejectedValueOnce(new Error("Some apply error")); // applyTransaction
 
-        const senderState = sandbox.app.resolve(SenderState);
         const promise = senderState.apply(transaction);
 
         await expect(promise).rejects.toBeInstanceOf(Contracts.TransactionPool.PoolError);
         await expect(promise).rejects.toHaveProperty("type", "ERR_APPLY");
+
+        expect(handlerRegistry.getActivatedHandlerForData).toBeCalledWith(transaction.data);
+        expect(triggers.call).toBeCalledWith("verifyTransaction", { handler, transaction });
+        expect(triggers.call).toBeCalledWith("throwIfCannotEnterPool", { handler, transaction });
+        expect(triggers.call).toBeCalledWith("applyTransaction", { handler, transaction });
     });
 
     it("should call handler to apply transaction", async () => {
+        const senderState = container.resolve(SenderState);
+        const handler = {};
+
         (Managers.configManager.get as jest.Mock).mockReturnValue(123); // network.pubKeyHash
         (Crypto.Slots.getTime as jest.Mock).mockReturnValue(13600);
         configuration.getRequired.mockReturnValueOnce(1024); // maxTransactionBytes
         expirationService.isExpired.mockReturnValueOnce(false);
-        handler.verify.mockResolvedValue(true);
+        handlerRegistry.getActivatedHandlerForData.mockResolvedValueOnce(handler);
+        triggers.call.mockResolvedValueOnce(true); // verifyTransaction
+        triggers.call.mockResolvedValueOnce(undefined); // throwIfCannotEnterPool
+        triggers.call.mockResolvedValueOnce(undefined); // applyTransaction
 
-        const senderState = sandbox.app.resolve(SenderState);
         await senderState.apply(transaction);
 
-        expect(handler.throwIfCannotEnterPool).toBeCalledWith(transaction);
-        expect(handler.apply).toBeCalledWith(transaction);
+        expect(handlerRegistry.getActivatedHandlerForData).toBeCalledWith(transaction.data);
+        expect(triggers.call).toBeCalledWith("verifyTransaction", { handler, transaction });
+        expect(triggers.call).toBeCalledWith("throwIfCannotEnterPool", { handler, transaction });
+        expect(triggers.call).toBeCalledWith("applyTransaction", { handler, transaction });
     });
 });
 
 describe("SenderState.revert", () => {
     it("should call handler to revert transaction", async () => {
-        const senderState = sandbox.app.resolve(SenderState);
+        const senderState = container.resolve(SenderState);
+        const handler = {};
+
+        handlerRegistry.getActivatedHandlerForData.mockResolvedValueOnce(handler);
+        triggers.call.mockResolvedValueOnce(undefined); // revertTransaction
+
         await senderState.revert(transaction);
 
-        expect(handler.revert).toBeCalledWith(transaction);
+        expect(handlerRegistry.getActivatedHandlerForData).toBeCalledWith(transaction.data);
+        expect(triggers.call).toBeCalledWith("revertTransaction", { handler, transaction });
     });
 });

--- a/__tests__/unit/core-transaction-pool/service.test.ts
+++ b/__tests__/unit/core-transaction-pool/service.test.ts
@@ -5,6 +5,7 @@ import { Service } from "../../../packages/core-transaction-pool/src/service";
 
 const logger = {
     debug: jest.fn(),
+    info: jest.fn(),
     warning: jest.fn(),
     error: jest.fn(),
 };

--- a/packages/core-kernel/src/contracts/transaction-pool/expiration-service.ts
+++ b/packages/core-kernel/src/contracts/transaction-pool/expiration-service.ts
@@ -2,6 +2,6 @@ import { Interfaces } from "@arkecosystem/crypto";
 
 export interface ExpirationService {
     canExpire(transaction: Interfaces.ITransaction): boolean;
-    isExpired(transaction: Interfaces.ITransaction): boolean;
-    getExpirationHeight(transaction: Interfaces.ITransaction): number;
+    isExpired(transaction: Interfaces.ITransaction): Promise<boolean>;
+    getExpirationHeight(transaction: Interfaces.ITransaction): Promise<number>;
 }

--- a/packages/core-kernel/src/contracts/transaction-pool/service.ts
+++ b/packages/core-kernel/src/contracts/transaction-pool/service.ts
@@ -6,7 +6,7 @@ export interface Service {
     addTransaction(transaction: Interfaces.ITransaction): Promise<void>;
     removeTransaction(transaction: Interfaces.ITransaction): Promise<void>;
     acceptForgedTransaction(transaction: Interfaces.ITransaction): Promise<void>;
-    readdTransactions(prevTransactions?: Interfaces.ITransaction[]): Promise<void>;
+    readdTransactions(precedingTransactions?: Interfaces.ITransaction[]): Promise<void>;
     cleanUp(): Promise<void>;
-    flush(): void;
+    flush(): Promise<void>;
 }

--- a/packages/core-transaction-pool/src/expiration-service.ts
+++ b/packages/core-transaction-pool/src/expiration-service.ts
@@ -2,7 +2,7 @@ import { Container, Contracts, Providers, Utils as AppUtils } from "@arkecosyste
 import { Crypto, Interfaces } from "@arkecosystem/crypto";
 
 @Container.injectable()
-export class ExpirationService {
+export class ExpirationService implements Contracts.TransactionPool.ExpirationService {
     @Container.inject(Container.Identifiers.Application)
     public readonly app!: Contracts.Kernel.Application;
 

--- a/packages/core-transaction-pool/src/service.ts
+++ b/packages/core-transaction-pool/src/service.ts
@@ -27,13 +27,17 @@ export class Service implements Contracts.TransactionPool.Service {
     @Container.inject(Container.Identifiers.TransactionPoolExpirationService)
     private readonly expirationService!: Contracts.TransactionPool.ExpirationService;
 
+    private readonly updateLocks: Promise<void>[] = [];
+
+    private rebuildLock?: Promise<void>;
+
     public async boot(): Promise<void> {
         this.emitter.listen(Enums.CryptoEvent.MilestoneChanged, {
             handle: () => this.readdTransactions(),
         });
 
         if (process.env.CORE_RESET_DATABASE || process.env.CORE_RESET_POOL) {
-            this.flush();
+            await this.flush();
         } else {
             await this.readdTransactions();
         }
@@ -44,130 +48,219 @@ export class Service implements Contracts.TransactionPool.Service {
     }
 
     public async addTransaction(transaction: Interfaces.ITransaction): Promise<void> {
-        AppUtils.assert.defined<string>(transaction.id);
-        if (this.storage.hasTransaction(transaction.id)) {
-            throw new TransactionAlreadyInPoolError(transaction);
+        while (this.rebuildLock) {
+            this.logger.debug(`${transaction} add is waiting for rebuild lock`);
+            await this.rebuildLock;
         }
 
-        this.storage.addTransaction(transaction.id, transaction.serialized);
+        const fn = async () => {
+            AppUtils.assert.defined<string>(transaction.id);
+            if (this.storage.hasTransaction(transaction.id)) {
+                throw new TransactionAlreadyInPoolError(transaction);
+            }
+
+            this.storage.addTransaction(transaction.id, transaction.serialized);
+            try {
+                await this.addTransactionToMempool(transaction);
+                this.logger.debug(`${transaction} added to pool`);
+                this.emitter.dispatch(Enums.TransactionEvent.AddedToPool, transaction.data);
+            } catch (error) {
+                this.storage.removeTransaction(transaction.id);
+                this.emitter.dispatch(Enums.TransactionEvent.RejectedByPool, transaction.data);
+                throw error;
+            }
+        };
+
+        const promise = fn();
+        this.updateLocks.push(promise);
         try {
-            await this.addTransactionToMempool(transaction);
-            this.logger.debug(`${transaction} added to pool`);
-            this.emitter.dispatch(Enums.TransactionEvent.AddedToPool, transaction.data);
-        } catch (error) {
-            this.storage.removeTransaction(transaction.id);
-            this.emitter.dispatch(Enums.TransactionEvent.RejectedByPool, transaction.data);
-            throw error;
+            await promise;
+        } finally {
+            this.updateLocks.splice(this.updateLocks.indexOf(promise), 1);
         }
     }
 
     public async removeTransaction(transaction: Interfaces.ITransaction): Promise<void> {
-        AppUtils.assert.defined<string>(transaction.id);
-        if (this.storage.hasTransaction(transaction.id) === false) {
-            this.logger.error(`${transaction} not found`);
-            return;
+        while (this.rebuildLock) {
+            this.logger.debug(`${transaction} remove is waiting for rebuild lock`);
+            await this.rebuildLock;
         }
 
-        const removedTransactions = await this.mempool.removeTransaction(transaction);
-        for (const removedTransaction of removedTransactions) {
-            AppUtils.assert.defined<string>(removedTransaction.id);
-            this.storage.removeTransaction(removedTransaction.id);
-            this.logger.debug(`${removedTransaction} removed from pool`);
-        }
+        const fn = async () => {
+            AppUtils.assert.defined<string>(transaction.id);
+            if (this.storage.hasTransaction(transaction.id) === false) {
+                this.logger.error(`${transaction} not found`);
+                return;
+            }
 
-        if (!removedTransactions.find((t) => t.id === transaction.id)) {
-            this.storage.removeTransaction(transaction.id);
-            this.logger.error(`${transaction} removed from pool (wasn't in mempool)`);
-        }
+            const removedTransactions = await this.mempool.removeTransaction(transaction);
+            for (const removedTransaction of removedTransactions) {
+                AppUtils.assert.defined<string>(removedTransaction.id);
+                this.storage.removeTransaction(removedTransaction.id);
+                this.logger.debug(`${removedTransaction} removed from pool`);
+            }
 
-        this.emitter.dispatch(Enums.TransactionEvent.RemovedFromPool, transaction.data);
+            if (!removedTransactions.find((t) => t.id === transaction.id)) {
+                this.storage.removeTransaction(transaction.id);
+                this.logger.error(`${transaction} removed from pool (wasn't in mempool)`);
+            }
+
+            this.emitter.dispatch(Enums.TransactionEvent.RemovedFromPool, transaction.data);
+        };
+
+        const promise = fn();
+        this.updateLocks.push(promise);
+        try {
+            await promise;
+        } finally {
+            this.updateLocks.splice(this.updateLocks.indexOf(promise), 1);
+        }
     }
 
     public async acceptForgedTransaction(transaction: Interfaces.ITransaction): Promise<void> {
-        AppUtils.assert.defined<string>(transaction.id);
-        if (this.storage.hasTransaction(transaction.id) === false) {
-            return;
+        while (this.rebuildLock) {
+            this.logger.debug(`${transaction} accept forged is waiting for rebuild lock`);
+            await this.rebuildLock;
         }
 
-        const removedTransactions = await this.mempool.acceptForgedTransaction(transaction);
-        for (const removedTransaction of removedTransactions) {
-            AppUtils.assert.defined<string>(removedTransaction.id);
-            this.storage.removeTransaction(removedTransaction.id);
-            this.logger.debug(`${removedTransaction} removed from pool`);
-        }
+        const fn = async () => {
+            AppUtils.assert.defined<string>(transaction.id);
+            if (this.storage.hasTransaction(transaction.id) === false) {
+                return;
+            }
 
-        if (removedTransactions.find((t) => t.id === transaction.id)) {
-            this.logger.debug(`${transaction} forged and accepted by pool`);
-        } else {
-            this.storage.removeTransaction(transaction.id);
-            this.logger.error(`${transaction} forged and accepted by pool (wasn't in mempool)`);
+            const removedTransactions = await this.mempool.acceptForgedTransaction(transaction);
+            for (const removedTransaction of removedTransactions) {
+                AppUtils.assert.defined<string>(removedTransaction.id);
+                this.storage.removeTransaction(removedTransaction.id);
+                this.logger.debug(`${removedTransaction} removed from pool`);
+            }
+
+            if (removedTransactions.find((t) => t.id === transaction.id)) {
+                this.logger.debug(`${transaction} forged and accepted by pool`);
+            } else {
+                this.storage.removeTransaction(transaction.id);
+                this.logger.error(`${transaction} forged and accepted by pool (wasn't in mempool)`);
+            }
+        };
+
+        const promise = fn();
+        this.updateLocks.push(promise);
+        try {
+            await promise;
+        } finally {
+            this.updateLocks.splice(this.updateLocks.indexOf(promise), 1);
         }
     }
 
-    public async readdTransactions(prevTransactions?: Interfaces.ITransaction[]): Promise<void> {
-        this.mempool.flush();
+    public async readdTransactions(precedingTransactions?: Interfaces.ITransaction[]): Promise<void> {
+        while (this.rebuildLock) {
+            this.logger.debug(`Re-add is waiting for rebuild lock`);
+            await this.rebuildLock;
+        }
 
-        let precedingSuccessCount = 0;
-        let precedingErrorCount = 0;
-        let pendingSuccessCount = 0;
-        let pendingErrorCount = 0;
+        const fn = async () => {
+            if (this.updateLocks.length) {
+                this.logger.debug(`Re-add is waiting for update locks`);
+                await Promise.all(this.updateLocks);
+                AppUtils.assert.boolean(this.updateLocks.length === 0);
+            }
 
-        if (prevTransactions) {
-            for (const transaction of prevTransactions) {
-                try {
-                    await this.addTransactionToMempool(transaction);
-                    AppUtils.assert.defined<string>(transaction.id);
-                    this.storage.addTransaction(transaction.id, transaction.serialized);
-                    precedingSuccessCount++;
-                } catch (error) {
-                    precedingErrorCount++;
+            this.mempool.flush();
+
+            let precedingSuccessCount = 0;
+            let precedingErrorCount = 0;
+            let pendingSuccessCount = 0;
+            let pendingErrorCount = 0;
+
+            if (precedingTransactions) {
+                for (const { id, serialized } of precedingTransactions) {
+                    try {
+                        AppUtils.assert.defined<string>(id);
+                        const precedingTransaction = Transactions.TransactionFactory.fromBytes(serialized);
+                        await this.addTransactionToMempool(precedingTransaction);
+                        this.storage.addTransaction(id, serialized);
+                        precedingSuccessCount++;
+                    } catch (error) {
+                        this.logger.debug(`Failed to re-add and wasn't added to storage: ${error.message}`);
+                        precedingErrorCount++;
+                    }
                 }
             }
-        }
 
-        for (const { id, serialized } of this.storage.getAllTransactions()) {
-            try {
-                const transaction = Transactions.TransactionFactory.fromBytes(serialized);
-                await this.addTransactionToMempool(transaction);
-                pendingSuccessCount++;
-            } catch (error) {
-                this.storage.removeTransaction(id);
-                pendingErrorCount++;
+            for (const { id, serialized } of this.storage.getAllTransactions()) {
+                try {
+                    const pendingTransaction = Transactions.TransactionFactory.fromBytes(serialized);
+                    await this.addTransactionToMempool(pendingTransaction);
+                    pendingSuccessCount++;
+                } catch (error) {
+                    this.storage.removeTransaction(id);
+                    this.logger.debug(`Failed to re-add and was removed from storage: ${error.message}`);
+                    pendingErrorCount++;
+                }
             }
-        }
 
-        if (precedingSuccessCount === 1) {
-            this.logger.info(`${precedingSuccessCount} preceding transaction was re-added to pool`);
-        }
-        if (precedingSuccessCount > 1) {
-            this.logger.info(`${precedingSuccessCount} preceding transactions were re-added to pool`);
-        }
-        if (precedingErrorCount === 1) {
-            this.logger.warning(`${precedingErrorCount} preceding transaction was not re-added to pool`);
-        }
-        if (precedingErrorCount > 1) {
-            this.logger.warning(`${precedingErrorCount} preceding transactions were not re-added to pool`);
-        }
-        if (pendingSuccessCount === 1) {
-            this.logger.info(`${pendingSuccessCount} pending transaction was re-added to pool`);
-        }
-        if (pendingSuccessCount > 1) {
-            this.logger.info(`${pendingSuccessCount} pending transactions were re-added to pool`);
-        }
-        if (pendingErrorCount === 1) {
-            this.logger.warning(`${pendingErrorCount} pending transaction was not re-added to pool`);
-        }
-        if (pendingErrorCount > 1) {
-            this.logger.warning(`${pendingErrorCount} pending transactions were not re-added to pool`);
+            if (precedingSuccessCount === 1) {
+                this.logger.info(`${precedingSuccessCount} preceding transaction was re-added to pool`);
+            }
+            if (precedingSuccessCount > 1) {
+                this.logger.info(`${precedingSuccessCount} preceding transactions were re-added to pool`);
+            }
+            if (precedingErrorCount === 1) {
+                this.logger.warning(`${precedingErrorCount} preceding transaction was not re-added to pool`);
+            }
+            if (precedingErrorCount > 1) {
+                this.logger.warning(`${precedingErrorCount} preceding transactions were not re-added to pool`);
+            }
+            if (pendingSuccessCount === 1) {
+                this.logger.info(`${pendingSuccessCount} pending transaction was re-added to pool`);
+            }
+            if (pendingSuccessCount > 1) {
+                this.logger.info(`${pendingSuccessCount} pending transactions were re-added to pool`);
+            }
+            if (pendingErrorCount === 1) {
+                this.logger.warning(`${pendingErrorCount} pending transaction was not re-added to pool`);
+            }
+            if (pendingErrorCount > 1) {
+                this.logger.warning(`${pendingErrorCount} pending transactions were not re-added to pool`);
+            }
+        };
+
+        this.rebuildLock = fn();
+
+        try {
+            await this.rebuildLock;
+        } finally {
+            this.rebuildLock = undefined;
         }
     }
 
     public async cleanUp(): Promise<void> {
-        await this.cleanExpired();
-        await this.cleanLowestPriority();
+        while (this.rebuildLock) {
+            this.logger.debug(`Clean-up is waiting for rebuild lock`);
+            await this.rebuildLock;
+        }
+
+        const fn = async () => {
+            await this.cleanExpired();
+            await this.cleanLowestPriority();
+        };
+
+        const promise = fn();
+        this.updateLocks.push(promise);
+        try {
+            await promise;
+        } finally {
+            this.updateLocks.splice(this.updateLocks.indexOf(promise), 1);
+        }
     }
 
-    public flush(): void {
+    public async flush(): Promise<void> {
+        while (this.rebuildLock) {
+            this.logger.debug(`Flush is waiting for rebuild lock`);
+            await this.rebuildLock;
+        }
+
         this.mempool.flush();
         this.storage.flush();
     }

--- a/packages/core-transaction-pool/src/service.ts
+++ b/packages/core-transaction-pool/src/service.ts
@@ -1,5 +1,6 @@
 import { Container, Contracts, Enums, Providers, Utils as AppUtils } from "@arkecosystem/core-kernel";
 import { Interfaces, Transactions } from "@arkecosystem/crypto";
+import assert from "assert";
 
 import { TransactionAlreadyInPoolError, TransactionPoolFullError } from "./errors";
 
@@ -163,7 +164,7 @@ export class Service implements Contracts.TransactionPool.Service {
             if (this.updateLocks.length) {
                 this.logger.debug(`Re-add is waiting for update locks`);
                 await Promise.all(this.updateLocks);
-                AppUtils.assert.boolean(this.updateLocks.length === 0);
+                assert(this.updateLocks.length === 0);
             }
 
             this.mempool.flush();

--- a/packages/core-transaction-pool/src/service.ts
+++ b/packages/core-transaction-pool/src/service.ts
@@ -77,7 +77,9 @@ export class Service implements Contracts.TransactionPool.Service {
         try {
             await promise;
         } finally {
-            this.updateLocks.splice(this.updateLocks.indexOf(promise), 1);
+            const index = this.updateLocks.indexOf(promise);
+            assert(index !== -1);
+            this.updateLocks.splice(index, 1);
         }
     }
 
@@ -114,7 +116,9 @@ export class Service implements Contracts.TransactionPool.Service {
         try {
             await promise;
         } finally {
-            this.updateLocks.splice(this.updateLocks.indexOf(promise), 1);
+            const index = this.updateLocks.indexOf(promise);
+            assert(index !== -1);
+            this.updateLocks.splice(index, 1);
         }
     }
 
@@ -150,7 +154,9 @@ export class Service implements Contracts.TransactionPool.Service {
         try {
             await promise;
         } finally {
-            this.updateLocks.splice(this.updateLocks.indexOf(promise), 1);
+            const index = this.updateLocks.indexOf(promise);
+            assert(index !== -1);
+            this.updateLocks.splice(index, 1);
         }
     }
 
@@ -252,7 +258,9 @@ export class Service implements Contracts.TransactionPool.Service {
         try {
             await promise;
         } finally {
-            this.updateLocks.splice(this.updateLocks.indexOf(promise), 1);
+            const index = this.updateLocks.indexOf(promise);
+            assert(index !== -1);
+            this.updateLocks.splice(index, 1);
         }
     }
 


### PR DESCRIPTION
## Summary

There are two kind of operations executed in pool:
* `addTransaction`, `removeTransaction`, `acceptForgedTransaction`, and `cleanUp` are update operations evolving pool.
* `flush` and `readdTransactions` are rebuild operations that work on pool as a whole.

These two kind of operations cannot happen simultaneously. The key difference is that `flush` and `readdTransaction` are wiping mempool, storage, and in general require full rebuild of senders wallet repositories.

While `addTransaction`, `removeTransaction`, `acceptForgedTransaction`, and `cleanUp` were synchronized on sender level, they were not synchronized with `flush` and `readdTransactions`. This caused problem in entity transaction handler after pool started handling milestone change. I wasn't able to pinpoint the actual race cause, but got rough idea what sequence of events caused it:

1. Transaction is added to pool.
1. Transaction is forged into new block.
1. While forged block is chained, transaction is accepted.
1. While forged block is chained, milestone change is triggered.
1. Milestone change attempts to re-add transaction, while it's being removed due to accept.

In general solution is to allow `addTransaction`, `removeTransaction`, `acceptForgedTransaction`, and `cleanUp` to execute in parallel, but `readdTransactions` and `flush` to lock pool completely until finished:

* `readdTransactions` and `flush` set themself into `rebuildLock`.
* `addTransaction`, `removeTransaction`, `acceptForgedTransaction`, and `cleanUp` wait for `rebuildLock` before adding themself into `updateLocks`
* `readdTransactions` and `flush` wait for any pending `updateLocks` to finish before touching storage or mempool.

## Checklist

- [ ] Tests
- [x] Ready to be merged