### PR TITLE
refactor(core-utils): use JSON.parse instead of fast-json-parse

### DIFF
--- a/packages/core-utils/package.json
+++ b/packages/core-utils/package.json
@@ -23,7 +23,6 @@
         "@arkecosystem/crypto": "^2.6.49",
         "cli-table3": "^0.5.1",
         "dayjs": "^1.8.15",
-        "fast-json-parse": "^1.0.3",
         "got": "^9.6.0",
         "immutable": "^4.0.0-rc.12",
         "nanomatch": "^1.2.13"

--- a/packages/core-utils/src/httpie.ts
+++ b/packages/core-utils/src/httpie.ts
@@ -21,7 +21,7 @@ export class HttpieError extends Error {
                 Object.defineProperty(this, "response", {
                     enumerable: false,
                     value: {
-                        body: JSON.parse(error.response.body || {}),
+                        body: JSON.parse(error.response.body),
                         headers: error.response.headers,
                         status: error.response.statusCode,
                     },
@@ -94,7 +94,7 @@ class Httpie {
             const { body, headers, statusCode } = await got[method](url, opts);
 
             return {
-                body: JSON.parse(body || {}),
+                body: JSON.parse(body),
                 headers,
                 status: statusCode,
             };

--- a/packages/core-utils/src/httpie.ts
+++ b/packages/core-utils/src/httpie.ts
@@ -1,6 +1,5 @@
 // tslint:disable: max-classes-per-file
 
-import parseJSON from "fast-json-parse";
 import got from "got";
 
 export class HttpieError extends Error {
@@ -18,14 +17,18 @@ export class HttpieError extends Error {
         });
 
         if (error.response) {
-            Object.defineProperty(this, "response", {
-                enumerable: false,
-                value: {
-                    body: parseJSON(error.response.body).value,
-                    headers: error.response.headers,
-                    status: error.response.statusCode,
-                },
-            });
+            try {
+                Object.defineProperty(this, "response", {
+                    enumerable: false,
+                    value: {
+                        body: JSON.parse(error.response.body || {}),
+                        headers: error.response.headers,
+                        status: error.response.statusCode,
+                    },
+                });
+            } catch {
+                // Do nothing if the response body parsing fails.
+            }
         }
 
         Error.captureStackTrace(this, this.constructor);
@@ -91,7 +94,7 @@ class Httpie {
             const { body, headers, statusCode } = await got[method](url, opts);
 
             return {
-                body: parseJSON(body).value,
+                body: JSON.parse(body || {}),
                 headers,
                 status: statusCode,
             };

--- a/yarn.lock
+++ b/yarn.lock
@@ -7858,11 +7858,6 @@ fast-glob@^3.0.3:
     merge2 "^1.3.0"
     micromatch "^4.0.2"
 
-fast-json-parse@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/fast-json-parse/-/fast-json-parse-1.0.3.tgz#43e5c61ee4efa9265633046b770fb682a7577c4d"
-  integrity sha512-FRWsaZRWEJ1ESVNbDWmsAlqDk96gPQezzLghafp5J4GUKjbCz3OkAHuZs5TuPEtkbVQERysLp9xv6c24fBm8Aw==
-
 fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"


### PR DESCRIPTION
Removes the `fast-json-parse` module because it's no longer necessary.