### PR TITLE
fix(core-tester-cli): use incremental timestamps for `make:block`

### DIFF
--- a/packages/core-tester-cli/src/commands/make/block.ts
+++ b/packages/core-tester-cli/src/commands/make/block.ts
@@ -78,7 +78,7 @@ export class BlockCommand extends BaseCommand {
 
             const newBlock = delegate.forge(transactions, {
                 previousBlock,
-                timestamp: Crypto.Slots.getSlotNumber(Crypto.Slots.getTime()) * milestone.blocktime,
+                timestamp: (Crypto.Slots.getSlotNumber(Crypto.Slots.getTime()) + i) * milestone.blocktime,
                 reward: milestone.reward,
             });
 


### PR DESCRIPTION
Blocks generated with this command no longer worked for tests because they contained a static timestamp while `blockchain.processBlocks` in v2.6.39 expects incremental timestamps. 

This fixes that.