### PR TITLE
refactor(core-transaction-pool): union query typeGroup with number

### DIFF
--- a/packages/core-kernel/src/contracts/transaction-pool/query.ts
+++ b/packages/core-kernel/src/contracts/transaction-pool/query.ts
@@ -13,7 +13,7 @@ export interface QueryIterable extends Iterable<Interfaces.ITransaction> {
     wherePredicate(predicate: QueryPredicate): QueryIterable;
     whereId(id: string): QueryIterable;
     whereType(type: Enums.TransactionType): QueryIterable;
-    whereTypeGroup(typeGroup: Enums.TransactionTypeGroup): QueryIterable;
+    whereTypeGroup(typeGroup: Enums.TransactionTypeGroup | number): QueryIterable;
     whereVersion(version: number): QueryIterable;
     whereKind(transaction: Interfaces.ITransaction): QueryIterable;
 

--- a/packages/core-transaction-pool/src/query.ts
+++ b/packages/core-transaction-pool/src/query.ts
@@ -35,7 +35,7 @@ export class QueryIterable implements Contracts.TransactionPool.QueryIterable {
         return this.wherePredicate((t) => t.type === type);
     }
 
-    public whereTypeGroup(typeGroup: Enums.TransactionTypeGroup): QueryIterable {
+    public whereTypeGroup(typeGroup: Enums.TransactionTypeGroup | number): QueryIterable {
         return this.wherePredicate((t) => t.typeGroup === typeGroup);
     }
 


### PR DESCRIPTION
## Summary

Union `typeGroup` with `number` so that pool can be queried from other packages.

## Checklist

- [x] Ready to be merged
