### PR TITLE
fix(core-database): fix delete blocks

### DIFF
--- a/__tests__/functional/core-database/repositories/block-repository.test.ts
+++ b/__tests__/functional/core-database/repositories/block-repository.test.ts
@@ -226,6 +226,31 @@ describe("BlockRepository.deleteBlocks", () => {
         const promise = blockRepository.deleteBlocks([block2.data]);
         await expect(promise).rejects.toThrow("Removing blocks from the middle");
     });
+
+    it("should throw when deleting non-continuous chunk (order in reverse)", async () => {
+        const blockRepository = getCustomRepository(BlockRepository);
+        await blockRepository.saveBlocks([block1, block2, block3]);
+        const promise = blockRepository.deleteBlocks([block3.data, block2.data, block1.data]);
+        await expect(promise).rejects.toThrow("Blocks chunk to delete isn't continuous");
+    });
+
+    it("should throw when deleting non-continuous chunk (missing block)", async () => {
+        const blockRepository = getCustomRepository(BlockRepository);
+        await blockRepository.saveBlocks([block1, block2, block3]);
+        const promise = blockRepository.deleteBlocks([block3.data, block1.data]);
+        await expect(promise).rejects.toThrow("Blocks chunk to delete isn't continuous");
+    });
+
+    it("should throw when deleted count doesn't match expected", async () => {
+        const blockRepository = getCustomRepository(BlockRepository);
+        await blockRepository.saveBlocks([block1, block2, block3]);
+        const promise = blockRepository.deleteBlocks([
+            block1.data,
+            block2.data,
+            { ...block3.data, id: "non-existing" },
+        ]);
+        await expect(promise).rejects.toThrow("Failed to delete all blocks from database");
+    });
 });
 
 describe("BlockRepository.findManyByExpression", () => {

--- a/packages/core-blockchain/src/blockchain.ts
+++ b/packages/core-blockchain/src/blockchain.ts
@@ -330,7 +330,7 @@ export class Blockchain implements Contracts.Blockchain.Blockchain {
 
         await __removeBlocks(nblocks);
 
-        await this.blockRepository.deleteBlocks(removedBlocks);
+        await this.blockRepository.deleteBlocks(removedBlocks.reverse());
 
         if (this.transactionPool) {
             this.transactionPool.readdTransactions(removedTransactions.reverse());


### PR DESCRIPTION
## Summary

It appears that `BlockRepository.deleteBlocks` was called with array in reverse order (higher height first). This should have raised _Removing blocks from the middle_ error, but didn't. I added more checks, tests, and reversed block order (similarly to how transactions are re-added to pool).

This is an attempt to shield `BlockRepository.deleteBlocks` so it can't be called with incorrect arguments that will not throw some error.

## Checklist

- [x] Tests
- [ ] Ready to be merged
