### PR TITLE
fix(core-kernel): boot without .env file

### DIFF
--- a/__tests__/unit/core-kernel/bootstrap/app/load-environment-variables.test.ts
+++ b/__tests__/unit/core-kernel/bootstrap/app/load-environment-variables.test.ts
@@ -1,0 +1,46 @@
+import "jest-extended";
+
+import { Application } from "@packages/core-kernel/src/application";
+import { LoadEnvironmentVariables } from "@packages/core-kernel/src/bootstrap/app";
+import { Container, Identifiers } from "@packages/core-kernel/src/ioc";
+
+let app: Application;
+
+const mockLogger = {
+    alert: jest.fn(),
+};
+
+const mockDriver = {
+    loadEnvironmentVariables: jest.fn(),
+};
+
+const mockConfigManager = {
+    driver: jest.fn().mockReturnValue(mockDriver),
+};
+
+beforeEach(() => {
+    app = new Application(new Container());
+
+    app.bind(Identifiers.LogService).toConstantValue(mockLogger);
+    app.bind(Identifiers.ConfigManager).toConstantValue(mockConfigManager);
+});
+
+describe("LoadCryptography", () => {
+    it("should bootstrap and load env variables", async () => {
+        app.bind(Identifiers.ApplicationNetwork).toConstantValue("testnet");
+
+        await app.resolve<LoadEnvironmentVariables>(LoadEnvironmentVariables).bootstrap();
+
+        expect(mockLogger.alert).not.toBeCalled();
+    });
+
+    it("should bootstrap and alert if loadEnvironmentVariables throws error", async () => {
+        mockDriver.loadEnvironmentVariables = jest.fn().mockImplementation(() => {
+            throw new Error("Error loading .env variables.");
+        });
+
+        await app.resolve<LoadEnvironmentVariables>(LoadEnvironmentVariables).bootstrap();
+
+        expect(mockLogger.alert).toBeCalled();
+    });
+});

--- a/packages/core-kernel/src/bootstrap/app/load-environment-variables.ts
+++ b/packages/core-kernel/src/bootstrap/app/load-environment-variables.ts
@@ -1,4 +1,4 @@
-import { Application } from "../../contracts/kernel";
+import { Application, Logger } from "../../contracts/kernel";
 import { Identifiers, inject, injectable } from "../../ioc";
 import { ConfigManager, ConfigRepository } from "../../services/config";
 import { Bootstrapper } from "../interfaces";
@@ -27,9 +27,13 @@ export class LoadEnvironmentVariables implements Bootstrapper {
     public async bootstrap(): Promise<void> {
         const configRepository: ConfigRepository = this.app.get<ConfigRepository>(Identifiers.ConfigRepository);
 
-        await this.app
-            .get<ConfigManager>(Identifiers.ConfigManager)
-            .driver(configRepository.get<string>("configLoader", "local"))
-            .loadEnvironmentVariables();
+        try {
+            await this.app
+                .get<ConfigManager>(Identifiers.ConfigManager)
+                .driver(configRepository.get<string>("configLoader", "local"))
+                .loadEnvironmentVariables();
+        } catch (error) {
+            this.app.get<Logger>(Identifiers.LogService).alert(error.message);
+        }
     }
 }

--- a/packages/core-kernel/src/services/config/drivers/local.ts
+++ b/packages/core-kernel/src/services/config/drivers/local.ts
@@ -69,7 +69,9 @@ export class LocalConfigLoader implements ConfigLoader {
             const config: Record<string, Primitive> = dotenv.parseFile(this.app.environmentFile());
 
             for (const [key, value] of Object.entries(config)) {
-                set(process.env, key, value);
+                if (process.env[key] === undefined) {
+                    set(process.env, key, value);
+                }
             }
         } catch (error) {
             throw new EnvironmentConfigurationCannotBeLoaded(error.message);


### PR DESCRIPTION
## Summary

This PR solves  #3929

Changes:
1. If .env file is not present program log alert and starts
1. If variable is set in process and in .env, variable from process (system) is taken

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged
