### PR TITLE
test(core-snapshot): increase coverage to 100%

### DIFF
--- a/__tests__/unit/core-snapshots/filesystem/filesystem.test.ts
+++ b/__tests__/unit/core-snapshots/filesystem/filesystem.test.ts
@@ -1,11 +1,12 @@
 import "jest-extended";
-import { dirSync, setGracefulCleanup } from "tmp";
 
 import { Container } from "@arkecosystem/core-kernel";
-import { Sandbox } from "@packages/core-test-framework";
-import { Identifiers } from "@packages/core-snapshots/src/ioc";
-import { Filesystem } from "@packages/core-snapshots/src/filesystem/filesystem";
 import { LocalFilesystem } from "@packages/core-kernel/src/services/filesystem/drivers/local";
+import { Filesystem } from "@packages/core-snapshots/src/filesystem/filesystem";
+import { Identifiers } from "@packages/core-snapshots/src/ioc";
+import { Sandbox } from "@packages/core-test-framework";
+import { cloneDeep } from "lodash";
+import { dirSync, setGracefulCleanup } from "tmp";
 
 import { metaData } from "../__fixtures__/assets";
 
@@ -66,6 +67,83 @@ describe("Filesystem", () => {
             await expect(filesystem.writeMetaData(metaData)).toResolve();
 
             await expect(filesystem.readMetaData()).resolves.toEqual(metaData);
+        });
+    });
+
+    describe("validateMetaData", () => {
+        let tmpMeta;
+
+        beforeEach(() => {
+            const dir: string = dirSync().name;
+            const subdir: string = `${dir}/sub`;
+
+            filesystem.getSnapshotPath = jest.fn().mockReturnValue(subdir);
+
+            tmpMeta = cloneDeep(metaData);
+        });
+
+        it("should throw if codec is missing", async () => {
+            delete tmpMeta.codec;
+
+            await expect(filesystem.writeMetaData(tmpMeta)).toResolve();
+
+            await expect(filesystem.readMetaData()).rejects.toThrowError();
+        });
+
+        it("should throw if skipCompression is missing", async () => {
+            delete tmpMeta.skipCompression;
+
+            await expect(filesystem.writeMetaData(tmpMeta)).toResolve();
+
+            await expect(filesystem.readMetaData()).rejects.toThrowError();
+        });
+
+        it("should throw if blocks is missing", async () => {
+            delete tmpMeta.blocks;
+
+            await expect(filesystem.writeMetaData(tmpMeta)).toResolve();
+
+            await expect(filesystem.readMetaData()).rejects.toThrowError();
+        });
+
+        it("should throw if blocks.count is missing", async () => {
+            delete tmpMeta.blocks.count;
+
+            await expect(filesystem.writeMetaData(tmpMeta)).toResolve();
+
+            await expect(filesystem.readMetaData()).rejects.toThrowError();
+        });
+
+        it("should throw if transactions is missing", async () => {
+            delete tmpMeta.transactions;
+
+            await expect(filesystem.writeMetaData(tmpMeta)).toResolve();
+
+            await expect(filesystem.readMetaData()).rejects.toThrowError();
+        });
+
+        it("should throw if transactions.count is missing", async () => {
+            delete tmpMeta.transactions.count;
+
+            await expect(filesystem.writeMetaData(tmpMeta)).toResolve();
+
+            await expect(filesystem.readMetaData()).rejects.toThrowError();
+        });
+
+        it("should throw if rounds is missing", async () => {
+            delete tmpMeta.rounds;
+
+            await expect(filesystem.writeMetaData(tmpMeta)).toResolve();
+
+            await expect(filesystem.readMetaData()).rejects.toThrowError();
+        });
+
+        it("should throw if rounds.count is missing", async () => {
+            delete tmpMeta.rounds.count;
+
+            await expect(filesystem.writeMetaData(tmpMeta)).toResolve();
+
+            await expect(filesystem.readMetaData()).rejects.toThrowError();
         });
     });
 });

--- a/__tests__/unit/core-snapshots/service-provider.test.ts
+++ b/__tests__/unit/core-snapshots/service-provider.test.ts
@@ -22,8 +22,10 @@ beforeEach(() => {
     sandbox = new Sandbox();
 
     sandbox.app.bind(Container.Identifiers.LogService).toConstantValue({});
+});
 
-    sandbox.app.bind(Container.Identifiers.DatabaseConnection).toConstantValue({});
+afterEach(() => {
+    jest.clearAllMocks();
 });
 
 describe("ServiceProvider", () => {
@@ -34,6 +36,14 @@ describe("ServiceProvider", () => {
     });
 
     it("should register", async () => {
+        await expect(serviceProvider.register()).toResolve();
+        expect(spyOnGetCustomRepository).toHaveBeenCalledTimes(3);
+        expect(spyOnCreateConnection).toHaveBeenCalled();
+    });
+
+    it("should register is default connection is already active", async () => {
+        sandbox.app.bind(Container.Identifiers.DatabaseConnection).toConstantValue({});
+
         await expect(serviceProvider.register()).toResolve();
         expect(spyOnGetCustomRepository).toHaveBeenCalledTimes(3);
         expect(spyOnCreateConnection).toHaveBeenCalled();

--- a/__tests__/unit/core-snapshots/workers/actions/__support__/helper.ts
+++ b/__tests__/unit/core-snapshots/workers/actions/__support__/helper.ts
@@ -1,13 +1,14 @@
-import { Readable } from "stream";
-import { decamelize } from "xcase";
-import { Assets } from "../../../__fixtures__";
 import { WorkerAction } from "@packages/core-snapshots/src/contracts";
+import { Readable } from "stream";
 import WorkerThreads from "worker_threads";
+import { decamelize } from "xcase";
+
+import { Assets } from "../../../__fixtures__";
 
 export class ReadableStream extends Readable {
     private count = 0;
 
-    constructor(private prefix: string, private table: string) {
+    public constructor(private prefix: string, private table: string) {
         super({ objectMode: true });
     }
 
@@ -21,11 +22,11 @@ export class ReadableStream extends Readable {
     }
 
     private appendPrefix(entity: any) {
-        let itemToReturn = {};
+        const itemToReturn = {};
 
-        let item = entity;
+        const item = entity;
 
-        for (let key of Object.keys(item)) {
+        for (const key of Object.keys(item)) {
             itemToReturn[this.prefix + decamelize(key)] = item[key];
         }
 

--- a/__tests__/unit/core-snapshots/workers/actions/test-worker-action.test.ts
+++ b/__tests__/unit/core-snapshots/workers/actions/test-worker-action.test.ts
@@ -1,7 +1,25 @@
 import "jest-extended";
+
 import { TestWorkerAction } from "@packages/core-snapshots/src/workers/actions";
 
-let testWorkerAction = new TestWorkerAction();
+const testWorkerAction = new TestWorkerAction();
+
+jest.mock("worker_threads", () => {
+    const { EventEmitter } = require("events");
+    class ParentPort extends EventEmitter {
+        public constructor() {
+            super();
+        }
+
+        public postMessage(data) {
+            this.emit("message", data);
+        }
+    }
+
+    return {
+        parentPort: new ParentPort(),
+    };
+});
 
 describe("TestWorkerAction", () => {
     it("should start with no action", async () => {
@@ -25,7 +43,7 @@ describe("TestWorkerAction", () => {
             table: "wait",
         });
 
-        let promise = testWorkerAction.start();
+        const promise = testWorkerAction.start();
 
         await new Promise((resolve) => {
             setTimeout(() => {

--- a/__tests__/unit/core-snapshots/workers/worker-wrapper.test.ts
+++ b/__tests__/unit/core-snapshots/workers/worker-wrapper.test.ts
@@ -1,8 +1,8 @@
 import "jest-extended";
 
-import { Worker } from "worker_threads";
 import { WorkerWrapper } from "@packages/core-snapshots/src/workers/worker-wrapper";
 import { EventEmitter } from "events";
+import { Worker } from "worker_threads";
 
 let mockWorker: any;
 
@@ -27,7 +27,7 @@ afterEach(() => {
 describe("WorkerWrapper", () => {
     describe("Terminate", () => {
         it("should call terminate", async () => {
-            let workerWrapper = new WorkerWrapper({});
+            const workerWrapper = new WorkerWrapper({});
 
             await workerWrapper.terminate();
 
@@ -37,9 +37,9 @@ describe("WorkerWrapper", () => {
 
     describe("Start", () => {
         it("should resolve on [started] event", async () => {
-            let workerWrapper = new WorkerWrapper({});
+            const workerWrapper = new WorkerWrapper({});
 
-            let promise = workerWrapper.start();
+            const promise = workerWrapper.start();
 
             await new Promise((resolve) => {
                 setTimeout(() => {
@@ -55,9 +55,9 @@ describe("WorkerWrapper", () => {
         });
 
         it("should resolve on [exit] event", async () => {
-            let workerWrapper = new WorkerWrapper({});
+            const workerWrapper = new WorkerWrapper({});
 
-            let promise = workerWrapper.start();
+            const promise = workerWrapper.start();
 
             await new Promise((resolve) => {
                 setTimeout(() => {
@@ -70,9 +70,9 @@ describe("WorkerWrapper", () => {
         });
 
         it("should reject on [exception] message event", async () => {
-            let workerWrapper = new WorkerWrapper({});
+            const workerWrapper = new WorkerWrapper({});
 
-            let promise = workerWrapper.start();
+            const promise = workerWrapper.start();
 
             await new Promise((resolve) => {
                 setTimeout(() => {
@@ -88,9 +88,9 @@ describe("WorkerWrapper", () => {
         });
 
         it("should reject on [any] message event", async () => {
-            let workerWrapper = new WorkerWrapper({});
+            const workerWrapper = new WorkerWrapper({});
 
-            let promise = workerWrapper.start();
+            const promise = workerWrapper.start();
 
             await new Promise((resolve) => {
                 setTimeout(() => {
@@ -106,9 +106,9 @@ describe("WorkerWrapper", () => {
         });
 
         it("should reject on [error] event", async () => {
-            let workerWrapper = new WorkerWrapper({});
+            const workerWrapper = new WorkerWrapper({});
 
-            let promise = workerWrapper.start();
+            const promise = workerWrapper.start();
 
             await new Promise((resolve) => {
                 setTimeout(() => {
@@ -123,11 +123,11 @@ describe("WorkerWrapper", () => {
 
     describe("Sync", () => {
         it("should resolve on [synced] event", async () => {
-            let workerWrapper = new WorkerWrapper({});
+            const workerWrapper = new WorkerWrapper({});
 
-            let promise = workerWrapper.sync({});
+            const promise = workerWrapper.sync({});
 
-            let data = {
+            const data = {
                 dummy: "dummy_data",
             };
 
@@ -145,9 +145,9 @@ describe("WorkerWrapper", () => {
         });
 
         it("should resolve with undefined on [exit] event", async () => {
-            let workerWrapper = new WorkerWrapper({});
+            const workerWrapper = new WorkerWrapper({});
 
-            let promise = workerWrapper.sync({});
+            const promise = workerWrapper.sync({});
 
             await new Promise((resolve) => {
                 setTimeout(() => {
@@ -159,10 +159,21 @@ describe("WorkerWrapper", () => {
             await expect(promise).resolves.toBeUndefined();
         });
 
-        it("should reject on [exception] message event", async () => {
-            let workerWrapper = new WorkerWrapper({});
+        it("should resolve if worker already exit", async () => {
+            const workerWrapper = new WorkerWrapper({});
 
-            let promise = workerWrapper.sync({});
+            // @ts-ignore
+            workerWrapper.isDone = true;
+
+            const promise = workerWrapper.sync({});
+
+            await expect(promise).resolves.toBeUndefined();
+        });
+
+        it("should reject on [exception] message event", async () => {
+            const workerWrapper = new WorkerWrapper({});
+
+            const promise = workerWrapper.sync({});
 
             await new Promise((resolve) => {
                 setTimeout(() => {
@@ -178,9 +189,9 @@ describe("WorkerWrapper", () => {
         });
 
         it("should reject on [any] message event", async () => {
-            let workerWrapper = new WorkerWrapper({});
+            const workerWrapper = new WorkerWrapper({});
 
-            let promise = workerWrapper.sync({});
+            const promise = workerWrapper.sync({});
 
             await new Promise((resolve) => {
                 setTimeout(() => {
@@ -196,9 +207,9 @@ describe("WorkerWrapper", () => {
         });
 
         it("should reject on [error] event", async () => {
-            let workerWrapper = new WorkerWrapper({});
+            const workerWrapper = new WorkerWrapper({});
 
-            let promise = workerWrapper.sync({});
+            const promise = workerWrapper.sync({});
 
             await new Promise((resolve) => {
                 setTimeout(() => {

--- a/packages/core-snapshots/src/database-service.ts
+++ b/packages/core-snapshots/src/database-service.ts
@@ -206,18 +206,18 @@ export class SnapshotDatabaseService implements Database.DatabaseService {
             throw new Error("Database is empty");
         }
 
-        const firstHeight = start || 1;
-        const lastHeight = end || lastBlock.height;
+        const firstRound = Utils.roundCalculator.calculateRound(start || 1);
+        const lastRound = Utils.roundCalculator.calculateRound(end || lastBlock.height);
 
-        const firstRound = Utils.roundCalculator.calculateRound(firstHeight);
-        const lastRound = Utils.roundCalculator.calculateRound(lastHeight);
+        const startHeight = firstRound.roundHeight;
+        const endHeight = lastRound.roundHeight - 1;
 
-        if (firstRound.roundHeight >= lastRound.roundHeight) {
+        if (startHeight >= endHeight) {
             throw new Error("Start round is greater or equal to end round");
         }
 
-        const firstBlock = await this.blockRepository.findByHeight(firstRound.roundHeight);
-        lastBlock = await this.blockRepository.findByHeight(lastRound.roundHeight);
+        const firstBlock = await this.blockRepository.findByHeight(startHeight);
+        lastBlock = await this.blockRepository.findByHeight(endHeight);
 
         Utils.assert.defined<Models.Block>(firstBlock);
         Utils.assert.defined<Models.Block>(lastBlock);
@@ -229,7 +229,7 @@ export class SnapshotDatabaseService implements Database.DatabaseService {
 
             firstRoundRound: firstRound.round,
             lastRoundRound: lastRound.round,
-            roundsCount: await this.roundRepository.countInRange(firstRound.round, lastRound.round),
+            roundsCount: await this.roundRepository.countInRange(firstRound.round, lastRound.round - 1),
 
             firstTransactionTimestamp: firstBlock.timestamp,
             lastTransactionTimestamp: lastBlock.timestamp,

--- a/packages/core-snapshots/src/database-service.ts
+++ b/packages/core-snapshots/src/database-service.ts
@@ -37,10 +37,10 @@ export class SnapshotDatabaseService implements Database.DatabaseService {
     private skipCompression: boolean = false;
     private verifyData: boolean = false;
 
-    public init(codec?: string, skipCompression?: boolean, verify: boolean = false): void {
-        this.codec = codec || "default";
-        this.skipCompression = skipCompression || false;
-        this.verifyData = verify || false;
+    public init(codec: string = "default", skipCompression: boolean = false, verify: boolean = false): void {
+        this.codec = codec;
+        this.skipCompression = skipCompression;
+        this.verifyData = verify;
     }
 
     public async truncate(): Promise<void> {
@@ -101,9 +101,9 @@ export class SnapshotDatabaseService implements Database.DatabaseService {
 
             throw err;
         } finally {
-            await blocksWorker?.terminate();
-            await transactionsWorker?.terminate();
-            await roundsWorker?.terminate();
+            await blocksWorker.terminate();
+            await transactionsWorker.terminate();
+            await roundsWorker.terminate();
         }
     }
 
@@ -166,13 +166,9 @@ export class SnapshotDatabaseService implements Database.DatabaseService {
             for (const height of milestoneHeights) {
                 const promises = [] as any;
 
-                // console.log("Run blocks with: ",{ nextValue: height, nextField: "height"})
                 promises.push(blocksWorker.sync({ nextValue: height, nextField: "height" }));
 
                 if (result && result.height > 0) {
-                    // console.log("Run transactions with: ", { nextCount: result.numberOfTransactions, height: result.height - 1  })
-                    // console.log("Run rounds with: ", { nextCount: Utils.roundCalculator.calculateRound(result.height).round, height: result.height - 1  })
-
                     promises.push(
                         transactionsWorker.sync({ nextCount: result.numberOfTransactions, height: result.height - 1 }),
                     );
@@ -186,8 +182,6 @@ export class SnapshotDatabaseService implements Database.DatabaseService {
 
                 result = (await Promise.all(promises))[0];
 
-                // console.log("Result: ", result)
-
                 if (!result) {
                     break;
                 }
@@ -199,9 +193,9 @@ export class SnapshotDatabaseService implements Database.DatabaseService {
 
             throw err;
         } finally {
-            await blocksWorker?.terminate();
-            await transactionsWorker?.terminate();
-            await roundsWorker?.terminate();
+            await blocksWorker.terminate();
+            await transactionsWorker.terminate();
+            await roundsWorker.terminate();
         }
     }
 
@@ -213,7 +207,7 @@ export class SnapshotDatabaseService implements Database.DatabaseService {
         }
 
         const firstHeight = start || 1;
-        const lastHeight = end || lastBlock?.height || 1;
+        const lastHeight = end || lastBlock.height;
 
         const firstRound = Utils.roundCalculator.calculateRound(firstHeight);
         const lastRound = Utils.roundCalculator.calculateRound(lastHeight);

--- a/packages/core-snapshots/src/filesystem/filesystem.ts
+++ b/packages/core-snapshots/src/filesystem/filesystem.ts
@@ -42,11 +42,11 @@ export class Filesystem {
     }
 
     private validateMetaData(meta: Meta.MetaData): void {
-        Utils.assert.defined(meta?.codec);
-        Utils.assert.defined(meta?.skipCompression);
+        Utils.assert.defined(meta.codec);
+        Utils.assert.defined(meta.skipCompression);
 
-        Utils.assert.defined(meta?.blocks?.count);
-        Utils.assert.defined(meta?.transactions?.count);
-        Utils.assert.defined(meta?.rounds?.count);
+        Utils.assert.defined(meta.blocks?.count);
+        Utils.assert.defined(meta.transactions?.count);
+        Utils.assert.defined(meta.rounds?.count);
     }
 }

--- a/packages/core-snapshots/src/filesystem/stream-reader.ts
+++ b/packages/core-snapshots/src/filesystem/stream-reader.ts
@@ -138,6 +138,7 @@ export class StreamReader {
             }
 
             let copyLength = 0;
+            /* istanbul ignore next */
             if (this.offset + remaining <= this.length) {
                 copyLength = remaining;
             } else {

--- a/packages/core-snapshots/src/repositories/block-repository.ts
+++ b/packages/core-snapshots/src/repositories/block-repository.ts
@@ -18,7 +18,7 @@ export class BlockRepository extends Repositories.AbstractRepository<Models.Bloc
     }
 
     public async rollback(roundInfo: Contracts.Shared.RoundInfo): Promise<void> {
-        const block = await this.findByHeight(roundInfo.roundHeight);
+        const block = await this.findByHeight(roundInfo.roundHeight - 1);
 
         if (!block) {
             throw new Error("Cannot find block on height " + roundInfo.roundHeight);
@@ -43,7 +43,7 @@ export class BlockRepository extends Repositories.AbstractRepository<Models.Bloc
                 .createQueryBuilder()
                 .delete()
                 .from(Models.Round)
-                .where("round > :round", { round: roundInfo.round })
+                .where("round > :round", { round: roundInfo.round - 1 })
                 .execute();
         });
     }

--- a/packages/core-snapshots/src/repositories/block-repository.ts
+++ b/packages/core-snapshots/src/repositories/block-repository.ts
@@ -8,13 +8,13 @@ import { Repository } from "../contracts";
 export class BlockRepository extends Repositories.AbstractRepository<Models.Block> implements Repository {
     public async getReadStream(start: number, end: number): Promise<NodeJS.ReadableStream> {
         return this.createQueryBuilder()
-            .where("height >= :start AND height < :end", { start, end })
+            .where("height >= :start AND height <= :end", { start, end })
             .orderBy("height", "ASC")
             .stream();
     }
 
     public async countInRange(start: number, end: number): Promise<number> {
-        return this.createQueryBuilder().where("height >= :start AND height < :end", { start, end }).getCount();
+        return this.createQueryBuilder().where("height >= :start AND height <= :end", { start, end }).getCount();
     }
 
     public async rollback(roundInfo: Contracts.Shared.RoundInfo): Promise<void> {

--- a/packages/core-snapshots/src/repositories/round-repository.ts
+++ b/packages/core-snapshots/src/repositories/round-repository.ts
@@ -7,12 +7,12 @@ import { Repository } from "../contracts";
 export class RoundRepository extends Repositories.AbstractRepository<Models.Round> implements Repository {
     public async getReadStream(start: number, end: number): Promise<NodeJS.ReadableStream> {
         return this.createQueryBuilder()
-            .where("round >= :start AND round < :end", { start, end })
+            .where("round >= :start AND round <= :end", { start, end })
             .orderBy("round", "ASC")
             .stream();
     }
 
     public async countInRange(start: number, end: number): Promise<number> {
-        return this.createQueryBuilder().where("round >= :start AND round < :end", { start, end }).getCount();
+        return this.createQueryBuilder().where("round >= :start AND round <= :end", { start, end }).getCount();
     }
 }

--- a/packages/core-snapshots/src/repositories/transaction-repository.ts
+++ b/packages/core-snapshots/src/repositories/transaction-repository.ts
@@ -7,13 +7,13 @@ import { Repository } from "../contracts";
 export class TransactionRepository extends Repositories.AbstractRepository<Models.Transaction> implements Repository {
     public async getReadStream(start: number, end: number): Promise<NodeJS.ReadableStream> {
         return this.createQueryBuilder()
-            .where("timestamp >= :start AND timestamp < :end", { start, end })
+            .where("timestamp >= :start AND timestamp <= :end", { start, end })
             .orderBy("timestamp", "ASC")
             .addOrderBy("sequence", "ASC")
             .stream();
     }
 
     public async countInRange(start: number, end: number): Promise<number> {
-        return this.createQueryBuilder().where("timestamp >= :start AND timestamp < :end", { start, end }).getCount();
+        return this.createQueryBuilder().where("timestamp >= :start AND timestamp <= :end", { start, end }).getCount();
     }
 }

--- a/packages/core-snapshots/src/workers/actions/read-processor.ts
+++ b/packages/core-snapshots/src/workers/actions/read-processor.ts
@@ -24,31 +24,24 @@ export class ReadProcessor {
     ) {}
 
     public sync(data: any): void {
-        // console.log("Sync", data);
-
         this.nextField = data.nextField;
         this.nextValue = data.nextValue;
         this.nextCount = data.nextCount;
 
         if (data.height) {
-            /* istanbul ignore next */
             Managers.configManager.setHeight(data.height);
         }
 
+        /* istanbul ignore next */
         if (this.onResume) {
-            /* istanbul ignore next */
             this.onResume();
         }
         this.isRunning = true;
 
         this.emitCount();
 
-        // parentPort?.postMessage({
-        //     action: "log",
-        //     data: "Resume: " + JSON.stringify(data)
-        // })
-
         // On first message is not defined
+        /* istanbul ignore next */
         if (this.callOnMessage) {
             this.callOnMessage();
         }
@@ -57,15 +50,15 @@ export class ReadProcessor {
     public async start() {
         await this.streamReader.open();
 
-        parentPort?.postMessage({
+        parentPort!.postMessage({
             action: "started",
         });
 
         await this.waitForSynchronization(false);
 
         const interval = setInterval(() => {
+            /* istanbul ignore next */
             if (this.isRunning) {
-                /* istanbul ignore next */
                 this.emitCount();
             }
         }, 500);
@@ -75,11 +68,6 @@ export class ReadProcessor {
 
         while ((entity = await this.streamReader.readNext())) {
             this.count++;
-
-            // parentPort?.postMessage({
-            //     action: "log",
-            //     data: "count: " + this.count
-            // })
 
             if (this.nextValue && entity[this.nextField] > this.nextValue!) {
                 await this.waitOrContinue(this.count, previousEntity, entity);
@@ -110,7 +98,7 @@ export class ReadProcessor {
     }
 
     private emitCount(): void {
-        parentPort?.postMessage({
+        parentPort!.postMessage({
             action: "count",
             data: this.count,
         });
@@ -137,11 +125,6 @@ export class ReadProcessor {
 
     private waitForSynchronization(emit: boolean = true): Promise<void> {
         return new Promise<void>(async (resolve) => {
-            // parentPort?.postMessage({
-            //     action: "log",
-            //     data: "Wait: "
-            // })
-
             if (this.onWait) {
                 await this.onWait();
             }
@@ -159,11 +142,6 @@ export class ReadProcessor {
     }
 
     private emitSynchronized() {
-        // parentPort?.postMessage({
-        //     action: "log",
-        //     data: "wait"
-        // })
-
         parentPort!.postMessage({
             action: "synchronized",
             data: {

--- a/packages/core-snapshots/src/workers/actions/restore-worker-action.ts
+++ b/packages/core-snapshots/src/workers/actions/restore-worker-action.ts
@@ -9,7 +9,7 @@ export class RestoreWorkerAction extends AbstractWorkerAction {
     private entities = [] as any[];
 
     public sync(data: any): void {
-        this.readProcessor?.sync(data);
+        this.readProcessor!.sync(data);
     }
 
     public async start() {
@@ -26,7 +26,6 @@ export class RestoreWorkerAction extends AbstractWorkerAction {
                 }
 
                 if (this.options!.verify) {
-                    /* istanbul ignore next */
                     verify(entity, previousEntity);
                 }
 

--- a/packages/core-snapshots/src/workers/actions/test-worker-action.ts
+++ b/packages/core-snapshots/src/workers/actions/test-worker-action.ts
@@ -13,6 +13,7 @@ export class TestWorkerAction implements WorkerAction {
     }
 
     public sync(data: any): void {
+        /* istanbul ignore next */
         if (this.resume) {
             this.resume();
         }
@@ -28,7 +29,7 @@ export class TestWorkerAction implements WorkerAction {
         }
 
         if (this.options.table === "wait") {
-            parentPort?.postMessage({
+            parentPort!.postMessage({
                 action: "started",
             });
 

--- a/packages/core-snapshots/src/workers/actions/verify-worker-action.ts
+++ b/packages/core-snapshots/src/workers/actions/verify-worker-action.ts
@@ -8,7 +8,7 @@ export class VerifyWorkerAction extends AbstractWorkerAction {
     private readProcessor: ReadProcessor | undefined = undefined;
 
     public sync(data: any): void {
-        this.readProcessor?.sync(data);
+        this.readProcessor!.sync(data);
     }
 
     public async start() {

--- a/packages/core-snapshots/src/workers/worker-wrapper.ts
+++ b/packages/core-snapshots/src/workers/worker-wrapper.ts
@@ -45,9 +45,7 @@ export class WorkerWrapper extends EventEmitter {
     public sync(data: any): Promise<any> {
         return new Promise((resolve, reject) => {
             if (this.isDone) {
-                /* istanbul ignore next */
                 resolve();
-                /* istanbul ignore next */
                 return;
             }
 
@@ -77,6 +75,7 @@ export class WorkerWrapper extends EventEmitter {
     private handleMessage(data) {
         // Actions: count, started, synced, exit, error
         this.emit(data.action, data.data);
+        /* istanbul ignore next */
         if (data.action !== "count" && data.action !== "log") {
             this.emit("*", { name: data.action, data: data.data });
         }

--- a/packages/core-snapshots/src/workers/worker.ts
+++ b/packages/core-snapshots/src/workers/worker.ts
@@ -36,8 +36,8 @@ export const init = async () => {
 
     app = new Application(new Container.Container());
 
+    /* istanbul ignore next */
     if (_workerData.connection) {
-        /* istanbul ignore next */
         app.bind(Identifiers.SnapshotDatabaseConnection).toConstantValue(
             await connect({ connection: _workerData.connection }),
         );


### PR DESCRIPTION
## Summary

This PR increases coverage of the core-snapshots package to 100%. 

There is also small fix which will dump blocks rounded to the last known block in the round. Previous code included first block of the round, which can cause some problems. 

Snapshot limitations: 
- it is not possible to dump database if last block in round was missed
- dump requires n + 1 blocks in the database, if we want to dump n blocks.

## Checklist

- [X] Tests
- [X] Ready to be merged
