### PR TITLE
chore(core-snapshots): skip verification of transactions sent from multisignature wallets

### DIFF
--- a/__tests__/unit/core-snapshots/verifier.test.ts
+++ b/__tests__/unit/core-snapshots/verifier.test.ts
@@ -61,8 +61,26 @@ describe("Verifier", () => {
             Verifier.verifyTransaction(Assets.transactions[0]);
         });
 
+        it("should pass if transaction is  signed with multisignature", async () => {
+            Transactions.TransactionFactory.fromBytes = jest.fn().mockReturnValue({ isVerified: true, data: { signatures: [] } });
+            let transaction = { ...Assets.transactions[0] };
+
+            transaction.timestamp = 100;
+
+            Verifier.verifyTransaction(transaction);
+        });
+
+        it("should pass if transaction is valid", async () => {
+            Transactions.TransactionFactory.fromBytes = jest.fn().mockReturnValue({ isVerified: true, data: {} });
+            let transaction = { ...Assets.transactions[0] };
+
+            transaction.timestamp = 100;
+
+            Verifier.verifyTransaction(transaction);
+        });
+
         it("should throw if transaction is not valid", async () => {
-            Transactions.TransactionFactory.fromBytes = jest.fn().mockReturnValue(false);
+            Transactions.TransactionFactory.fromBytes = jest.fn().mockReturnValue({ isVerified: false, data: {} });
             let transaction = { ...Assets.transactions[0] };
 
             transaction.timestamp = 100;

--- a/packages/core-snapshots/src/verifier.ts
+++ b/packages/core-snapshots/src/verifier.ts
@@ -60,7 +60,12 @@ export class Verifier {
 
         let isVerified = false;
         try {
-            isVerified = Transactions.TransactionFactory.fromBytes(transaction.serialized).isVerified;
+            const transactionDeserialized = Transactions.TransactionFactory.fromBytes(transaction.serialized);
+            if (transactionDeserialized.data.signatures) {
+                return;
+            } else {
+                isVerified = transactionDeserialized.isVerified;
+            }
         } catch (err) {
             throw new Exceptions.TransactionVerifyException(transaction.id, err.message);
         }


### PR DESCRIPTION
## Summary

This PR fixes #3538 

Validation of transaction from multisignature wallets is skipped, because it will require additional logic, applying transactions and using wallet registry. Because core-snapshots should stay simple, lightweight and fast as possible we don't check those transactions. They should be validated on the node boot. 

## Checklist

- [x] Tests
- [x] Ready to be merged
