### PR TITLE
feat(core-p2p, core-api): include estimateTotalCount into peers response

### DIFF
--- a/packages/core-api/src/resources/peer.ts
+++ b/packages/core-api/src/resources/peer.ts
@@ -30,6 +30,7 @@ export class PeerResource implements Resource {
             version: resource.version,
             height: resource.state ? resource.state.height : resource.height,
             latency: resource.latency,
+            plugins: resource.plugins,
         };
     }
 }

--- a/packages/core-kernel/src/contracts/p2p/peer.ts
+++ b/packages/core-kernel/src/contracts/p2p/peer.ts
@@ -5,7 +5,7 @@ export interface PeerPorts {
 }
 
 export interface PeerPlugins {
-    [name: string]: { enabled: boolean; port: number };
+    [name: string]: { enabled: boolean; port: number; estimateTotalCount?: number };
 }
 
 export interface Peer {

--- a/packages/core-p2p/src/schemas.ts
+++ b/packages/core-p2p/src/schemas.ts
@@ -252,6 +252,9 @@ export const replySchemas = {
                                     enabled: {
                                         type: "boolean",
                                     },
+                                    estimateTotalCount: {
+                                        type: "boolean",
+                                    },
                                 },
                             },
                         },

--- a/packages/core-p2p/src/socket-server/utils/get-peer-config.ts
+++ b/packages/core-p2p/src/socket-server/utils/get-peer-config.ts
@@ -25,6 +25,10 @@ const transformPlugins = (plugins: PluginConfig[]): Contracts.P2P.PeerPlugins =>
             enabled: true, // default to true because "enabled" flag is in different place based on which plugin
             port,
         };
+
+        if (name.includes("core-api")) {
+            result[name].estimateTotalCount = pluginConfig.options.options.estimateTotalCount;
+        }
     }
 
     return result;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1775,7 +1775,7 @@
   resolved "https://registry.yarnpkg.com/@hapi/teamwork/-/teamwork-4.0.0.tgz#4aadbb88de13bce39ab8431565cd50c7ecc6327f"
   integrity sha512-V6xYOrr5aFv/IJqNPneaYCu8vuGTKisamqHVRS3JJnbZr18TrpXdsJOYk9pjPhFti+M2YETPebQLUr820N5NoQ==
 
-"@hapi/teamwork@5.x":
+"@hapi/teamwork@5.x.x":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@hapi/teamwork/-/teamwork-5.1.0.tgz#7801a61fc727f702fd2196ef7625eb4e389f4124"
   integrity sha512-llqoQTrAJDTXxG3c4Kz/uzhBS1TsmSBa/XG5SPcVXgmffHE1nFtyLIK0hNJHCB3EuBKT84adzd1hZNY9GJLWtg==


### PR DESCRIPTION
## Summary

This PR solves issue #3592. 

P2P API includes estimateTotalCount boolean property based on the node configuration achieved via CORE_API_NO_ESTIMATED_TOTAL_COUNT flag. 

Core-api peers endpoint now returns plugins with the estimateTotalCount property inside @arkecosystem/core-api plugin options.

Part of the response: 

```
        {
            "ip": "192.168.64.8",
            "port": "4000",
            "ports": {},
            "version": "3.0.0-next.0",
            "height": 85288,
            "latency": 31,
            "plugins": {
                "@arkecosystem/core-api": {
                    "enabled": true,
                    "port": 4003,
                    "estimateTotalCount": false
                },
                "@arkecosystem/core-webhooks": {
                    "enabled": true,
                    "port": 4004
                }
            }
        }
```

## Checklist

- [ ] Tests _(TBD)_
- [X] Ready to be merged
