### PR TITLE
chore(core-state): remove forget methods and use index instead

### DIFF
--- a/__tests__/functional/transaction-forging/delegate-resignation.test.ts
+++ b/__tests__/functional/transaction-forging/delegate-resignation.test.ts
@@ -153,7 +153,8 @@ describe("Transaction Forging - Delegate Resignation", () => {
 
             const takenDelegates = walletRepository.allByUsername().slice(0, 50);
             for (const delegate of takenDelegates) {
-                walletRepository.forgetByUsername(delegate.getAttribute("delegate.username"));
+                // @ts-ignore
+                walletRepository.forgetWallet(delegate);
             }
 
             // Resign a delegate

--- a/__tests__/functional/transaction-forging/delegate-resignation.test.ts
+++ b/__tests__/functional/transaction-forging/delegate-resignation.test.ts
@@ -153,8 +153,9 @@ describe("Transaction Forging - Delegate Resignation", () => {
 
             const takenDelegates = walletRepository.allByUsername().slice(0, 50);
             for (const delegate of takenDelegates) {
-                // @ts-ignore
-                walletRepository.forgetWallet(delegate);
+                for (const indexName of walletRepository.getIndexNames()) {
+                    walletRepository.getIndex(indexName).forgetWallet(delegate);
+                }
             }
 
             // Resign a delegate

--- a/__tests__/integration/core-api/handlers/delegates.test.ts
+++ b/__tests__/integration/core-api/handlers/delegates.test.ts
@@ -95,7 +95,7 @@ describe("API 2.0 - Delegates", () => {
             expect(response).toBeSuccessfulResponse();
             expect(response.data.data).toBeArray();
 
-            expect(response.data.data[0].username).toBe("genesis_51");
+            expect(response.data.data[0].username).toBe("genesis_10");
             expect(response.data.data[0].votes).toBe("0");
 
             // Apply the original vote balances

--- a/__tests__/unit/core-magistrate-api/controllers/entities.test.ts
+++ b/__tests__/unit/core-magistrate-api/controllers/entities.test.ts
@@ -105,7 +105,7 @@ describe("EntityController", () => {
                     id: registrationTxId,
                 },
             };
-            
+
             await expect(controller.show(request, undefined)).resolves.toThrowError("Entity not found");
         });
 
@@ -116,13 +116,13 @@ describe("EntityController", () => {
                 },
             };
 
-            walletRepository.forgetByIndex(MagistrateIndex.Entities, registrationTxId);
+            walletRepository.getIndex(MagistrateIndex.Entities).forget(registrationTxId);
 
             await expect(controller.show(request, undefined)).resolves.toThrowError("Entity not found");
         });
 
         it("should return error if wallet has not indexed entity attribute", async () => {
-            walletRepository.forgetByIndex(MagistrateIndex.Entities, registrationTxId);
+            walletRepository.getIndex(MagistrateIndex.Entities).forget(registrationTxId);
 
             senderWallet = buildSenderWallet(app);
 

--- a/__tests__/unit/core-state/block-state.test.ts
+++ b/__tests__/unit/core-state/block-state.test.ts
@@ -310,11 +310,6 @@ describe("BlockState", () => {
         expect(forgingWallet.balance).toEqual(balanceBefore);
     });
 
-    it("should throw if there is no forger wallet", async () => {
-        walletRepo.forgetByPublicKey(forgingWallet.publicKey);
-        await expect(blockState.applyBlock(blocks[0])).toReject();
-    });
-
     it("should update sender's and recipient's delegate's vote balance when applying transaction", async () => {
         const sendersDelegate = forgingWallet;
         sendersDelegate.setAttribute("delegate.voteBalance", Utils.BigNumber.ZERO);
@@ -575,14 +570,16 @@ describe("BlockState", () => {
 
             it("not fail to apply transaction if the recipient doesn't exist", async () => {
                 transaction.data.recipientId = "don'tExist";
-                walletRepo.forgetByAddress(recipientWallet.address);
+                // @ts-ignore
+                walletRepo.forgetWallet(recipientWallet);
 
                 await expect(blockState.applyTransaction(transaction)).toResolve();
             });
 
             it("not fail to revert transaction if the recipient doesn't exist", async () => {
                 transaction.data.recipientId = "don'tExist";
-                walletRepo.forgetByAddress(recipientWallet.address);
+                // @ts-ignore
+                walletRepo.forgetWallet(recipientWallet);
 
                 await expect(blockState.revertTransaction(transaction)).toResolve();
             });

--- a/__tests__/unit/core-state/block-state.test.ts
+++ b/__tests__/unit/core-state/block-state.test.ts
@@ -36,6 +36,14 @@ let spyApplyVoteBalances: jest.SpyInstance;
 let spyRevertVoteBalances: jest.SpyInstance;
 let spyRevertBlockFromForger: jest.SpyInstance;
 
+const forgetWallet = (wallet: Wallet) => {
+    for (const indexName of walletRepo.getIndexNames()) {
+        const index = walletRepo.getIndex(indexName);
+
+        index.forgetWallet(wallet);
+    }
+};
+
 beforeAll(async () => {
     const initialEnv = await setUp(setUpDefaults, true); // todo: why do I have to skip booting?
     walletRepo = initialEnv.walletRepo;
@@ -570,16 +578,16 @@ describe("BlockState", () => {
 
             it("not fail to apply transaction if the recipient doesn't exist", async () => {
                 transaction.data.recipientId = "don'tExist";
-                // @ts-ignore
-                walletRepo.forgetWallet(recipientWallet);
+
+                forgetWallet(recipientWallet);
 
                 await expect(blockState.applyTransaction(transaction)).toResolve();
             });
 
             it("not fail to revert transaction if the recipient doesn't exist", async () => {
                 transaction.data.recipientId = "don'tExist";
-                // @ts-ignore
-                walletRepo.forgetWallet(recipientWallet);
+
+                forgetWallet(recipientWallet);
 
                 await expect(blockState.revertTransaction(transaction)).toResolve();
             });

--- a/__tests__/unit/core-state/wallets/wallet-index.test.ts
+++ b/__tests__/unit/core-state/wallets/wallet-index.test.ts
@@ -6,47 +6,22 @@ import { setUp } from "../setup";
 
 let factory: Factory;
 
+let wallet: Wallets.Wallet;
+let walletIndex: WalletIndex;
+
 beforeAll(async () => {
     const initialEnv = await setUp();
     factory = initialEnv.factory.get("Wallet");
 });
 
+beforeEach(() => {
+    wallet = factory.make<Wallets.Wallet>();
+    walletIndex = new WalletIndex((index, wallet) => {
+        index.set(wallet.address, wallet);
+    });
+});
+
 describe("WalletIndex", () => {
-    let wallet: Wallets.Wallet;
-    let walletIndex: WalletIndex;
-
-    beforeAll(() => {
-        wallet = factory.make<Wallets.Wallet>();
-        walletIndex = new WalletIndex((index, wallet) => {
-            index.set(wallet.address, wallet);
-        });
-    });
-
-    it("should index and forget wallets", () => {
-        expect(walletIndex.has(wallet.address)).toBeFalse();
-
-        walletIndex.index(wallet);
-        expect(walletIndex.has(wallet.address)).toBeTrue();
-
-        walletIndex.forget(wallet.address);
-        expect(walletIndex.has(wallet.address)).toBeFalse();
-    });
-
-    it("should set and get addresses", () => {
-        expect(walletIndex.has(wallet.address)).toBeFalse();
-
-        walletIndex.index(wallet);
-        walletIndex.set(wallet.address, wallet);
-
-        expect(walletIndex.get(wallet.address)).toBe(wallet);
-        expect(walletIndex.has(wallet.address)).toBeTrue();
-
-        expect(walletIndex.values()).toContain(wallet);
-
-        walletIndex.clear();
-        expect(walletIndex.has(wallet.address)).toBeFalse();
-    });
-
     it("should be cloneable", () => {
         walletIndex.index(wallet);
         walletIndex.set(wallet.address, wallet);
@@ -65,5 +40,64 @@ describe("WalletIndex", () => {
     it("should return keys", () => {
         walletIndex.index(wallet);
         expect(walletIndex.keys()).toContain(wallet.address);
+    });
+
+    describe("set", () => {
+        it("should set and get addresses", () => {
+            expect(walletIndex.has(wallet.address)).toBeFalse();
+
+            walletIndex.index(wallet);
+            walletIndex.set(wallet.address, wallet);
+
+            expect(walletIndex.get(wallet.address)).toBe(wallet);
+            expect(walletIndex.has(wallet.address)).toBeTrue();
+
+            expect(walletIndex.values()).toContain(wallet);
+
+            walletIndex.clear();
+            expect(walletIndex.has(wallet.address)).toBeFalse();
+        });
+
+        it("should override key with new wallet", () => {
+            const anotherWallet = factory.make<Wallets.Wallet>();
+
+            walletIndex.set("key1", wallet);
+            walletIndex.set("key1", anotherWallet);
+
+            expect(walletIndex.get("key1")).toBe(anotherWallet);
+
+            const entries = walletIndex.entries();
+            expect(entries.length).toEqual(1);
+        });
+    });
+
+    describe("forget", () => {
+        it("should index and forget wallets", () => {
+            expect(walletIndex.has(wallet.address)).toBeFalse();
+
+            walletIndex.index(wallet);
+            expect(walletIndex.has(wallet.address)).toBeTrue();
+
+            walletIndex.forget(wallet.address);
+            expect(walletIndex.has(wallet.address)).toBeFalse();
+        });
+
+        it("should not throw if key is not indexed", () => {
+            walletIndex.forget(wallet.address);
+        });
+    });
+
+    describe("forgetWallet", () => {
+        it("should forget wallet", () => {
+            walletIndex.index(wallet);
+            expect(walletIndex.get(wallet.address)).toBe(wallet);
+
+            walletIndex.forgetWallet(wallet);
+            expect(walletIndex.get(wallet.address)).toBeUndefined();
+        });
+
+        it("should not throw if wallet is not indexed", () => {
+            walletIndex.forgetWallet(wallet);
+        });
     });
 });

--- a/__tests__/unit/core-state/wallets/wallet-repository-clone.test.ts
+++ b/__tests__/unit/core-state/wallets/wallet-repository-clone.test.ts
@@ -155,7 +155,6 @@ describe("Wallet Repository Clone", () => {
         expect(walletRepoClone.allByAddress()).toEqual([wallet]);
 
         // TODO: similarly, this behaviour is odd - as the code hasn't been overwritten in the extended class
-        walletRepoClone.forgetByAddress(address);
         expect(walletRepoClone.has(address)).toBeTrue();
     });
 

--- a/__tests__/unit/core-state/wallets/wallet-repository-copy-on-write.test.ts
+++ b/__tests__/unit/core-state/wallets/wallet-repository-copy-on-write.test.ts
@@ -196,7 +196,6 @@ describe("Wallet Repository Copy On Write", () => {
         expect(walletRepoCopyOnWrite.allByAddress()).toEqual([wallet]);
 
         // TODO: similarly, this behaviour is odd - as the code hasn't been overwritten in the extended class
-        walletRepoCopyOnWrite.forgetByAddress(address);
         expect(walletRepoCopyOnWrite.has(address)).toBeTrue();
     });
 

--- a/__tests__/unit/core-state/wallets/wallet-repository.test.ts
+++ b/__tests__/unit/core-state/wallets/wallet-repository.test.ts
@@ -166,7 +166,7 @@ describe("Wallet Repository", () => {
         expect(walletRepo.findByAddress(address)).toEqual(wallet);
     });
 
-    it("should get, set and forget wallets by address", () => {
+    it("should get and set wallets by address", () => {
         const address = "abcd";
         const wallet = walletRepo.createWallet(address);
 
@@ -193,9 +193,6 @@ describe("Wallet Repository", () => {
         expect(walletRepo.hasByIndex("addresses", address)).toBeTrue();
         expect(walletRepo.hasByIndex("addresses", nonExistingAddress)).toBeFalse();
         expect(walletRepo.allByAddress()).toEqual([wallet]);
-
-        walletRepo.forgetByAddress(address);
-        expect(walletRepo.has(address)).toBeFalse();
     });
 
     /**
@@ -217,7 +214,7 @@ describe("Wallet Repository", () => {
         expect(() => walletRepo.findByIndex("addresses", "iAlsoDontExist")).toThrow(errorMessage);
     });
 
-    it("should get, set and forget wallets by public key", () => {
+    it("should get and set wallets by public key", () => {
         const wallet = walletRepo.createWallet("abcde");
         const publicKey = "02337416a26d8d49ec27059bd0589c49bb474029c3627715380f4df83fb431aece";
         walletRepo.getIndex("publicKeys").set(publicKey, wallet);
@@ -233,9 +230,6 @@ describe("Wallet Repository", () => {
         expect(walletRepo.hasByIndex("publicKeys", publicKey)).toBeTrue();
         expect(walletRepo.hasByIndex("publicKeys", nonExistingPublicKey)).toBeFalse();
         expect(walletRepo.allByPublicKey()).toEqual([wallet]);
-
-        walletRepo.forgetByPublicKey(publicKey);
-        expect(walletRepo.has(publicKey)).toBeFalse();
     });
 
     it("should create a wallet if one is not found during public key lookup", () => {
@@ -252,7 +246,7 @@ describe("Wallet Repository", () => {
         expect(() => walletRepo.findByIndex("publicKeys", secondNotYetExistingPublicKey)).toThrow();
     });
 
-    it("should get, set and forget wallets by username", () => {
+    it("should get and set wallets by username", () => {
         const username = "testUsername";
         const wallet = walletRepo.createWallet("abcdef");
         /**
@@ -272,16 +266,12 @@ describe("Wallet Repository", () => {
         expect(walletRepo.hasByIndex("usernames", username)).toBeTrue();
         expect(walletRepo.hasByIndex("usernames", nonExistingUsername)).toBeFalse();
         expect(walletRepo.allByUsername()).toEqual([wallet]);
-
-        walletRepo.forgetByUsername(username);
-        expect(walletRepo.has(username)).toBeFalse();
     });
 
     it("should be able to index forgotten wallets", () => {
         const wallet1 = walletRepo.createWallet("wallet1");
         walletRepo.index(wallet1);
         expect(walletRepo.has("wallet1")).toBeTrue();
-        walletRepo.forgetByIndex("addresses", "wallet1");
         walletRepo.index(wallet1);
         expect(walletRepo.has("wallet1")).toBeTrue();
     });
@@ -290,11 +280,10 @@ describe("Wallet Repository", () => {
         const wallet1 = walletRepo.createWallet("wallet1");
         walletRepo.index(wallet1);
         wallet1.publicKey = undefined;
-        expect(() => walletRepo.forgetByIndex("addresses", "wallet2")).not.toThrow();
         expect(walletRepo.has("wallet2")).toBeFalse();
     });
 
-    it("should index array of wallets and forget using different indexers", () => {
+    it("should index array of wallets using different indexers", () => {
         const wallets: Contracts.State.Wallet[] = [];
         const walletAddresses: string[] = [];
         for (let i = 0; i < 6; i++) {
@@ -305,6 +294,7 @@ describe("Wallet Repository", () => {
         }
 
         walletRepo.index(wallets);
+
         walletAddresses.forEach((address) => expect(walletRepo.has(address)).toBeTrue());
 
         const publicKey = "22337416a26d8d49ec27059bd0589c49bb474029c3627715380f4df83fb431aece";
@@ -317,14 +307,7 @@ describe("Wallet Repository", () => {
 
         wallets.forEach((wallet) => walletRepo.index(wallet));
 
-        walletRepo.forgetByIndex("addresses", walletAddresses[0]);
-        walletRepo.forgetByIndex("publicKeys", publicKey);
-        walletRepo.forgetByIndex("usernames", "username");
-        walletRepo.forgetByIndex("resignations", "resign");
-        walletRepo.forgetByIndex("locks", "locks");
-        walletRepo.forgetByIndex("ipfs", "ipfs");
-
-        walletAddresses.forEach((address) => expect(walletRepo.has(address)).toBeFalse());
+        walletAddresses.forEach((address) => expect(walletRepo.has(address)).toBeTrue());
     });
 
     it("should get the nonce of a wallet", () => {
@@ -541,8 +524,8 @@ describe("Search", () => {
             spyStateStore.mockReturnValue(genesisBlock);
 
             const locks = walletRepo.search(Contracts.State.SearchScope.Locks, {});
-            expect(wallets.length).not.toEqual(0);
-            expect(locks.rows).toHaveLength(wallets.length);
+            expect(wallets.length).toEqual(52);
+            expect(locks.rows).toHaveLength(102); // First wallet have 50 locks
         });
 
         it("should return all locks with amount params", () => {
@@ -557,8 +540,8 @@ describe("Search", () => {
             spyStateStore.mockReturnValue(genesisBlock);
 
             const locks = walletRepo.search(Contracts.State.SearchScope.Locks, { amount: "" });
-            expect(wallets.length).not.toEqual(0);
-            expect(locks.rows).toHaveLength(wallets.length);
+            expect(wallets.length).toEqual(52);
+            expect(locks.rows).toHaveLength(102); // First wallet have 50 locks
         });
 
         it("should return only wallets which have correct lock ids", () => {

--- a/__tests__/unit/core-transactions/handlers/two/delegate-resignation.test.ts
+++ b/__tests__/unit/core-transactions/handlers/two/delegate-resignation.test.ts
@@ -188,6 +188,19 @@ describe("DelegateResignationTransaction", () => {
         });
 
         it("should not throw if wallet is a delegate - second sign", async () => {
+            // Add extra delegate so we don't get NotEnoughDelegatesError
+            const anotherDelegate: Wallets.Wallet = factoryBuilder
+                .get("Wallet")
+                .withOptions({
+                    passphrase: "anotherDelegate",
+                    nonce: 0,
+                })
+                .make();
+
+            anotherDelegate.setAttribute("delegate", { username: "another" });
+            walletRepository.index(anotherDelegate);
+            allDelegates.push(anotherDelegate);
+
             secondSignatureWallet.setAttribute("delegate", { username: "dummy" });
             walletRepository.index(secondSignatureWallet);
             await expect(

--- a/packages/core-kernel/src/contracts/state/wallets.ts
+++ b/packages/core-kernel/src/contracts/state/wallets.ts
@@ -180,14 +180,6 @@ export interface WalletRepository {
 
     index(wallets: Wallet | ReadonlyArray<Wallet>): void;
 
-    forgetByAddress(address: string): void;
-
-    forgetByPublicKey(publicKey: string): void;
-
-    forgetByUsername(username: string): void;
-
-    forgetByIndex(indexName: string, key: string): void;
-
     hasByAddress(address: string): boolean;
 
     hasByPublicKey(publicKey: string): boolean;

--- a/packages/core-kernel/src/contracts/state/wallets.ts
+++ b/packages/core-kernel/src/contracts/state/wallets.ts
@@ -11,6 +11,7 @@ export interface WalletIndex {
     get(key: string): Wallet | undefined;
     set(key: string, wallet: Wallet): void;
     forget(key: string): void;
+    forgetWallet(wallet: Wallet): void;
     entries(): ReadonlyArray<[string, Wallet]>;
     values(): ReadonlyArray<Wallet>;
     keys(): string[];

--- a/packages/core-magistrate-transactions/src/handlers/business-registration.ts
+++ b/packages/core-magistrate-transactions/src/handlers/business-registration.ts
@@ -9,7 +9,6 @@ import { Interfaces, Transactions } from "@arkecosystem/crypto";
 import { BusinessAlreadyRegisteredError } from "../errors";
 import { MagistrateApplicationEvents } from "../events";
 import { IBusinessWalletAttributes } from "../interfaces";
-import { MagistrateIndex } from "../wallet-indexes";
 import { MagistrateTransactionHandler } from "./magistrate-handler";
 
 @Container.injectable()
@@ -114,8 +113,6 @@ export class BusinessRegistrationTransactionHandler extends MagistrateTransactio
         const sender: Contracts.State.Wallet = this.walletRepository.findByPublicKey(transaction.data.senderPublicKey);
 
         sender.forgetAttribute("business");
-
-        this.walletRepository.forgetByIndex(MagistrateIndex.Businesses, transaction.data.senderPublicKey);
 
         this.walletRepository.index(sender);
     }

--- a/packages/core-magistrate-transactions/src/handlers/business-resignation.ts
+++ b/packages/core-magistrate-transactions/src/handlers/business-resignation.ts
@@ -2,6 +2,7 @@ import { Container, Contracts, Utils as AppUtils } from "@arkecosystem/core-kern
 import { Transactions as MagistrateTransactions } from "@arkecosystem/core-magistrate-crypto";
 import { Handlers } from "@arkecosystem/core-transactions";
 import { Interfaces, Transactions, Utils } from "@arkecosystem/crypto";
+
 import { BridgechainsAreNotResignedError, BusinessIsNotRegisteredError, BusinessIsResignedError } from "../errors";
 import { MagistrateApplicationEvents } from "../events";
 import { IBridgechainWalletAttributes, IBusinessWalletAttributes } from "../interfaces";
@@ -59,7 +60,10 @@ export class BusinessResignationTransactionHandler extends MagistrateTransaction
             throw new BusinessIsResignedError();
         }
 
-        const bridgechains: Record<string, IBridgechainWalletAttributes> = wallet.getAttribute("business.bridgechains", {});
+        const bridgechains: Record<string, IBridgechainWalletAttributes> = wallet.getAttribute(
+            "business.bridgechains",
+            {},
+        );
         if (Object.values(bridgechains).some((bridgechain) => !bridgechain.resigned)) {
             throw new BridgechainsAreNotResignedError();
         }
@@ -92,7 +96,6 @@ export class BusinessResignationTransactionHandler extends MagistrateTransaction
         const sender: Contracts.State.Wallet = this.walletRepository.findByPublicKey(transaction.data.senderPublicKey);
 
         sender.setAttribute("business.resigned", true);
-        this.walletRepository.index(sender);
     }
 
     public async revertForSender(transaction: Interfaces.ITransaction): Promise<void> {
@@ -103,7 +106,6 @@ export class BusinessResignationTransactionHandler extends MagistrateTransaction
         const sender: Contracts.State.Wallet = this.walletRepository.findByPublicKey(transaction.data.senderPublicKey);
 
         sender.forgetAttribute("business.resigned");
-        this.walletRepository.index(sender);
     }
 
     public async applyToRecipient(

--- a/packages/core-state/src/wallets/wallet-index.ts
+++ b/packages/core-state/src/wallets/wallet-index.ts
@@ -1,4 +1,3 @@
-// import { Container, Contracts, Services } from "@arkecosystem/core-kernel";
 import { Contracts } from "@arkecosystem/core-kernel";
 
 export class WalletIndex implements Contracts.State.WalletIndex {

--- a/packages/core-state/src/wallets/wallet-index.ts
+++ b/packages/core-state/src/wallets/wallet-index.ts
@@ -1,22 +1,24 @@
 import { Contracts } from "@arkecosystem/core-kernel";
 
 export class WalletIndex implements Contracts.State.WalletIndex {
-    private walletIndex: Record<string, Contracts.State.Wallet>;
+    private walletByKey: Map<string, Contracts.State.Wallet>;
+    private keysByWallet: Map<Contracts.State.Wallet, string[]>;
 
     public constructor(public readonly indexer: Contracts.State.WalletIndexer) {
-        this.walletIndex = {};
+        this.walletByKey = new Map<string, Contracts.State.Wallet>();
+        this.keysByWallet = new Map<Contracts.State.Wallet, string[]>();
     }
 
     public entries(): ReadonlyArray<[string, Contracts.State.Wallet]> {
-        return Object.entries(this.walletIndex);
+        return [...this.walletByKey.entries()];
     }
 
     public keys(): string[] {
-        return Object.keys(this.walletIndex);
+        return [...this.walletByKey.keys()];
     }
 
     public values(): ReadonlyArray<Contracts.State.Wallet> {
-        return Object.values(this.walletIndex);
+        return [...this.walletByKey.values()];
     }
 
     public index(wallet: Contracts.State.Wallet): void {
@@ -24,29 +26,68 @@ export class WalletIndex implements Contracts.State.WalletIndex {
     }
 
     public has(key: string): boolean {
-        return !!this.walletIndex[key];
+        return this.walletByKey.has(key);
     }
 
     public get(key: string): Contracts.State.Wallet {
-        return this.walletIndex[key];
+        return this.walletByKey.get(key) as Contracts.State.Wallet;
     }
 
     public set(key: string, wallet: Contracts.State.Wallet): void {
-        this.walletIndex[key] = wallet;
+        // Key already exists
+        if (this.walletByKey.has(key)) {
+            const existingWallet = this.walletByKey.get(key)!;
+
+            // Remove given key in case where key points to different wallet
+            const existingKeys = this.keysByWallet.get(existingWallet)!;
+            this.keysByWallet.set(existingWallet, [...existingKeys.filter((x) => x !== key)]);
+        }
+
+        this.walletByKey.set(key, wallet);
+
+        if (this.keysByWallet.has(wallet)) {
+            const existingKeys = this.keysByWallet.get(wallet)!;
+            this.keysByWallet.set(wallet, [...existingKeys, key]);
+        } else {
+            this.keysByWallet.set(wallet, [key]);
+        }
     }
 
     public forget(key: string): void {
-        delete this.walletIndex[key];
+        if (this.walletByKey.has(key)) {
+            const wallet = this.walletByKey.get(key)!;
+
+            const keys = this.keysByWallet.get(wallet)!;
+
+            this.keysByWallet.set(
+                wallet,
+                keys.filter((x) => x !== key),
+            );
+
+            this.walletByKey.delete(key);
+        }
+    }
+
+    public forgetWallet(wallet: Contracts.State.Wallet): void {
+        if (this.keysByWallet.has(wallet)) {
+            const keys = this.keysByWallet.get(wallet)!;
+
+            for (const key of keys) {
+                this.walletByKey.delete(key);
+            }
+
+            this.keysByWallet.delete(wallet);
+        }
     }
 
     public clear(): void {
-        this.walletIndex = {};
+        this.walletByKey = new Map<string, Contracts.State.Wallet>();
     }
 
     public clone(): Contracts.State.WalletIndex {
         const walletIndex = new WalletIndex(this.indexer);
 
-        for (const [key, value] of Object.entries(this.walletIndex)) {
+        for (const [key, value] of this.entries()) {
             walletIndex.set(key, value.clone());
         }
 

--- a/packages/core-state/src/wallets/wallet-repository.ts
+++ b/packages/core-state/src/wallets/wallet-repository.ts
@@ -126,31 +126,6 @@ export class WalletRepository implements Contracts.State.WalletRepository {
         return Utils.BigNumber.ZERO;
     }
 
-    public forgetByAddress(address: string): void {
-        this.forgetByIndex(Contracts.State.WalletIndexes.Addresses, address);
-    }
-
-    public forgetByPublicKey(publicKey: string): void {
-        this.forgetByIndex(Contracts.State.WalletIndexes.PublicKeys, publicKey);
-    }
-
-    public forgetByUsername(username: string): void {
-        this.forgetByIndex(Contracts.State.WalletIndexes.Usernames, username);
-    }
-
-    public forgetByIndex(indexName: string, key: string): void {
-        const forgottenWallet = this.getIndex(indexName).get(key);
-        for (const index of Object.values(this.indexes)) {
-            for (const [name, wallet] of index.entries()) {
-                if (wallet.publicKey === forgottenWallet?.publicKey) {
-                    index.forget(name);
-                }
-            }
-        }
-        // TODO: check whether this line is still needed?
-        this.getIndex(indexName).forget(key);
-    }
-
     public index(wallets: Contracts.State.Wallet | ReadonlyArray<Contracts.State.Wallet>): void {
         if (!Array.isArray(wallets)) {
             this.indexWallet(wallets as Contracts.State.Wallet);
@@ -234,8 +209,20 @@ export class WalletRepository implements Contracts.State.WalletRepository {
     }
 
     private indexWallet(wallet: Contracts.State.Wallet): void {
+        this.forgetWallet(wallet);
+
         for (const walletIndex of Object.values(this.indexes)) {
             walletIndex.index(wallet);
+        }
+    }
+
+    private forgetWallet(wallet: Contracts.State.Wallet): void {
+        for (const index of Object.values(this.indexes)) {
+            for (const [name, indexedWallet] of index.entries()) {
+                if (indexedWallet.publicKey === wallet?.publicKey) {
+                    index.forget(name);
+                }
+            }
         }
     }
 

--- a/packages/core-state/src/wallets/wallet-repository.ts
+++ b/packages/core-state/src/wallets/wallet-repository.ts
@@ -219,7 +219,7 @@ export class WalletRepository implements Contracts.State.WalletRepository {
     private forgetWallet(wallet: Contracts.State.Wallet): void {
         for (const index of Object.values(this.indexes)) {
             for (const [name, indexedWallet] of index.entries()) {
-                if (indexedWallet.publicKey === wallet?.publicKey) {
+                if (indexedWallet.address === wallet.address) {
                     index.forget(name);
                 }
             }

--- a/packages/core-state/src/wallets/wallet-repository.ts
+++ b/packages/core-state/src/wallets/wallet-repository.ts
@@ -209,20 +209,9 @@ export class WalletRepository implements Contracts.State.WalletRepository {
     }
 
     private indexWallet(wallet: Contracts.State.Wallet): void {
-        this.forgetWallet(wallet);
-
-        for (const walletIndex of Object.values(this.indexes)) {
-            walletIndex.index(wallet);
-        }
-    }
-
-    private forgetWallet(wallet: Contracts.State.Wallet): void {
         for (const index of Object.values(this.indexes)) {
-            for (const [name, indexedWallet] of index.entries()) {
-                if (indexedWallet.address === wallet.address) {
-                    index.forget(name);
-                }
-            }
+            index.forgetWallet(wallet);
+            index.index(wallet);
         }
     }
 

--- a/packages/core-transactions/src/handlers/one/delegate-registration.ts
+++ b/packages/core-transactions/src/handlers/one/delegate-registration.ts
@@ -137,9 +137,9 @@ export class DelegateRegistrationTransactionHandler extends TransactionHandler {
 
         const sender: Contracts.State.Wallet = this.walletRepository.findByPublicKey(transaction.data.senderPublicKey);
 
-        this.walletRepository.forgetByUsername(sender.getAttribute("delegate.username"));
-
         sender.forgetAttribute("delegate");
+
+        this.walletRepository.index(sender);
     }
 
     public async applyToRecipient(transaction: Interfaces.ITransaction): Promise<void> {}

--- a/packages/core-transactions/src/handlers/two/delegate-resignation.ts
+++ b/packages/core-transactions/src/handlers/two/delegate-resignation.ts
@@ -97,7 +97,7 @@ export class DelegateResignationTransactionHandler extends TransactionHandler {
 
         AppUtils.assert.defined<string>(transaction.data.senderPublicKey);
 
-        const senderWallet: Contracts.State.Wallet = this.walletRepository.findByPublicKey(
+        const senderWallet = this.walletRepository.findByPublicKey(
             transaction.data.senderPublicKey,
         );
 
@@ -111,7 +111,11 @@ export class DelegateResignationTransactionHandler extends TransactionHandler {
 
         AppUtils.assert.defined<string>(transaction.data.senderPublicKey);
 
-        this.walletRepository.findByPublicKey(transaction.data.senderPublicKey).forgetAttribute("delegate.resigned");
+        const senderWallet = this.walletRepository.findByPublicKey(transaction.data.senderPublicKey);
+
+        senderWallet.forgetAttribute("delegate.resigned");
+
+        this.walletRepository.index(senderWallet);
     }
 
     public async applyToRecipient(


### PR DESCRIPTION
## Summary

Remove all forget* methods on wallet-repository. Re implements index methods, which now forget wallet from all indexes and re add them back to keep consistency and integrity.

## Checklist

- [x] Tests
- [x] Ready to be merged
