### PR TITLE
fix(core-database): revertBlock

### DIFF
--- a/__tests__/unit/core-blockchain/blockchain.test.ts
+++ b/__tests__/unit/core-blockchain/blockchain.test.ts
@@ -61,6 +61,7 @@ describe("Blockchain", () => {
         logService.debug = jest.fn();
 
         stateStore.started = false;
+        stateStore.getMaxLastBlocks = jest.fn().mockReturnValue(200);
         stateStore.clearWakeUpTimeout = jest.fn();
         stateStore.wakeUpTimeout = undefined;
         stateStore.lastDownloadedBlock = undefined;
@@ -379,7 +380,7 @@ describe("Blockchain", () => {
                 const spyDispatch = jest.spyOn(blockchain, "dispatch");
                 stateStore.started = true;
                 stateStore.getLastBlock = jest.fn().mockReturnValue({ data: blockData });
-                
+
                 jest.spyOn(Crypto.Slots, "getSlotNumber").mockReturnValueOnce(1).mockReturnValueOnce(2);
                 jest.spyOn(Crypto.Slots, "getTimeInMsUntilNextSlot").mockReturnValueOnce(5000);
 
@@ -500,7 +501,7 @@ describe("Blockchain", () => {
             expect(spyQueuePush).toHaveBeenCalledWith({ blocks: [blockData] });
         });
 
-        it("should push a chunk to the queue when currentBlocksChunk.length > 100", async () => {
+        it("should push a chunk to the queue when currentBlocksChunk.length >= 100", async () => {
             const blockchain = sandbox.app.resolve<Blockchain>(Blockchain);
             blockchain.initialize({});
             stateStore.lastDownloadedBlock = { height: 23111 };
@@ -508,7 +509,7 @@ describe("Blockchain", () => {
             const spyQueuePush = jest.spyOn(blockchain.queue, "push");
 
             const blocksToEnqueue = [];
-            for (let i = 0; i <= 101; i++) {
+            for (let i = 0; i < 101; i++) {
                 // @ts-ignore
                 blocksToEnqueue.push(blockData);
             }

--- a/__tests__/unit/core-database/database-service.test.ts
+++ b/__tests__/unit/core-database/database-service.test.ts
@@ -666,12 +666,12 @@ describe("DatabaseService.getBlocks", () => {
         const block102 = { height: 102, transactions: [] };
 
         stateStore.getLastBlocksByHeight.mockReturnValueOnce([block101, block102]);
-        blockRepository.findByHeightRangeWithTransactions.mockResolvedValueOnce([block100, block101, block102]);
+        blockRepository.findByHeightRangeWithTransactions.mockResolvedValueOnce([block100]);
 
         const result = await databaseService.getBlocks(100, 3);
 
         expect(stateStore.getLastBlocksByHeight).toBeCalledWith(100, 102, undefined);
-        expect(blockRepository.findByHeightRangeWithTransactions).toBeCalledWith(100, 102);
+        expect(blockRepository.findByHeightRangeWithTransactions).toBeCalledWith(100, 100);
         expect(result).toEqual([block100, block101, block102]);
     });
 
@@ -683,12 +683,12 @@ describe("DatabaseService.getBlocks", () => {
         const block102 = { height: 102 };
 
         stateStore.getLastBlocksByHeight.mockReturnValueOnce([block101, block102]);
-        blockRepository.findByHeightRange.mockResolvedValueOnce([block100, block101, block102]);
+        blockRepository.findByHeightRange.mockResolvedValueOnce([block100]);
 
         const result = await databaseService.getBlocks(100, 3, true);
 
         expect(stateStore.getLastBlocksByHeight).toBeCalledWith(100, 102, true);
-        expect(blockRepository.findByHeightRange).toBeCalledWith(100, 102);
+        expect(blockRepository.findByHeightRange).toBeCalledWith(100, 100);
         expect(result).toEqual([block100, block101, block102]);
     });
 });

--- a/__tests__/unit/core-state/stores/state.test.ts
+++ b/__tests__/unit/core-state/stores/state.test.ts
@@ -31,6 +31,12 @@ beforeEach(() => {
 afterAll(() => jest.clearAllMocks());
 
 describe("State Storage", () => {
+    describe("getMaxLastBlocks", () => {
+        it("should return max last blocks limit", () => {
+            expect(stateStorage.getMaxLastBlocks()).toBe(100);
+        });
+    });
+
     describe("getLastHeight", () => {
         it("should return the last block height", () => {
             stateStorage.setLastBlock(blocks[0]);

--- a/packages/core-blockchain/src/blockchain.ts
+++ b/packages/core-blockchain/src/blockchain.ts
@@ -246,7 +246,8 @@ export class Blockchain implements Contracts.Blockchain.Blockchain {
             currentTransactionsCount += block.numberOfTransactions;
 
             const nextMilestone = milestoneHeights[0] && milestoneHeights[0] === block.height;
-            if (currentTransactionsCount >= 150 || currentBlocksChunk.length > 100 || nextMilestone) {
+
+            if (currentTransactionsCount >= 150 || currentBlocksChunk.length >= Math.min(this.state.getMaxLastBlocks(), 100) || nextMilestone) {
                 this.queue.push({ blocks: currentBlocksChunk });
                 currentBlocksChunk = [];
                 currentTransactionsCount = 0;

--- a/packages/core-database/src/database-service.ts
+++ b/packages/core-database/src/database-service.ts
@@ -275,7 +275,7 @@ export class DatabaseService {
             // ! but querying database is unnecessary when later blocks are missing too (aren't forged yet)
 
             if (blocks.length) {
-                end = blocks[0].height;
+                end = blocks[0].height - 1;
             }
 
             const blocksFromDB = headersOnly

--- a/packages/core-kernel/src/contracts/state/state-store.ts
+++ b/packages/core-kernel/src/contracts/state/state-store.ts
@@ -25,6 +25,11 @@ export interface StateStore {
     clearWakeUpTimeout(): void;
 
     /**
+     * Get block storage limit.
+     */
+    getMaxLastBlocks(): number;
+
+    /**
      * Get the last block height.
      */
     getLastHeight(): number;

--- a/packages/core-state/src/stores/state.ts
+++ b/packages/core-state/src/stores/state.ts
@@ -34,7 +34,7 @@ export class StateStore implements Contracts.State.StateStore {
     // can be configured with the option `state.maxLastBlocks`.
     private lastBlocks: OrderedMap<number, Interfaces.IBlock> = OrderedMap<number, Interfaces.IBlock>();
     // Stores the last n incoming transaction ids. The amount of transaction ids
-    // can be configred with the option `state.maxLastTransactionIds`.
+    // can be configured with the option `state.maxLastTransactionIds`.
     private cachedTransactionIds: OrderedSet<string> = OrderedSet();
 
     /**
@@ -61,6 +61,10 @@ export class StateStore implements Contracts.State.StateStore {
             clearTimeout(this.wakeUpTimeout);
             this.wakeUpTimeout = undefined;
         }
+    }
+
+    public getMaxLastBlocks(): number {
+        return this.configuration.getRequired<number>("storage.maxLastBlocks");
     }
 
     /**
@@ -119,9 +123,7 @@ export class StateStore implements Contracts.State.StateStore {
         }
 
         // Delete oldest block if size exceeds the maximum
-        const maxLastBlocks = this.configuration.getRequired<number>("storage.maxLastBlocks");
-
-        if (this.lastBlocks.size > maxLastBlocks) {
+        if (this.lastBlocks.size > this.getMaxLastBlocks()) {
             this.lastBlocks = this.lastBlocks.delete(this.lastBlocks.first<Interfaces.IBlock>().data.height);
         }
 

--- a/packages/core-transactions/src/handlers/two/ipfs.ts
+++ b/packages/core-transactions/src/handlers/two/ipfs.ts
@@ -97,6 +97,8 @@ export class IpfsTransactionHandler extends TransactionHandler {
             sender.forgetAttribute("ipfs");
         }
 
+        this.walletRepository.getIndex(Contracts.State.WalletIndexes.Ipfs).forget(transaction.data.asset.ipfs);
+
         this.walletRepository.index(sender);
     }
 


### PR DESCRIPTION
## Summary

This PR fixes: #3938

1. Removes ipfs entry from ipfs index on reverting ipfs transaction.

2. Take blocks for removal from state store if they exist, otherwise load them from database.

3. Limit enqued blocks chunk to fit stateStore maxLastBlocks lenght. This prevent loosing blocks if they not saved into the database and are removed from stateStore blocks ordered map. 

## Checklist

- [x] Ready to be merged


