### PR TITLE
fix(core-transactions): version 1 multi-signature handler should check milestone data

### DIFF
--- a/__tests__/unit/core-transactions/handlers/handler-registry.test.ts
+++ b/__tests__/unit/core-transactions/handlers/handler-registry.test.ts
@@ -17,7 +17,7 @@ import ByteBuffer from "bytebuffer";
 let app: Application;
 
 const NUMBER_OF_REGISTERED_CORE_HANDLERS = 16;
-const NUMBER_OF_ACTIVE_CORE_HANDLERS_AIP11_IS_FALSE = 8; // TODO: Check if correct
+const NUMBER_OF_ACTIVE_CORE_HANDLERS_AIP11_IS_FALSE = 9; // TODO: Check if correct
 const NUMBER_OF_ACTIVE_CORE_HANDLERS_AIP11_IS_TRUE = 12;
 
 const TEST_TRANSACTION_TYPE = 100;

--- a/__tests__/unit/core-transactions/handlers/one/multi-signature-registration.test.ts
+++ b/__tests__/unit/core-transactions/handlers/one/multi-signature-registration.test.ts
@@ -188,4 +188,19 @@ describe("MultiSignatureRegistrationTransaction", () => {
             );
         });
     });
+
+    describe("isActivated", () => {
+        it("should return true when aip11 is false", async () => {
+            configManager.getMilestone().aip11 = false;
+            await expect(handler.isActivated()).resolves.toBe(true);
+        });
+        it("should return true when aip11 is undefined", async () => {
+            configManager.getMilestone().aip11 = undefined;
+            await expect(handler.isActivated()).resolves.toBe(true);
+        });
+        it("should return false when aip11 is true", async () => {
+            configManager.getMilestone().aip11 = true;
+            await expect(handler.isActivated()).resolves.toBe(false);
+        });
+    });
 });

--- a/packages/core-transactions/src/handlers/one/multi-signature-registration.ts
+++ b/packages/core-transactions/src/handlers/one/multi-signature-registration.ts
@@ -1,5 +1,5 @@
 import { Container, Contracts, Utils as AppUtils } from "@arkecosystem/core-kernel";
-import { Interfaces, Transactions, Utils } from "@arkecosystem/crypto";
+import { Interfaces, Managers, Transactions, Utils } from "@arkecosystem/crypto";
 
 import { LegacyMultiSignatureError, MultiSignatureAlreadyRegisteredError } from "../../errors";
 import { TransactionHandler, TransactionHandlerConstructor } from "../transaction";
@@ -48,7 +48,7 @@ export class MultiSignatureRegistrationTransactionHandler extends TransactionHan
     }
 
     public async isActivated(): Promise<boolean> {
-        return false;
+        return !Managers.configManager.getMilestone().aip11;
     }
 
     public async throwIfCannotBeApplied(


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

The `MultiSignatureRegistrationTransactionHandler` (version 1) was always returning false for `.isActivated()` - this PR updates it to instead check milestones.

<!-- Why are these changes necessary? -->

Fixes #3866. Stops `DeactivatedTransactionHandlerError` from being thrown while syncing with devnet.

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [x] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
