### PR TITLE
fix(core-state): remove unnecessary assertion check to enable devnet sync

### DIFF
--- a/__tests__/unit/core-state/block-state.test.ts
+++ b/__tests__/unit/core-state/block-state.test.ts
@@ -573,11 +573,11 @@ describe("BlockState", () => {
                 expect(revertSpy).toHaveBeenCalledWith(transaction);
             });
 
-            it("fail to apply transaction if the recipient doesn't exist", async () => {
+            it("not fail to apply transaction if the recipient doesn't exist", async () => {
                 transaction.data.recipientId = "don'tExist";
                 walletRepo.forgetByAddress(recipientWallet.address);
 
-                await expect(blockState.applyTransaction(transaction)).toReject();
+                await expect(blockState.applyTransaction(transaction)).toResolve();
             });
 
             it("fail to revert transaction if the recipient doesn't exist", async () => {

--- a/__tests__/unit/core-state/block-state.test.ts
+++ b/__tests__/unit/core-state/block-state.test.ts
@@ -580,11 +580,11 @@ describe("BlockState", () => {
                 await expect(blockState.applyTransaction(transaction)).toResolve();
             });
 
-            it("fail to revert transaction if the recipient doesn't exist", async () => {
+            it("not fail to revert transaction if the recipient doesn't exist", async () => {
                 transaction.data.recipientId = "don'tExist";
                 walletRepo.forgetByAddress(recipientWallet.address);
 
-                await expect(blockState.revertTransaction(transaction)).toReject();
+                await expect(blockState.revertTransaction(transaction)).toResolve();
             });
         });
 

--- a/packages/core-state/src/block-state.ts
+++ b/packages/core-state/src/block-state.ts
@@ -99,9 +99,7 @@ export class BlockState {
         if (transaction.data.recipientId) {
             AppUtils.assert.defined<string>(transaction.data.recipientId);
 
-            if (this.walletRepository.hasByAddress(transaction.data.recipientId)) {
-                recipient = this.walletRepository.findByAddress(transaction.data.recipientId);
-            }
+            recipient = this.walletRepository.findByAddress(transaction.data.recipientId);
         }
 
         // @ts-ignore - Apply vote balance updates
@@ -121,15 +119,7 @@ export class BlockState {
         if (transaction.data.recipientId) {
             AppUtils.assert.defined<string>(transaction.data.recipientId);
 
-            if (this.walletRepository.hasByAddress(transaction.data.recipientId)) {
-                recipient = this.walletRepository.findByAddress(transaction.data.recipientId);
-            }
-
-            /**
-             * TODO: check this is desired behaviour?
-             * Presumably if a transaction specifies a recipient, that recipient should exist
-             */
-            AppUtils.assert.defined<Contracts.State.Wallet>(recipient);
+            recipient = this.walletRepository.findByAddress(transaction.data.recipientId);
         }
 
         await transactionHandler.revert(transaction);

--- a/packages/core-state/src/block-state.ts
+++ b/packages/core-state/src/block-state.ts
@@ -102,12 +102,6 @@ export class BlockState {
             if (this.walletRepository.hasByAddress(transaction.data.recipientId)) {
                 recipient = this.walletRepository.findByAddress(transaction.data.recipientId);
             }
-
-            /**
-             * TODO: check this is desired behaviour?
-             * Presumably if a transaction specifies a recipient, that recipient should exist
-             */
-            AppUtils.assert.defined<Contracts.State.Wallet>(recipient);
         }
 
         // @ts-ignore - Apply vote balance updates


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

This removes an assertion check inside `block-state.ts` which was causing problems with devnet sync. The behaviour was recently added and can therefore be removed. Change supports #3882.

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [x] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
