### PR TITLE
chore(crypto): add publickey verification

### DIFF
--- a/__tests__/unit/core-state/__utils__/build-delegate-and-vote-balances.ts
+++ b/__tests__/unit/core-state/__utils__/build-delegate-and-vote-balances.ts
@@ -4,15 +4,27 @@ import { SATOSHI } from "@packages/crypto/src/constants";
 
 export const buildDelegateAndVoteWallets = (numberDelegates: number, walletRepo: WalletRepository): Wallet[] => {
     const delegates: Wallet[] = [];
+    const delegateKeys: string[] = [
+        "02511f16ffb7b7e9afc12f04f317a11d9644e4be9eb5a5f64673946ad0f6336f34",
+        "0259d9ca7922c277b0e7407a88703bbb98f5da43a335b0eefa6c4642f072acfe79",
+        "03697abb61ee85e020a35a1d2701112e7e16477ac9d2eb2e8900a27995edc917a2",
+        "027e2269d8a770343223bedc49bab31b3c52fb4c1df6627153e6374ac23e2d878b",
+        "03858d4d3b77c7c227f6fe3e18b5807aa476828cb712663dcd79df87e439cc07c5",
+    ];
+
+    if (numberDelegates > delegateKeys.length) {
+        throw new Error(`Number of Test Delegates (${numberDelegates}) should not exceed ${delegateKeys.length}`);
+    }
+
     for (let i = 0; i < numberDelegates; i++) {
-        const delegateKey = i.toString().repeat(66);
+        const delegateKey = delegateKeys[i];
         const delegate = walletRepo.createWallet(Identities.Address.fromPublicKey(delegateKey));
         delegate.publicKey = delegateKey;
         delegate.setAttribute("delegate.username", `delegate${i}`);
         delegate.setAttribute("delegate.voteBalance", CryptoUtils.BigNumber.ZERO);
 
         const voter = walletRepo.createWallet(
-            Identities.Address.fromPublicKey((i + numberDelegates).toString().repeat(66)),
+            Identities.Address.fromPublicKey(delegateKeys[numberDelegates - 1 - i]),
         );
         const totalBalance = CryptoUtils.BigNumber.make(i + 1)
             .times(1000)

--- a/__tests__/unit/core-state/block-state.test.ts
+++ b/__tests__/unit/core-state/block-state.test.ts
@@ -685,7 +685,7 @@ describe("BlockState", () => {
 
             it("update vote balances for claims transactions", async () => {
                 const recipientsDelegate = walletRepo.findByPublicKey(
-                    "32337416a26d8d49ec27059bd0589c49bb474029c3627715380f4df83fb431aece",
+                    "034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed192",
                 );
                 sender.setAttribute("vote", forgingWallet.publicKey);
                 recipientWallet.setAttribute("vote", recipientsDelegate.publicKey);

--- a/__tests__/unit/core-state/wallets/wallet-repository.test.ts
+++ b/__tests__/unit/core-state/wallets/wallet-repository.test.ts
@@ -233,7 +233,7 @@ describe("Wallet Repository", () => {
     });
 
     it("should create a wallet if one is not found during public key lookup", () => {
-        const firstNotYetExistingPublicKey = "22337416a26d8d49ec27059bd0589c49bb474029c3627715380f4df83fb431aece";
+        const firstNotYetExistingPublicKey = "0235d486fea0193cbe77e955ab175b8f6eb9eaf784de689beffbd649989f5d6be3";
         expect(() => walletRepo.findByPublicKey(firstNotYetExistingPublicKey)).not.toThrow();
         expect(walletRepo.findByPublicKey(firstNotYetExistingPublicKey)).toBeInstanceOf(Wallet);
 
@@ -242,7 +242,7 @@ describe("Wallet Repository", () => {
          * Looking up a non-existing publicKey by findByPublicKey creates a wallet.
          * However looking up a non-existing publicKey using findByIndex() does not.
          */
-        const secondNotYetExistingPublicKey = "32337416a26d8d49ec27059bd0589c49bb474029c3627715380f4df83fb431aece";
+        const secondNotYetExistingPublicKey = "03a46f2547d20b47003c1c376788db5a54d67264df2ae914f70bf453b6a1fa1b3a";
         expect(() => walletRepo.findByIndex("publicKeys", secondNotYetExistingPublicKey)).toThrow();
     });
 
@@ -297,7 +297,7 @@ describe("Wallet Repository", () => {
 
         walletAddresses.forEach((address) => expect(walletRepo.has(address)).toBeTrue());
 
-        const publicKey = "22337416a26d8d49ec27059bd0589c49bb474029c3627715380f4df83fb431aece";
+        const publicKey = "02511f16ffb7b7e9afc12f04f317a11d9644e4be9eb5a5f64673946ad0f6336f34";
 
         walletRepo.getIndex("publicKeys").set(publicKey, wallets[1]);
         walletRepo.getIndex("usernames").set("username", wallets[2]);
@@ -313,14 +313,14 @@ describe("Wallet Repository", () => {
     it("should get the nonce of a wallet", () => {
         const wallet1 = walletRepo.createWallet("wallet1");
         wallet1.nonce = Utils.BigNumber.make(100);
-        wallet1.publicKey = "22337416a26d8d49ec27059bd0589c49bb474029c3627715380f4df83fb431aece";
+        wallet1.publicKey = "02511f16ffb7b7e9afc12f04f317a11d9644e4be9eb5a5f64673946ad0f6336f34";
         walletRepo.index(wallet1);
 
         expect(walletRepo.getNonce(wallet1.publicKey)).toEqual(Utils.BigNumber.make(100));
     });
 
     it("should return 0 nonce if there is no wallet", () => {
-        const publicKey = "22337416a26d8d49ec27059bd0589c49bb474029c3627715380f4df83fb431aece";
+        const publicKey = "03c075494ad044ab8c0b2dc7ccd19f649db844a4e558e539d3ac2610c4b90a5139";
         expect(walletRepo.getNonce(publicKey)).toEqual(Utils.BigNumber.ZERO);
     });
 

--- a/__tests__/unit/crypto/identities/public-key.test.ts
+++ b/__tests__/unit/crypto/identities/public-key.test.ts
@@ -119,4 +119,45 @@ describe("Identities - Public Key", () => {
             }).toThrowError(PublicKeyError);
         });
     });
+
+    describe("verify", () => {
+        const publicKeys = {
+            valid: [
+                data.publicKey,
+                "02b54f00d9de5a3ace28913fe78a15afcfe242926e94d9b517d06d2705b261f992",
+                "03b906102928cf97c6ddeb59cefb0e1e02105a22ab1acc3b4906214a16d494db0a",
+                "0235d486fea0193cbe77e955ab175b8f6eb9eaf784de689beffbd649989f5d6be3",
+                "03a46f2547d20b47003c1c376788db5a54d67264df2ae914f70bf453b6a1fa1b3a",
+                "03d7dfe44e771039334f4712fb95ad355254f674c8f5d286503199157b7bf7c357",
+                "0279f05076556da7173610a7676399c3620276ebbf8c67552ad3b1f26ec7627794",
+                "03c075494ad044ab8c0b2dc7ccd19f649db844a4e558e539d3ac2610c4b90a5139",
+                "03aa98d2a27ef50e34f6882a089d0915edc0d21c2c7eedc9bf3323f8ca8c260531",
+                "02d113acc492f613cfed6ec60fe31d0d0c1aa9787122070fb8dd76baf27f7a4766",
+            ],
+            invalid: [
+                "0",
+                "02b5Gf",
+                "NOT A VALID PUBLICKEY",
+                "000000000000000000000000000000000000000000000000000000000000000000",
+                "02b5Gf00d9de5a3ace28913fe78a15afcfe242926e94d9b517d06d2705b261f992",
+                "02e0f7449c5588f24492c338f2bc8f7865f755b958d48edb0f2d0056e50c3fd5b7",
+                "026f969d90fd494b04913eda9e0cf23f66eea5a70dfd5fb3e48f393397421c2b02",
+                "038c14b793cb19137e323a6d2e2a870bca2e7a493ec1153b3a95feb8a4873f8d08",
+                "32337416a26d8d49ec27059bd0589c49bb474029c3627715380f4df83fb431aece",
+                "22337416a26d8d49ec27059bd0589c49bb474029c3627715380f4df83fb431aece",
+            ],
+        };
+
+        it("should pass with valid public keys", () => {
+            publicKeys.valid.forEach((publicKey) => {
+                expect(PublicKey.verify(publicKey)).toBeTrue();
+            });
+        });
+
+        it("should fail with invalid public keys", () => {
+            publicKeys.invalid.forEach((publicKey) => {
+                expect(PublicKey.verify(publicKey)).toBeFalse();
+            });
+        });
+    });
 });

--- a/packages/crypto/src/identities/address.ts
+++ b/packages/crypto/src/identities/address.ts
@@ -12,7 +12,7 @@ export class Address {
     }
 
     public static fromPublicKey(publicKey: string, networkVersion?: number): string {
-        if (!/^[0-9A-Fa-f]{66}$/.test(publicKey)) {
+        if (!PublicKey.verify(publicKey)) {
             throw new PublicKeyError(publicKey);
         }
 

--- a/packages/crypto/src/identities/public-key.ts
+++ b/packages/crypto/src/identities/public-key.ts
@@ -19,7 +19,7 @@ export class PublicKey {
         const { min, publicKeys }: IMultiSignatureAsset = asset;
 
         for (const publicKey of publicKeys) {
-            if (!/^[0-9A-Fa-f]{66}$/.test(publicKey)) {
+            if (!this.verify(publicKey)) {
                 throw new PublicKeyError(publicKey);
             }
         }
@@ -34,5 +34,9 @@ export class PublicKey {
         return secp256k1
             .publicKeyCombine(keys.map((publicKey: string) => Buffer.from(publicKey, "hex")))
             .toString("hex");
+    }
+
+    public static verify(publicKey: string): boolean {
+        return secp256k1.publicKeyVerify(Buffer.from(publicKey, "hex"));
     }
 }


### PR DESCRIPTION
## Summary

Current master/develop only checks for valid hex during PublicKey validation, but does not verify the correctness of a publicKey.

This can lead to the unexpected creation of an unaccessible but technically-"valid" Address.

This PR recommends the following:
- add a `verify` method to `class PublicKey` using the already-present `secp256k1` module
- modify `Address.fromPublicKey` to drop hex-validation in favor of `PublicKey.verify`
- modify `PublicKey.fromMultiSignatureAsset` to drop hex-validation in favor of `PublicKey.verify`
- add relevant unit-tests

## Checklist

- [x] Tests
- [x] Ready to be merged

## Additional Comments

- No change of import modules needed
- maintains resolution of circular-dep fixes in c84b976

There are other areas that would benefit from the `PublicKey.verify` method; however, no additional checks are being added at this time.

It should also be stated that a developer should use this new method whenever:
- the correctness of a publicKey cannot be guaranteed
- the publicKey is NOT already being checked (_`.verify(sig, pubKey, msg)`_)
