### PR TITLE
feat(core-p2p): forget unresponsive peer

### DIFF
--- a/__tests__/unit/core-p2p/listeners.test.ts
+++ b/__tests__/unit/core-p2p/listeners.test.ts
@@ -1,5 +1,4 @@
 import { Container } from "@arkecosystem/core-kernel";
-
 import { DisconnectInvalidPeers, DisconnectPeer } from "@arkecosystem/core-p2p/src/listeners";
 import { Peer } from "@arkecosystem/core-p2p/src/peer";
 
@@ -77,7 +76,7 @@ describe("DisconnectPeer", () => {
     describe("handle", () => {
         it("should disconnect the peer provided", async () => {
             const peer = new Peer("187.176.1.1", 4000);
-            await disconnectPeer.handle({ data: peer });
+            await disconnectPeer.handle({ data: { peer: peer } });
 
             expect(storage.forgetPeer).toBeCalledTimes(1);
             expect(storage.forgetPeer).toBeCalledWith(peer);

--- a/__tests__/unit/core-p2p/service-provider.test.ts
+++ b/__tests__/unit/core-p2p/service-provider.test.ts
@@ -1,3 +1,5 @@
+import "jest-extended";
+
 import { Application, Container, Providers, Services } from "@arkecosystem/core-kernel";
 import { Peer } from "@arkecosystem/core-p2p/src/peer";
 import { ServiceProvider } from "@arkecosystem/core-p2p/src/service-provider";
@@ -15,6 +17,7 @@ describe("ServiceProvider", () => {
         [Container.Identifiers.PeerNetworkMonitor]: { initialize: jest.fn() },
         [Container.Identifiers.PeerProcessor]: { initialize: jest.fn() },
         [Container.Identifiers.PeerCommunicator]: { initialize: jest.fn() },
+        [Container.Identifiers.PeerEventListener]: { initialize: jest.fn() },
         [serverSymbol]: mockServer,
         [Container.Identifiers.TriggerService]: triggerService,
     };
@@ -74,7 +77,7 @@ describe("ServiceProvider", () => {
                 Identifiers.PeerProcessor,
                 Identifiers.PeerNetworkMonitor,
                 Identifiers.PeerTransactionBroadcaster,
-                "p2p.event-listener",
+                Identifiers.PeerEventListener,
             ]) {
                 expect(spyBind).toBeCalledWith(identifier);
             }

--- a/packages/core-kernel/src/contracts/p2p/peer.ts
+++ b/packages/core-kernel/src/contracts/p2p/peer.ts
@@ -21,6 +21,7 @@ export interface Peer {
     state: PeerState;
     plugins: PeerPlugins;
     lastPinged: Dayjs | undefined;
+    sequentialErrorCounter: number;
     verificationResult: PeerVerificationResult | undefined;
 
     isVerified(): boolean;

--- a/packages/core-kernel/src/ioc/identifiers.ts
+++ b/packages/core-kernel/src/ioc/identifiers.ts
@@ -88,6 +88,7 @@ export const Identifiers = {
     PeerProcessor: Symbol.for("Peer<Processor>"),
     PeerStorage: Symbol.for("Peer<Storage>"),
     PeerTransactionBroadcaster: Symbol.for("Peer<TransactionBroadcaster>"),
+    PeerEventListener: Symbol.for("Peer<EventListener>"),
     // Transaction Pool
     TransactionPoolService: Symbol.for("TransactionPool<Service>"),
     TransactionPoolCleaner: Symbol.for("TransactionPool<Cleaner>"),

--- a/packages/core-p2p/src/defaults.ts
+++ b/packages/core-p2p/src/defaults.ts
@@ -30,7 +30,7 @@ export const defaults = {
      */
     maxSameSubnetPeers: process.env.CORE_P2P_MAX_PEERS_SAME_SUBNET || 5,
     /**
-     * The maximum peer consecutive errors before peer is foget from peer store. 
+     * The maximum peer consecutive errors before peer is forget from peer store.
      */
     maxPeerSequentialErrors: process.env.CORE_P2P_MAX_PEER_SEQUENTIAL_ERRORS || 3,
     /**

--- a/packages/core-p2p/src/defaults.ts
+++ b/packages/core-p2p/src/defaults.ts
@@ -30,6 +30,10 @@ export const defaults = {
      */
     maxSameSubnetPeers: process.env.CORE_P2P_MAX_PEERS_SAME_SUBNET || 5,
     /**
+     * The maximum peer consecutive errors before peer is foget from peer store. 
+     */
+    maxPeerSequentialErrors: process.env.CORE_P2P_MAX_PEER_SEQUENTIAL_ERRORS || 3,
+    /**
      * The list of IPs we allow to be added to the peer list.
      */
     whitelist: ["*"],

--- a/packages/core-p2p/src/listeners.ts
+++ b/packages/core-p2p/src/listeners.ts
@@ -71,13 +71,13 @@ export class DisconnectPeer implements Contracts.Kernel.EventListener {
     private readonly storage!: Contracts.P2P.PeerStorage;
 
     /**
-     * @param {*} {data}
+     * @param {*} {peer}
      * @returns {Promise<void>}
      * @memberof DisconnectPeer
      */
     public async handle({ data }): Promise<void> {
-        this.connector.disconnect(data);
+        this.connector.disconnect(data.peer);
 
-        this.storage.forgetPeer(data);
+        this.storage.forgetPeer(data.peer);
     }
 }

--- a/packages/core-p2p/src/peer.ts
+++ b/packages/core-p2p/src/peer.ts
@@ -34,6 +34,12 @@ export class Peer implements Contracts.P2P.Peer {
     public lastPinged: Dayjs | undefined;
 
     /**
+     * @type {(number)}
+     * @memberof Peer
+     */
+    public sequentialErrorCounter: number = 0;
+
+    /**
      * @type {(PeerVerificationResult | undefined)}
      * @memberof Peer
      */

--- a/packages/core-p2p/src/service-provider.ts
+++ b/packages/core-p2p/src/service-provider.ts
@@ -41,6 +41,8 @@ export class ServiceProvider extends Providers.ServiceProvider {
      * @memberof ServiceProvider
      */
     public async boot(): Promise<void> {
+        this.app.get<EventListener>(Container.Identifiers.PeerEventListener).initialize();
+
         return this.app.get<Server>(this.serverSymbol).boot();
     }
 
@@ -79,7 +81,7 @@ export class ServiceProvider extends Providers.ServiceProvider {
 
         this.app.get<PeerProcessor>(Container.Identifiers.PeerProcessor).initialize();
 
-        this.app.bind("p2p.event-listener").to(EventListener).inSingletonScope();
+        this.app.bind(Container.Identifiers.PeerEventListener).to(EventListener).inSingletonScope();
 
         this.app.bind(Container.Identifiers.PeerTransactionBroadcaster).to(TransactionBroadcaster);
     }


### PR DESCRIPTION
## Summary

This PR solves issue #3880 and #3883

Peer will be removed from peer list after 3 (default) sequential unsuccessful responses. Each time peer respond error counter is reset. 

CORE_P2P_MAX_PEER_SEQUENTIAL_ERRORS flag is used  to increase the limit of unsuccessful responses, which can be useful on networks with quicker block times. 

## Checklist

- [x] Tests
- [x] Ready to be merged
