### PR TITLE
fix(core-blockchain): add missing return type to this.queue

### DIFF
--- a/packages/core-blockchain/src/blockchain.ts
+++ b/packages/core-blockchain/src/blockchain.ts
@@ -84,7 +84,7 @@ export class Blockchain implements blockchain.IBlockchain {
         this.actions = stateMachine.actionMap(this);
         this.blockProcessor = new BlockProcessor(this);
 
-        this.queue = async.queue(async (blockList: { blocks: Interfaces.IBlockData[] }) : Promise<Interfaces.IBlock[] | undefined> => {
+        this.queue = async.queue(async (blockList: { blocks: Interfaces.IBlockData[] }): Promise<Interfaces.IBlock[] | undefined> => {
             try {
                 return await this.processBlocks(blockList.blocks);
             } catch (error) {

--- a/packages/core-blockchain/src/blockchain.ts
+++ b/packages/core-blockchain/src/blockchain.ts
@@ -84,7 +84,7 @@ export class Blockchain implements blockchain.IBlockchain {
         this.actions = stateMachine.actionMap(this);
         this.blockProcessor = new BlockProcessor(this);
 
-        this.queue = async.queue(async (blockList: { blocks: Interfaces.IBlockData[] }) => {
+        this.queue = async.queue(async (blockList: { blocks: Interfaces.IBlockData[] }) : Promise<Interfaces.IBlock[] | undefined> => {
             try {
                 return await this.processBlocks(blockList.blocks);
             } catch (error) {


### PR DESCRIPTION
Currently `yarn lint` fails on the master branch (2.6.39).

This PR fixes the related linting error by defining the return type for `this.queue` in `core-blockchain`.