### PR TITLE
fix(core-p2p): limit max connection retries

### DIFF
--- a/packages/core-p2p/src/peer-connector.ts
+++ b/packages/core-p2p/src/peer-connector.ts
@@ -74,7 +74,7 @@ export class PeerConnector implements Contracts.P2P.PeerConnector {
             this.logger.debug(`Socket error (peer ${peer.ip}) : ${error.message}`);
         };
 
-        await connection.connect();
+        await connection.connect({ retries: 1 });
 
         return connection;
     }


### PR DESCRIPTION
## Summary

This PR limits connection retries while making connection from infinity (default) to 1 retry. This fix removes repeated logs: 
Socket error (peer <IP>) : Connection terminated while waiting to connect, caused by infinite retries.

Number of retries can be increased to higher value if necessary. 

## Checklist

- [x] Ready to be merged
