### PR TITLE
refactor(core-api): use shorter default timeouts

### DIFF
--- a/__tests__/unit/core-api/plugins/cache.test.ts
+++ b/__tests__/unit/core-api/plugins/cache.test.ts
@@ -25,6 +25,7 @@ describe("Cache", () => {
                 pagination: {
                     limit: 100,
                 },
+                socketTimeout: 5000,
                 cache: {
                     enabled: true,
                     stdTTL: 0, // unlimited

--- a/__tests__/unit/core-api/plugins/hapi-ajv.test.ts
+++ b/__tests__/unit/core-api/plugins/hapi-ajv.test.ts
@@ -24,6 +24,7 @@ describe("Hapi Ajv", () => {
                 pagination: {
                     limit: 100,
                 },
+                socketTimeout: 5000,
                 cache: {
                     enabled: true,
                     stdTTL: 0, // unlimited

--- a/__tests__/unit/core-api/plugins/pagination.test.ts
+++ b/__tests__/unit/core-api/plugins/pagination.test.ts
@@ -23,6 +23,7 @@ describe("Pagination", () => {
                 pagination: {
                     limit: 100,
                 },
+                socketTimeout: 5000,
             },
         };
 

--- a/__tests__/unit/core-api/plugins/rate-limit.test.ts
+++ b/__tests__/unit/core-api/plugins/rate-limit.test.ts
@@ -24,6 +24,7 @@ describe("Rate limit", () => {
                 pagination: {
                     limit: 100,
                 },
+                socketTimeout: 5000,
                 rateLimit: {
                     enabled: true,
                     points: 1,

--- a/__tests__/unit/core-api/plugins/whitelist.test.ts
+++ b/__tests__/unit/core-api/plugins/whitelist.test.ts
@@ -22,6 +22,7 @@ describe("Whitelist", () => {
                 pagination: {
                     limit: 100,
                 },
+                socketTimeout: 5000,
                 whitelist: ["127.0.0.1"],
             },
         };

--- a/__tests__/unit/core-api/server.test.ts
+++ b/__tests__/unit/core-api/server.test.ts
@@ -26,6 +26,7 @@ describe("Server", () => {
                 pagination: {
                     limit: 100,
                 },
+                socketTimeout: 5000,
                 whitelist: ["*"],
             },
         };

--- a/packages/core-api/src/defaults.ts
+++ b/packages/core-api/src/defaults.ts
@@ -36,6 +36,7 @@ export const defaults = {
         pagination: {
             limit: 100,
         },
+        socketTimeout: 5000,
         whitelist: ["*"],
     },
     options: {

--- a/packages/core-api/src/server.ts
+++ b/packages/core-api/src/server.ts
@@ -58,7 +58,9 @@ export class Server {
         this.server = new HapiServer(this.getServerOptions(optionsServer));
 
         const timeout: number = this.configuration.getRequired<number>("plugins.socketTimeout");
-        this.server.listener.timeout = this.server.listener.keepAliveTimeout = this.server.listener.headersTimeout = timeout;
+        this.server.listener.timeout = timeout;
+        this.server.listener.keepAliveTimeout = timeout;
+        this.server.listener.headersTimeout = timeout;
 
         this.server.app.app = this.app;
         this.server.app.schemas = createSchemas({

--- a/packages/core-api/src/server.ts
+++ b/packages/core-api/src/server.ts
@@ -56,6 +56,10 @@ export class Server {
     public async initialize(name: string, optionsServer: Types.JsonObject): Promise<void> {
         this.name = name;
         this.server = new HapiServer(this.getServerOptions(optionsServer));
+
+        const timeout: number = this.configuration.getRequired<number>("plugins.socketTimeout");
+        this.server.listener.timeout = this.server.listener.keepAliveTimeout = this.server.listener.headersTimeout = timeout;
+
         this.server.app.app = this.app;
         this.server.app.schemas = createSchemas({
             pagination: {


### PR DESCRIPTION
## Summary

This PR stops a user from opening and keeping open multiple long lived TCP connections to the public API server which is enabled by default. It prevents server resource starvation by implementing a shorter maximum timeout (default: 5 seconds) so connections will be closed if no request is received after that time.