### PR TITLE
fix(core-api): fix order in delegates/{id}/blocks

### DIFF
--- a/packages/core-api/src/routes/delegates.ts
+++ b/packages/core-api/src/routes/delegates.ts
@@ -63,7 +63,7 @@ export const register = (server: Hapi.Server): void => {
                 query: Joi.object({
                     ...server.app.schemas.blockCriteriaSchemas,
                     ...server.app.schemas.pagination,
-                    orderBy: server.app.schemas.orderBy,
+                    orderBy: server.app.schemas.blocksOrderBy,
                     transform: Joi.bool().default(true),
                 }),
             },


### PR DESCRIPTION
## Summary

Order block by `height:desc` for `delegates/{id}/blocks`