### PR TITLE
fix(core-database): fix round order

### DIFF
--- a/__tests__/functional/core-database/repositories/round-repository.test.ts
+++ b/__tests__/functional/core-database/repositories/round-repository.test.ts
@@ -45,15 +45,21 @@ describe("RoundRepository.findById", () => {
         await roundRepository.save(([
             new DelegateWalletMock("delegate1 public key", 1, Utils.BigNumber.make("100")),
             new DelegateWalletMock("delegate2 public key", 1, Utils.BigNumber.make("200")),
+            new DelegateWalletMock("delegate3 public key", 1, Utils.BigNumber.make("200")),
         ] as unknown) as Contracts.State.Wallet[]);
 
         const round1Delegates = await roundRepository.getRound(1);
 
-        expect(round1Delegates.length).toBe(2);
+        expect(round1Delegates.length).toBe(3);
         expect(round1Delegates).toMatchObject([
             {
                 round: Utils.BigNumber.make("1"),
                 publicKey: "delegate2 public key",
+                balance: Utils.BigNumber.make("200"),
+            },
+            {
+                round: Utils.BigNumber.make("1"),
+                publicKey: "delegate3 public key",
                 balance: Utils.BigNumber.make("200"),
             },
             {

--- a/__tests__/functional/core-database/repositories/round-repository.test.ts
+++ b/__tests__/functional/core-database/repositories/round-repository.test.ts
@@ -47,19 +47,19 @@ describe("RoundRepository.findById", () => {
             new DelegateWalletMock("delegate2 public key", 1, Utils.BigNumber.make("200")),
         ] as unknown) as Contracts.State.Wallet[]);
 
-        const round1Delegates = await roundRepository.findById("1");
+        const round1Delegates = await roundRepository.getRound(1);
 
         expect(round1Delegates.length).toBe(2);
         expect(round1Delegates).toMatchObject([
             {
                 round: Utils.BigNumber.make("1"),
-                publicKey: "delegate1 public key",
-                balance: Utils.BigNumber.make("100"),
+                publicKey: "delegate2 public key",
+                balance: Utils.BigNumber.make("200"),
             },
             {
                 round: Utils.BigNumber.make("1"),
-                publicKey: "delegate2 public key",
-                balance: Utils.BigNumber.make("200"),
+                publicKey: "delegate1 public key",
+                balance: Utils.BigNumber.make("100"),
             },
         ]);
     });

--- a/__tests__/unit/core-database/database-service.test.ts
+++ b/__tests__/unit/core-database/database-service.test.ts
@@ -41,7 +41,7 @@ const transactionRepository = {
 };
 
 const roundRepository = {
-    find: jest.fn(),
+    getRound: jest.fn(),
     save: jest.fn(),
     delete: jest.fn(),
 };
@@ -146,7 +146,7 @@ beforeEach(() => {
     transactionRepository.findByBlockIds.mockReset();
     transactionRepository.getStatistics.mockReset();
 
-    roundRepository.find.mockReset();
+    roundRepository.getRound.mockReset();
     roundRepository.save.mockReset();
     roundRepository.delete.mockReset();
 
@@ -573,7 +573,7 @@ describe("DatabaseService.getActiveDelegates", () => {
         const delegatePublicKey = "03287bfebba4c7881a0509717e71b34b63f31e40021c321f89ae04f84be6d6ac37";
         const delegateVoteBalance = Utils.BigNumber.make("100");
         const roundDelegateModel = { publicKey: delegatePublicKey, balance: delegateVoteBalance };
-        roundRepository.find.mockResolvedValueOnce([roundDelegateModel]);
+        roundRepository.getRound.mockResolvedValueOnce([roundDelegateModel]);
 
         const newDelegateWallet = { setAttribute: jest.fn(), clone: jest.fn() };
         walletRepository.createWallet.mockReturnValueOnce(newDelegateWallet);

--- a/packages/core-database/src/database-service.ts
+++ b/packages/core-database/src/database-service.ts
@@ -209,7 +209,7 @@ export class DatabaseService {
 
         // When called during applyRound we already know the delegates, so we don't have to query the database.
         if (!delegates) {
-            delegates = (await this.roundRepository.find({ round })).map(({ publicKey, balance }) => {
+            delegates = (await this.roundRepository.getRound(round)).map(({ publicKey, balance }) => {
                 // ! find wallet by public key and clone it
                 const wallet = this.walletRepository.createWallet(Identities.Address.fromPublicKey(publicKey));
                 wallet.publicKey = publicKey;

--- a/packages/core-database/src/repositories/round-repository.ts
+++ b/packages/core-database/src/repositories/round-repository.ts
@@ -18,6 +18,7 @@ export class RoundRepository extends Repository<Round> {
             .select()
             .where("round = :round", { round })
             .orderBy("balance", "DESC")
+            .addOrderBy("public_key", "ASC")
             .getMany();
     }
 

--- a/packages/core-database/src/repositories/round-repository.ts
+++ b/packages/core-database/src/repositories/round-repository.ts
@@ -13,6 +13,14 @@ export class RoundRepository extends Repository<Round> {
         });
     }
 
+    public async getRound(round: number): Promise<Round[]> {
+        return this.createQueryBuilder()
+            .select()
+            .where("round = :round", { round })
+            .orderBy("balance", "DESC")
+            .getMany();
+    }
+
     public async save(delegates: readonly Contracts.State.Wallet[]): Promise<never> {
         const round: { publicKey: string; balance: Utils.BigNumber; round: number }[] = delegates.map(
             (delegate: Contracts.State.Wallet) => ({


### PR DESCRIPTION
## Summary

While checking block generator block processor loads round from database, but rows aren't guaranteed to be ordered. There is no built-in guarantee in db on which order rows will come out. Usually they are in order they were added, but it might be mixed.

New `RoundRepository.getRound` method returns rows the same way they were sorted when list of round delegates was built ordered by `balance desc, public_key asc`.

Equivalent to:
```typescript
this.activeDelegates.sort((a, b) => {
    const voteBalanceA = a.getAttribute("delegate.voteBalance");
    const voteBalanceB = b.getAttribute("delegate.voteBalance");
    const diff = voteBalanceB.comparedTo(voteBalanceA);
    if (diff === 0) {
        return a.publicKey.localeCompare(b.publicKey, "en");
    }
    return diff
})
```

## Checklist

- [x] Tests
- [x] Ready to be merged
