### PR TITLE
fix(core-database): expose two methods for findByHeightRangeWithTransactions

### DIFF
--- a/__tests__/functional/core-database/__support__/index.ts
+++ b/__tests__/functional/core-database/__support__/index.ts
@@ -1,6 +1,6 @@
 import { Container, Providers } from "@arkecosystem/core-kernel";
 import { Sandbox } from "@arkecosystem/core-test-framework";
-import { Interfaces } from "@arkecosystem/crypto";
+import { Interfaces, Transactions } from "@arkecosystem/crypto";
 import { Connection, createConnection } from "typeorm";
 
 import { Block } from "../../../../packages/core-database/src/models/block";
@@ -58,7 +58,7 @@ export const toBlockModel = (block: Interfaces.IBlock): Block => {
 export const toBlockModelWithTransactions = (block: Interfaces.IBlock): Block => {
     const model = toBlockModel(block);
     const transactions = block.transactions.map(
-        (t) => t.serialized.toString("hex"),
+        (t) => Transactions.TransactionFactory.fromBytesUnsafe(t.serialized).data,
     );
     Object.assign(model, { transactions });
     return model;

--- a/__tests__/unit/core-database/database-service.test.ts
+++ b/__tests__/unit/core-database/database-service.test.ts
@@ -329,6 +329,7 @@ describe("DatabaseService.restoreCurrentRound", () => {
             roundInfo: expect.anything(),
             delegates: undefined,
         });
+        // @ts-ignore
         expect(databaseService.forgingDelegates).toEqual(forgingDelegates);
     });
 });
@@ -364,7 +365,9 @@ describe("DatabaseService.applyBlock", () => {
         // still previous last block!
         stateStore.getLastBlock.mockReturnValueOnce(lastBlock);
 
+        // @ts-ignore
         databaseService.blocksInCurrentRound = [];
+        // @ts-ignore
         databaseService.forgingDelegates = [delegateWallet] as any;
 
         const transaction = {};
@@ -373,6 +376,7 @@ describe("DatabaseService.applyBlock", () => {
 
         expect(stateStore.getLastBlock).toBeCalledTimes(1);
         expect(blockState.applyBlock).toBeCalledWith(block);
+        // @ts-ignore
         expect(databaseService.blocksInCurrentRound).toEqual([block]);
         expect(events.dispatch).toBeCalledWith("forger.missing", { delegate: delegateWallet });
         expect(handler.emitEvents).toBeCalledWith(transaction, events);
@@ -408,8 +412,10 @@ describe("DatabaseService.applyRound", () => {
         const forgingDelegate = { getAttribute: jest.fn() };
         const forgingDelegateRound = 1;
         forgingDelegate.getAttribute.mockReturnValueOnce(forgingDelegateRound);
+        // @ts-ignore
         databaseService.forgingDelegates = [forgingDelegate] as any;
 
+        // @ts-ignore
         databaseService.blocksInCurrentRound = [{ data: { generatorPublicKey: "delegate public key" } }] as any;
 
         const delegateWallet = { publicKey: "delegate public key", getAttribute: jest.fn() };
@@ -445,8 +451,10 @@ describe("DatabaseService.applyRound", () => {
         const forgingDelegate = { getAttribute: jest.fn() };
         const forgingDelegateRound = 1;
         forgingDelegate.getAttribute.mockReturnValueOnce(forgingDelegateRound);
+        // @ts-ignore
         databaseService.forgingDelegates = [forgingDelegate] as any;
 
+        // @ts-ignore
         databaseService.blocksInCurrentRound = [];
 
         const delegateWallet = { publicKey: "delegate public key", getAttribute: jest.fn() };
@@ -482,8 +490,10 @@ describe("DatabaseService.applyRound", () => {
         const forgingDelegate = { getAttribute: jest.fn() };
         const forgingDelegateRound = 1;
         forgingDelegate.getAttribute.mockReturnValueOnce(forgingDelegateRound);
+        // @ts-ignore
         databaseService.forgingDelegates = [forgingDelegate] as any;
 
+        // @ts-ignore
         databaseService.blocksInCurrentRound = [{ data: { height: 1 } }] as any;
 
         const delegateWallet = { publicKey: "delegate public key", getAttribute: jest.fn() };
@@ -540,6 +550,7 @@ describe("DatabaseService.applyRound", () => {
         const forgingDelegate = { getAttribute: jest.fn() };
         const forgingDelegateRound = 2;
         forgingDelegate.getAttribute.mockReturnValueOnce(forgingDelegateRound);
+        // @ts-ignore
         databaseService.forgingDelegates = [forgingDelegate] as any;
 
         const height = 51;
@@ -557,7 +568,9 @@ describe("DatabaseService.getActiveDelegates", () => {
 
         const lastBlock = Blocks.BlockFactory.fromData(block1760000, getTimeStampForBlock);
 
+        // @ts-ignore
         blockRepository.findLatest.mockResolvedValueOnce(lastBlock.data);
+        // @ts-ignore
         transactionRepository.findByBlockIds.mockResolvedValueOnce(lastBlock.transactions);
 
         const delegatePublicKey = "03287bfebba4c7881a0509717e71b34b63f31e40021c321f89ae04f84be6d6ac37";
@@ -595,12 +608,14 @@ describe("DatabaseService.getActiveDelegates", () => {
         const forgingDelegate = { getAttribute: jest.fn() };
         const forgingDelegateRound = 2;
         forgingDelegate.getAttribute.mockReturnValueOnce(forgingDelegateRound);
+        // @ts-ignore
         databaseService.forgingDelegates = [forgingDelegate] as any;
 
         const roundInfo = { round: 2 };
         const result = await databaseService.getActiveDelegates(roundInfo as any);
 
         expect(forgingDelegate.getAttribute).toBeCalledWith("delegate.round");
+        // @ts-ignore
         expect(result).toBe(databaseService.forgingDelegates);
     });
 });
@@ -610,13 +625,19 @@ describe("DatabaseService.getBlock", () => {
         const databaseService = container.resolve(DatabaseService);
 
         const block = Blocks.BlockFactory.fromData(block1760000, getTimeStampForBlock);
+        // @ts-ignore
         blockRepository.findOne.mockResolvedValueOnce({ ...block.data });
+        // @ts-ignore
         transactionRepository.find.mockResolvedValueOnce(block.transactions);
 
+        // @ts-ignore
         const result = await databaseService.getBlock(block.data.id);
+        // @ts-ignore
         Object.assign(result, { getBlockTimeStampLookup: block["getBlockTimeStampLookup"] });
 
+        // @ts-ignore
         expect(blockRepository.findOne).toBeCalledWith(block.data.id);
+        // @ts-ignore
         expect(transactionRepository.find).toBeCalledWith({ blockId: block.data.id });
         expect(result).toEqual(block);
     });
@@ -955,6 +976,7 @@ describe("DatabaseService.revertBlock", () => {
             data: { id: "123", height: 100 },
             transactions: [transaction1, transaction2],
         };
+        // @ts-ignore
         databaseService.blocksInCurrentRound = [block as any];
 
         await databaseService.revertBlock(block as any);
@@ -1006,6 +1028,7 @@ describe("DatabaseService.revertRound", () => {
         expect(getDposPreviousRoundState).toBeCalled();
         expect(walletRepository.findByUsername).toBeCalledWith(prevRoundDelegateUsername);
         expect(delegateWallet.setAttribute).toBeCalledWith("delegate.rank", prevRoundDelegateRank);
+        // @ts-ignore
         expect(databaseService.forgingDelegates).toEqual(forgingDelegates);
         expect(roundRepository.delete).toBeCalledWith({ round: 2 });
     });

--- a/__tests__/unit/core-database/database-service.test.ts
+++ b/__tests__/unit/core-database/database-service.test.ts
@@ -22,6 +22,7 @@ const blockRepository = {
     findOne: jest.fn(),
     findByHeightRange: jest.fn(),
     findByHeightRangeWithTransactions: jest.fn(),
+    findByHeightRangeWithTransactionsForDownload: jest.fn(),
     findByHeights: jest.fn(),
     findLatest: jest.fn(),
     findByIds: jest.fn(),
@@ -130,6 +131,7 @@ beforeEach(() => {
 
     blockRepository.findOne.mockReset();
     blockRepository.findByHeightRange.mockReset();
+    blockRepository.findByHeightRangeWithTransactionsForDownload.mockReset();
     blockRepository.findByHeightRangeWithTransactions.mockReset();
     blockRepository.findByHeights.mockReset();
     blockRepository.findLatest.mockReset();
@@ -699,11 +701,11 @@ describe("DatabaseService.getBlocksForDownload", () => {
         const block101 = { height: 101, transactions: [] };
         const block102 = { height: 102, transactions: [] };
 
-        blockRepository.findByHeightRangeWithTransactions.mockResolvedValueOnce([block100, block101, block102]);
+        blockRepository.findByHeightRangeWithTransactionsForDownload.mockResolvedValueOnce([block100, block101, block102]);
 
         const result = await databaseService.getBlocksForDownload(100, 3);
 
-        expect(blockRepository.findByHeightRangeWithTransactions).toBeCalledWith(100, 102);
+        expect(blockRepository.findByHeightRangeWithTransactionsForDownload).toBeCalledWith(100, 102);
         expect(result).toEqual([block100, block101, block102]);
     });
 

--- a/__tests__/unit/core-database/service-provider.test.ts
+++ b/__tests__/unit/core-database/service-provider.test.ts
@@ -1,8 +1,8 @@
-import { Application, Container, Providers } from "@arkecosystem/core-kernel";
+import { Application, Container, Providers } from "@packages/core-kernel";
 import { createConnection, getCustomRepository } from "typeorm";
 
-import { defaults } from "../../../packages/core-database/src/defaults";
-import { ServiceProvider } from "../../../packages/core-database/src/service-provider";
+import { defaults } from "@packages/core-database/src/defaults";
+import { ServiceProvider } from "@packages/core-database/src/service-provider";
 
 jest.mock("typeorm", () => {
     return Object.assign(jest.requireActual("typeorm"), {

--- a/packages/core-database/src/database-service.ts
+++ b/packages/core-database/src/database-service.ts
@@ -11,9 +11,6 @@ import { TransactionRepository } from "./repositories/transaction-repository";
 // TODO: maybe we should introduce `BlockLike`, `TransactionLike`, `RoundLke` interfaces to remove the need to cast
 @Container.injectable()
 export class DatabaseService {
-    // TODO: make private readonly
-    public restoredDatabaseIntegrity: boolean = false;
-
     @Container.inject(Container.Identifiers.Application)
     private readonly app!: Contracts.Kernel.Application;
 
@@ -68,6 +65,9 @@ export class DatabaseService {
 
     @Container.inject(Container.Identifiers.EventDispatcherService)
     private readonly events!: Contracts.Kernel.EventDispatcher;
+
+    // TODO: make private readonly
+    public restoredDatabaseIntegrity: boolean = false;
 
     private blocksInCurrentRound: Interfaces.IBlock[] = [];
 

--- a/packages/core-database/src/database-service.ts
+++ b/packages/core-database/src/database-service.ts
@@ -297,7 +297,7 @@ export class DatabaseService {
         }
 
         // TODO: fix types
-        return (this.blockRepository.findByHeightRangeWithTransactions(
+        return (this.blockRepository.findByHeightRangeWithTransactionsForDownload(
             offset,
             offset + limit - 1,
         ) as unknown) as Promise<Contracts.Shared.DownloadBlock[]>;

--- a/packages/core-database/src/repositories/block-repository.ts
+++ b/packages/core-database/src/repositories/block-repository.ts
@@ -68,7 +68,7 @@ export class BlockRepository extends AbstractRepository<Block> {
                     }
                 },
             );
-        });
+        }) as Contracts.Shared.DownloadBlock[];
     }
 
     public async findByHeightRangeWithTransactions(start: number, end: number): Promise<Interfaces.IBlockData[]> {


### PR DESCRIPTION
## Summary

This PR creates two similar methods findByHeightRangeWithTransactions and findByHeightRangeWithTransactionsForDownload. It fixes the problem on node boot, because serialized transaction cannot be verified by block schema. Second method is used for p2p purposes.  

## Checklist

- [x] Ready to be merged
