### PR TITLE
fix(crypto): use bundled file for `browser` field

### DIFF
--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -16,7 +16,7 @@
     ],
     "main": "dist/index.js",
     "umd:main": "dist/index.umd.js",
-    "browser": "dist/index.browser.js",
+    "browser": "dist/index.bundled.js",
     "module": "dist/index.esm.js",
     "unpkg": "dist/index.bundled.min.js",
     "jsdelivr": "dist/index.bundled.min.js",

--- a/packages/crypto/rollup.config.js
+++ b/packages/crypto/rollup.config.js
@@ -51,36 +51,8 @@ const moduleConfig = {
     external: allModules,
 };
 
-/** Remove Node's builtin packages and optimize to run in modern browsers */
-const browserConfig = {
-    input: "src/index.ts",
-    output: [
-        {
-            file: pkg.browser,
-            format: "esm",
-        },
-    ],
-    plugins: [
-        json(),
-        resolve({ preferBuiltins: false, browser: true }),
-        commonjs({ include: /node_modules/ }),
-        ts({
-            transpiler: "babel",
-            transpileOnly: true,
-            tsconfig: {
-                declaration: false,
-            },
-            babelConfig: {
-                presets: [["@babel/preset-env", { loose: false, modules: false, targets: { esmodules: true } }]],
-            },
-        }),
-        ...polyfillsPlugins,
-    ],
-    external: dependencies,
-};
-
 /** Full version with all polyfills and dependencies attached to the file */
-const unpkgConfig = {
+const browserConfig = {
     input: "src/index.ts",
     output: [
         {
@@ -91,7 +63,7 @@ const unpkgConfig = {
             ]
         },
         {
-            file: pkg.unpkg.replace(".min", ""),
+            file: pkg.browser,
             format: "esm",
         },
     ],
@@ -144,4 +116,4 @@ const umdConfig = {
     ],
 };
 
-export default [moduleConfig, browserConfig, unpkgConfig, umdConfig];
+export default [moduleConfig, browserConfig, umdConfig];


### PR DESCRIPTION
## Summary

Some dependencies also use Node builtin modules, so it seems useless to build the current config.

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
