### PR TITLE
chore(core-p2p): implement HEAD HTTP request for ping

### DIFF
--- a/__tests__/unit/core-p2p/peer-communicator.test.ts
+++ b/__tests__/unit/core-p2p/peer-communicator.test.ts
@@ -278,9 +278,8 @@ describe("PeerCommunicator", () => {
                 "core-api": { enabled: true, port: 4100 },
                 "custom-plugin": { enabled: true, port: 4200 },
             };
-            jest.spyOn(KernelUtils.http, "get")
+            jest.spyOn(KernelUtils.http, "head")
                 .mockResolvedValueOnce({
-                    data: { data: { nethash: Managers.configManager.get("network.nethash") } },
                     statusCode: 200,
                 } as any)
                 .mockResolvedValueOnce({ data: {}, statusCode: 200 } as any);
@@ -297,9 +296,8 @@ describe("PeerCommunicator", () => {
                 "core-api": { enabled: true, port: 4100 },
                 "custom-plugin": { enabled: true, port: 4200 },
             };
-            jest.spyOn(KernelUtils.http, "get")
+            jest.spyOn(KernelUtils.http, "head")
                 .mockResolvedValueOnce({
-                    data: { data: { nethash: Managers.configManager.get("network.nethash") } },
                     statusCode: 500,
                 } as any)
                 .mockResolvedValueOnce({ data: {}, statusCode: 500 } as any);
@@ -310,30 +308,28 @@ describe("PeerCommunicator", () => {
             expect(peer.ports["custom-plugin"]).toBe(-1);
         });
 
-        it("should update peer.ports even when wrong nethash", async () => {
-            const ip = "187.168.65.65";
-            const port = 4000;
-            const apiPort = 4100;
-            const wrongNethash = "wrongNethash";
-            const peer = new Peer(ip, port);
-            peer.plugins = {
-                "core-api": { enabled: true, port: apiPort },
-                "custom-plugin": { enabled: true, port: 4200 },
-            };
-            jest.spyOn(KernelUtils.http, "get")
-                .mockResolvedValueOnce({
-                    data: { data: { nethash: wrongNethash } },
-                    statusCode: 200,
-                } as any)
-                .mockResolvedValueOnce({ data: {}, statusCode: 200 } as any);
-
-            await peerCommunicator.pingPorts(peer);
-
-            expect(peer.ports["core-api"]).toBe(apiPort);
-            expect(peer.ports["custom-plugin"]).toBeDefined();
-            expect(logger.warning).toBeCalledTimes(0);
-            expect(emitter.dispatch).toBeCalledTimes(0);
-        });
+        // it("should update peer.ports even when wrong nethash", async () => {
+        //     const ip = "187.168.65.65";
+        //     const port = 4000;
+        //     const apiPort = 4100;
+        //     const peer = new Peer(ip, port);
+        //     peer.plugins = {
+        //         "core-api": { enabled: true, port: apiPort },
+        //         "custom-plugin": { enabled: true, port: 4200 },
+        //     };
+        //     jest.spyOn(KernelUtils.http, "head")
+        //         .mockResolvedValueOnce({
+        //             statusCode: 200,
+        //         } as any)
+        //         .mockResolvedValueOnce({ data: {}, statusCode: 200 } as any);
+        //
+        //     await peerCommunicator.pingPorts(peer);
+        //
+        //     expect(peer.ports["core-api"]).toBe(apiPort);
+        //     expect(peer.ports["custom-plugin"]).toBeDefined();
+        //     expect(logger.warning).toBeCalledTimes(0);
+        //     expect(emitter.dispatch).toBeCalledTimes(0);
+        // });
 
         it("should set peer ports = -1 when pinging the port fails", async () => {
             const peer = new Peer("187.168.65.65", 4000);

--- a/packages/core-cli/package.json
+++ b/packages/core-cli/package.json
@@ -23,7 +23,7 @@
     "dependencies": {
         "@arkecosystem/core-kernel": "^3.0.0-alpha.0",
         "@arkecosystem/crypto": "^3.0.0-alpha.0",
-        "@arkecosystem/utils": "^1.1.7",
+        "@arkecosystem/utils": "^1.2.0",
         "@hapi/joi": "^17.1.0",
         "boxen": "^4.2.0",
         "cli-table3": "^0.6.0",

--- a/packages/core-kernel/package.json
+++ b/packages/core-kernel/package.json
@@ -22,7 +22,7 @@
     },
     "dependencies": {
         "@arkecosystem/crypto": "^3.0.0-alpha.0",
-        "@arkecosystem/utils": "^1.1.7",
+        "@arkecosystem/utils": "^1.2.0",
         "@hapi/joi": "^17.1.0",
         "@pm2/io": "^4.3.5",
         "chalk": "^4.0.0",

--- a/packages/core-p2p/src/peer-communicator.ts
+++ b/packages/core-p2p/src/peer-communicator.ts
@@ -103,15 +103,12 @@ export class PeerCommunicator implements Contracts.P2P.PeerCommunicator {
             Object.entries(peer.plugins).map(async ([name, plugin]) => {
                 peer.ports[name] = -1;
                 try {
-                    // TODO use HEAD and implement HEAD in @arkecosystem/utils
-                    const { statusCode } = await Utils.http.get(`http://${peer.ip}:${plugin.port}/`);
+                    const { statusCode } = await Utils.http.head(`http://${peer.ip}:${plugin.port}/`);
 
                     if (statusCode === 200) {
                         peer.ports[name] = plugin.port;
                     }
-                } catch {
-                    // tslint:disable-next-line: no-empty
-                }
+                } catch {}
             }),
         );
     }

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -31,7 +31,7 @@
         "prepublishOnly": "yarn build:rollup"
     },
     "dependencies": {
-        "@arkecosystem/utils": "^1.1.7",
+        "@arkecosystem/utils": "^1.2.0",
         "ajv": "^6.10.2",
         "ajv-keywords": "^3.4.1",
         "bcrypto": "^5.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,16 +2,17 @@
 # yarn lockfile v1
 
 
-"@arkecosystem/utils@^1.1.7":
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/@arkecosystem/utils/-/utils-1.1.7.tgz#3c36695b3bb578c33c9dcbfb5e1cf4647b95da21"
-  integrity sha512-L6otSODmR+td2ePnoZ++PMFI4kCokS3WakeJ/8r7epfe5C+iHVmRRYRbMHcuHQ2cw1xWwEDhYZcJaWUaXLXUHQ==
+"@arkecosystem/utils@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@arkecosystem/utils/-/utils-1.2.0.tgz#f58e9dca0e4478503e996c5f276bb210ab142e92"
+  integrity sha512-FNemFa4V0/8O4ZDpCGxvrnt8U6PmDq4fyxFaCx6wgJmSTxoxxJpvKCnhXPTbYtDGyhk0XsmittTj3uHZQQCXVQ==
   dependencies:
-    "@hapi/bourne" "^1.3.2"
+    "@hapi/bourne" "^2.0.0"
     deepmerge "^4.2.2"
-    fast-copy "^2.0.3"
-    fast-deep-equal "^2.0.1"
-    fast-sort "^1.6.0"
+    fast-copy "^2.1.0"
+    fast-deep-equal "^3.1.3"
+    fast-sort "^2.2.0"
+    type-fest "^0.16.0"
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.5.5":
   version "7.5.5"
@@ -2102,7 +2103,7 @@
     "@hapi/boom" "9.x.x"
     "@hapi/hoek" "9.x.x"
 
-"@hapi/bourne@1.x.x", "@hapi/bourne@^1.3.2":
+"@hapi/bourne@1.x.x":
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/@hapi/bourne/-/bourne-1.3.2.tgz#0a7095adea067243ce3283e1b56b8a8f453b242a"
   integrity sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA==
@@ -7764,7 +7765,7 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
-fast-copy@^2.0.3:
+fast-copy@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-copy/-/fast-copy-2.1.0.tgz#99c1b842aee063f8212d6f749080c196a822b293"
   integrity sha512-j4VxAVJsu9NHveYrIj0+nJxXe2lOlibKTlyy0jH8DBwcuV6QyXTy0zTqZhmMKo7EYvuaUk/BFj/o6NU6grE5ag==
@@ -7778,6 +7779,11 @@ fast-deep-equal@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz#545145077c501491e33b15ec408c294376e94ae4"
   integrity sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==
+
+fast-deep-equal@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
+  integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
 fast-diff@^1.1.2:
   version "1.2.0"
@@ -7837,10 +7843,10 @@ fast-safe-stringify@^2.0.7:
   resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz#124aa885899261f68aedb42a7c080de9da608743"
   integrity sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==
 
-fast-sort@^1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/fast-sort/-/fast-sort-1.6.0.tgz#68c6d94ce309ead19d562014159902c80c68d0a0"
-  integrity sha512-sjV6dxWdHs14cef7GzJgCWSOagw57cUBYMey+seWeOsU0HgMf2g4Wkdflv65X/8E4UWptUcq9EZ3YqSXUnUy9Q==
+fast-sort@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/fast-sort/-/fast-sort-2.2.0.tgz#20903763531fbcbb41c9df5ab1bf5f2cefc8476a"
+  integrity sha512-W7zqnn2zsYoQA87FKmYtgOsbJohOrh7XrtZrCVHN5XZKqTBTv5UG+rSS3+iWbg/nepRQUOu+wnas8BwtK8kiCg==
 
 fast-stringify@^1.1.0:
   version "1.1.2"


### PR DESCRIPTION
## Summary

This PR solves #3920.

All @arkecosystem/utils dependencies has been updated to version 1.2.0.

P2P Ping method is using HEAD instead GET HTTP request.  

## Checklist

- [x] Tests
- [x] Ready to be merged
