### PR TITLE
fix(core-state): remove state=blockchain tag from block state

### DIFF
--- a/__tests__/unit/core-state/setup.ts
+++ b/__tests__/unit/core-state/setup.ts
@@ -278,7 +278,7 @@ export const setUp = async (setUpOptions = setUpDefaults, skipBoot = false): Pro
         Container.Identifiers.DposPreviousRoundStateProvider,
     );
 
-    const blockState = sandbox.app.get<BlockState>(Container.Identifiers.BlockState);
+    const blockState = sandbox.app.getTagged<BlockState>(Container.Identifiers.BlockState, "state", "blockchain");
 
     const dPosState = sandbox.app.getTagged<DposState>(Container.Identifiers.DposState, "state", "blockchain");
 

--- a/packages/core-state/src/block-state.ts
+++ b/packages/core-state/src/block-state.ts
@@ -5,12 +5,7 @@ import { Enums, Identities, Interfaces, Utils } from "@arkecosystem/crypto";
 // todo: review the implementation and make use of ioc
 @Container.injectable()
 export class BlockState {
-    // @Container.inject(Container.Identifiers.Application)
-    // private readonly app!: Contracts.Kernel.Application;
-
     @Container.inject(Container.Identifiers.WalletRepository)
-    @Container.tagged("state", "blockchain") // TODO: Without this line - and despite
-    // being intialised in the same way as the service provider - the tests fail to find a correct binding
     private walletRepository!: Contracts.State.WalletRepository;
 
     @Container.inject(Container.Identifiers.TransactionHandlerRegistry)


### PR DESCRIPTION
## Summary

Tags got mixed. BlockState was referenced with `state=clone`, but it itself was using wallet repository with `state=blockchain`. There are legit cases where one would need access to both wallet repositories. I will try to find a way to make it more difficult to misuse them.

Gonna start on #3798 and replace tags with child containers. So that blockchain wallet repository is default root one. Temp and copy-on-write wallet repositories has to be explicitly created through factory while being in blockchain context. Attempting to get blockchain wallet repository will also require explicit function call that is available only in temp and copy-on-write contexts.

So that one can't mix them by accident, but can mix them explicitly only in specific known cases.

## Checklist

- [x] Tests
- [x] Ready to be merged
