### PR TITLE
refactor(core-blockchain): initialize blockchain when resolved first time

### DIFF
--- a/__tests__/unit/core-blockchain/blockchain.test.ts
+++ b/__tests__/unit/core-blockchain/blockchain.test.ts
@@ -12,6 +12,7 @@ import delay from "delay";
 describe("Blockchain", () => {
     let sandbox: Sandbox;
 
+    const configuration: any = {};
     const logService: any = {};
     const stateStore: any = {};
     const databaseService: any = {};
@@ -26,6 +27,7 @@ describe("Blockchain", () => {
     beforeAll(() => {
         sandbox = new Sandbox();
 
+        sandbox.app.bind(Container.Identifiers.PluginConfiguration).toConstantValue(configuration);
         sandbox.app.bind(Container.Identifiers.LogService).toConstantValue(logService);
         sandbox.app.bind(Container.Identifiers.StateStore).toConstantValue(stateStore);
         sandbox.app.bind(Container.Identifiers.DatabaseService).toConstantValue(databaseService);
@@ -55,11 +57,14 @@ describe("Blockchain", () => {
     beforeEach(() => {
         jest.restoreAllMocks();
 
+        configuration.getOptional = jest.fn((key, defaultValue) => defaultValue);
+
         logService.warning = jest.fn();
         logService.info = jest.fn();
         logService.error = jest.fn();
         logService.debug = jest.fn();
 
+        stateStore.reset = jest.fn();
         stateStore.started = false;
         stateStore.getMaxLastBlocks = jest.fn().mockReturnValue(200);
         stateStore.clearWakeUpTimeout = jest.fn();
@@ -102,19 +107,16 @@ describe("Blockchain", () => {
 
     describe("initialize", () => {
         it("should log a warning if networkStart option is provided", () => {
-            const blockchain = sandbox.app.resolve<Blockchain>(Blockchain);
-
-            blockchain.initialize({});
-            expect(logService.warning).toBeCalledTimes(0);
-
-            blockchain.initialize({ networkStart: false });
-            expect(logService.warning).toBeCalledTimes(0);
-
-            blockchain.initialize({ networkStart: true });
+            configuration.getOptional.mockReturnValueOnce(true);
+            sandbox.app.resolve<Blockchain>(Blockchain);
             expect(logService.warning).toBeCalledTimes(1);
         });
-    });
 
+        it("should not log a warning if networkStart option isn't provided", () => {
+            sandbox.app.resolve<Blockchain>(Blockchain);
+            expect(logService.warning).toBeCalledTimes(0);
+        });
+    });
     describe("dispatch", () => {
         it("should call transition method on stateMachine with the event provided", () => {
             const blockchain = sandbox.app.resolve<Blockchain>(Blockchain);
@@ -207,7 +209,6 @@ describe("Blockchain", () => {
     describe("dispose", () => {
         it("should call clearWakeUpTimeout on stateStore and dispatch 'STOP'", async () => {
             const blockchain = sandbox.app.resolve<Blockchain>(Blockchain);
-            blockchain.initialize({});
 
             const spyDispatch = jest.spyOn(blockchain, "dispatch");
 
@@ -271,7 +272,6 @@ describe("Blockchain", () => {
     describe("clearAndStopQueue", () => {
         it("should set state.lastDownloadedBlock from this.getLastBlock() and clear queue", () => {
             const blockchain = sandbox.app.resolve<Blockchain>(Blockchain);
-            blockchain.initialize({});
 
             const spyClearQueue = jest.spyOn(blockchain, "clearQueue");
             stateStore.lastDownloadedBlock = undefined;
@@ -288,7 +288,6 @@ describe("Blockchain", () => {
     describe("clearQueue", () => {
         it("should call queue.remove", () => {
             const blockchain = sandbox.app.resolve<Blockchain>(Blockchain);
-            blockchain.initialize({});
 
             const spyQueueRemove = jest.spyOn(blockchain.queue, "remove");
 
@@ -321,7 +320,6 @@ describe("Blockchain", () => {
         describe("when state is started", () => {
             it("should dispatch 'NEWBLOCK', BlockEvent.Received and enqueue the block", async () => {
                 const blockchain = sandbox.app.resolve<Blockchain>(Blockchain);
-                blockchain.initialize({});
                 const spyDispatch = jest.spyOn(blockchain, "dispatch");
                 const spyEnqueue = jest.spyOn(blockchain, "enqueueBlocks");
                 stateStore.started = true;
@@ -341,7 +339,6 @@ describe("Blockchain", () => {
 
             it("should not dispatch anything nor enqueue the block if receivedSlot > currentSlot", async () => {
                 const blockchain = sandbox.app.resolve<Blockchain>(Blockchain);
-                blockchain.initialize({});
                 const spyEnqueue = jest.spyOn(blockchain, "enqueueBlocks");
                 stateStore.started = true;
                 stateStore.getLastBlock = jest.fn().mockReturnValue({ data: blockData });
@@ -356,7 +353,6 @@ describe("Blockchain", () => {
 
             it("should handle block from forger if in right slot", async () => {
                 const blockchain = sandbox.app.resolve<Blockchain>(Blockchain);
-                blockchain.initialize({});
                 const spyEnqueue = jest.spyOn(blockchain, "enqueueBlocks");
                 const spyDispatch = jest.spyOn(blockchain, "dispatch");
                 stateStore.started = true;
@@ -375,7 +371,6 @@ describe("Blockchain", () => {
 
             it.each([[true], [false]])("should not handle block if in wrong slot", async (fromForger) => {
                 const blockchain = sandbox.app.resolve<Blockchain>(Blockchain);
-                blockchain.initialize({});
                 const spyEnqueue = jest.spyOn(blockchain, "enqueueBlocks");
                 const spyDispatch = jest.spyOn(blockchain, "dispatch");
                 stateStore.started = true;
@@ -392,7 +387,6 @@ describe("Blockchain", () => {
 
             it("should not handle block from forger if less than 2 seconds left in slot", async () => {
                 const blockchain = sandbox.app.resolve<Blockchain>(Blockchain);
-                blockchain.initialize({});
                 const spyEnqueue = jest.spyOn(blockchain, "enqueueBlocks");
                 const spyDispatch = jest.spyOn(blockchain, "dispatch");
                 stateStore.started = true;
@@ -409,7 +403,6 @@ describe("Blockchain", () => {
 
             it("should handle block if not from forger if less than 2 seconds left in slot", async () => {
                 const blockchain = sandbox.app.resolve<Blockchain>(Blockchain);
-                blockchain.initialize({});
                 const spyEnqueue = jest.spyOn(blockchain, "enqueueBlocks");
                 const spyDispatch = jest.spyOn(blockchain, "dispatch");
                 stateStore.started = true;
@@ -463,7 +456,6 @@ describe("Blockchain", () => {
 
         it("should just return if blocks provided are an empty array", async () => {
             const blockchain = sandbox.app.resolve<Blockchain>(Blockchain);
-            blockchain.initialize({});
             const spyQueuePush = jest.spyOn(blockchain.queue, "push");
 
             blockchain.enqueueBlocks([]);
@@ -472,7 +464,6 @@ describe("Blockchain", () => {
 
         it("should enqueue the blocks", async () => {
             const blockchain = sandbox.app.resolve<Blockchain>(Blockchain);
-            blockchain.initialize({});
             stateStore.lastDownloadedBlock = { height: 23111 };
 
             const spyQueuePush = jest.spyOn(blockchain.queue, "push");
@@ -484,7 +475,6 @@ describe("Blockchain", () => {
 
         it("should push a chunk to the queue when currentTransactionsCount >= 150", async () => {
             const blockchain = sandbox.app.resolve<Blockchain>(Blockchain);
-            blockchain.initialize({});
             stateStore.lastDownloadedBlock = { height: 23111 };
 
             const spyQueuePush = jest.spyOn(blockchain.queue, "push");
@@ -503,7 +493,6 @@ describe("Blockchain", () => {
 
         it("should push a chunk to the queue when currentBlocksChunk.length >= 100", async () => {
             const blockchain = sandbox.app.resolve<Blockchain>(Blockchain);
-            blockchain.initialize({});
             stateStore.lastDownloadedBlock = { height: 23111 };
 
             const spyQueuePush = jest.spyOn(blockchain.queue, "push");
@@ -522,7 +511,6 @@ describe("Blockchain", () => {
 
         it("should push a chunk to the queue when hitting new milestone", async () => {
             const blockchain = sandbox.app.resolve<Blockchain>(Blockchain);
-            blockchain.initialize({});
             stateStore.lastDownloadedBlock = { height: 7555 };
 
             const spyQueuePush = jest.spyOn(blockchain.queue, "push");
@@ -580,7 +568,6 @@ describe("Blockchain", () => {
     describe("removeBlocks", () => {
         it("should call revertBlock and setLastBlock for each block to be removed, and deleteBlocks with all blocks removed", async () => {
             const blockchain = sandbox.app.resolve<Blockchain>(Blockchain);
-            blockchain.initialize({});
 
             const blocksToRemove = [blockHeight2, blockHeight3];
             stateStore.getLastBlock = jest
@@ -604,7 +591,6 @@ describe("Blockchain", () => {
 
         it("should default to removing until genesis block when asked to remove more", async () => {
             const blockchain = sandbox.app.resolve<Blockchain>(Blockchain);
-            blockchain.initialize({});
 
             const genesisBlock = Networks.testnet.genesisBlock;
             stateStore.getLastBlock = jest
@@ -648,7 +634,6 @@ describe("Blockchain", () => {
 
         it("should process a new chained block", async () => {
             const blockchain = sandbox.app.resolve<Blockchain>(Blockchain);
-            blockchain.initialize({});
 
             stateStore.getLastBlock = jest.fn().mockReturnValue({ data: lastBlock });
             blockProcessor.process = jest.fn().mockReturnValue(BlockProcessorResult.Accepted);
@@ -659,7 +644,6 @@ describe("Blockchain", () => {
 
         it("should process a valid block already known", async () => {
             const blockchain = sandbox.app.resolve<Blockchain>(Blockchain);
-            blockchain.initialize({});
 
             stateStore.getLastBlock = jest.fn().mockReturnValue({ data: lastBlock });
             const spyClearQueue = jest.spyOn(blockchain, "clearQueue");
@@ -673,7 +657,6 @@ describe("Blockchain", () => {
 
         it("should not process the remaining block if one is not accepted", async () => {
             const blockchain = sandbox.app.resolve<Blockchain>(Blockchain);
-            blockchain.initialize({});
 
             const genesisBlock = Networks.testnet.genesisBlock;
             stateStore.getLastBlock = jest.fn().mockReturnValue({ data: genesisBlock });
@@ -688,7 +671,6 @@ describe("Blockchain", () => {
 
         it("should revert block when blockRepository saveBlocks fails", async () => {
             const blockchain = sandbox.app.resolve<Blockchain>(Blockchain);
-            blockchain.initialize({});
 
             stateStore.getLastBlock = jest.fn().mockReturnValue({ data: lastBlock });
             databaseService.getLastBlock = jest.fn().mockReturnValue({ data: lastBlock });
@@ -706,7 +688,6 @@ describe("Blockchain", () => {
 
         it("should broadcast a block if (Crypto.Slots.getSlotNumber() * blocktime <= block.data.timestamp)", async () => {
             const blockchain = sandbox.app.resolve<Blockchain>(Blockchain);
-            blockchain.initialize({});
 
             const getTimeStampForBlock = (height: number) => {
                 switch (height) {
@@ -742,7 +723,6 @@ describe("Blockchain", () => {
         describe("calling processBlocks from the queue", () => {
             it("should call processBlocks from queue handler", async () => {
                 const blockchain = sandbox.app.resolve<Blockchain>(Blockchain);
-                blockchain.initialize({});
                 stateStore.getLastBlock = jest.fn().mockReturnValue({ data: lastBlock });
                 blockProcessor.process = jest.fn().mockReturnValue(BlockProcessorResult.Accepted);
                 stateStore.lastDownloadedBlock = { height: 23111 };
@@ -760,7 +740,6 @@ describe("Blockchain", () => {
 
             it("should log an error when processBlocks throws for any reason", async () => {
                 const blockchain = sandbox.app.resolve<Blockchain>(Blockchain);
-                blockchain.initialize({});
                 stateStore.getLastBlock = jest.fn().mockImplementationOnce(() => {
                     throw new Error("oops");
                 });
@@ -814,7 +793,6 @@ describe("Blockchain", () => {
     describe("forkBlock", () => {
         it("should set forkedBlock, clear and stop queue and dispatch 'FORK'", () => {
             const blockchain = sandbox.app.resolve<Blockchain>(Blockchain);
-            blockchain.initialize({});
 
             const forkedBlock = { data: { id: "1234", height: 8877 } };
             const numberOfBlocksToRollback = 34;

--- a/packages/core-blockchain/src/service-provider.ts
+++ b/packages/core-blockchain/src/service-provider.ts
@@ -4,31 +4,22 @@ import { ProcessBlockAction } from "./actions";
 import { Blockchain } from "./blockchain";
 import { BlockProcessor } from "./processor";
 import { StateMachine } from "./state-machine";
-import { blockchainMachine } from "./state-machine/machine";
 
 export class ServiceProvider extends Providers.ServiceProvider {
     public async register(): Promise<void> {
         this.app.bind(Container.Identifiers.StateMachine).to(StateMachine).inSingletonScope();
-
-        const blockchain: Blockchain = this.app.resolve<Blockchain>(Blockchain);
-
-        this.app.bind(Container.Identifiers.BlockchainService).toConstantValue(blockchain);
-
+        this.app.bind(Container.Identifiers.BlockchainService).to(Blockchain).inSingletonScope();
         this.app.bind(Container.Identifiers.BlockProcessor).to(BlockProcessor).inSingletonScope();
-
-        blockchain.initialize(this.config().all()); // ? why it isn't in boot?
-
-        this.app.get<Contracts.State.StateStore>(Container.Identifiers.StateStore).reset(blockchainMachine);
 
         this.registerActions();
     }
 
     public async boot(): Promise<void> {
-        await this.app.get<Blockchain>(Container.Identifiers.BlockchainService).boot();
+        await this.app.get<Contracts.Blockchain.Blockchain>(Container.Identifiers.BlockchainService).boot();
     }
 
     public async dispose(): Promise<void> {
-        await this.app.get<Blockchain>(Container.Identifiers.BlockchainService).dispose();
+        await this.app.get<Contracts.Blockchain.Blockchain>(Container.Identifiers.BlockchainService).dispose();
     }
 
     public async bootWhen(): Promise<boolean> {

--- a/packages/core-kernel/src/contracts/blockchain/blockchain.ts
+++ b/packages/core-kernel/src/contracts/blockchain/blockchain.ts
@@ -6,13 +6,6 @@ export interface Blockchain {
     queue: any;
 
     /**
-     * Create a new blockchain manager instance.
-     * @param  {Object} options
-     * @return {void}
-     */
-    initialize(options: { networkStart?: boolean }): this;
-
-    /**
      * Dispatch an event to transition the state machine.
      * @param  {String} event
      * @return {void}
@@ -23,7 +16,7 @@ export interface Blockchain {
      * Start the blockchain and wait for it to be ready.
      * @return {void}
      */
-    boot(skipStartedCheck): Promise<boolean>;
+    boot(skipStartedCheck?: boolean): Promise<boolean>;
 
     dispose(): Promise<void>;
 


### PR DESCRIPTION
## Summary

`Blockchain` class was resolved during `register`, which chain-resolved wallet repository and all wallet indices which were registered, any wallet index that is registered afterwards wasn't available.

The reason why it was resolved is because `Blockchain` class needed additional constructor logic to setup state machine. I marked `initialize` function with `@postConstruct` decorator and removed direct `resolve` and `initialize` call from `register.

Now plugin that adds wallet index (e.g. `core-magistrate-transactions`) doesn't have to be registered before `core-blockchain`.

## Checklist

- [x] Tests
- [ ] Ready to be merged
