### PR TITLE
chore(core-api): get registered server route

### DIFF
--- a/packages/core-api/src/server.ts
+++ b/packages/core-api/src/server.ts
@@ -137,6 +137,10 @@ export class Server {
         return this.server.route(routes);
     }
 
+    public getRoute(method: string, path: string): ServerRoute | undefined {
+        return this.server.table().find((route) => route.method === method.toLowerCase() && route.path === path);
+    }
+
     /**
      * @param {(string | ServerInjectOptions)} options
      * @returns {Promise<void>}


### PR DESCRIPTION
## Summary

This PR solves #3571 

ServerRoute can be obtained via getRoute method. ServerRoute can be later used for altering or extending response and overriding existing route handler.

## Checklist

- [x] Tests
- [x] Ready to be merged
