### PR TITLE
feat(core-manager): disable individual watchers

### DIFF
--- a/__tests__/unit/core-manager/listener.test.ts
+++ b/__tests__/unit/core-manager/listener.test.ts
@@ -18,8 +18,29 @@ const mockEventDispatcher = {
     }),
 };
 
+const mockWatchDefaults = {
+    blocks: true,
+    errors: true,
+    logs: true,
+    queries: true,
+    queues: true,
+    rounds: true,
+    schedules: true,
+    transactions: true,
+    wallets: true,
+    webhooks: true,
+};
+
 beforeEach(() => {
     sandbox = new Sandbox();
+
+    sandbox.app.bind(Container.Identifiers.PluginConfiguration).toConstantValue({
+        getRequired: jest.fn().mockImplementation((name) =>
+        {
+            const field = name.split(".")[2];
+            return mockWatchDefaults[field];
+        }),
+    });
 
     sandbox.app.bind(Container.Identifiers.WatcherDatabaseService).toConstantValue(mockDatabase);
     sandbox.app.bind(Container.Identifiers.EventDispatcherService).toConstantValue(mockEventDispatcher);
@@ -28,7 +49,9 @@ beforeEach(() => {
     listener = sandbox.app.get(Container.Identifiers.WatcherEventListener);
 });
 
-afterEach(() => {});
+afterEach(() => {
+    jest.clearAllMocks();
+});
 
 describe("Listener", () => {
     describe("Boot", () => {
@@ -38,6 +61,111 @@ describe("Listener", () => {
             handler.handle({ name: "dummy_event", data: "dummy_data" });
 
             expect(mockDatabase.addEvent).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe("Filter - block", () => {
+        it("should pass", async () => {
+            listener.boot();
+            handler.handle({ name: "block.", data: "dummy_data" });
+            expect(mockDatabase.addEvent).toHaveBeenCalledTimes(1);
+        });
+
+        it("should not pass", async () => {
+            mockWatchDefaults.blocks = false;
+            listener.boot();
+            handler.handle({ name: "block.", data: "dummy_data" });
+            expect(mockDatabase.addEvent).toHaveBeenCalledTimes(0);
+        });
+    });
+
+    describe("Filter - log error", () => {
+        it("should pass", async () => {
+            listener.boot();
+            handler.handle({ name: "log.error", data: "dummy_data" });
+            expect(mockDatabase.addEvent).toHaveBeenCalledTimes(1);
+        });
+
+        it("should not pass", async () => {
+            mockWatchDefaults.errors = false;
+            listener.boot();
+            handler.handle({ name: "log.error", data: "dummy_data" });
+            expect(mockDatabase.addEvent).toHaveBeenCalledTimes(0);
+        });
+    });
+
+    describe("Filter - queue", () => {
+        it("should pass", async () => {
+            listener.boot();
+            handler.handle({ name: "queue.", data: "dummy_data" });
+            expect(mockDatabase.addEvent).toHaveBeenCalledTimes(1);
+        });
+
+        it("should not pass", async () => {
+            mockWatchDefaults.queues = false;
+            listener.boot();
+            handler.handle({ name: "queue.", data: "dummy_data" });
+            expect(mockDatabase.addEvent).toHaveBeenCalledTimes(0);
+        });
+    });
+
+    describe("Filter - round", () => {
+        it("should pass", async () => {
+            listener.boot();
+            handler.handle({ name: "round.", data: "dummy_data" });
+            expect(mockDatabase.addEvent).toHaveBeenCalledTimes(1);
+        });
+
+        it("should not pass", async () => {
+            mockWatchDefaults.rounds = false;
+            listener.boot();
+            handler.handle({ name: "round.", data: "dummy_data" });
+            expect(mockDatabase.addEvent).toHaveBeenCalledTimes(0);
+        });
+    });
+
+    describe("Filter - schedule", () => {
+        it("should pass", async () => {
+            listener.boot();
+            handler.handle({ name: "schedule.", data: "dummy_data" });
+            expect(mockDatabase.addEvent).toHaveBeenCalledTimes(1);
+        });
+
+        it("should not pass", async () => {
+            mockWatchDefaults.schedules = false;
+            listener.boot();
+            handler.handle({ name: "schedule.", data: "dummy_data" });
+            expect(mockDatabase.addEvent).toHaveBeenCalledTimes(0);
+        });
+    });
+
+    describe("Filter - transaction", () => {
+        it("should pass", async () => {
+            listener.boot();
+            handler.handle({ name: "transaction.", data: "dummy_data" });
+            expect(mockDatabase.addEvent).toHaveBeenCalledTimes(1);
+        });
+
+        it("should not pass", async () => {
+            mockWatchDefaults.transactions = false;
+            listener.boot();
+            handler.handle({ name: "transaction.", data: "dummy_data" });
+            expect(mockDatabase.addEvent).toHaveBeenCalledTimes(0);
+        });
+    });
+
+    describe("Filter - webhooks", () => {
+        it("should pass", async () => {
+            listener.boot();
+            handler.handle({ name: "webhooks.", data: "dummy_data" });
+            expect(mockDatabase.addEvent).toHaveBeenCalledTimes(1);
+        });
+
+        it("should not pass", async () => {
+            mockWatchDefaults.webhooks = false;
+            listener.boot();
+            handler.handle({ name: "webhooks.", data: "dummy_data" });
+            expect(mockDatabase.addEvent).toHaveBeenCalledTimes(0);
         });
     });
 });

--- a/__tests__/unit/core-manager/service-provider.test.ts
+++ b/__tests__/unit/core-manager/service-provider.test.ts
@@ -113,6 +113,31 @@ describe("ServiceProvider", () => {
         await expect(serviceProvider.dispose()).toResolve();
     });
 
+    it("should boot event listener", async () => {
+        const usedDefaults = { ...defaults };
+
+        usedDefaults.watcher.enabled = true;
+
+        setPluginConfiguration(app, serviceProvider, usedDefaults);
+
+        await expect(serviceProvider.register()).toResolve();
+
+        const mockEventListener = {
+            boot: jest.fn(),
+        };
+
+        app.unbind(Identifiers.EventsListener);
+
+        app.bind(Identifiers.EventsListener).toConstantValue(mockEventListener);
+
+        await expect(serviceProvider.boot()).toResolve();
+
+        expect(app.isBound(Identifiers.EventsListener)).toBeTrue();
+        expect(mockEventListener.boot).toHaveBeenCalledTimes(1);
+
+        await expect(serviceProvider.dispose()).toResolve();
+    });
+
     it("should not be required", async () => {
         await expect(serviceProvider.required()).resolves.toBeFalse();
     });

--- a/packages/core-manager/src/defaults.ts
+++ b/packages/core-manager/src/defaults.ts
@@ -3,6 +3,19 @@ export const defaults = {
         enabled: process.env.CORE_WATCHER_ENABLED || false,
         resetDatabase: process.env.CORE_RESET_DATABASE,
         storage: `${process.env.CORE_PATH_DATA}/events.sqlite`,
+        watch: {
+            blocks: !process.env.CORE_WATCH_BLOCKS_DISABLED,
+            transactions: !process.env.CORE_WATCH_TRANSACTIONS_DISABLED,
+            wallets: !process.env.CORE_WATCH_WALLETS_DISABLED,
+            rounds: !process.env.CORE_WATCH_ROUNDS_DISABLED,
+            errors: !process.env.CORE_WATCH_ERRORS_DISABLED,
+            logs: !process.env.CORE_WATCH_LOGS_DISABLED,
+            queries: !process.env.CORE_WATCH_QUERIES_DISABLED,
+            jobs: !process.env.CORE_WATCH_JOBS_DISABLED,
+            queues: !process.env.CORE_WATCH_QUEUES_DISABLED,
+            schedules: !process.env.CORE_WATCH_SCHEDULES_DISABLED,
+            webhooks: !process.env.CORE_WATCH_WEBHOOKS_DISABLED,
+        },
     },
     server: {
         http: {

--- a/packages/core-manager/src/defaults.ts
+++ b/packages/core-manager/src/defaults.ts
@@ -5,15 +5,14 @@ export const defaults = {
         storage: `${process.env.CORE_PATH_DATA}/events.sqlite`,
         watch: {
             blocks: !process.env.CORE_WATCH_BLOCKS_DISABLED,
-            transactions: !process.env.CORE_WATCH_TRANSACTIONS_DISABLED,
-            wallets: !process.env.CORE_WATCH_WALLETS_DISABLED,
-            rounds: !process.env.CORE_WATCH_ROUNDS_DISABLED,
             errors: !process.env.CORE_WATCH_ERRORS_DISABLED,
             logs: !process.env.CORE_WATCH_LOGS_DISABLED,
             queries: !process.env.CORE_WATCH_QUERIES_DISABLED,
-            jobs: !process.env.CORE_WATCH_JOBS_DISABLED,
             queues: !process.env.CORE_WATCH_QUEUES_DISABLED,
+            rounds: !process.env.CORE_WATCH_ROUNDS_DISABLED,
             schedules: !process.env.CORE_WATCH_SCHEDULES_DISABLED,
+            transactions: !process.env.CORE_WATCH_TRANSACTIONS_DISABLED,
+            wallets: !process.env.CORE_WATCH_WALLETS_DISABLED,
             webhooks: !process.env.CORE_WATCH_WEBHOOKS_DISABLED,
         },
     },
@@ -29,6 +28,7 @@ export const defaults = {
             host: process.env.CORE_MONITOR_SSL_HOST || "0.0.0.0",
             port: process.env.CORE_MONITOR_SSL_PORT || 8445,
             tls: {
+                // TODO: Take from CORE_API_SSL_KEY if not provided
                 key: process.env.CORE_MONITOR_SSL_KEY,
                 cert: process.env.CORE_MONITOR_SSL_CERT,
             },

--- a/packages/core-manager/src/listener.ts
+++ b/packages/core-manager/src/listener.ts
@@ -1,9 +1,13 @@
-import { Container, Contracts } from "@arkecosystem/core-kernel";
+import { Container, Contracts, Providers } from "@arkecosystem/core-kernel";
 
 import { DatabaseService } from "./database-service";
 
 @Container.injectable()
 export class Listener {
+    @Container.inject(Container.Identifiers.PluginConfiguration)
+    @Container.tagged("plugin", "@arkecosystem/core-manager")
+    private readonly configuration!: Providers.PluginConfiguration;
+
     @Container.inject(Container.Identifiers.EventDispatcherService)
     private readonly eventDispatcher!: Contracts.Kernel.EventDispatcher;
 
@@ -19,6 +23,37 @@ export class Listener {
     }
 
     private handleEvents(data: { name: Contracts.Kernel.EventName; data: any }) {
-        this.databaseService.addEvent(data.name.toString(), data.data);
+        if (this.canAddEvent(data.name.toString())) {
+            this.databaseService.addEvent(data.name.toString(), data.data);
+        }
+    }
+
+    private canAddEvent(name: string): boolean {
+        if (name.startsWith("block") && !this.configuration.getRequired<boolean>("watcher.watch.blocks")) {
+            return false;
+        }
+        if (name.startsWith("log.error") && !this.configuration.getRequired<boolean>("watcher.watch.errors")) {
+            return false;
+        }
+        if (name.startsWith("queue") && !this.configuration.getRequired<boolean>("watcher.watch.queues")) {
+            return false;
+        }
+        if (name.startsWith("round") && !this.configuration.getRequired<boolean>("watcher.watch.rounds")) {
+            return false;
+        }
+        if (name.startsWith("schedule") && !this.configuration.getRequired<boolean>("watcher.watch.schedule")) {
+            return false;
+        }
+        if (name.startsWith("transaction") && !this.configuration.getRequired<boolean>("watcher.watch.transactions")) {
+            return false;
+        }
+        if (name.startsWith("wallet") && !this.configuration.getRequired<boolean>("watcher.watch.wallets")) {
+            return false;
+        }
+        if (name.startsWith("webhooks") && !this.configuration.getRequired<boolean>("watcher.watch.webhooks")) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/packages/core-manager/src/listener.ts
+++ b/packages/core-manager/src/listener.ts
@@ -41,13 +41,10 @@ export class Listener {
         if (name.startsWith("round") && !this.configuration.getRequired<boolean>("watcher.watch.rounds")) {
             return false;
         }
-        if (name.startsWith("schedule") && !this.configuration.getRequired<boolean>("watcher.watch.schedule")) {
+        if (name.startsWith("schedule") && !this.configuration.getRequired<boolean>("watcher.watch.schedules")) {
             return false;
         }
         if (name.startsWith("transaction") && !this.configuration.getRequired<boolean>("watcher.watch.transactions")) {
-            return false;
-        }
-        if (name.startsWith("wallet") && !this.configuration.getRequired<boolean>("watcher.watch.wallets")) {
             return false;
         }
         if (name.startsWith("webhooks") && !this.configuration.getRequired<boolean>("watcher.watch.webhooks")) {


### PR DESCRIPTION
## Summary

This PR implements additional logic for enabling and disabling single watcher component using environment variables.

List of env variables:

- CORE_WATCH_BLOCKS_DISABLED,
- CORE_WATCH_ERRORS_DISABLED,
- CORE_WATCH_LOGS_DISABLED,
- CORE_WATCH_QUERIES_DISABLED,
- CORE_WATCH_QUEUES_DISABLED,
- CORE_WATCH_ROUNDS_DISABLED,
- CORE_WATCH_SCHEDULES_DISABLED,
- CORE_WATCH_TRANSACTIONS_DISABLED,
- CORE_WATCH_WALLETS_DISABLED,
- CORE_WATCH_WEBHOOKS_DISABLED,

## Checklist

- [x] Tests
- [x] Ready to be merged