### PR TITLE
chore(core-database): use GIN index on transactions.asset

### DIFF
--- a/packages/core-database/src/migrations/20200317000000-add-blocks-and-transactions-indexes.ts
+++ b/packages/core-database/src/migrations/20200317000000-add-blocks-and-transactions-indexes.ts
@@ -3,7 +3,7 @@ import { MigrationInterface, QueryRunner } from "typeorm";
 export class AddBlocksAndTransactionsIndexes20200317000000 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<any> {
         await queryRunner.query(`
-            CREATE INDEX transactions_asset ON transactions(asset);
+            CREATE INDEX transactions_asset ON transactions USING GIN(asset);
             CREATE INDEX transactions_amount ON transactions(amount);
             CREATE INDEX transactions_fee ON transactions(fee);
             CREATE INDEX transactions_nonce_idx ON transactions(nonce);


### PR DESCRIPTION
## Summary

This PR solves: #3947

Using GIN index for transactions.asset (JSONB type) instead default B-TREE index. 

## Checklist

- [x] Ready to be merged

