### PR TITLE
fix(core-p2p): Ensure peer port is always an integer to avoid socket validation errors

### DIFF
--- a/__tests__/unit/core-p2p/service-provider.test.ts
+++ b/__tests__/unit/core-p2p/service-provider.test.ts
@@ -1,7 +1,6 @@
-import { Container, Application, Providers, Services } from "@arkecosystem/core-kernel";
-
-import { ServiceProvider } from "@arkecosystem/core-p2p/src/service-provider";
+import { Application, Container, Providers, Services } from "@arkecosystem/core-kernel";
 import { Peer } from "@arkecosystem/core-p2p/src/peer";
+import { ServiceProvider } from "@arkecosystem/core-p2p/src/service-provider";
 
 describe("ServiceProvider", () => {
     const serverSymbol = Symbol.for("P2P<Server>");
@@ -19,10 +18,12 @@ describe("ServiceProvider", () => {
         [serverSymbol]: mockServer,
         [Container.Identifiers.TriggerService]: triggerService,
     };
-    let factoryBound; 
+    let factoryBound;
     const appBind = {
         to: () => ({ inSingletonScope: () => {} }),
-        toFactory: (factoryFn) => { factoryBound = factoryFn },
+        toFactory: (factoryFn) => {
+            factoryBound = factoryFn;
+        },
     };
     let application = {
         bind: (key) => appBind,
@@ -49,7 +50,9 @@ describe("ServiceProvider", () => {
         const pluginConfiguration = app.resolve<Providers.PluginConfiguration>(Providers.PluginConfiguration);
         pluginConfiguration.from("core-p2p", {
             // @ts-ignore
-            server: {},
+            server: {
+                port: "4005",
+            },
         });
         serviceProvider.setConfig(pluginConfiguration);
 
@@ -137,6 +140,16 @@ describe("ServiceProvider", () => {
     describe("required", () => {
         it("should return true", async () => {
             expect(await serviceProvider.required()).toBeTrue();
+        });
+    });
+    describe("peerFactory", () => {
+        it("should create a peer with integer port number, when using string config", async () => {
+            await serviceProvider.register();
+            const ip = "188.133.1.2";
+            const testPeer = factoryBound()(ip);
+            expect(testPeer).toBeInstanceOf(Peer);
+            expect(typeof testPeer.port).toBe("number");
+            expect(testPeer.port).toEqual(4005);
         });
     });
 });

--- a/__tests__/unit/core-p2p/socket-server/utils/get-headers.test.ts
+++ b/__tests__/unit/core-p2p/socket-server/utils/get-headers.test.ts
@@ -1,5 +1,5 @@
-import { getHeaders } from "@arkecosystem/core-p2p/src/socket-server/utils/get-headers";
 import { Container } from "@arkecosystem/core-kernel";
+import { getHeaders } from "@arkecosystem/core-p2p/src/socket-server/utils/get-headers";
 
 describe("getHeaders", () => {
     const version = "3.0.9";
@@ -28,5 +28,31 @@ describe("getHeaders", () => {
         const headers = getHeaders(app as any);
 
         expect(headers).toEqual({ version, port, height: undefined });
+    });
+
+    it("should return port as an integer (when it is set in config as a string)", () => {
+        const version = "3.0.9";
+        const port = "4005";
+        const height = 387;
+        const stateStore = { started: true };
+        const blockchain = { getLastHeight: () => height };
+        const appGet = {
+            [Container.Identifiers.StateStore]: stateStore,
+            [Container.Identifiers.BlockchainService]: blockchain,
+        };
+        const app = {
+            version: () => version,
+            getTagged: () => ({ get: () => port }),
+            get: (key) => appGet[key],
+        };
+
+        stateStore.started = false;
+        const headers = getHeaders(app as any);
+
+        const portNumberAsString = app.getTagged().get();
+        expect(typeof portNumberAsString).toBe("string");
+        expect(portNumberAsString).toEqual("4005");
+        expect(typeof headers.port).toBe("number");
+        expect(headers.port).toEqual(4005);
     });
 });

--- a/packages/core-p2p/src/service-provider.ts
+++ b/packages/core-p2p/src/service-provider.ts
@@ -59,7 +59,7 @@ export class ServiceProvider extends Providers.ServiceProvider {
     private registerFactories(): void {
         this.app
             .bind(Container.Identifiers.PeerFactory)
-            .toFactory<Peer>(() => (ip: string) => new Peer(ip, this.config().get<number>("server.port")!));
+            .toFactory<Peer>(() => (ip: string) => new Peer(ip, Number(this.config().get<number>("server.port"))!));
     }
 
     private registerServices(): void {

--- a/packages/core-p2p/src/socket-server/utils/get-headers.ts
+++ b/packages/core-p2p/src/socket-server/utils/get-headers.ts
@@ -7,13 +7,15 @@ export const getHeaders = (app: Contracts.Kernel.Application) => {
         height: number | undefined;
     } = {
         version: app.version(),
-        port: app
-            .getTagged<Providers.PluginConfiguration>(
-                Container.Identifiers.PluginConfiguration,
-                "plugin",
-                "@arkecosystem/core-p2p",
-            )
-            .get<number>("port"),
+        port: Number(
+            app
+                .getTagged<Providers.PluginConfiguration>(
+                    Container.Identifiers.PluginConfiguration,
+                    "plugin",
+                    "@arkecosystem/core-p2p",
+                )
+                .get<number>("port"),
+        ),
         height: undefined,
     };
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

Ensures that the port number used to construct the `Peer` class always uses an integer (instead of a string). This requires converting a string that may be set from config or environment variables.

<!-- Why are these changes necessary? -->

This fixes the socket data validation issues. As per #3860

<!-- How were these changes implemented? -->

The change is implemented by using a `Number()` conversion on string config.

## Checklist

<!-- Have you done all of these things?  -->

- [x] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
