### PR TITLE
fix(core-database): order transactions by sequence on block save

### DIFF
--- a/packages/core-database/src/repositories/block-repository.ts
+++ b/packages/core-database/src/repositories/block-repository.ts
@@ -159,13 +159,17 @@ export class BlockRepository extends AbstractRepository<Block> {
                 });
 
                 if (block.transactions.length > 0) {
-                    const transactions = block.transactions.map((tx) =>
-                        Object.assign(new Transaction(), {
-                            ...tx.data,
-                            timestamp: tx.timestamp,
-                            serialized: tx.serialized,
-                        }),
-                    );
+                    const transactions = block.transactions
+                        .map((tx) =>
+                            Object.assign(new Transaction(), {
+                                ...tx.data,
+                                timestamp: tx.timestamp,
+                                serialized: tx.serialized,
+                            }),
+                        )
+                        .sort((a: Transaction, b: Transaction) => {
+                            return a.sequence - b.sequence;
+                        });
 
                     transactionEntities.push(...transactions);
                 }


### PR DESCRIPTION
## Summary

This PR solves issue that occurs while syncing blocks from another mainnet peer. Some transactions have order exceptions and  needs to be re-ordered by sequence number to be accepted by database. 

## Checklist

- [x] Ready to be merged