### PR TITLE
refactor(core-transactions): remove custom wallet repository

### DIFF
--- a/__tests__/unit/core-magistrate-transactions/handlers/__mocks__/transaction-handler.ts
+++ b/__tests__/unit/core-magistrate-transactions/handlers/__mocks__/transaction-handler.ts
@@ -8,17 +8,11 @@ export class TransactionHandler {
     protected app = app;
     protected walletRepository = walletRepository;
 
-    public applyToSender(transaction, customWalletRepository?) {
+    public applyToSender(transaction) {}
 
-    }
+    public revertForSender(transaction) {}
 
-    public revertForSender(transaction, customWalletRepository?) {
-
-    }
-
-    public throwIfCannotBeApplied(transaction, wallet, customWalletRepository?) {
-
-    }
+    public throwIfCannotBeApplied(transaction, wallet) {}
 
     protected getTransactionReader() {
         return transactionReader;
@@ -26,7 +20,7 @@ export class TransactionHandler {
 
     protected getConstructor() {
         return {
-            staticFee: () => "50000000"
+            staticFee: () => "50000000",
         };
     }
 }

--- a/__tests__/unit/core-magistrate-transactions/handlers/bridgechain-registration.test.ts
+++ b/__tests__/unit/core-magistrate-transactions/handlers/bridgechain-registration.test.ts
@@ -155,9 +155,7 @@ describe("BusinessRegistration", () => {
         });
 
         it("should not throw", async () => {
-            await expect(
-                handler.throwIfCannotBeApplied(bridgechainRegistrationTransaction, senderWallet, walletRepository),
-            ).toResolve();
+            await expect(handler.throwIfCannotBeApplied(bridgechainRegistrationTransaction, senderWallet)).toResolve();
         });
 
         it("should not throw without custom wallet repository", async () => {
@@ -168,22 +166,20 @@ describe("BusinessRegistration", () => {
             configManager.set("network.pubKeyHash", 99);
             configManager.set("exceptions.transactions", [bridgechainRegistrationTransaction.data.id]);
 
-            await expect(
-                handler.throwIfCannotBeApplied(bridgechainRegistrationTransaction, senderWallet, walletRepository),
-            ).toResolve();
+            await expect(handler.throwIfCannotBeApplied(bridgechainRegistrationTransaction, senderWallet)).toResolve();
         });
 
         it("should throw if wallet is not business", async () => {
             senderWallet.forgetAttribute("business");
             await expect(
-                handler.throwIfCannotBeApplied(bridgechainRegistrationTransaction, senderWallet, walletRepository),
+                handler.throwIfCannotBeApplied(bridgechainRegistrationTransaction, senderWallet),
             ).rejects.toThrowError(WalletIsNotBusinessError);
         });
 
         it("should throw if business is resigned", async () => {
             senderWallet.setAttribute("business.resigned", true);
             await expect(
-                handler.throwIfCannotBeApplied(bridgechainRegistrationTransaction, senderWallet, walletRepository),
+                handler.throwIfCannotBeApplied(bridgechainRegistrationTransaction, senderWallet),
             ).rejects.toThrowError(BusinessIsResignedError);
         });
 
@@ -204,7 +200,7 @@ describe("BusinessRegistration", () => {
             walletRepository.index(senderWallet);
 
             await expect(
-                handler.throwIfCannotBeApplied(bridgechainRegistrationTransaction, senderWallet, walletRepository),
+                handler.throwIfCannotBeApplied(bridgechainRegistrationTransaction, senderWallet),
             ).rejects.toThrowError(BridgechainAlreadyRegisteredError);
         });
 
@@ -222,7 +218,7 @@ describe("BusinessRegistration", () => {
             walletRepository.index(senderWallet);
 
             await expect(
-                handler.throwIfCannotBeApplied(bridgechainRegistrationTransaction, senderWallet, walletRepository),
+                handler.throwIfCannotBeApplied(bridgechainRegistrationTransaction, senderWallet),
             ).rejects.toThrowError(GenesisHashAlreadyRegisteredError);
         });
 
@@ -232,14 +228,14 @@ describe("BusinessRegistration", () => {
             };
 
             await expect(
-                handler.throwIfCannotBeApplied(bridgechainRegistrationTransaction, senderWallet, walletRepository),
+                handler.throwIfCannotBeApplied(bridgechainRegistrationTransaction, senderWallet),
             ).rejects.toThrowError(PortKeyMustBeValidPackageNameError);
         });
 
         it("should throw if wallet has insufficient balance", async () => {
             senderWallet.balance = Utils.BigNumber.ZERO;
             await expect(
-                handler.throwIfCannotBeApplied(bridgechainRegistrationTransaction, senderWallet, walletRepository),
+                handler.throwIfCannotBeApplied(bridgechainRegistrationTransaction, senderWallet),
             ).rejects.toThrowError(InsufficientBalanceError);
         });
     });
@@ -254,7 +250,7 @@ describe("BusinessRegistration", () => {
         it("should be ok", async () => {
             const senderBalance = senderWallet.balance;
 
-            await handler.apply(bridgechainRegistrationTransaction, walletRepository);
+            await handler.apply(bridgechainRegistrationTransaction);
 
             expect(
                 senderWallet.getAttribute("business.bridgechains")[bridgechainRegistrationAsset.genesisHash]
@@ -296,14 +292,14 @@ describe("BusinessRegistration", () => {
         it("should be ok", async () => {
             const senderBalance = senderWallet.balance;
 
-            await handler.apply(bridgechainRegistrationTransaction, walletRepository);
+            await handler.apply(bridgechainRegistrationTransaction);
 
             expect(
                 senderWallet.getAttribute("business.bridgechains")[bridgechainRegistrationAsset.genesisHash]
                     .bridgechainAsset,
             ).toEqual(bridgechainRegistrationAsset);
 
-            await handler.revert(bridgechainRegistrationTransaction, walletRepository);
+            await handler.revert(bridgechainRegistrationTransaction);
 
             expect(
                 senderWallet.hasAttribute("business.bridgechains")[bridgechainRegistrationAsset.genesisHash],

--- a/__tests__/unit/core-magistrate-transactions/handlers/bridgechain-resignation.test.ts
+++ b/__tests__/unit/core-magistrate-transactions/handlers/bridgechain-resignation.test.ts
@@ -148,22 +148,20 @@ describe("BusinessRegistration", () => {
 
     describe("throwIfCannotBeApplied", () => {
         it("should not throw", async () => {
-            await expect(
-                handler.throwIfCannotBeApplied(bridgechainResignationTransaction, senderWallet, walletRepository),
-            ).toResolve();
+            await expect(handler.throwIfCannotBeApplied(bridgechainResignationTransaction, senderWallet)).toResolve();
         });
 
         it("should throw if wallet is not business", async () => {
             senderWallet.forgetAttribute("business");
             await expect(
-                handler.throwIfCannotBeApplied(bridgechainResignationTransaction, senderWallet, walletRepository),
+                handler.throwIfCannotBeApplied(bridgechainResignationTransaction, senderWallet),
             ).rejects.toThrowError(WalletIsNotBusinessError);
         });
 
         it("should throw if business is resigned", async () => {
             senderWallet.setAttribute("business.resigned", true);
             await expect(
-                handler.throwIfCannotBeApplied(bridgechainResignationTransaction, senderWallet, walletRepository),
+                handler.throwIfCannotBeApplied(bridgechainResignationTransaction, senderWallet),
             ).rejects.toThrowError(BusinessIsResignedError);
         });
 
@@ -173,7 +171,7 @@ describe("BusinessRegistration", () => {
 
             senderWallet.setAttribute("business", businessAttributes);
             await expect(
-                handler.throwIfCannotBeApplied(bridgechainResignationTransaction, senderWallet, walletRepository),
+                handler.throwIfCannotBeApplied(bridgechainResignationTransaction, senderWallet),
             ).rejects.toThrowError(BridgechainIsNotRegisteredByWalletError);
         });
 
@@ -185,7 +183,7 @@ describe("BusinessRegistration", () => {
                 .build();
 
             await expect(
-                handler.throwIfCannotBeApplied(bridgechainResignationTransaction, senderWallet, walletRepository),
+                handler.throwIfCannotBeApplied(bridgechainResignationTransaction, senderWallet),
             ).rejects.toThrowError(BridgechainIsNotRegisteredByWalletError);
         });
 
@@ -195,7 +193,7 @@ describe("BusinessRegistration", () => {
 
             senderWallet.setAttribute("business", businessAttributes);
             await expect(
-                handler.throwIfCannotBeApplied(bridgechainResignationTransaction, senderWallet, walletRepository),
+                handler.throwIfCannotBeApplied(bridgechainResignationTransaction, senderWallet),
             ).rejects.toThrowError(BridgechainIsResignedError);
         });
 
@@ -203,14 +201,14 @@ describe("BusinessRegistration", () => {
             delete bridgechainResignationTransaction.data.asset;
 
             await expect(
-                handler.throwIfCannotBeApplied(bridgechainResignationTransaction, senderWallet, walletRepository),
+                handler.throwIfCannotBeApplied(bridgechainResignationTransaction, senderWallet),
             ).rejects.toThrowError();
         });
 
         it("should throw if wallet has insufficient balance", async () => {
             senderWallet.balance = Utils.BigNumber.ZERO;
             await expect(
-                handler.throwIfCannotBeApplied(bridgechainResignationTransaction, senderWallet, walletRepository),
+                handler.throwIfCannotBeApplied(bridgechainResignationTransaction, senderWallet),
             ).rejects.toThrowError(InsufficientBalanceError);
         });
     });
@@ -235,7 +233,7 @@ describe("BusinessRegistration", () => {
         it("should be ok", async () => {
             const senderBalance = senderWallet.balance;
 
-            await handler.apply(bridgechainResignationTransaction, walletRepository);
+            await handler.apply(bridgechainResignationTransaction);
 
             expect(
                 senderWallet.getAttribute("business.bridgechains")[bridgechainRegistrationAsset.genesisHash].resigned,
@@ -251,7 +249,7 @@ describe("BusinessRegistration", () => {
         it("should throw if transaction asset is missing", async () => {
             delete bridgechainResignationTransaction.data.asset;
 
-            await expect(handler.apply(bridgechainResignationTransaction, walletRepository)).rejects.toThrowError();
+            await expect(handler.apply(bridgechainResignationTransaction)).rejects.toThrowError();
         });
     });
 
@@ -259,13 +257,13 @@ describe("BusinessRegistration", () => {
         it("should be ok", async () => {
             const senderBalance = senderWallet.balance;
 
-            await handler.apply(bridgechainResignationTransaction, walletRepository);
+            await handler.apply(bridgechainResignationTransaction);
 
             expect(
                 senderWallet.getAttribute("business.bridgechains")[bridgechainRegistrationAsset.genesisHash].resigned,
             ).toBeTrue();
 
-            await handler.revert(bridgechainResignationTransaction, walletRepository);
+            await handler.revert(bridgechainResignationTransaction);
 
             expect(
                 senderWallet.getAttribute("business.bridgechains")[bridgechainRegistrationAsset.genesisHash].resigned,
@@ -275,7 +273,7 @@ describe("BusinessRegistration", () => {
         });
 
         it("should throw if transaction asset is missing", async () => {
-            await handler.apply(bridgechainResignationTransaction, walletRepository);
+            await handler.apply(bridgechainResignationTransaction);
 
             expect(
                 senderWallet.getAttribute("business.bridgechains")[bridgechainRegistrationAsset.genesisHash].resigned,
@@ -283,7 +281,7 @@ describe("BusinessRegistration", () => {
 
             delete bridgechainResignationTransaction.data.asset;
 
-            await expect(handler.revert(bridgechainResignationTransaction, walletRepository)).rejects.toThrowError();
+            await expect(handler.revert(bridgechainResignationTransaction)).rejects.toThrowError();
         });
     });
 });

--- a/__tests__/unit/core-magistrate-transactions/handlers/bridgechain-update.test.ts
+++ b/__tests__/unit/core-magistrate-transactions/handlers/bridgechain-update.test.ts
@@ -182,22 +182,20 @@ describe("BusinessRegistration", () => {
 
     describe("throwIfCannotBeApplied", () => {
         it("should not throw", async () => {
-            await expect(
-                handler.throwIfCannotBeApplied(bridgechainUpdateTransaction, senderWallet, walletRepository),
-            ).toResolve();
+            await expect(handler.throwIfCannotBeApplied(bridgechainUpdateTransaction, senderWallet)).toResolve();
         });
 
         it("should throw if wallet is not business", async () => {
             senderWallet.forgetAttribute("business");
             await expect(
-                handler.throwIfCannotBeApplied(bridgechainUpdateTransaction, senderWallet, walletRepository),
+                handler.throwIfCannotBeApplied(bridgechainUpdateTransaction, senderWallet),
             ).rejects.toThrowError(BusinessIsNotRegisteredError);
         });
 
         it("should throw if business is resigned", async () => {
             senderWallet.setAttribute("business.resigned", true);
             await expect(
-                handler.throwIfCannotBeApplied(bridgechainUpdateTransaction, senderWallet, walletRepository),
+                handler.throwIfCannotBeApplied(bridgechainUpdateTransaction, senderWallet),
             ).rejects.toThrowError(BusinessIsResignedError);
         });
 
@@ -206,7 +204,7 @@ describe("BusinessRegistration", () => {
             delete businessAttributes.bridgechains;
 
             await expect(
-                handler.throwIfCannotBeApplied(bridgechainUpdateTransaction, senderWallet, walletRepository),
+                handler.throwIfCannotBeApplied(bridgechainUpdateTransaction, senderWallet),
             ).rejects.toThrowError(BridgechainIsNotRegisteredByWalletError);
         });
 
@@ -220,7 +218,7 @@ describe("BusinessRegistration", () => {
                 .build();
 
             await expect(
-                handler.throwIfCannotBeApplied(bridgechainUpdateTransaction, senderWallet, walletRepository),
+                handler.throwIfCannotBeApplied(bridgechainUpdateTransaction, senderWallet),
             ).rejects.toThrowError(BridgechainIsNotRegisteredByWalletError);
         });
 
@@ -229,7 +227,7 @@ describe("BusinessRegistration", () => {
             businessAttributes.bridgechains[bridgechainRegistrationAsset.genesisHash].resigned = true;
 
             await expect(
-                handler.throwIfCannotBeApplied(bridgechainUpdateTransaction, senderWallet, walletRepository),
+                handler.throwIfCannotBeApplied(bridgechainUpdateTransaction, senderWallet),
             ).rejects.toThrowError(BridgechainIsResignedError);
         });
 
@@ -237,7 +235,7 @@ describe("BusinessRegistration", () => {
             bridgechainUpdateTransaction.data.asset!.bridgechainUpdate.ports = { "@arkecosystem/INVALID": 55555 };
 
             await expect(
-                handler.throwIfCannotBeApplied(bridgechainUpdateTransaction, senderWallet, walletRepository),
+                handler.throwIfCannotBeApplied(bridgechainUpdateTransaction, senderWallet),
             ).rejects.toThrowError(PortKeyMustBeValidPackageNameError);
         });
     });
@@ -260,7 +258,7 @@ describe("BusinessRegistration", () => {
         it("should be ok", async () => {
             const senderBalance = senderWallet.balance;
 
-            await handler.apply(bridgechainUpdateTransaction, walletRepository);
+            await handler.apply(bridgechainUpdateTransaction);
 
             const bridgechainUpdateAssetClone = Object.assign({}, bridgechainUpdateAsset);
             delete bridgechainUpdateAssetClone.bridgechainId;
@@ -314,7 +312,7 @@ describe("BusinessRegistration", () => {
                 .sign(passphrases[0])
                 .build();
 
-            await handler.apply(secondBridgechainUpdateTransaction, walletRepository);
+            await handler.apply(secondBridgechainUpdateTransaction);
 
             const secondBridgechainUpdateAssetClone = Object.assign({}, secondBridgechainUpdateAsset);
             delete secondBridgechainUpdateAssetClone.bridgechainId;
@@ -334,7 +332,7 @@ describe("BusinessRegistration", () => {
                 secondBridgechainUpdateTransaction.data,
             ]);
 
-            await handler.revert(secondBridgechainUpdateTransaction, walletRepository);
+            await handler.revert(secondBridgechainUpdateTransaction);
 
             expect(
                 senderWallet.getAttribute("business.bridgechains")[bridgechainRegistrationAsset.genesisHash]

--- a/__tests__/unit/core-magistrate-transactions/handlers/business-registration.test.ts
+++ b/__tests__/unit/core-magistrate-transactions/handlers/business-registration.test.ts
@@ -116,22 +116,20 @@ describe("BusinessRegistration", () => {
 
     describe("throwIfCannotBeApplied", () => {
         it("should not throw", async () => {
-            await expect(
-                handler.throwIfCannotBeApplied(businessRegistrationTransaction, senderWallet, walletRepository),
-            ).toResolve();
+            await expect(handler.throwIfCannotBeApplied(businessRegistrationTransaction, senderWallet)).toResolve();
         });
 
         it("should throw if business already registered", async () => {
             senderWallet.setAttribute("business", {});
             await expect(
-                handler.throwIfCannotBeApplied(businessRegistrationTransaction, senderWallet, walletRepository),
+                handler.throwIfCannotBeApplied(businessRegistrationTransaction, senderWallet),
             ).rejects.toThrowError(BusinessAlreadyRegisteredError);
         });
 
         it("should throw if wallet has insufficient balance", async () => {
             senderWallet.balance = Utils.BigNumber.ZERO;
             await expect(
-                handler.throwIfCannotBeApplied(businessRegistrationTransaction, senderWallet, walletRepository),
+                handler.throwIfCannotBeApplied(businessRegistrationTransaction, senderWallet),
             ).rejects.toThrowError(InsufficientBalanceError);
         });
     });
@@ -154,7 +152,7 @@ describe("BusinessRegistration", () => {
         it("should be ok", async () => {
             const senderBalance = senderWallet.balance;
 
-            await handler.apply(businessRegistrationTransaction, walletRepository);
+            await handler.apply(businessRegistrationTransaction);
 
             expect(senderWallet.hasAttribute("business")).toBeTrue();
             expect(senderWallet.getAttribute("business.businessAsset")).toEqual(businessRegistrationAsset);
@@ -173,7 +171,7 @@ describe("BusinessRegistration", () => {
         it("should throw if transaction asset is missing", async () => {
             delete businessRegistrationTransaction.data.asset;
 
-            await expect(handler.apply(businessRegistrationTransaction, walletRepository)).rejects.toThrowError();
+            await expect(handler.apply(businessRegistrationTransaction)).rejects.toThrowError();
         });
     });
 
@@ -181,11 +179,11 @@ describe("BusinessRegistration", () => {
         it("should be ok", async () => {
             const senderBalance = senderWallet.balance;
 
-            await handler.apply(businessRegistrationTransaction, walletRepository);
+            await handler.apply(businessRegistrationTransaction);
 
             expect(senderWallet.hasAttribute("business")).toBeTrue();
 
-            await handler.revert(businessRegistrationTransaction, walletRepository);
+            await handler.revert(businessRegistrationTransaction);
 
             expect(senderWallet.hasAttribute("business")).toBeFalse();
             expect(senderWallet.balance).toEqual(Utils.BigNumber.make(senderBalance));

--- a/__tests__/unit/core-magistrate-transactions/handlers/business-resignation.test.ts
+++ b/__tests__/unit/core-magistrate-transactions/handlers/business-resignation.test.ts
@@ -123,29 +123,27 @@ describe("BusinessRegistration", () => {
 
     describe("throwIfCannotBeApplied", () => {
         it("should not throw", async () => {
-            await expect(
-                handler.throwIfCannotBeApplied(businessResignationTransaction, senderWallet, walletRepository),
-            ).toResolve();
+            await expect(handler.throwIfCannotBeApplied(businessResignationTransaction, senderWallet)).toResolve();
         });
 
         it("should throw if business is not registered", async () => {
             senderWallet.forgetAttribute("business");
-            await expect(
-                handler.throwIfCannotBeApplied(businessResignationTransaction, senderWallet, walletRepository),
-            ).rejects.toThrow(BusinessIsNotRegisteredError);
+            await expect(handler.throwIfCannotBeApplied(businessResignationTransaction, senderWallet)).rejects.toThrow(
+                BusinessIsNotRegisteredError,
+            );
         });
 
         it("should throw if business is resigned", async () => {
             senderWallet.setAttribute("business.resigned", true);
-            await expect(
-                handler.throwIfCannotBeApplied(businessResignationTransaction, senderWallet, walletRepository),
-            ).rejects.toThrow(BusinessIsResignedError);
+            await expect(handler.throwIfCannotBeApplied(businessResignationTransaction, senderWallet)).rejects.toThrow(
+                BusinessIsResignedError,
+            );
         });
 
         it("should throw if wallet has insufficient balance", async () => {
             senderWallet.balance = Utils.BigNumber.ZERO;
             await expect(
-                handler.throwIfCannotBeApplied(businessResignationTransaction, senderWallet, walletRepository),
+                handler.throwIfCannotBeApplied(businessResignationTransaction, senderWallet),
             ).rejects.toThrowError(InsufficientBalanceError);
         });
     });
@@ -172,7 +170,7 @@ describe("BusinessRegistration", () => {
                 senderWallet,
             );
 
-            await handler.apply(businessResignationTransaction, walletRepository);
+            await handler.apply(businessResignationTransaction);
 
             expect(senderWallet.hasAttribute("business")).toBeTrue();
             expect(senderWallet.getAttribute("business.resigned")).toBeTrue();
@@ -193,11 +191,11 @@ describe("BusinessRegistration", () => {
         it("should be ok", async () => {
             const senderBalance = senderWallet.balance;
 
-            await handler.apply(businessResignationTransaction, walletRepository);
+            await handler.apply(businessResignationTransaction);
 
             expect(senderWallet.getAttribute("business.resigned")).toBeTrue();
 
-            await handler.revert(businessResignationTransaction, walletRepository);
+            await handler.revert(businessResignationTransaction);
 
             expect(senderWallet.hasAttribute("business.resigned")).toBeFalse();
             expect(senderWallet.balance).toEqual(Utils.BigNumber.make(senderBalance));

--- a/__tests__/unit/core-magistrate-transactions/handlers/business-update.test.ts
+++ b/__tests__/unit/core-magistrate-transactions/handlers/business-update.test.ts
@@ -135,30 +135,28 @@ describe("BusinessRegistration", () => {
 
     describe("throwIfCannotBeApplied", () => {
         it("should not throw", async () => {
-            await expect(
-                handler.throwIfCannotBeApplied(businessUpdateTransaction, senderWallet, walletRepository),
-            ).toResolve();
+            await expect(handler.throwIfCannotBeApplied(businessUpdateTransaction, senderWallet)).toResolve();
         });
 
         it("should throw if business is not registered", async () => {
             senderWallet.forgetAttribute("business");
-            await expect(
-                handler.throwIfCannotBeApplied(businessUpdateTransaction, senderWallet, walletRepository),
-            ).rejects.toThrow(BusinessIsNotRegisteredError);
+            await expect(handler.throwIfCannotBeApplied(businessUpdateTransaction, senderWallet)).rejects.toThrow(
+                BusinessIsNotRegisteredError,
+            );
         });
 
         it("should throw if business is resigned", async () => {
             senderWallet.setAttribute("business.resigned", true);
-            await expect(
-                handler.throwIfCannotBeApplied(businessUpdateTransaction, senderWallet, walletRepository),
-            ).rejects.toThrow(BusinessIsResignedError);
+            await expect(handler.throwIfCannotBeApplied(businessUpdateTransaction, senderWallet)).rejects.toThrow(
+                BusinessIsResignedError,
+            );
         });
 
         it("should throw if wallet has insufficient balance", async () => {
             senderWallet.balance = Utils.BigNumber.ZERO;
-            await expect(
-                handler.throwIfCannotBeApplied(businessUpdateTransaction, senderWallet, walletRepository),
-            ).rejects.toThrowError(InsufficientBalanceError);
+            await expect(handler.throwIfCannotBeApplied(businessUpdateTransaction, senderWallet)).rejects.toThrowError(
+                InsufficientBalanceError,
+            );
         });
     });
 
@@ -180,7 +178,7 @@ describe("BusinessRegistration", () => {
         it("should be ok", async () => {
             const senderBalance = senderWallet.balance;
 
-            await handler.apply(businessUpdateTransaction, walletRepository);
+            await handler.apply(businessUpdateTransaction);
 
             expect(senderWallet.getAttribute("business.businessAsset")).toEqual(businessUpdateAsset);
 
@@ -195,7 +193,7 @@ describe("BusinessRegistration", () => {
         it("should be ok", async () => {
             const senderBalance = senderWallet.balance;
 
-            await handler.apply(businessUpdateTransaction, walletRepository);
+            await handler.apply(businessUpdateTransaction);
 
             expect(senderWallet.getAttribute("business.businessAsset")).toEqual(businessUpdateAsset);
 
@@ -207,7 +205,7 @@ describe("BusinessRegistration", () => {
 
             transactionHistoryService.findManyByCriteria.mockResolvedValue([businessRegistrationTransaction.data]);
 
-            await handler.revert(businessUpdateTransaction, walletRepository);
+            await handler.revert(businessUpdateTransaction);
 
             expect(senderWallet.getAttribute("business.businessAsset")).toEqual(businessRegistrationAsset);
             expect(senderWallet.balance).toEqual(Utils.BigNumber.make(senderBalance));
@@ -240,7 +238,7 @@ describe("BusinessRegistration", () => {
                 .sign(passphrases[0])
                 .build();
 
-            await handler.apply(secondBusinessUpdateTransaction, walletRepository);
+            await handler.apply(secondBusinessUpdateTransaction);
 
             expect(senderWallet.getAttribute("business.businessAsset")).toEqual({
                 ...businessRegistrationAsset,
@@ -254,7 +252,7 @@ describe("BusinessRegistration", () => {
                 secondBusinessUpdateTransaction.data,
             ]);
 
-            await handler.revert(secondBusinessUpdateTransaction, walletRepository);
+            await handler.revert(secondBusinessUpdateTransaction);
 
             expect(senderWallet.getAttribute("business.businessAsset")).toEqual({
                 ...businessRegistrationAsset,

--- a/__tests__/unit/core-magistrate-transactions/handlers/general.test.ts
+++ b/__tests__/unit/core-magistrate-transactions/handlers/general.test.ts
@@ -102,15 +102,13 @@ describe("BusinessRegistration", () => {
             configManager.set("network.pubKeyHash", 99);
             configManager.set("exceptions.transactions", [businessRegistrationTransaction.data.id]);
 
-            await expect(
-                handler.throwIfCannotBeApplied(businessRegistrationTransaction, senderWallet, walletRepository),
-            ).toResolve();
+            await expect(handler.throwIfCannotBeApplied(businessRegistrationTransaction, senderWallet)).toResolve();
         });
 
         it("should throw on fee mismatch", async () => {
             businessRegistrationTransaction.data.fee = Utils.BigNumber.ZERO;
             await expect(
-                handler.throwIfCannotBeApplied(businessRegistrationTransaction, senderWallet, walletRepository),
+                handler.throwIfCannotBeApplied(businessRegistrationTransaction, senderWallet),
             ).rejects.toThrowError(StaticFeeMismatchError);
         });
     });

--- a/__tests__/unit/core-transactions/handlers/handler-registry.test.ts
+++ b/__tests__/unit/core-transactions/handlers/handler-registry.test.ts
@@ -1,6 +1,6 @@
 import "jest-extended";
 
-import { Contracts, Services } from "@packages/core-kernel";
+import { Services } from "@packages/core-kernel";
 import { Application } from "@packages/core-kernel/src/application";
 import { Container, Identifiers } from "@packages/core-kernel/src/ioc";
 import {

--- a/__tests__/unit/core-transactions/handlers/handler-registry.test.ts
+++ b/__tests__/unit/core-transactions/handlers/handler-registry.test.ts
@@ -81,15 +81,9 @@ class TestTransactionHandler extends TransactionHandler {
         return true;
     }
 
-    async applyToRecipient(
-        transaction: Interfaces.ITransaction,
-        customWalletRepository?: Contracts.State.WalletRepository,
-    ): Promise<void> {}
+    async applyToRecipient(transaction: Interfaces.ITransaction): Promise<void> {}
 
-    async revertForRecipient(
-        transaction: Interfaces.ITransaction,
-        customWalletRepository?: Contracts.State.WalletRepository,
-    ): Promise<void> {}
+    async revertForRecipient(transaction: Interfaces.ITransaction): Promise<void> {}
 }
 
 class TestWithDependencyTransactionHandler extends TransactionHandler {
@@ -113,15 +107,9 @@ class TestWithDependencyTransactionHandler extends TransactionHandler {
         return true;
     }
 
-    async applyToRecipient(
-        transaction: Interfaces.ITransaction,
-        customWalletRepository?: Contracts.State.WalletRepository,
-    ): Promise<void> {}
+    async applyToRecipient(transaction: Interfaces.ITransaction): Promise<void> {}
 
-    async revertForRecipient(
-        transaction: Interfaces.ITransaction,
-        customWalletRepository?: Contracts.State.WalletRepository,
-    ): Promise<void> {}
+    async revertForRecipient(transaction: Interfaces.ITransaction): Promise<void> {}
 }
 
 beforeEach(() => {

--- a/__tests__/unit/core-transactions/handlers/one/multi-signature-registration.test.ts
+++ b/__tests__/unit/core-transactions/handlers/one/multi-signature-registration.test.ts
@@ -147,18 +147,16 @@ describe("MultiSignatureRegistrationTransaction", () => {
         });
 
         it("should throw", async () => {
-            await expect(
-                handler.throwIfCannotBeApplied(multiSignatureTransaction, senderWallet, walletRepository),
-            ).rejects.toThrow(LegacyMultiSignatureError);
+            await expect(handler.throwIfCannotBeApplied(multiSignatureTransaction, senderWallet)).rejects.toThrow(
+                LegacyMultiSignatureError,
+            );
         });
 
         it("should not throw defined as exception", async () => {
             configManager.set("network.pubKeyHash", 99);
             configManager.set("exceptions.transactions", [multiSignatureTransaction.id]);
 
-            await expect(
-                handler.throwIfCannotBeApplied(multiSignatureTransaction, senderWallet, walletRepository),
-            ).toResolve();
+            await expect(handler.throwIfCannotBeApplied(multiSignatureTransaction, senderWallet)).toResolve();
         });
     });
 

--- a/__tests__/unit/core-transactions/handlers/two/delegate-registration.test.ts
+++ b/__tests__/unit/core-transactions/handlers/two/delegate-registration.test.ts
@@ -178,18 +178,12 @@ describe("DelegateRegistrationTransaction", () => {
 
     describe("throwIfCannotBeApplied", () => {
         it("should not throw", async () => {
-            await expect(
-                handler.throwIfCannotBeApplied(delegateRegistrationTransaction, senderWallet, walletRepository),
-            ).toResolve();
+            await expect(handler.throwIfCannotBeApplied(delegateRegistrationTransaction, senderWallet)).toResolve();
         });
 
         it("should not throw - second sign", async () => {
             await expect(
-                handler.throwIfCannotBeApplied(
-                    secondSignaturedDelegateRegistrationTransaction,
-                    secondSignatureWallet,
-                    walletRepository,
-                ),
+                handler.throwIfCannotBeApplied(secondSignaturedDelegateRegistrationTransaction, secondSignatureWallet),
             ).toResolve();
         });
 
@@ -205,15 +199,15 @@ describe("DelegateRegistrationTransaction", () => {
 
             senderWallet.setAttribute("multiSignature", multiSignatureAsset);
 
-            await expect(
-                handler.throwIfCannotBeApplied(delegateRegistrationTransaction, senderWallet, walletRepository),
-            ).rejects.toThrow(NotSupportedForMultiSignatureWalletError);
+            await expect(handler.throwIfCannotBeApplied(delegateRegistrationTransaction, senderWallet)).rejects.toThrow(
+                NotSupportedForMultiSignatureWalletError,
+            );
         });
 
         // it("should throw if transaction does not have delegate", async () => {
         //     delegateRegistrationTransaction.data.asset.delegate.username! = null;
         //
-        //     await expect(handler.throwIfCannotBeApplied(delegateRegistrationTransaction, senderWallet, walletRepository)).rejects.toThrow(
+        //     await expect(handler.throwIfCannotBeApplied(delegateRegistrationTransaction, senderWallet)).rejects.toThrow(
         //         WalletNotADelegateError,
         //     );
         // });
@@ -221,9 +215,9 @@ describe("DelegateRegistrationTransaction", () => {
         it("should throw if wallet already registered a username", async () => {
             senderWallet.setAttribute("delegate", { username: "dummy" });
 
-            await expect(
-                handler.throwIfCannotBeApplied(delegateRegistrationTransaction, senderWallet, walletRepository),
-            ).rejects.toThrow(WalletIsAlreadyDelegateError);
+            await expect(handler.throwIfCannotBeApplied(delegateRegistrationTransaction, senderWallet)).rejects.toThrow(
+                WalletIsAlreadyDelegateError,
+            );
         });
 
         it("should throw if another wallet already registered a username", async () => {
@@ -239,17 +233,17 @@ describe("DelegateRegistrationTransaction", () => {
 
             walletRepository.index(delegateWallet);
 
-            await expect(
-                handler.throwIfCannotBeApplied(delegateRegistrationTransaction, senderWallet, walletRepository),
-            ).rejects.toThrow(WalletUsernameAlreadyRegisteredError);
+            await expect(handler.throwIfCannotBeApplied(delegateRegistrationTransaction, senderWallet)).rejects.toThrow(
+                WalletUsernameAlreadyRegisteredError,
+            );
         });
 
         it("should throw if wallet has insufficient funds", async () => {
             senderWallet.balance = Utils.BigNumber.ZERO;
 
-            await expect(
-                handler.throwIfCannotBeApplied(delegateRegistrationTransaction, senderWallet, walletRepository),
-            ).rejects.toThrow(InsufficientBalanceError);
+            await expect(handler.throwIfCannotBeApplied(delegateRegistrationTransaction, senderWallet)).rejects.toThrow(
+                InsufficientBalanceError,
+            );
         });
     });
 
@@ -297,7 +291,7 @@ describe("DelegateRegistrationTransaction", () => {
 
     describe("apply", () => {
         it("should set username", async () => {
-            await handler.apply(delegateRegistrationTransaction, walletRepository);
+            await handler.apply(delegateRegistrationTransaction);
             expect(senderWallet.getAttribute("delegate.username")).toBe("dummy");
         });
     });
@@ -306,12 +300,12 @@ describe("DelegateRegistrationTransaction", () => {
         it("should unset username", async () => {
             expect(senderWallet.hasAttribute("delegate.username")).toBeFalse();
 
-            await handler.apply(delegateRegistrationTransaction, walletRepository);
+            await handler.apply(delegateRegistrationTransaction);
 
             expect(senderWallet.hasAttribute("delegate.username")).toBeTrue();
             expect(senderWallet.getAttribute("delegate.username")).toBe("dummy");
 
-            await handler.revert(delegateRegistrationTransaction, walletRepository);
+            await handler.revert(delegateRegistrationTransaction);
 
             expect(senderWallet.nonce.isZero()).toBeTrue();
             expect(senderWallet.hasAttribute("delegate.username")).toBeFalse();

--- a/__tests__/unit/core-transactions/handlers/two/general.test.ts
+++ b/__tests__/unit/core-transactions/handlers/two/general.test.ts
@@ -113,31 +113,29 @@ describe("General Tests", () => {
 
     describe("verify", () => {
         it("should be verified", async () => {
-            await expect(handler.verify(transferTransaction, walletRepository)).resolves.toBeTrue();
+            await expect(handler.verify(transferTransaction)).resolves.toBeTrue();
         });
 
         it("should be verified with multi sign", async () => {
-            await expect(handler.verify(multiSignatureTransferTransaction, walletRepository)).resolves.toBeTrue();
+            await expect(handler.verify(multiSignatureTransferTransaction)).resolves.toBeTrue();
         });
     });
 
     describe("throwIfCannotBeApplied", () => {
         it("should not throw", async () => {
-            await expect(
-                handler.throwIfCannotBeApplied(transferTransaction, senderWallet, walletRepository),
-            ).toResolve();
+            await expect(handler.throwIfCannotBeApplied(transferTransaction, senderWallet)).toResolve();
         });
 
         it("should throw if wallet publicKey does not match transaction senderPublicKey", async () => {
             transferTransaction.data.senderPublicKey = "a".repeat(66);
-            await expect(
-                handler.throwIfCannotBeApplied(transferTransaction, senderWallet, walletRepository),
-            ).rejects.toThrowError(SenderWalletMismatchError);
+            await expect(handler.throwIfCannotBeApplied(transferTransaction, senderWallet)).rejects.toThrowError(
+                SenderWalletMismatchError,
+            );
         });
 
         it("should throw if the transaction has a second signature but wallet does not", async () => {
             await expect(
-                handler.throwIfCannotBeApplied(transactionWithSecondSignature, senderWallet, walletRepository),
+                handler.throwIfCannotBeApplied(transactionWithSecondSignature, senderWallet),
             ).rejects.toThrowError(UnexpectedSecondSignatureError);
         });
 
@@ -147,16 +145,16 @@ describe("General Tests", () => {
                 "secondPublicKey",
                 "038082dad560a22ea003022015e3136b21ef1ffd9f2fd50049026cbe8e2258ca17",
             );
-            await expect(
-                handler.throwIfCannotBeApplied(transferTransaction, secondSigWallet, walletRepository),
-            ).rejects.toThrowError(UnexpectedSecondSignatureError);
+            await expect(handler.throwIfCannotBeApplied(transferTransaction, secondSigWallet)).rejects.toThrowError(
+                UnexpectedSecondSignatureError,
+            );
         });
 
         it("should throw if nonce is invalid", async () => {
             senderWallet.nonce = Utils.BigNumber.make(1);
-            await expect(
-                handler.throwIfCannotBeApplied(transferTransaction, senderWallet, walletRepository),
-            ).rejects.toThrowError(UnexpectedNonceError);
+            await expect(handler.throwIfCannotBeApplied(transferTransaction, senderWallet)).rejects.toThrowError(
+                UnexpectedNonceError,
+            );
         });
 
         it("should throw if sender has legacy multi signature", async () => {
@@ -172,9 +170,9 @@ describe("General Tests", () => {
             };
 
             senderWallet.setAttribute("multiSignature", multiSignatureAsset);
-            await expect(
-                handler.throwIfCannotBeApplied(transferTransaction, senderWallet, walletRepository),
-            ).rejects.toThrowError(LegacyMultiSignatureError);
+            await expect(handler.throwIfCannotBeApplied(transferTransaction, senderWallet)).rejects.toThrowError(
+                LegacyMultiSignatureError,
+            );
         });
 
         it("should throw if sender has multi signature, but indexed wallet has not", async () => {
@@ -189,9 +187,9 @@ describe("General Tests", () => {
 
             const multiSigWallet = buildSenderWallet(factoryBuilder);
             multiSigWallet.setAttribute("multiSignature", multiSignatureAsset);
-            await expect(
-                handler.throwIfCannotBeApplied(transferTransaction, multiSigWallet, walletRepository),
-            ).rejects.toThrowError(UnexpectedMultiSignatureError);
+            await expect(handler.throwIfCannotBeApplied(transferTransaction, multiSigWallet)).rejects.toThrowError(
+                UnexpectedMultiSignatureError,
+            );
         });
 
         it("should throw if sender and transaction multi signatures does not match", async () => {
@@ -206,11 +204,7 @@ describe("General Tests", () => {
 
             multiSignatureWallet.setAttribute("multiSignature", multiSignatureAsset);
             await expect(
-                handler.throwIfCannotBeApplied(
-                    multiSignatureTransferTransaction,
-                    multiSignatureWallet,
-                    walletRepository,
-                ),
+                handler.throwIfCannotBeApplied(multiSignatureTransferTransaction, multiSignatureWallet),
             ).rejects.toThrowError(InvalidMultiSignatureError);
         });
 
@@ -220,24 +214,24 @@ describe("General Tests", () => {
                 "0116779a98b2009b35d4003dda7628e46365f1a52068489bfbd80594770967a3949f76bc09e204eddd7d460e1e519b826c53dc6e2c9573096326dbc495050cf292",
                 "02687bd0f4a91be39daf648a5b1e1af5ffa4a3d4319b2e38b1fc2dc206db03f542f3b26c4803e0b4c8a53ddfb6cf4533b512d71ae869d4e4ccba989c4a4222396b",
             ];
-            await expect(
-                handler.throwIfCannotBeApplied(transferTransaction, senderWallet, walletRepository),
-            ).rejects.toThrowError(UnexpectedMultiSignatureError);
+            await expect(handler.throwIfCannotBeApplied(transferTransaction, senderWallet)).rejects.toThrowError(
+                UnexpectedMultiSignatureError,
+            );
         });
 
         it("should throw if wallet and transaction second signatures does not match", async () => {
             senderWallet.setAttribute("secondPublicKey", "invalid-public-key");
-            await expect(
-                handler.throwIfCannotBeApplied(transactionWithSecondSignature, senderWallet, walletRepository),
-            ).rejects.toThrow(InvalidSecondSignatureError);
+            await expect(handler.throwIfCannotBeApplied(transactionWithSecondSignature, senderWallet)).rejects.toThrow(
+                InvalidSecondSignatureError,
+            );
         });
 
         it("should throw if wallet has not enough balance", async () => {
             // 1 arktoshi short
             senderWallet.balance = transferTransaction.data.amount.plus(transferTransaction.data.fee).minus(1);
-            await expect(
-                handler.throwIfCannotBeApplied(transferTransaction, senderWallet, walletRepository),
-            ).rejects.toThrow(InsufficientBalanceError);
+            await expect(handler.throwIfCannotBeApplied(transferTransaction, senderWallet)).rejects.toThrow(
+                InsufficientBalanceError,
+            );
         });
 
         it("should be true even with publicKey case mismatch", async () => {
@@ -247,7 +241,7 @@ describe("General Tests", () => {
             const instance: Interfaces.ITransaction = Transactions.TransactionFactory.fromData(
                 transferTransaction.data,
             );
-            await expect(handler.throwIfCannotBeApplied(instance, senderWallet, walletRepository)).toResolve();
+            await expect(handler.throwIfCannotBeApplied(instance, senderWallet)).toResolve();
         });
     });
 
@@ -319,7 +313,7 @@ describe("General Tests", () => {
         });
 
         it("should resolve", async () => {
-            await expect(handler.apply(transferTransaction, walletRepository)).toResolve();
+            await expect(handler.apply(transferTransaction)).toResolve();
         });
 
         it("should not fail due to case mismatch", async () => {
@@ -330,7 +324,7 @@ describe("General Tests", () => {
             const senderBalance = senderWallet.balance;
             const recipientBalance = recipientWallet.balance;
 
-            await handler.apply(instance, walletRepository);
+            await handler.apply(instance);
 
             expect(senderWallet.balance).toEqual(
                 Utils.BigNumber.make(senderBalance).minus(instance.data.amount).minus(instance.data.fee),
@@ -342,7 +336,7 @@ describe("General Tests", () => {
         it("should resolve defined as exception", async () => {
             configManager.set("exceptions.transactions", [transferTransaction.id]);
             configManager.set("network.pubKeyHash", 99);
-            await expect(handler.apply(transferTransaction, walletRepository)).toResolve();
+            await expect(handler.apply(transferTransaction)).toResolve();
         });
 
         it("should resolve with V1", async () => {
@@ -355,35 +349,31 @@ describe("General Tests", () => {
                 .sign(passphrases[0])
                 .build();
 
-            await expect(handler.apply(transferTransaction, walletRepository)).toResolve();
+            await expect(handler.apply(transferTransaction)).toResolve();
         });
 
         it("should throw with negative balance", async () => {
             senderWallet.balance = Utils.BigNumber.ZERO;
-            await expect(handler.apply(transferTransaction, walletRepository)).rejects.toThrow(
-                InsufficientBalanceError,
-            );
+            await expect(handler.apply(transferTransaction)).rejects.toThrow(InsufficientBalanceError);
         });
 
         it("should throw with negative balance if environment is not test", async () => {
             process.env.CORE_ENV === "unitest";
             senderWallet.balance = Utils.BigNumber.ZERO;
-            await expect(handler.apply(transferTransaction, walletRepository)).rejects.toThrow(
-                InsufficientBalanceError,
-            );
+            await expect(handler.apply(transferTransaction)).rejects.toThrow(InsufficientBalanceError);
         });
     });
 
     describe("revert", () => {
         it("should resolve", async () => {
-            await expect(handler.apply(transferTransaction, walletRepository)).toResolve();
-            await expect(handler.revert(transferTransaction, walletRepository)).toResolve();
+            await expect(handler.apply(transferTransaction)).toResolve();
+            await expect(handler.revert(transferTransaction)).toResolve();
         });
 
         it("should throw if nonce is invalid", async () => {
-            await expect(handler.apply(transferTransaction, walletRepository)).toResolve();
+            await expect(handler.apply(transferTransaction)).toResolve();
             senderWallet.nonce = Utils.BigNumber.make(100);
-            await expect(handler.revert(transferTransaction, walletRepository)).rejects.toThrow(UnexpectedNonceError);
+            await expect(handler.revert(transferTransaction)).rejects.toThrow(UnexpectedNonceError);
         });
 
         it("should not fail due to case mismatch", async () => {
@@ -396,7 +386,7 @@ describe("General Tests", () => {
             const senderBalance = senderWallet.balance;
             const recipientBalance = recipientWallet.balance;
 
-            await handler.revert(instance, walletRepository);
+            await handler.revert(instance);
             expect(senderWallet.balance).toEqual(
                 Utils.BigNumber.make(senderBalance).plus(instance.data.amount).plus(instance.data.fee),
             );

--- a/__tests__/unit/core-transactions/handlers/two/htlc-lock.test.ts
+++ b/__tests__/unit/core-transactions/handlers/two/htlc-lock.test.ts
@@ -180,37 +180,27 @@ describe("Htlc lock", () => {
 
         describe("throwIfCannotBeApplied", () => {
             it("should not throw", async () => {
-                await expect(
-                    handler.throwIfCannotBeApplied(htlcLockTransaction, senderWallet, walletRepository),
-                ).toResolve();
+                await expect(handler.throwIfCannotBeApplied(htlcLockTransaction, senderWallet)).toResolve();
             });
 
             it("should not throw - second sign", async () => {
                 await expect(
-                    handler.throwIfCannotBeApplied(
-                        secondSignatureHtlcLockTransaction,
-                        secondSignatureWallet,
-                        walletRepository,
-                    ),
+                    handler.throwIfCannotBeApplied(secondSignatureHtlcLockTransaction, secondSignatureWallet),
                 ).toResolve();
             });
 
             it("should not throw - multi sign", async () => {
                 await expect(
-                    handler.throwIfCannotBeApplied(
-                        multiSignatureHtlcLockTransaction,
-                        multiSignatureWallet,
-                        walletRepository,
-                    ),
+                    handler.throwIfCannotBeApplied(multiSignatureHtlcLockTransaction, multiSignatureWallet),
                 ).toResolve();
             });
 
             it("should throw if wallet has insufficient funds", async () => {
                 senderWallet.balance = Utils.BigNumber.ZERO;
 
-                await expect(
-                    handler.throwIfCannotBeApplied(htlcLockTransaction, senderWallet, walletRepository),
-                ).rejects.toThrow(InsufficientBalanceError);
+                await expect(handler.throwIfCannotBeApplied(htlcLockTransaction, senderWallet)).rejects.toThrow(
+                    InsufficientBalanceError,
+                );
             });
 
             it("should throw if lock is already expired", async () => {
@@ -222,9 +212,9 @@ describe("Htlc lock", () => {
                     htlcLockTransaction.data.asset!.lock!.expiration.value = Crypto.Slots.getTime();
                 }
 
-                await expect(
-                    handler.throwIfCannotBeApplied(htlcLockTransaction, senderWallet, walletRepository),
-                ).rejects.toThrow(HtlcLockExpiredError);
+                await expect(handler.throwIfCannotBeApplied(htlcLockTransaction, senderWallet)).rejects.toThrow(
+                    HtlcLockExpiredError,
+                );
 
                 if (expirationType === Enums.HtlcLockExpirationType.BlockHeight) {
                     htlcLockTransaction.data.asset!.lock!.expiration.value = 1000;
@@ -232,9 +222,7 @@ describe("Htlc lock", () => {
                     htlcLockTransaction.data.asset!.lock!.expiration.value = Crypto.Slots.getTime() + 10000;
                 }
 
-                await expect(
-                    handler.throwIfCannotBeApplied(htlcLockTransaction, senderWallet, walletRepository),
-                ).toResolve();
+                await expect(handler.throwIfCannotBeApplied(htlcLockTransaction, senderWallet)).toResolve();
 
                 process.env.CORE_ENV = "test";
             });
@@ -242,13 +230,11 @@ describe("Htlc lock", () => {
 
         describe("apply", () => {
             it("should apply htlc lock transaction", async () => {
-                await expect(
-                    handler.throwIfCannotBeApplied(htlcLockTransaction, senderWallet, walletRepository),
-                ).toResolve();
+                await expect(handler.throwIfCannotBeApplied(htlcLockTransaction, senderWallet)).toResolve();
 
                 const balanceBefore = senderWallet.balance;
 
-                await handler.apply(htlcLockTransaction, walletRepository);
+                await handler.apply(htlcLockTransaction);
 
                 expect(senderWallet.getAttribute("htlc.locks", {})[htlcLockTransaction.id!]).toBeDefined();
                 expect(senderWallet.getAttribute("htlc.lockedBalance")).toEqual(htlcLockTransaction.data.amount);
@@ -260,13 +246,11 @@ describe("Htlc lock", () => {
 
         describe("revert", () => {
             it("should be ok", async () => {
-                await expect(
-                    handler.throwIfCannotBeApplied(htlcLockTransaction, senderWallet, walletRepository),
-                ).toResolve();
+                await expect(handler.throwIfCannotBeApplied(htlcLockTransaction, senderWallet)).toResolve();
 
                 const balanceBefore = senderWallet.balance;
 
-                await handler.apply(htlcLockTransaction, walletRepository);
+                await handler.apply(htlcLockTransaction);
 
                 expect(senderWallet.getAttribute("htlc.locks", {})[htlcLockTransaction.id!]).toBeDefined();
                 expect(senderWallet.getAttribute("htlc.lockedBalance", Utils.BigNumber.ZERO)).toEqual(
@@ -276,7 +260,7 @@ describe("Htlc lock", () => {
                     balanceBefore.minus(htlcLockTransaction.data.fee).minus(htlcLockTransaction.data.amount),
                 );
 
-                await handler.revert(htlcLockTransaction, walletRepository);
+                await handler.revert(htlcLockTransaction);
 
                 expect(senderWallet.getAttribute("htlc.locks", {})[htlcLockTransaction.id!]).toBeUndefined();
                 expect(senderWallet.getAttribute("htlc.lockedBalance", Utils.BigNumber.ZERO)).toEqual(

--- a/__tests__/unit/core-transactions/handlers/two/ipfs.test.ts
+++ b/__tests__/unit/core-transactions/handlers/two/ipfs.test.ts
@@ -122,52 +122,52 @@ describe("Ipfs", () => {
         });
 
         it("should not throw", async () => {
-            await expect(handler.throwIfCannotBeApplied(ipfsTransaction, senderWallet, walletRepository)).toResolve();
+            await expect(handler.throwIfCannotBeApplied(ipfsTransaction, senderWallet)).toResolve();
         });
 
         it("should not throw defined as exception", async () => {
             configManager.set("network.pubKeyHash", 99);
             configManager.set("exceptions.transactions", [ipfsTransaction.id]);
 
-            await expect(handler.throwIfCannotBeApplied(ipfsTransaction, senderWallet, walletRepository)).toResolve();
+            await expect(handler.throwIfCannotBeApplied(ipfsTransaction, senderWallet)).toResolve();
         });
 
         it("should not throw - second sign", async () => {
             await expect(
-                handler.throwIfCannotBeApplied(secondSignatureIpfsTransaction, secondSignatureWallet, walletRepository),
+                handler.throwIfCannotBeApplied(secondSignatureIpfsTransaction, secondSignatureWallet),
             ).toResolve();
         });
 
         it("should not throw - multi sign", async () => {
             await expect(
-                handler.throwIfCannotBeApplied(multiSignatureIpfsTransaction, multiSignatureWallet, walletRepository),
+                handler.throwIfCannotBeApplied(multiSignatureIpfsTransaction, multiSignatureWallet),
             ).toResolve();
         });
 
         it("should throw if wallet has insufficient funds", async () => {
             senderWallet.balance = Utils.BigNumber.ZERO;
 
-            await expect(
-                handler.throwIfCannotBeApplied(ipfsTransaction, senderWallet, walletRepository),
-            ).rejects.toThrow(InsufficientBalanceError);
+            await expect(handler.throwIfCannotBeApplied(ipfsTransaction, senderWallet)).rejects.toThrow(
+                InsufficientBalanceError,
+            );
         });
 
         it("should throw if hash already exists", async () => {
-            await expect(handler.throwIfCannotBeApplied(ipfsTransaction, senderWallet, walletRepository)).toResolve();
-            await expect(handler.apply(ipfsTransaction, walletRepository)).toResolve();
-            await expect(
-                handler.throwIfCannotBeApplied(ipfsTransaction, senderWallet, walletRepository),
-            ).rejects.toThrow(IpfsHashAlreadyExists);
+            await expect(handler.throwIfCannotBeApplied(ipfsTransaction, senderWallet)).toResolve();
+            await expect(handler.apply(ipfsTransaction)).toResolve();
+            await expect(handler.throwIfCannotBeApplied(ipfsTransaction, senderWallet)).rejects.toThrow(
+                IpfsHashAlreadyExists,
+            );
         });
     });
 
     describe("apply", () => {
         it("should apply ipfs transaction", async () => {
-            await expect(handler.throwIfCannotBeApplied(ipfsTransaction, senderWallet, walletRepository)).toResolve();
+            await expect(handler.throwIfCannotBeApplied(ipfsTransaction, senderWallet)).toResolve();
 
             const balanceBefore = senderWallet.balance;
 
-            await handler.apply(ipfsTransaction, walletRepository);
+            await handler.apply(ipfsTransaction);
 
             expect(
                 senderWallet.getAttribute<Contracts.State.WalletIpfsAttributes>("ipfs.hashes")[
@@ -180,11 +180,11 @@ describe("Ipfs", () => {
 
     describe("revert", () => {
         it("should be ok", async () => {
-            await expect(handler.throwIfCannotBeApplied(ipfsTransaction, senderWallet, walletRepository)).toResolve();
+            await expect(handler.throwIfCannotBeApplied(ipfsTransaction, senderWallet)).toResolve();
 
             const balanceBefore = senderWallet.balance;
 
-            await handler.apply(ipfsTransaction, walletRepository);
+            await handler.apply(ipfsTransaction);
 
             expect(senderWallet.balance).toEqual(balanceBefore.minus(ipfsTransaction.data.fee));
             expect(
@@ -193,7 +193,7 @@ describe("Ipfs", () => {
                 ],
             ).toBeTrue();
 
-            await handler.revert(ipfsTransaction, walletRepository);
+            await handler.revert(ipfsTransaction);
 
             expect(senderWallet.hasAttribute("ipfs")).toBeFalse();
             expect(senderWallet.balance).toEqual(balanceBefore);

--- a/__tests__/unit/core-transactions/handlers/two/multi-payment.test.ts
+++ b/__tests__/unit/core-transactions/handlers/two/multi-payment.test.ts
@@ -126,43 +126,33 @@ describe("MultiPaymentTransaction", () => {
 
     describe("throwIfCannotBeApplied", () => {
         it("should not throw", async () => {
-            await expect(
-                handler.throwIfCannotBeApplied(multiPaymentTransaction, senderWallet, walletRepository),
-            ).toResolve();
+            await expect(handler.throwIfCannotBeApplied(multiPaymentTransaction, senderWallet)).toResolve();
         });
 
         it("should not throw - second sign", async () => {
             await expect(
-                handler.throwIfCannotBeApplied(
-                    secondSignatureMultiPaymentTransaction,
-                    secondSignatureWallet,
-                    walletRepository,
-                ),
+                handler.throwIfCannotBeApplied(secondSignatureMultiPaymentTransaction, secondSignatureWallet),
             ).toResolve();
         });
 
         it("should not throw - multi sign", async () => {
             await expect(
-                handler.throwIfCannotBeApplied(
-                    multiSignatureMultiPaymentTransaction,
-                    multiSignatureWallet,
-                    walletRepository,
-                ),
+                handler.throwIfCannotBeApplied(multiSignatureMultiPaymentTransaction, multiSignatureWallet),
             ).toResolve();
         });
 
         it("should throw if wallet has insufficient funds", async () => {
             senderWallet.balance = Utils.BigNumber.ZERO;
-            await expect(
-                handler.throwIfCannotBeApplied(multiPaymentTransaction, senderWallet, walletRepository),
-            ).rejects.toThrow(InsufficientBalanceError);
+            await expect(handler.throwIfCannotBeApplied(multiPaymentTransaction, senderWallet)).rejects.toThrow(
+                InsufficientBalanceError,
+            );
         });
 
         it("should throw if wallet has insufficient funds send all payouts", async () => {
             senderWallet.balance = Utils.BigNumber.make(150); // short by the fee
-            await expect(
-                handler.throwIfCannotBeApplied(multiPaymentTransaction, senderWallet, walletRepository),
-            ).rejects.toThrow(InsufficientBalanceError);
+            await expect(handler.throwIfCannotBeApplied(multiPaymentTransaction, senderWallet)).rejects.toThrow(
+                InsufficientBalanceError,
+            );
         });
     });
 
@@ -174,7 +164,7 @@ describe("MultiPaymentTransaction", () => {
                 Utils.BigNumber.ZERO,
             );
 
-            await handler.apply(multiPaymentTransaction, walletRepository);
+            await handler.apply(multiPaymentTransaction);
 
             expect(senderWallet.balance).toEqual(
                 Utils.BigNumber.make(senderBalance).minus(totalPaymentsAmount).minus(multiPaymentTransaction.data.fee),
@@ -201,7 +191,7 @@ describe("MultiPaymentTransaction", () => {
                 Utils.BigNumber.ZERO,
             );
 
-            await handler.revert(multiPaymentTransaction, walletRepository);
+            await handler.revert(multiPaymentTransaction);
             expect(senderWallet.balance).toEqual(
                 Utils.BigNumber.make(senderBalance).plus(totalPaymentsAmount).plus(multiPaymentTransaction.data.fee),
             );

--- a/__tests__/unit/core-transactions/handlers/two/multi-signature-registration.test.ts
+++ b/__tests__/unit/core-transactions/handlers/two/multi-signature-registration.test.ts
@@ -152,36 +152,30 @@ describe("MultiSignatureRegistrationTransaction", () => {
         });
 
         it("should not throw", async () => {
-            await expect(
-                handler.throwIfCannotBeApplied(multiSignatureTransaction, senderWallet, walletRepository),
-            ).toResolve();
+            await expect(handler.throwIfCannotBeApplied(multiSignatureTransaction, senderWallet)).toResolve();
         });
 
         it("should not throw - second sign", async () => {
             await expect(
-                handler.throwIfCannotBeApplied(
-                    secondSignatureMultiSignatureTransaction,
-                    secondSignatureWallet,
-                    walletRepository,
-                ),
+                handler.throwIfCannotBeApplied(secondSignatureMultiSignatureTransaction, secondSignatureWallet),
             ).toResolve();
         });
 
         it("should throw if the wallet already has multisignatures", async () => {
             recipientWallet.setAttribute("multiSignature", multiSignatureTransaction.data.asset!.multiSignature);
 
-            await expect(
-                handler.throwIfCannotBeApplied(multiSignatureTransaction, senderWallet, walletRepository),
-            ).rejects.toThrow(MultiSignatureAlreadyRegisteredError);
+            await expect(handler.throwIfCannotBeApplied(multiSignatureTransaction, senderWallet)).rejects.toThrow(
+                MultiSignatureAlreadyRegisteredError,
+            );
         });
 
         it("should throw if failure to verify signatures", async () => {
             handler.verifySignatures = jest.fn(() => false);
             senderWallet.forgetAttribute("multiSignature");
 
-            await expect(
-                handler.throwIfCannotBeApplied(multiSignatureTransaction, senderWallet, walletRepository),
-            ).rejects.toThrow(InvalidMultiSignatureError);
+            await expect(handler.throwIfCannotBeApplied(multiSignatureTransaction, senderWallet)).rejects.toThrow(
+                InvalidMultiSignatureError,
+            );
         });
 
         it("should throw with aip11 set to false and transaction is legacy", async () => {
@@ -205,9 +199,9 @@ describe("MultiSignatureRegistrationTransaction", () => {
 
             handler.verifySignatures = jest.fn().mockReturnValue(true);
 
-            await expect(
-                handler.throwIfCannotBeApplied(multiSignatureTransaction, senderWallet, walletRepository),
-            ).rejects.toThrow(UnexpectedMultiSignatureError);
+            await expect(handler.throwIfCannotBeApplied(multiSignatureTransaction, senderWallet)).rejects.toThrow(
+                UnexpectedMultiSignatureError,
+            );
         });
 
         // TODO: check value 02 thwors DuplicateParticipantInMultiSignatureError, 03 throws nodeError
@@ -216,9 +210,7 @@ describe("MultiSignatureRegistrationTransaction", () => {
                 "00",
                 "02",
             );
-            await expect(
-                handler.throwIfCannotBeApplied(multiSignatureTransaction, senderWallet, walletRepository),
-            ).rejects.toThrow(
+            await expect(handler.throwIfCannotBeApplied(multiSignatureTransaction, senderWallet)).rejects.toThrow(
                 Error,
                 // InvalidMultiSignatureError,
             );
@@ -231,9 +223,9 @@ describe("MultiSignatureRegistrationTransaction", () => {
             Transactions.Verifier.verifySecondSignature = jest.fn(() => true);
 
             multiSignatureTransaction.data.asset!.multiSignature!.publicKeys.splice(0, 2);
-            await expect(
-                handler.throwIfCannotBeApplied(multiSignatureTransaction, senderWallet, walletRepository),
-            ).rejects.toThrow(MultiSignatureMinimumKeysError);
+            await expect(handler.throwIfCannotBeApplied(multiSignatureTransaction, senderWallet)).rejects.toThrow(
+                MultiSignatureMinimumKeysError,
+            );
         });
 
         it("should throw if the number of keys does not equal the signature count", async () => {
@@ -243,9 +235,9 @@ describe("MultiSignatureRegistrationTransaction", () => {
             Transactions.Verifier.verifySecondSignature = jest.fn(() => true);
 
             multiSignatureTransaction.data.signatures!.splice(0, 2);
-            await expect(
-                handler.throwIfCannotBeApplied(multiSignatureTransaction, senderWallet, walletRepository),
-            ).rejects.toThrow(MultiSignatureKeyCountMismatchError);
+            await expect(handler.throwIfCannotBeApplied(multiSignatureTransaction, senderWallet)).rejects.toThrow(
+                MultiSignatureKeyCountMismatchError,
+            );
         });
 
         it("should throw if the same participant provides multiple signatures", async () => {
@@ -277,13 +269,11 @@ describe("MultiSignatureRegistrationTransaction", () => {
                 Identities.PublicKey.fromMultiSignatureAsset(multiSignatureTransaction.data.asset!.multiSignature!),
             );
 
-            await expect(
-                handler.throwIfCannotBeApplied(multiSignatureTransaction, participantWallet, walletRepository),
-            ).toResolve();
+            await expect(handler.throwIfCannotBeApplied(multiSignatureTransaction, participantWallet)).toResolve();
 
             expect(multiSigWallet.hasMultiSignature()).toBeFalse();
 
-            await handler.apply(multiSignatureTransaction, walletRepository);
+            await handler.apply(multiSignatureTransaction);
 
             expect(multiSigWallet.hasMultiSignature()).toBeTrue();
 
@@ -324,9 +314,9 @@ describe("MultiSignatureRegistrationTransaction", () => {
             senderWallet.forgetAttribute("multiSignature");
             senderWallet.balance = Utils.BigNumber.ZERO;
 
-            await expect(
-                handler.throwIfCannotBeApplied(multiSignatureTransaction, senderWallet, walletRepository),
-            ).rejects.toThrow(InsufficientBalanceError);
+            await expect(handler.throwIfCannotBeApplied(multiSignatureTransaction, senderWallet)).rejects.toThrow(
+                InsufficientBalanceError,
+            );
         });
     });
 
@@ -354,7 +344,7 @@ describe("MultiSignatureRegistrationTransaction", () => {
             expect(senderWallet.balance).toEqual(Utils.BigNumber.make(100390000000));
             expect(recipientWallet.balance).toEqual(Utils.BigNumber.ZERO);
 
-            await handler.apply(multiSignatureTransaction, walletRepository);
+            await handler.apply(multiSignatureTransaction);
 
             expect(senderWallet.balance).toEqual(Utils.BigNumber.make(98390000000));
             expect(recipientWallet.balance).toEqual(Utils.BigNumber.ZERO);
@@ -370,7 +360,7 @@ describe("MultiSignatureRegistrationTransaction", () => {
         it("should be ok", async () => {
             senderWallet.nonce = Utils.BigNumber.make(1);
 
-            await handler.revert(multiSignatureTransaction, walletRepository);
+            await handler.revert(multiSignatureTransaction);
 
             expect(senderWallet.nonce.isZero()).toBeTrue();
             expect(senderWallet.hasMultiSignature()).toBeFalse();

--- a/__tests__/unit/core-transactions/handlers/two/second-signature-registration.test.ts
+++ b/__tests__/unit/core-transactions/handlers/two/second-signature-registration.test.ts
@@ -103,9 +103,7 @@ describe("SecondSignatureRegistrationTransaction", () => {
 
     describe("throwIfCannotBeApplied", () => {
         it("should not throw", async () => {
-            await expect(
-                handler.throwIfCannotBeApplied(secondSignatureTransaction, senderWallet, walletRepository),
-            ).toResolve();
+            await expect(handler.throwIfCannotBeApplied(secondSignatureTransaction, senderWallet)).toResolve();
         });
 
         it("should throw if wallet already has a second signature", async () => {
@@ -114,9 +112,9 @@ describe("SecondSignatureRegistrationTransaction", () => {
                 "02def27da9336e7fbf63131b8d7e5c9f45b296235db035f1f4242c507398f0f21d",
             );
 
-            await expect(
-                handler.throwIfCannotBeApplied(secondSignatureTransaction, senderWallet, walletRepository),
-            ).rejects.toThrow(SecondSignatureAlreadyRegisteredError);
+            await expect(handler.throwIfCannotBeApplied(secondSignatureTransaction, senderWallet)).rejects.toThrow(
+                SecondSignatureAlreadyRegisteredError,
+            );
         });
 
         it("should throw if wallet already has a multi signature", async () => {
@@ -131,17 +129,17 @@ describe("SecondSignatureRegistrationTransaction", () => {
 
             senderWallet.setAttribute("multiSignature", multiSignatureAsset);
 
-            await expect(
-                handler.throwIfCannotBeApplied(secondSignatureTransaction, senderWallet, walletRepository),
-            ).rejects.toThrow(NotSupportedForMultiSignatureWalletError);
+            await expect(handler.throwIfCannotBeApplied(secondSignatureTransaction, senderWallet)).rejects.toThrow(
+                NotSupportedForMultiSignatureWalletError,
+            );
         });
 
         it("should throw if wallet has insufficient funds", async () => {
             senderWallet.balance = Utils.BigNumber.ZERO;
 
-            await expect(
-                handler.throwIfCannotBeApplied(secondSignatureTransaction, senderWallet, walletRepository),
-            ).rejects.toThrow(InsufficientBalanceError);
+            await expect(handler.throwIfCannotBeApplied(secondSignatureTransaction, senderWallet)).rejects.toThrow(
+                InsufficientBalanceError,
+            );
         });
     });
 
@@ -161,46 +159,40 @@ describe("SecondSignatureRegistrationTransaction", () => {
 
     describe("apply", () => {
         it("should not throw with second signature registration", async () => {
-            await expect(
-                handler.throwIfCannotBeApplied(secondSignatureTransaction, senderWallet, walletRepository),
-            ).toResolve();
+            await expect(handler.throwIfCannotBeApplied(secondSignatureTransaction, senderWallet)).toResolve();
 
-            await handler.apply(secondSignatureTransaction, walletRepository);
+            await handler.apply(secondSignatureTransaction);
             expect(senderWallet.getAttribute("secondPublicKey")).toBe(
                 "02def27da9336e7fbf63131b8d7e5c9f45b296235db035f1f4242c507398f0f21d",
             );
         });
 
         it("should be invalid to apply a second signature registration twice", async () => {
-            await expect(
-                handler.throwIfCannotBeApplied(secondSignatureTransaction, senderWallet, walletRepository),
-            ).toResolve();
+            await expect(handler.throwIfCannotBeApplied(secondSignatureTransaction, senderWallet)).toResolve();
 
-            await handler.apply(secondSignatureTransaction, walletRepository);
+            await handler.apply(secondSignatureTransaction);
             expect(senderWallet.getAttribute("secondPublicKey")).toBe(
                 "02def27da9336e7fbf63131b8d7e5c9f45b296235db035f1f4242c507398f0f21d",
             );
 
-            await expect(
-                handler.throwIfCannotBeApplied(secondSignatureTransaction, senderWallet, walletRepository),
-            ).rejects.toThrow(SecondSignatureAlreadyRegisteredError);
+            await expect(handler.throwIfCannotBeApplied(secondSignatureTransaction, senderWallet)).rejects.toThrow(
+                SecondSignatureAlreadyRegisteredError,
+            );
         });
     });
 
     describe("revert", () => {
         it("should be ok", async () => {
             expect(senderWallet.hasAttribute("secondPublicKey")).toBe(false);
-            await expect(
-                handler.throwIfCannotBeApplied(secondSignatureTransaction, senderWallet, walletRepository),
-            ).toResolve();
+            await expect(handler.throwIfCannotBeApplied(secondSignatureTransaction, senderWallet)).toResolve();
 
-            await handler.apply(secondSignatureTransaction, walletRepository);
+            await handler.apply(secondSignatureTransaction);
             expect(senderWallet.hasAttribute("secondPublicKey")).toBe(true);
             expect(senderWallet.getAttribute("secondPublicKey")).toBe(
                 "02def27da9336e7fbf63131b8d7e5c9f45b296235db035f1f4242c507398f0f21d",
             );
 
-            await handler.revert(secondSignatureTransaction, walletRepository);
+            await handler.revert(secondSignatureTransaction);
             expect(senderWallet.hasAttribute("secondPublicKey")).toBe(false);
         });
     });

--- a/__tests__/unit/core-transactions/handlers/two/transfer.test.ts
+++ b/__tests__/unit/core-transactions/handlers/two/transfer.test.ts
@@ -132,43 +132,33 @@ describe("TransferTransaction", () => {
 
     describe("throwIfCannotBeApplied", () => {
         it("should not throw", async () => {
-            await expect(
-                handler.throwIfCannotBeApplied(transferTransaction, senderWallet, walletRepository),
-            ).toResolve();
+            await expect(handler.throwIfCannotBeApplied(transferTransaction, senderWallet)).toResolve();
         });
 
         it("should not throw - second sign", async () => {
             await expect(
-                handler.throwIfCannotBeApplied(
-                    secondSignatureTransferTransaction,
-                    secondSignatureWallet,
-                    walletRepository,
-                ),
+                handler.throwIfCannotBeApplied(secondSignatureTransferTransaction, secondSignatureWallet),
             ).toResolve();
         });
 
         it("should not throw - multi sign", async () => {
             await expect(
-                handler.throwIfCannotBeApplied(
-                    multiSignatureTransferTransaction,
-                    multiSignatureWallet,
-                    walletRepository,
-                ),
+                handler.throwIfCannotBeApplied(multiSignatureTransferTransaction, multiSignatureWallet),
             ).toResolve();
         });
 
         it("should throw", async () => {
             transferTransaction.data.senderPublicKey = "a".repeat(66);
-            await expect(
-                handler.throwIfCannotBeApplied(transferTransaction, senderWallet, walletRepository),
-            ).rejects.toThrow(SenderWalletMismatchError);
+            await expect(handler.throwIfCannotBeApplied(transferTransaction, senderWallet)).rejects.toThrow(
+                SenderWalletMismatchError,
+            );
         });
 
         it("should throw if wallet has insufficient funds for vote", async () => {
             senderWallet.balance = Utils.BigNumber.ZERO;
-            await expect(
-                handler.throwIfCannotBeApplied(transferTransaction, senderWallet, walletRepository),
-            ).rejects.toThrow(InsufficientBalanceError);
+            await expect(handler.throwIfCannotBeApplied(transferTransaction, senderWallet)).rejects.toThrow(
+                InsufficientBalanceError,
+            );
         });
 
         it("should throw if sender is cold wallet", async () => {
@@ -189,9 +179,9 @@ describe("TransferTransaction", () => {
                 .sign(passphrases[3])
                 .build();
 
-            await expect(
-                handler.throwIfCannotBeApplied(transferTransaction, coldWallet, walletRepository),
-            ).rejects.toThrow(ColdWalletError);
+            await expect(handler.throwIfCannotBeApplied(transferTransaction, coldWallet)).rejects.toThrow(
+                ColdWalletError,
+            );
         });
 
         it("should not throw if recipient is cold wallet", async () => {
@@ -212,9 +202,7 @@ describe("TransferTransaction", () => {
                 .sign(passphrases[0])
                 .build();
 
-            await expect(
-                handler.throwIfCannotBeApplied(transferTransaction, senderWallet, walletRepository),
-            ).toResolve();
+            await expect(handler.throwIfCannotBeApplied(transferTransaction, senderWallet)).toResolve();
         });
     });
 
@@ -237,7 +225,7 @@ describe("TransferTransaction", () => {
             const senderBalance = senderWallet.balance;
             const recipientBalance = recipientWallet.balance;
 
-            await handler.apply(transferTransaction, walletRepository);
+            await handler.apply(transferTransaction);
 
             expect(senderWallet.balance).toEqual(
                 Utils.BigNumber.make(senderBalance)
@@ -256,7 +244,7 @@ describe("TransferTransaction", () => {
             const senderBalance = senderWallet.balance;
             const recipientBalance = recipientWallet.balance;
 
-            await handler.apply(transferTransaction, walletRepository);
+            await handler.apply(transferTransaction);
 
             expect(senderWallet.balance).toEqual(
                 Utils.BigNumber.make(senderBalance)
@@ -268,7 +256,7 @@ describe("TransferTransaction", () => {
                 Utils.BigNumber.make(recipientBalance).plus(transferTransaction.data.amount),
             );
 
-            await handler.revert(transferTransaction, walletRepository);
+            await handler.revert(transferTransaction);
 
             expect(senderWallet.balance).toEqual(Utils.BigNumber.make(senderBalance));
 

--- a/packages/core-magistrate-transactions/src/handlers/bridgechain-resignation.ts
+++ b/packages/core-magistrate-transactions/src/handlers/bridgechain-resignation.ts
@@ -56,7 +56,6 @@ export class BridgechainResignationTransactionHandler extends MagistrateTransact
     public async throwIfCannotBeApplied(
         transaction: Interfaces.ITransaction,
         wallet: Contracts.State.Wallet,
-        customWalletRepository?: Contracts.State.WalletRepository,
     ): Promise<void> {
         if (!wallet.hasAttribute("business")) {
             throw new WalletIsNotBusinessError();
@@ -92,7 +91,7 @@ export class BridgechainResignationTransactionHandler extends MagistrateTransact
             throw new BridgechainIsResignedError();
         }
 
-        return super.throwIfCannotBeApplied(transaction, wallet, customWalletRepository);
+        return super.throwIfCannotBeApplied(transaction, wallet);
     }
 
     public emitEvents(transaction: Interfaces.ITransaction, emitter: Contracts.Kernel.EventDispatcher): void {
@@ -118,17 +117,12 @@ export class BridgechainResignationTransactionHandler extends MagistrateTransact
         }
     }
 
-    public async applyToSender(
-        transaction: Interfaces.ITransaction,
-        customWalletRepository?: Contracts.State.WalletRepository,
-    ): Promise<void> {
-        await super.applyToSender(transaction, customWalletRepository);
-
-        const walletRepository: Contracts.State.WalletRepository = customWalletRepository ?? this.walletRepository;
+    public async applyToSender(transaction: Interfaces.ITransaction): Promise<void> {
+        await super.applyToSender(transaction);
 
         Utils.assert.defined<string>(transaction.data.senderPublicKey);
 
-        const businessAttributes: IBusinessWalletAttributes = walletRepository
+        const businessAttributes: IBusinessWalletAttributes = this.walletRepository
             .findByPublicKey(transaction.data.senderPublicKey)
             .getAttribute<IBusinessWalletAttributes>("business");
 
@@ -145,17 +139,12 @@ export class BridgechainResignationTransactionHandler extends MagistrateTransact
         businessAttributes.bridgechains[bridgechainResignation.bridgechainId].resigned = true;
     }
 
-    public async revertForSender(
-        transaction: Interfaces.ITransaction,
-        customWalletRepository?: Contracts.State.WalletRepository,
-    ): Promise<void> {
-        await super.revertForSender(transaction, customWalletRepository);
-
-        const walletRepository: Contracts.State.WalletRepository = customWalletRepository ?? this.walletRepository;
+    public async revertForSender(transaction: Interfaces.ITransaction): Promise<void> {
+        await super.revertForSender(transaction);
 
         Utils.assert.defined<string>(transaction.data.senderPublicKey);
 
-        const businessAttributes: IBusinessWalletAttributes = walletRepository
+        const businessAttributes: IBusinessWalletAttributes = this.walletRepository
             .findByPublicKey(transaction.data.senderPublicKey)
             .getAttribute<IBusinessWalletAttributes>("business");
 
@@ -173,13 +162,11 @@ export class BridgechainResignationTransactionHandler extends MagistrateTransact
 
     public async applyToRecipient(
         transaction: Interfaces.ITransaction,
-        customWalletRepository?: Contracts.State.WalletRepository,
         // tslint:disable-next-line: no-empty
     ): Promise<void> {}
 
     public async revertForRecipient(
         transaction: Interfaces.ITransaction,
-        customWalletRepository?: Contracts.State.WalletRepository,
         // tslint:disable-next-line:no-empty
     ): Promise<void> {}
 }

--- a/packages/core-magistrate-transactions/src/handlers/entity.ts
+++ b/packages/core-magistrate-transactions/src/handlers/entity.ts
@@ -68,7 +68,6 @@ export class EntityTransactionHandler extends Handlers.TransactionHandler {
     public async throwIfCannotBeApplied(
         transaction: CryptoInterfaces.ITransaction,
         wallet: Contracts.State.Wallet,
-        customWalletRepository?: Contracts.State.WalletRepository,
     ): Promise<void> {
         if (Utils.isException(transaction.data.id)) {
             return;
@@ -79,56 +78,43 @@ export class EntityTransactionHandler extends Handlers.TransactionHandler {
             throw new StaticFeeMismatchError(staticFee.toFixed());
         }
 
-        super.throwIfCannotBeApplied(transaction, wallet, customWalletRepository);
-        const walletRepository: Contracts.State.WalletRepository = customWalletRepository ?? this.walletRepository;
+        super.throwIfCannotBeApplied(transaction, wallet);
 
         const handler = this.getHandler(transaction);
         if (!handler) {
             throw new EntityWrongSubTypeError(); // wrong sub type / type association
         }
 
-        return this.getHandler(transaction)!.throwIfCannotBeApplied(transaction, wallet, walletRepository);
+        return this.getHandler(transaction)!.throwIfCannotBeApplied(transaction, wallet, this.walletRepository);
     }
 
     public emitEvents(transaction: Interfaces.ITransaction, emitter: Contracts.Kernel.EventDispatcher): void {
         return this.getHandler(transaction)!.emitEvents(transaction, emitter);
     }
 
-    public async applyToSender(
-        transaction: Interfaces.ITransaction,
-        customWalletRepository?: Contracts.State.WalletRepository,
-    ): Promise<void> {
-        await super.applyToSender(transaction, customWalletRepository);
+    public async applyToSender(transaction: Interfaces.ITransaction): Promise<void> {
+        await super.applyToSender(transaction);
 
-        const walletRepository: Contracts.State.WalletRepository = customWalletRepository ?? this.walletRepository;
-
-        return this.getHandler(transaction)!.applyToSender(transaction, walletRepository);
+        return this.getHandler(transaction)!.applyToSender(transaction, this.walletRepository);
     }
 
-    public async revertForSender(
-        transaction: Interfaces.ITransaction,
-        customWalletRepository?: Contracts.State.WalletRepository,
-    ): Promise<void> {
-        await super.revertForSender(transaction, customWalletRepository);
-
-        const walletRepository: Contracts.State.WalletRepository = customWalletRepository ?? this.walletRepository;
+    public async revertForSender(transaction: Interfaces.ITransaction): Promise<void> {
+        await super.revertForSender(transaction);
 
         return this.getHandler(transaction)!.revertForSender(
             transaction,
-            walletRepository,
+            this.walletRepository,
             this.transactionHistoryService,
         );
     }
 
     public async applyToRecipient(
         transaction: Interfaces.ITransaction,
-        customWalletRepository?: Contracts.State.WalletRepository,
         // tslint:disable-next-line: no-empty
     ): Promise<void> {}
 
     public async revertForRecipient(
         transaction: Interfaces.ITransaction,
-        customWalletRepository?: Contracts.State.WalletRepository,
         // tslint:disable-next-line:no-empty
     ): Promise<void> {}
 

--- a/packages/core-magistrate-transactions/src/handlers/magistrate-handler.ts
+++ b/packages/core-magistrate-transactions/src/handlers/magistrate-handler.ts
@@ -16,7 +16,6 @@ export abstract class MagistrateTransactionHandler extends Handlers.TransactionH
     public async throwIfCannotBeApplied(
         transaction: CryptoInterfaces.ITransaction,
         wallet: Contracts.State.Wallet,
-        customWalletRepository?: Contracts.State.WalletRepository,
     ): Promise<void> {
         if (Utils.isException(transaction.data.id)) {
             return;
@@ -27,6 +26,6 @@ export abstract class MagistrateTransactionHandler extends Handlers.TransactionH
             throw new StaticFeeMismatchError(staticFee.toFixed());
         }
 
-        return super.throwIfCannotBeApplied(transaction, wallet, customWalletRepository);
+        return super.throwIfCannotBeApplied(transaction, wallet);
     }
 }

--- a/packages/core-transactions/src/handlers/one/multi-signature-registration.ts
+++ b/packages/core-transactions/src/handlers/one/multi-signature-registration.ts
@@ -47,7 +47,6 @@ export class MultiSignatureRegistrationTransactionHandler extends TransactionHan
     public async throwIfCannotBeApplied(
         transaction: Interfaces.ITransaction,
         wallet: Contracts.State.Wallet,
-        customWalletRepository?: Contracts.State.WalletRepository,
     ): Promise<void> {
         const { data }: Interfaces.ITransaction = transaction;
 
@@ -66,13 +65,7 @@ export class MultiSignatureRegistrationTransactionHandler extends TransactionHan
         );
     }
 
-    public async applyToRecipient(
-        transaction: Interfaces.ITransaction,
-        customWalletRepository?: Contracts.State.WalletRepository | undefined,
-    ): Promise<void> {}
+    public async applyToRecipient(transaction: Interfaces.ITransaction): Promise<void> {}
 
-    public async revertForRecipient(
-        transaction: Interfaces.ITransaction,
-        customWalletRepository?: Contracts.State.WalletRepository | undefined,
-    ): Promise<void> {}
+    public async revertForRecipient(transaction: Interfaces.ITransaction): Promise<void> {}
 }

--- a/packages/core-transactions/src/handlers/one/transfer.ts
+++ b/packages/core-transactions/src/handlers/one/transfer.ts
@@ -29,9 +29,8 @@ export class TransferTransactionHandler extends TransactionHandler {
     public async throwIfCannotBeApplied(
         transaction: Interfaces.ITransaction,
         sender: Contracts.State.Wallet,
-        customWalletRepository?: Contracts.State.WalletRepository,
     ): Promise<void> {
-        return super.throwIfCannotBeApplied(transaction, sender, customWalletRepository);
+        return super.throwIfCannotBeApplied(transaction, sender);
     }
 
     public hasVendorField(): boolean {
@@ -52,28 +51,18 @@ export class TransferTransactionHandler extends TransactionHandler {
         }
     }
 
-    public async applyToRecipient(
-        transaction: Interfaces.ITransaction,
-        customWalletRepository?: Contracts.State.WalletRepository,
-    ): Promise<void> {
-        const walletRepository: Contracts.State.WalletRepository = customWalletRepository ?? this.walletRepository;
-
+    public async applyToRecipient(transaction: Interfaces.ITransaction): Promise<void> {
         Utils.assert.defined<string>(transaction.data.recipientId);
 
-        const recipient: Contracts.State.Wallet = walletRepository.findByAddress(transaction.data.recipientId);
+        const recipient: Contracts.State.Wallet = this.walletRepository.findByAddress(transaction.data.recipientId);
 
         recipient.balance = recipient.balance.plus(transaction.data.amount);
     }
 
-    public async revertForRecipient(
-        transaction: Interfaces.ITransaction,
-        customWalletRepository?: Contracts.State.WalletRepository,
-    ): Promise<void> {
-        const walletRepository: Contracts.State.WalletRepository = customWalletRepository ?? this.walletRepository;
-
+    public async revertForRecipient(transaction: Interfaces.ITransaction): Promise<void> {
         Utils.assert.defined<string>(transaction.data.recipientId);
 
-        const recipient: Contracts.State.Wallet = walletRepository.findByAddress(transaction.data.recipientId);
+        const recipient: Contracts.State.Wallet = this.walletRepository.findByAddress(transaction.data.recipientId);
 
         recipient.balance = recipient.balance.minus(transaction.data.amount);
     }

--- a/packages/core-transactions/src/handlers/one/vote.ts
+++ b/packages/core-transactions/src/handlers/one/vote.ts
@@ -39,17 +39,15 @@ export class VoteTransactionHandler extends TransactionHandler {
     public async throwIfCannotBeApplied(
         transaction: Interfaces.ITransaction,
         wallet: Contracts.State.Wallet,
-        customWalletRepository?: Contracts.State.WalletRepository,
     ): Promise<void> {
         Utils.assert.defined<string[]>(transaction.data.asset?.votes);
 
         const vote: string = transaction.data.asset.votes[0];
-        const walletRepository: Contracts.State.WalletRepository = customWalletRepository ?? this.walletRepository;
 
         let walletVote: string | undefined;
 
         const delegatePublicKey: string = vote.slice(1);
-        const delegateWallet: Contracts.State.Wallet = walletRepository.findByPublicKey(delegatePublicKey);
+        const delegateWallet: Contracts.State.Wallet = this.walletRepository.findByPublicKey(delegatePublicKey);
 
         if (wallet.hasAttribute("vote")) {
             walletVote = wallet.getAttribute("vote");
@@ -75,7 +73,7 @@ export class VoteTransactionHandler extends TransactionHandler {
             throw new VotedForNonDelegateError(vote);
         }
 
-        return super.throwIfCannotBeApplied(transaction, wallet, customWalletRepository);
+        return super.throwIfCannotBeApplied(transaction, wallet);
     }
 
     public emitEvents(transaction: Interfaces.ITransaction, emitter: Contracts.Kernel.EventDispatcher): void {
@@ -106,17 +104,12 @@ export class VoteTransactionHandler extends TransactionHandler {
         }
     }
 
-    public async applyToSender(
-        transaction: Interfaces.ITransaction,
-        customWalletRepository?: Contracts.State.WalletRepository,
-    ): Promise<void> {
-        await super.applyToSender(transaction, customWalletRepository);
-
-        const walletRepository: Contracts.State.WalletRepository = customWalletRepository ?? this.walletRepository;
+    public async applyToSender(transaction: Interfaces.ITransaction): Promise<void> {
+        await super.applyToSender(transaction);
 
         Utils.assert.defined<string>(transaction.data.senderPublicKey);
 
-        const sender: Contracts.State.Wallet = walletRepository.findByPublicKey(transaction.data.senderPublicKey);
+        const sender: Contracts.State.Wallet = this.walletRepository.findByPublicKey(transaction.data.senderPublicKey);
 
         Utils.assert.defined<string[]>(transaction.data.asset?.votes);
 
@@ -129,17 +122,12 @@ export class VoteTransactionHandler extends TransactionHandler {
         }
     }
 
-    public async revertForSender(
-        transaction: Interfaces.ITransaction,
-        customWalletRepository?: Contracts.State.WalletRepository,
-    ): Promise<void> {
-        await super.revertForSender(transaction, customWalletRepository);
-
-        const walletRepository: Contracts.State.WalletRepository = customWalletRepository ?? this.walletRepository;
+    public async revertForSender(transaction: Interfaces.ITransaction): Promise<void> {
+        await super.revertForSender(transaction);
 
         Utils.assert.defined<string>(transaction.data.senderPublicKey);
 
-        const sender: Contracts.State.Wallet = walletRepository.findByPublicKey(transaction.data.senderPublicKey);
+        const sender: Contracts.State.Wallet = this.walletRepository.findByPublicKey(transaction.data.senderPublicKey);
 
         Utils.assert.defined<Interfaces.ITransactionAsset>(transaction.data.asset?.votes);
 
@@ -152,13 +140,7 @@ export class VoteTransactionHandler extends TransactionHandler {
         }
     }
 
-    public async applyToRecipient(
-        transaction: Interfaces.ITransaction,
-        walletRepository: Contracts.State.WalletRepository,
-    ): Promise<void> {}
+    public async applyToRecipient(transaction: Interfaces.ITransaction): Promise<void> {}
 
-    public async revertForRecipient(
-        transaction: Interfaces.ITransaction,
-        walletRepository: Contracts.State.WalletRepository,
-    ): Promise<void> {}
+    public async revertForRecipient(transaction: Interfaces.ITransaction): Promise<void> {}
 }

--- a/packages/core-transactions/src/handlers/two/multi-payment.ts
+++ b/packages/core-transactions/src/handlers/two/multi-payment.ts
@@ -40,7 +40,6 @@ export class MultiPaymentTransactionHandler extends TransactionHandler {
     public async throwIfCannotBeApplied(
         transaction: Interfaces.ITransaction,
         wallet: Contracts.State.Wallet,
-        customWalletRepository?: Contracts.State.WalletRepository,
     ): Promise<void> {
         AppUtils.assert.defined<Interfaces.IMultiPaymentItem[]>(transaction.data.asset?.payments);
 
@@ -51,16 +50,11 @@ export class MultiPaymentTransactionHandler extends TransactionHandler {
             throw new InsufficientBalanceError();
         }
 
-        return super.throwIfCannotBeApplied(transaction, wallet, customWalletRepository);
+        return super.throwIfCannotBeApplied(transaction, wallet);
     }
 
-    public async applyToSender(
-        transaction: Interfaces.ITransaction,
-        customWalletRepository?: Contracts.State.WalletRepository,
-    ): Promise<void> {
-        await super.applyToSender(transaction, customWalletRepository);
-
-        const walletRepository: Contracts.State.WalletRepository = customWalletRepository ?? this.walletRepository;
+    public async applyToSender(transaction: Interfaces.ITransaction): Promise<void> {
+        await super.applyToSender(transaction);
 
         AppUtils.assert.defined<Interfaces.IMultiPaymentItem[]>(transaction.data.asset?.payments);
 
@@ -71,18 +65,13 @@ export class MultiPaymentTransactionHandler extends TransactionHandler {
 
         AppUtils.assert.defined<string>(transaction.data.senderPublicKey);
 
-        const sender: Contracts.State.Wallet = walletRepository.findByPublicKey(transaction.data.senderPublicKey);
+        const sender: Contracts.State.Wallet = this.walletRepository.findByPublicKey(transaction.data.senderPublicKey);
 
         sender.balance = sender.balance.minus(totalPaymentsAmount);
     }
 
-    public async revertForSender(
-        transaction: Interfaces.ITransaction,
-        customWalletRepository?: Contracts.State.WalletRepository,
-    ): Promise<void> {
-        await super.revertForSender(transaction, customWalletRepository);
-
-        const walletRepository: Contracts.State.WalletRepository = customWalletRepository ?? this.walletRepository;
+    public async revertForSender(transaction: Interfaces.ITransaction): Promise<void> {
+        await super.revertForSender(transaction);
 
         AppUtils.assert.defined<Interfaces.IMultiPaymentItem[]>(transaction.data.asset?.payments);
 
@@ -93,36 +82,26 @@ export class MultiPaymentTransactionHandler extends TransactionHandler {
 
         AppUtils.assert.defined<string>(transaction.data.senderPublicKey);
 
-        const sender: Contracts.State.Wallet = walletRepository.findByPublicKey(transaction.data.senderPublicKey);
+        const sender: Contracts.State.Wallet = this.walletRepository.findByPublicKey(transaction.data.senderPublicKey);
 
         sender.balance = sender.balance.plus(totalPaymentsAmount);
     }
 
-    public async applyToRecipient(
-        transaction: Interfaces.ITransaction,
-        customWalletRepository?: Contracts.State.WalletRepository,
-    ): Promise<void> {
-        const walletRepository: Contracts.State.WalletRepository = customWalletRepository ?? this.walletRepository;
-
+    public async applyToRecipient(transaction: Interfaces.ITransaction): Promise<void> {
         AppUtils.assert.defined<Interfaces.IMultiPaymentItem[]>(transaction.data.asset?.payments);
 
         for (const payment of transaction.data.asset.payments) {
-            const recipient: Contracts.State.Wallet = walletRepository.findByAddress(payment.recipientId);
+            const recipient: Contracts.State.Wallet = this.walletRepository.findByAddress(payment.recipientId);
 
             recipient.balance = recipient.balance.plus(payment.amount);
         }
     }
 
-    public async revertForRecipient(
-        transaction: Interfaces.ITransaction,
-        customWalletRepository?: Contracts.State.WalletRepository,
-    ): Promise<void> {
-        const walletRepository: Contracts.State.WalletRepository = customWalletRepository ?? this.walletRepository;
-
+    public async revertForRecipient(transaction: Interfaces.ITransaction): Promise<void> {
         AppUtils.assert.defined<Interfaces.IMultiPaymentItem[]>(transaction.data.asset?.payments);
 
         for (const payment of transaction.data.asset.payments) {
-            const recipient: Contracts.State.Wallet = walletRepository.findByAddress(payment.recipientId);
+            const recipient: Contracts.State.Wallet = this.walletRepository.findByAddress(payment.recipientId);
 
             recipient.balance = recipient.balance.minus(payment.amount);
         }


### PR DESCRIPTION
## Summary

Custom wallet repository was pool isolation technique that was replaced back in March. Since then `customWalletRepository` wasn't passed into handlers, but handlers weren't updated to remove unnecessary parameter. All mentions of `customWalletRepository` are now removed making handlers slightly more straightforward.

## Checklist

- [ ] Documentation _is there anything that needs to be updated?_
- [x] Tests
- [x] Ready to be merged
