### PR TITLE
fix(core-kernel): dynamically import @pm2/io

### DIFF
--- a/packages/core-kernel/src/services/process-actions/drivers/pm2.ts
+++ b/packages/core-kernel/src/services/process-actions/drivers/pm2.ts
@@ -1,12 +1,16 @@
-import pmx from "@pm2/io";
-
 import { ProcessAction, ProcessActionsService } from "../../../contracts/kernel/process-actions";
 import { injectable } from "../../../ioc";
 
 @injectable()
 export class Pm2ProcessActionsService implements ProcessActionsService {
+    private readonly pmx;
+
+    public constructor() {
+        this.pmx = require("@pm2/io");
+    }
+
     public register(remoteAction: ProcessAction): void {
-        pmx.action(remoteAction.name, (reply) => {
+        this.pmx.action(remoteAction.name, (reply) => {
             remoteAction
                 .handler()
                 .then((response) => {


### PR DESCRIPTION
## Summary

Dynamically import @pm2/io package. This prevents pm2 initialization before service registration. Pm2 was previously loaded on core-kernel import, which had unwanted side effects. 

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged

