### PR TITLE
fix(core-kernel): prevent watcher from calling app.reboot multiple times

### DIFF
--- a/packages/core-kernel/src/services/config/watcher.ts
+++ b/packages/core-kernel/src/services/config/watcher.ts
@@ -37,6 +37,7 @@ export class Watcher {
             for (const event of events) {
                 if (event.action === ActionType.MODIFIED && configFiles.includes(event.file)) {
                     this.app.reboot();
+                    break;
                 }
             }
         });


### PR DESCRIPTION
## Summary

Watcher was calling `app.reboot` for every file that was changed.

## Checklist

- [x] Ready to be merged