### PR TITLE
chore(core-kernel): process env over .env

### DIFF
--- a/packages/core-kernel/src/services/config/drivers/local.ts
+++ b/packages/core-kernel/src/services/config/drivers/local.ts
@@ -69,7 +69,9 @@ export class LocalConfigLoader implements ConfigLoader {
             const config: Record<string, Primitive> = dotenv.parseFile(this.app.environmentFile());
 
             for (const [key, value] of Object.entries(config)) {
-                set(process.env, key, value);
+                if (process.env[key] === undefined) {
+                    set(process.env, key, value);
+                }
             }
         } catch (error) {
             throw new EnvironmentConfigurationCannotBeLoaded(error.message);


### PR DESCRIPTION
## Summary

This PR solves #3933 

If process.env is defined it will be used even if variable is defined in .env file.

## Checklist

- [x] Ready to be merged
