### PR TITLE
feat(core-api): enable registering routes with pagination

### DIFF
--- a/__tests__/unit/core-api/plugins/pagination.test.ts
+++ b/__tests__/unit/core-api/plugins/pagination.test.ts
@@ -35,6 +35,13 @@ describe("Pagination", () => {
             handler: () => {
                 return customResponse;
             },
+            options: {
+                plugins: {
+                    pagination: {
+                        enabled: true,
+                    },
+                },
+            },
         };
 
         injectOptions = {
@@ -96,11 +103,35 @@ describe("Pagination", () => {
         );
     });
 
+    it("should return paginated payload with data in results if pagination have not enabled property", async () => {
+        customResponse = {
+            results: customResponse,
+        };
+
+        customRoute.options = {
+            plugins: {
+                pagination: {},
+            },
+        };
+
+        const server = await initServer(app, defaults, customRoute);
+
+        const response = await server.inject(injectOptions);
+        const payload = JSON.parse(response.payload || {});
+        expect(payload.data).toEqual(customResponse.results);
+        expect(payload.meta).toEqual(
+            expect.objectContaining({
+                count: 3,
+                pageCount: 1,
+            }),
+        );
+    });
+
     it("should not return paginated payload if disabled on route", async () => {
         customRoute.options = {
             plugins: {
                 pagination: {
-                    pagination: false,
+                    enabled: false,
                 },
             },
         };

--- a/packages/core-api/src/plugins/pagination/ext.ts
+++ b/packages/core-api/src/plugins/pagination/ext.ts
@@ -4,57 +4,12 @@ import { Utils } from "@arkecosystem/core-kernel";
 import Hoek from "@hapi/hoek";
 import Qs from "querystring";
 
-interface IRoute {
-    method: string;
-    path: string;
-}
-
 export class Ext {
     private readonly routePathPrefix = "/api";
-    private readonly routes: IRoute[] = [
-        { method: "get", path: "/blocks" },
-        { method: "get", path: "/blocks/{id}/transactions" },
-        { method: "post", path: "/blocks/search" },
-        { method: "get", path: "/bridgechains" },
-        { method: "post", path: "/bridgechains/search" },
-        { method: "get", path: "/businesses" },
-        { method: "get", path: "/businesses/{id}/bridgechains" },
-        { method: "post", path: "/businesses/search" },
-        { method: "get", path: "/delegates" },
-        { method: "get", path: "/delegates/{id}/blocks" },
-        { method: "get", path: "/delegates/{id}/voters" },
-        { method: "post", path: "/delegates/search" },
-        { method: "get", path: "/locks" },
-        { method: "post", path: "/locks/search" },
-        { method: "post", path: "/locks/unlocked" },
-        { method: "get", path: "/peers" },
-        { method: "get", path: "/transactions" },
-        { method: "post", path: "/transactions/search" },
-        { method: "get", path: "/transactions/unconfirmed" },
-        { method: "get", path: "/votes" },
-        { method: "get", path: "/wallets" },
-        { method: "get", path: "/wallets/top" },
-        { method: "get", path: "/wallets/{id}/locks" },
-        { method: "get", path: "/wallets/{id}/transactions" },
-        { method: "get", path: "/wallets/{id}/transactions/received" },
-        { method: "get", path: "/wallets/{id}/transactions/sent" },
-        { method: "get", path: "/wallets/{id}/votes" },
-        { method: "post", path: "/wallets/search" },
-    ];
-
     public constructor(private readonly config) {}
 
     public isValidRoute(request) {
-        if (!this.hasPagination(request)) {
-            return false;
-        }
-
-        const { method, path } = request.route;
-
-        return (
-            this.routes.find((route) => route.method === method && `${this.routePathPrefix}${route.path}` === path) !==
-            undefined
-        );
+        return this.hasPagination(request);
     }
 
     public onPreHandler(request, h) {
@@ -155,12 +110,16 @@ export class Ext {
     }
 
     public hasPagination(request) {
-        const routeOptions = this.getRouteOptions(request);
+        const pagination = this.getRoutePaginationOptions(request);
 
-        return Object.prototype.hasOwnProperty.call(routeOptions, "pagination") ? routeOptions.pagination : true;
+        if (!pagination) {
+            return false;
+        }
+
+        return pagination.enabled !== undefined ? pagination.enabled : true;
     }
 
-    private getRouteOptions(request) {
-        return request.route.settings.plugins.pagination || {};
+    private getRoutePaginationOptions(request) {
+        return request.route.settings.plugins.pagination;
     }
 }

--- a/packages/core-api/src/routes/blocks.ts
+++ b/packages/core-api/src/routes/blocks.ts
@@ -20,6 +20,11 @@ export const register = (server: Hapi.Server): void => {
                     transform: Joi.bool().default(true),
                 }),
             },
+            plugins: {
+                pagination: {
+                    enabled: true,
+                },
+            },
         },
     });
 
@@ -81,6 +86,11 @@ export const register = (server: Hapi.Server): void => {
                     transform: Joi.bool().default(true),
                 }),
             },
+            plugins: {
+                pagination: {
+                    enabled: true,
+                },
+            },
         },
     });
 
@@ -98,6 +108,11 @@ export const register = (server: Hapi.Server): void => {
                 payload: Joi.object({
                     ...server.app.schemas.blockCriteriaSchemas,
                 }),
+            },
+            plugins: {
+                pagination: {
+                    enabled: true,
+                },
             },
         },
     });

--- a/packages/core-api/src/routes/delegates.ts
+++ b/packages/core-api/src/routes/delegates.ts
@@ -30,6 +30,11 @@ export const register = (server: Hapi.Server): void => {
                     },
                 }),
             },
+            plugins: {
+                pagination: {
+                    enabled: true,
+                },
+            },
         },
     });
 
@@ -61,6 +66,11 @@ export const register = (server: Hapi.Server): void => {
                     orderBy: server.app.schemas.orderBy,
                     transform: Joi.bool().default(true),
                 }),
+            },
+            plugins: {
+                pagination: {
+                    enabled: true,
+                },
             },
         },
     });
@@ -95,6 +105,11 @@ export const register = (server: Hapi.Server): void => {
                     },
                 }),
             },
+            plugins: {
+                pagination: {
+                    enabled: true,
+                },
+            },
         },
     });
 
@@ -126,6 +141,11 @@ export const register = (server: Hapi.Server): void => {
                     producedBlocks: server.app.schemas.integerBetween,
                     voteBalance: server.app.schemas.integerBetween,
                 }),
+            },
+            plugins: {
+                pagination: {
+                    enabled: true,
+                },
             },
         },
     });

--- a/packages/core-api/src/routes/locks.ts
+++ b/packages/core-api/src/routes/locks.ts
@@ -29,6 +29,11 @@ export const register = (server: Hapi.Server): void => {
                     },
                 }),
             },
+            plugins: {
+                pagination: {
+                    enabled: true,
+                },
+            },
         },
     });
 
@@ -79,6 +84,11 @@ export const register = (server: Hapi.Server): void => {
                     isExpired: Joi.bool(),
                 }),
             },
+            plugins: {
+                pagination: {
+                    enabled: true,
+                },
+            },
         },
     });
 
@@ -95,6 +105,11 @@ export const register = (server: Hapi.Server): void => {
                 payload: Joi.object({
                     ids: Joi.array().unique().min(1).max(25).items(Joi.string().hex().length(64)),
                 }),
+            },
+            plugins: {
+                pagination: {
+                    enabled: true,
+                },
             },
         },
     });

--- a/packages/core-api/src/routes/peers.ts
+++ b/packages/core-api/src/routes/peers.ts
@@ -22,6 +22,11 @@ export const register = (server: Hapi.Server): void => {
                     },
                 }),
             },
+            plugins: {
+                pagination: {
+                    enabled: true,
+                },
+            },
         },
     });
 

--- a/packages/core-api/src/routes/transactions.ts
+++ b/packages/core-api/src/routes/transactions.ts
@@ -21,6 +21,11 @@ export const register = (server: Hapi.Server): void => {
                     transform: Joi.bool().default(true),
                 }),
             },
+            plugins: {
+                pagination: {
+                    enabled: true,
+                },
+            },
         },
     });
 
@@ -83,6 +88,11 @@ export const register = (server: Hapi.Server): void => {
                     },
                 }),
             },
+            plugins: {
+                pagination: {
+                    enabled: true,
+                },
+            },
         },
     });
 
@@ -113,6 +123,11 @@ export const register = (server: Hapi.Server): void => {
                 payload: Joi.object({
                     ...server.app.schemas.transactionCriteriaSchemas,
                 }),
+            },
+            plugins: {
+                pagination: {
+                    enabled: true,
+                },
             },
         },
     });

--- a/packages/core-api/src/routes/votes.ts
+++ b/packages/core-api/src/routes/votes.ts
@@ -20,6 +20,11 @@ export const register = (server: Hapi.Server): void => {
                     transform: Joi.bool().default(true),
                 }),
             },
+            plugins: {
+                pagination: {
+                    enabled: true,
+                },
+            },
         },
     });
 

--- a/packages/core-api/src/routes/wallets.ts
+++ b/packages/core-api/src/routes/wallets.ts
@@ -28,6 +28,11 @@ export const register = (server: Hapi.Server): void => {
                     },
                 }),
             },
+            plugins: {
+                pagination: {
+                    enabled: true,
+                },
+            },
         },
     });
 
@@ -51,6 +56,11 @@ export const register = (server: Hapi.Server): void => {
                         producedBlocks: Joi.number().integer().min(0),
                     },
                 }),
+            },
+            plugins: {
+                pagination: {
+                    enabled: true,
+                },
             },
         },
     });
@@ -84,6 +94,11 @@ export const register = (server: Hapi.Server): void => {
                     transform: Joi.bool().default(true),
                 }),
             },
+            plugins: {
+                pagination: {
+                    enabled: true,
+                },
+            },
         },
     });
 
@@ -102,6 +117,11 @@ export const register = (server: Hapi.Server): void => {
                     orderBy: server.app.schemas.transactionsOrderBy,
                     transform: Joi.bool().default(true),
                 }),
+            },
+            plugins: {
+                pagination: {
+                    enabled: true,
+                },
             },
         },
     });
@@ -122,6 +142,11 @@ export const register = (server: Hapi.Server): void => {
                     transform: Joi.bool().default(true),
                 }),
             },
+            plugins: {
+                pagination: {
+                    enabled: true,
+                },
+            },
         },
     });
 
@@ -141,6 +166,11 @@ export const register = (server: Hapi.Server): void => {
                     transform: Joi.bool().default(true),
                 }),
             },
+            plugins: {
+                pagination: {
+                    enabled: true,
+                },
+            },
         },
     });
 
@@ -159,6 +189,11 @@ export const register = (server: Hapi.Server): void => {
                     orderBy: server.app.schemas.transactionsOrderBy,
                     transform: Joi.bool().default(true),
                 }),
+            },
+            plugins: {
+                pagination: {
+                    enabled: true,
+                },
             },
         },
     });
@@ -196,6 +231,11 @@ export const register = (server: Hapi.Server): void => {
                         to: Joi.number().integer().min(0),
                     }),
                 }),
+            },
+            plugins: {
+                pagination: {
+                    enabled: true,
+                },
             },
         },
     });


### PR DESCRIPTION
## Summary

This PR relates to #3894. 

Instead of exposing paginated routes list, every route can define optional paginate property inside options.plugins on route registration. 

Example: 

```
server.route({
        method: "GET",
        path: "...",
        handler: ...,
        options: {
             plugins: {
                pagination: {
                    enabled: true,
                },
            },
        }
})
```

## Checklist

- [x] Tests 
- [x] Ready to be merged
