### PR TITLE
fix(crypto): transaction builder should build and sign versioned transactions

### DIFF
--- a/__tests__/unit/crypto/transactions/builders/transactions/transaction-builder.test.ts
+++ b/__tests__/unit/crypto/transactions/builders/transactions/transaction-builder.test.ts
@@ -161,7 +161,7 @@ describe.each([
 
                 expect(spyKeys).toHaveBeenCalledWith(identity.bip39);
                 expect(spySign).toHaveBeenCalledWith((builder as any).getSigningObject(), identity.keys, {
-                    versionSpecified: false,
+                    disableVersionCheck: false,
                 });
             });
 
@@ -175,7 +175,7 @@ describe.each([
                 expect(builder.data.senderPublicKey).toBe(identity.keys.publicKey);
                 expect(spyKeys).toHaveBeenCalledWith(identity.bip39);
                 expect(spySign).toHaveBeenCalledWith((builder as any).getSigningObject(), identity.keys, {
-                    versionSpecified: false,
+                    disableVersionCheck: false,
                 });
             });
         });
@@ -192,7 +192,7 @@ describe.each([
                     wif: 186,
                 });
                 expect(spySign).toHaveBeenCalledWith((builder as any).getSigningObject(), identity.keys, {
-                    versionSpecified: false,
+                    disableVersionCheck: false,
                 });
             });
 
@@ -204,7 +204,7 @@ describe.each([
 
                 expect(builder.data.senderPublicKey).toBe(identity.publicKey);
                 expect(spySign).toHaveBeenCalledWith((builder as any).getSigningObject(), identity.keys, {
-                    versionSpecified: false,
+                    disableVersionCheck: false,
                 });
             });
         });

--- a/packages/crypto/src/interfaces/transactions.ts
+++ b/packages/crypto/src/interfaces/transactions.ts
@@ -21,7 +21,7 @@ export interface ITransaction {
     serialize(options?: ISerializeOptions): ByteBuffer | undefined;
     deserialize(buf: ByteBuffer): void;
 
-    verify(): boolean;
+    verify(options?: IVerifyOptions): boolean;
     verifySchema(strict?: boolean): ISchemaValidationResult;
 
     toJson(): ITransactionJson;
@@ -164,10 +164,16 @@ export interface IHtlcExpiration {
 
 export interface IDeserializeOptions {
     acceptLegacyVersion?: boolean;
+    versionSpecified?: boolean;
+}
+
+export interface IVerifyOptions {
+    versionSpecified?: boolean;
 }
 
 export interface ISerializeOptions {
     acceptLegacyVersion?: boolean;
+    versionSpecified?: boolean;
     excludeSignature?: boolean;
     excludeSecondSignature?: boolean;
     excludeMultiSignature?: boolean;

--- a/packages/crypto/src/interfaces/transactions.ts
+++ b/packages/crypto/src/interfaces/transactions.ts
@@ -164,16 +164,16 @@ export interface IHtlcExpiration {
 
 export interface IDeserializeOptions {
     acceptLegacyVersion?: boolean;
-    versionSpecified?: boolean;
+    disableVersionCheck?: boolean;
 }
 
 export interface IVerifyOptions {
-    versionSpecified?: boolean;
+    disableVersionCheck?: boolean;
 }
 
 export interface ISerializeOptions {
     acceptLegacyVersion?: boolean;
-    versionSpecified?: boolean;
+    disableVersionCheck?: boolean;
     excludeSignature?: boolean;
     excludeSecondSignature?: boolean;
     excludeMultiSignature?: boolean;

--- a/packages/crypto/src/transactions/builders/transactions/transaction.ts
+++ b/packages/crypto/src/transactions/builders/transactions/transaction.ts
@@ -15,7 +15,7 @@ export abstract class TransactionBuilder<TBuilder extends TransactionBuilder<TBu
 
     protected signWithSenderAsRecipient = false;
 
-    private versionSpecified = false;
+    private disableVersionCheck = false;
 
     public constructor() {
         this.data = {
@@ -29,13 +29,13 @@ export abstract class TransactionBuilder<TBuilder extends TransactionBuilder<TBu
 
     public build(data: Partial<ITransactionData> = {}): ITransaction {
         return TransactionFactory.fromData({ ...this.data, ...data }, false, {
-            versionSpecified: this.versionSpecified,
+            disableVersionCheck: this.disableVersionCheck,
         });
     }
 
     public version(version: number): TBuilder {
         this.data.version = version;
-        this.versionSpecified = true;
+        this.disableVersionCheck = true;
         return this.instance();
     }
 
@@ -138,7 +138,7 @@ export abstract class TransactionBuilder<TBuilder extends TransactionBuilder<TBu
     }
 
     public verify(): boolean {
-        return Verifier.verifyHash(this.data, this.versionSpecified);
+        return Verifier.verifyHash(this.data, this.disableVersionCheck);
     }
 
     public getStruct(): ITransactionData {
@@ -179,7 +179,7 @@ export abstract class TransactionBuilder<TBuilder extends TransactionBuilder<TBu
         }
 
         this.data.signature = Signer.sign(this.getSigningObject(), keys, {
-            versionSpecified: this.versionSpecified,
+            disableVersionCheck: this.disableVersionCheck,
         });
 
         return this.instance();

--- a/packages/crypto/src/transactions/builders/transactions/transaction.ts
+++ b/packages/crypto/src/transactions/builders/transactions/transaction.ts
@@ -138,7 +138,7 @@ export abstract class TransactionBuilder<TBuilder extends TransactionBuilder<TBu
     }
 
     public verify(): boolean {
-        return Verifier.verifyHash(this.data);
+        return Verifier.verifyHash(this.data, this.versionSpecified);
     }
 
     public getStruct(): ITransactionData {

--- a/packages/crypto/src/transactions/builders/transactions/transaction.ts
+++ b/packages/crypto/src/transactions/builders/transactions/transaction.ts
@@ -15,6 +15,8 @@ export abstract class TransactionBuilder<TBuilder extends TransactionBuilder<TBu
 
     protected signWithSenderAsRecipient = false;
 
+    private versionSpecified = false;
+
     public constructor() {
         this.data = {
             id: undefined,
@@ -26,12 +28,14 @@ export abstract class TransactionBuilder<TBuilder extends TransactionBuilder<TBu
     }
 
     public build(data: Partial<ITransactionData> = {}): ITransaction {
-        return TransactionFactory.fromData({ ...this.data, ...data }, false);
+        return TransactionFactory.fromData({ ...this.data, ...data }, false, {
+            versionSpecified: this.versionSpecified,
+        });
     }
 
     public version(version: number): TBuilder {
         this.data.version = version;
-
+        this.versionSpecified = true;
         return this.instance();
     }
 
@@ -174,7 +178,9 @@ export abstract class TransactionBuilder<TBuilder extends TransactionBuilder<TBu
             this.data.recipientId = Address.fromPublicKey(keys.publicKey, this.data.network);
         }
 
-        this.data.signature = Signer.sign(this.getSigningObject(), keys);
+        this.data.signature = Signer.sign(this.getSigningObject(), keys, {
+            versionSpecified: this.versionSpecified,
+        });
 
         return this.instance();
     }

--- a/packages/crypto/src/transactions/deserializer.ts
+++ b/packages/crypto/src/transactions/deserializer.ts
@@ -47,7 +47,7 @@ export class Deserializer {
         if (data.version) {
             if (
                 options.acceptLegacyVersion ||
-                options.versionSpecified ||
+                options.disableVersionCheck ||
                 isSupportedTransactionVersion(data.version)
             ) {
                 if (data.version === 1) {

--- a/packages/crypto/src/transactions/deserializer.ts
+++ b/packages/crypto/src/transactions/deserializer.ts
@@ -45,7 +45,11 @@ export class Deserializer {
         this.deserializeSignatures(data, buffer);
 
         if (data.version) {
-            if (options.acceptLegacyVersion || isSupportedTransactionVersion(data.version)) {
+            if (
+                options.acceptLegacyVersion ||
+                options.versionSpecified ||
+                isSupportedTransactionVersion(data.version)
+            ) {
                 if (data.version === 1) {
                     this.applyV1Compatibility(data);
                 }

--- a/packages/crypto/src/transactions/factory.ts
+++ b/packages/crypto/src/transactions/factory.ts
@@ -23,8 +23,8 @@ export class TransactionFactory {
         return this.fromSerialized(hex);
     }
 
-    public static fromBytes(buffer: Buffer, strict = true): ITransaction {
-        return this.fromSerialized(buffer.toString("hex"), strict);
+    public static fromBytes(buffer: Buffer, strict = true, options: IDeserializeOptions = {}): ITransaction {
+        return this.fromSerialized(buffer.toString("hex"), strict, options);
     }
 
     /**
@@ -55,7 +55,7 @@ export class TransactionFactory {
         return this.fromData(data);
     }
 
-    public static fromData(data: ITransactionData, strict = true): ITransaction {
+    public static fromData(data: ITransactionData, strict = true, options: IDeserializeOptions = {}): ITransaction {
         const { value, error } = Verifier.verifySchema(data, strict);
 
         if (error && !isException(value.id)) {
@@ -71,13 +71,13 @@ export class TransactionFactory {
 
         Serializer.serialize(transaction);
 
-        return this.fromBytes(transaction.serialized, strict);
+        return this.fromBytes(transaction.serialized, strict, options);
     }
 
-    private static fromSerialized(serialized: string, strict = true): ITransaction {
+    private static fromSerialized(serialized: string, strict = true, options: IDeserializeOptions = {}): ITransaction {
         try {
-            const transaction = Deserializer.deserialize(serialized);
-            transaction.data.id = Utils.getId(transaction.data);
+            const transaction = Deserializer.deserialize(serialized, options);
+            transaction.data.id = Utils.getId(transaction.data, options);
 
             const { value, error } = Verifier.verifySchema(transaction.data, strict);
 
@@ -85,7 +85,7 @@ export class TransactionFactory {
                 throw new TransactionSchemaError(error);
             }
 
-            transaction.isVerified = transaction.verify();
+            transaction.isVerified = transaction.verify(options);
 
             return transaction;
         } catch (error) {

--- a/packages/crypto/src/transactions/serializer.ts
+++ b/packages/crypto/src/transactions/serializer.ts
@@ -15,7 +15,7 @@ export class Serializer {
     public static getBytes(transaction: ITransactionData, options: ISerializeOptions = {}): Buffer {
         const version: number = transaction.version || 1;
 
-        if (options.acceptLegacyVersion || options.versionSpecified || isSupportedTransactionVersion(version)) {
+        if (options.acceptLegacyVersion || options.disableVersionCheck || isSupportedTransactionVersion(version)) {
             if (version === 1) {
                 return this.getBytesV1(transaction, options);
             }

--- a/packages/crypto/src/transactions/serializer.ts
+++ b/packages/crypto/src/transactions/serializer.ts
@@ -15,7 +15,7 @@ export class Serializer {
     public static getBytes(transaction: ITransactionData, options: ISerializeOptions = {}): Buffer {
         const version: number = transaction.version || 1;
 
-        if (options.acceptLegacyVersion || isSupportedTransactionVersion(version)) {
+        if (options.acceptLegacyVersion || options.versionSpecified || isSupportedTransactionVersion(version)) {
             if (version === 1) {
                 return this.getBytesV1(transaction, options);
             }

--- a/packages/crypto/src/transactions/signer.ts
+++ b/packages/crypto/src/transactions/signer.ts
@@ -5,7 +5,9 @@ import { Utils } from "./utils";
 
 export class Signer {
     public static sign(transaction: ITransactionData, keys: IKeyPair, options?: ISerializeOptions): string {
-        options = options || { excludeSignature: true, excludeSecondSignature: true };
+        if (!options || (options.excludeSignature === undefined && options.excludeSecondSignature === undefined)) {
+            options = { excludeSignature: true, excludeSecondSignature: true, ...options };
+        }
 
         const hash: Buffer = Utils.toHash(transaction, options);
         const signature: string =

--- a/packages/crypto/src/transactions/types/transaction.ts
+++ b/packages/crypto/src/transactions/types/transaction.ts
@@ -3,7 +3,13 @@ import ByteBuffer from "bytebuffer";
 import { TransactionTypeGroup } from "../../enums";
 import { NotImplemented } from "../../errors";
 import { Address } from "../../identities";
-import { ISchemaValidationResult, ITransaction, ITransactionData, ITransactionJson } from "../../interfaces";
+import {
+    ISchemaValidationResult,
+    ISerializeOptions,
+    ITransaction,
+    ITransactionData,
+    ITransactionJson,
+} from "../../interfaces";
 import { configManager } from "../../managers/config";
 import { BigNumber } from "../../utils/bignum";
 import { Verifier } from "../verifier";
@@ -42,8 +48,8 @@ export abstract class Transaction implements ITransaction {
         return this.defaultStaticFee;
     }
 
-    public verify(): boolean {
-        return Verifier.verify(this.data);
+    public verify(options?: ISerializeOptions): boolean {
+        return Verifier.verify(this.data, options);
     }
 
     public verifySecondSignature(publicKey: string): boolean {

--- a/packages/crypto/src/transactions/verifier.ts
+++ b/packages/crypto/src/transactions/verifier.ts
@@ -17,7 +17,7 @@ export class Verifier {
             return false;
         }
 
-        return Verifier.verifyHash(data, options?.versionSpecified);
+        return Verifier.verifyHash(data, options?.disableVersionCheck);
     }
 
     public static verifySecondSignature(
@@ -32,7 +32,7 @@ export class Verifier {
         }
 
         const hash: Buffer = Utils.toHash(transaction, {
-            versionSpecified: options?.versionSpecified,
+            disableVersionCheck: options?.disableVersionCheck,
             excludeSecondSignature: true,
         });
         return this.internalVerifySignature(hash, secondSignature, publicKey);
@@ -86,7 +86,7 @@ export class Verifier {
         return verified;
     }
 
-    public static verifyHash(data: ITransactionData, versionSpecified = false): boolean {
+    public static verifyHash(data: ITransactionData, disableVersionCheck = false): boolean {
         const { signature, senderPublicKey } = data;
 
         if (!signature || !senderPublicKey) {
@@ -94,7 +94,7 @@ export class Verifier {
         }
 
         const hash: Buffer = Utils.toHash(data, {
-            versionSpecified,
+            disableVersionCheck,
             excludeSignature: true,
             excludeSecondSignature: true,
         });


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

This updates the `TransactionBuilder` to successfully build and sign transactions when the version number has been specifically set. 

<!-- Why are these changes necessary? -->

Better dx - if the version has been specifically set on the transaction, we would not expect the Builder to throw a `TransactionVersionError`. As requested in #3099

<!-- How were these changes implemented? -->

Adds a flag to check to de/serialisation options

## Checklist

<!-- Have you done all of these things?  -->

- [x] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
