### PR TITLE
chore(core-state): autoIndex option

### DIFF
--- a/__tests__/unit/core-api/__support__/index.ts
+++ b/__tests__/unit/core-api/__support__/index.ts
@@ -113,36 +113,43 @@ export const initApp = (): Application => {
     app.bind<Contracts.State.WalletIndexerIndex>(Identifiers.WalletRepositoryIndexerIndex).toConstantValue({
         name: Contracts.State.WalletIndexes.Addresses,
         indexer: addressesIndexer,
+        autoIndex: true,
     });
 
     app.bind<Contracts.State.WalletIndexerIndex>(Container.Identifiers.WalletRepositoryIndexerIndex).toConstantValue({
         name: Contracts.State.WalletIndexes.PublicKeys,
         indexer: publicKeysIndexer,
+        autoIndex: true,
     });
 
     app.bind<Contracts.State.WalletIndexerIndex>(Container.Identifiers.WalletRepositoryIndexerIndex).toConstantValue({
         name: Contracts.State.WalletIndexes.Usernames,
         indexer: usernamesIndexer,
+        autoIndex: true,
     });
 
     app.bind<Contracts.State.WalletIndexerIndex>(Container.Identifiers.WalletRepositoryIndexerIndex).toConstantValue({
         name: Contracts.State.WalletIndexes.Ipfs,
         indexer: ipfsIndexer,
+        autoIndex: true,
     });
 
     app.bind<Contracts.State.WalletIndexerIndex>(Container.Identifiers.WalletRepositoryIndexerIndex).toConstantValue({
         name: Contracts.State.WalletIndexes.Locks,
         indexer: locksIndexer,
+        autoIndex: true,
     });
 
     app.bind<Contracts.State.WalletIndexerIndex>(Container.Identifiers.WalletRepositoryIndexerIndex).toConstantValue({
         name: MagistrateIndex.Businesses,
         indexer: businessIndexer,
+        autoIndex: true,
     });
 
     app.bind<Contracts.State.WalletIndexerIndex>(Container.Identifiers.WalletRepositoryIndexerIndex).toConstantValue({
         name: MagistrateIndex.Bridgechains,
         indexer: bridgechainIndexer,
+        autoIndex: true,
     });
 
     app.bind(Identifiers.WalletFactory).toFactory<Contracts.State.Wallet>(

--- a/__tests__/unit/core-magistrate-api/__support__/index.ts
+++ b/__tests__/unit/core-magistrate-api/__support__/index.ts
@@ -95,41 +95,49 @@ export const initApp = (): Application => {
     app.bind<Contracts.State.WalletIndexerIndex>(Identifiers.WalletRepositoryIndexerIndex).toConstantValue({
         name: Contracts.State.WalletIndexes.Addresses,
         indexer: addressesIndexer,
+        autoIndex: true,
     });
 
     app.bind<Contracts.State.WalletIndexerIndex>(Container.Identifiers.WalletRepositoryIndexerIndex).toConstantValue({
         name: Contracts.State.WalletIndexes.PublicKeys,
         indexer: publicKeysIndexer,
+        autoIndex: true,
     });
 
     app.bind<Contracts.State.WalletIndexerIndex>(Container.Identifiers.WalletRepositoryIndexerIndex).toConstantValue({
         name: Contracts.State.WalletIndexes.Usernames,
         indexer: usernamesIndexer,
+        autoIndex: true,
     });
 
     app.bind<Contracts.State.WalletIndexerIndex>(Container.Identifiers.WalletRepositoryIndexerIndex).toConstantValue({
         name: Contracts.State.WalletIndexes.Ipfs,
         indexer: ipfsIndexer,
+        autoIndex: true,
     });
 
     app.bind<Contracts.State.WalletIndexerIndex>(Container.Identifiers.WalletRepositoryIndexerIndex).toConstantValue({
         name: Contracts.State.WalletIndexes.Locks,
         indexer: locksIndexer,
+        autoIndex: true,
     });
 
     app.bind<Contracts.State.WalletIndexerIndex>(Container.Identifiers.WalletRepositoryIndexerIndex).toConstantValue({
         name: MagistrateIndex.Businesses,
         indexer: businessIndexer,
+        autoIndex: true,
     });
 
     app.bind<Contracts.State.WalletIndexerIndex>(Container.Identifiers.WalletRepositoryIndexerIndex).toConstantValue({
         name: MagistrateIndex.Bridgechains,
         indexer: bridgechainIndexer,
+        autoIndex: true,
     });
 
     app.bind<Contracts.State.WalletIndexerIndex>(Container.Identifiers.WalletRepositoryIndexerIndex).toConstantValue({
         name: MagistrateIndex.Entities,
         indexer: entityIndexer,
+        autoIndex: true,
     });
 
     app.bind(Identifiers.WalletFactory).toFactory<Contracts.State.Wallet>(

--- a/__tests__/unit/core-magistrate-transactions/__support__/app.ts
+++ b/__tests__/unit/core-magistrate-transactions/__support__/app.ts
@@ -58,41 +58,49 @@ export const initApp = (): Application => {
     app.bind<Contracts.State.WalletIndexerIndex>(Identifiers.WalletRepositoryIndexerIndex).toConstantValue({
         name: Contracts.State.WalletIndexes.Addresses,
         indexer: addressesIndexer,
+        autoIndex: true,
     });
 
     app.bind<Contracts.State.WalletIndexerIndex>(Container.Identifiers.WalletRepositoryIndexerIndex).toConstantValue({
         name: Contracts.State.WalletIndexes.PublicKeys,
         indexer: publicKeysIndexer,
+        autoIndex: true,
     });
 
     app.bind<Contracts.State.WalletIndexerIndex>(Container.Identifiers.WalletRepositoryIndexerIndex).toConstantValue({
         name: Contracts.State.WalletIndexes.Usernames,
         indexer: usernamesIndexer,
+        autoIndex: true,
     });
 
     app.bind<Contracts.State.WalletIndexerIndex>(Container.Identifiers.WalletRepositoryIndexerIndex).toConstantValue({
         name: Contracts.State.WalletIndexes.Ipfs,
         indexer: ipfsIndexer,
+        autoIndex: true,
     });
 
     app.bind<Contracts.State.WalletIndexerIndex>(Container.Identifiers.WalletRepositoryIndexerIndex).toConstantValue({
         name: Contracts.State.WalletIndexes.Locks,
         indexer: locksIndexer,
+        autoIndex: true,
     });
 
     app.bind<Contracts.State.WalletIndexerIndex>(Container.Identifiers.WalletRepositoryIndexerIndex).toConstantValue({
         name: MagistrateIndex.Businesses,
         indexer: businessIndexer,
+        autoIndex: true,
     });
 
     app.bind<Contracts.State.WalletIndexerIndex>(Container.Identifiers.WalletRepositoryIndexerIndex).toConstantValue({
         name: MagistrateIndex.Bridgechains,
         indexer: bridgechainIndexer,
+        autoIndex: true,
     });
 
     app.bind<Contracts.State.WalletIndexerIndex>(Container.Identifiers.WalletRepositoryIndexerIndex).toConstantValue({
         name: MagistrateIndex.Entities,
         indexer: entityIndexer,
+        autoIndex: true,
     });
 
     app.bind(Identifiers.WalletFactory).toFactory<Contracts.State.Wallet>(

--- a/__tests__/unit/core-state/wallets/wallet-index.test.ts
+++ b/__tests__/unit/core-state/wallets/wallet-index.test.ts
@@ -18,7 +18,7 @@ beforeEach(() => {
     wallet = factory.make<Wallets.Wallet>();
     walletIndex = new WalletIndex((index, wallet) => {
         index.set(wallet.address, wallet);
-    });
+    }, true);
 });
 
 describe("WalletIndex", () => {

--- a/__tests__/unit/core-state/wallets/wallet-repository.test.ts
+++ b/__tests__/unit/core-state/wallets/wallet-repository.test.ts
@@ -38,6 +38,7 @@ beforeAll(async () => {
         .toConstantValue({
             name: MagistrateIndex.Businesses,
             indexer: businessIndexer,
+            autoIndex: true,
         });
 
     initialEnv.sandbox.app
@@ -45,6 +46,7 @@ beforeAll(async () => {
         .toConstantValue({
             name: MagistrateIndex.Bridgechains,
             indexer: bridgechainIndexer,
+            autoIndex: true,
         });
 
     // TODO: why does this have to be rebound here?

--- a/__tests__/unit/core-transactions/handlers/__support__/app.ts
+++ b/__tests__/unit/core-transactions/handlers/__support__/app.ts
@@ -52,26 +52,31 @@ export const initApp = (): Application => {
     app.bind<Contracts.State.WalletIndexerIndex>(Identifiers.WalletRepositoryIndexerIndex).toConstantValue({
         name: Contracts.State.WalletIndexes.Addresses,
         indexer: addressesIndexer,
+        autoIndex: true,
     });
 
     app.bind<Contracts.State.WalletIndexerIndex>(Container.Identifiers.WalletRepositoryIndexerIndex).toConstantValue({
         name: Contracts.State.WalletIndexes.PublicKeys,
         indexer: publicKeysIndexer,
+        autoIndex: true,
     });
 
     app.bind<Contracts.State.WalletIndexerIndex>(Container.Identifiers.WalletRepositoryIndexerIndex).toConstantValue({
         name: Contracts.State.WalletIndexes.Usernames,
         indexer: usernamesIndexer,
+        autoIndex: true,
     });
 
     app.bind<Contracts.State.WalletIndexerIndex>(Container.Identifiers.WalletRepositoryIndexerIndex).toConstantValue({
         name: Contracts.State.WalletIndexes.Ipfs,
         indexer: ipfsIndexer,
+        autoIndex: true,
     });
 
     app.bind<Contracts.State.WalletIndexerIndex>(Container.Identifiers.WalletRepositoryIndexerIndex).toConstantValue({
         name: Contracts.State.WalletIndexes.Locks,
         indexer: locksIndexer,
+        autoIndex: true,
     });
 
     app.bind(Identifiers.WalletFactory).toFactory<Contracts.State.Wallet>(

--- a/packages/core-kernel/src/contracts/state/wallets.ts
+++ b/packages/core-kernel/src/contracts/state/wallets.ts
@@ -6,6 +6,7 @@ import { ListResult } from "../search";
 
 export interface WalletIndex {
     readonly indexer: WalletIndexer;
+    readonly autoIndex: boolean;
     index(wallet: Wallet): void;
     has(key: string): boolean;
     get(key: string): Wallet | undefined;
@@ -21,7 +22,7 @@ export interface WalletIndex {
 
 export type WalletIndexer = (index: WalletIndex, wallet: Wallet) => void;
 
-export type WalletIndexerIndex = { name: string; indexer: WalletIndexer };
+export type WalletIndexerIndex = { name: string; indexer: WalletIndexer; autoIndex: boolean };
 
 export enum WalletIndexes {
     Addresses = "addresses",

--- a/packages/core-magistrate-transactions/src/service-provider.ts
+++ b/packages/core-magistrate-transactions/src/service-provider.ts
@@ -27,14 +27,14 @@ export class ServiceProvider extends Providers.ServiceProvider {
     private registerIndexers(): void {
         this.app
             .bind<Contracts.State.WalletIndexerIndex>(Container.Identifiers.WalletRepositoryIndexerIndex)
-            .toConstantValue({ name: MagistrateIndex.Businesses, indexer: businessIndexer });
+            .toConstantValue({ name: MagistrateIndex.Businesses, indexer: businessIndexer, autoIndex: true });
 
         this.app
             .bind<Contracts.State.WalletIndexerIndex>(Container.Identifiers.WalletRepositoryIndexerIndex)
-            .toConstantValue({ name: MagistrateIndex.Bridgechains, indexer: bridgechainIndexer });
+            .toConstantValue({ name: MagistrateIndex.Bridgechains, indexer: bridgechainIndexer, autoIndex: true });
 
         this.app
             .bind<Contracts.State.WalletIndexerIndex>(Container.Identifiers.WalletRepositoryIndexerIndex)
-            .toConstantValue({ name: MagistrateIndex.Entities, indexer: entityIndexer });
+            .toConstantValue({ name: MagistrateIndex.Entities, indexer: entityIndexer, autoIndex: true });
     }
 }

--- a/packages/core-state/src/wallets/indexers/wallet-indexes.ts
+++ b/packages/core-state/src/wallets/indexers/wallet-indexes.ts
@@ -14,31 +14,37 @@ export const registerIndexers = (app: Contracts.Kernel.Application): void => {
     app.bind(Container.Identifiers.WalletRepositoryIndexerIndex).toConstantValue({
         name: Contracts.State.WalletIndexes.Addresses,
         indexer: addressesIndexer,
+        autoIndex: true,
     });
 
     app.bind(Container.Identifiers.WalletRepositoryIndexerIndex).toConstantValue({
         name: Contracts.State.WalletIndexes.PublicKeys,
         indexer: publicKeysIndexer,
+        autoIndex: true,
     });
 
     app.bind(Container.Identifiers.WalletRepositoryIndexerIndex).toConstantValue({
         name: Contracts.State.WalletIndexes.Usernames,
         indexer: usernamesIndexer,
+        autoIndex: true,
     });
 
     app.bind(Container.Identifiers.WalletRepositoryIndexerIndex).toConstantValue({
         name: Contracts.State.WalletIndexes.Resignations,
         indexer: resignationsIndexer,
+        autoIndex: true,
     });
 
     app.bind(Container.Identifiers.WalletRepositoryIndexerIndex).toConstantValue({
         name: Contracts.State.WalletIndexes.Locks,
         indexer: locksIndexer,
+        autoIndex: true,
     });
 
     app.bind(Container.Identifiers.WalletRepositoryIndexerIndex).toConstantValue({
         name: Contracts.State.WalletIndexes.Ipfs,
         indexer: ipfsIndexer,
+        autoIndex: true,
     });
 };
 

--- a/packages/core-state/src/wallets/wallet-index.ts
+++ b/packages/core-state/src/wallets/wallet-index.ts
@@ -4,7 +4,7 @@ export class WalletIndex implements Contracts.State.WalletIndex {
     private walletByKey: Map<string, Contracts.State.Wallet>;
     private keysByWallet: Map<Contracts.State.Wallet, Set<string>>;
 
-    public constructor(public readonly indexer: Contracts.State.WalletIndexer) {
+    public constructor(public readonly indexer: Contracts.State.WalletIndexer, public readonly autoIndex: boolean) {
         this.walletByKey = new Map<string, Contracts.State.Wallet>();
         this.keysByWallet = new Map<Contracts.State.Wallet, Set<string>>();
     }
@@ -84,7 +84,7 @@ export class WalletIndex implements Contracts.State.WalletIndex {
     }
 
     public clone(): Contracts.State.WalletIndex {
-        const walletIndex = new WalletIndex(this.indexer);
+        const walletIndex = new WalletIndex(this.indexer, this.autoIndex);
 
         for (const [key, value] of this.entries()) {
             walletIndex.set(key, value.clone());

--- a/packages/core-state/src/wallets/wallet-index.ts
+++ b/packages/core-state/src/wallets/wallet-index.ts
@@ -34,11 +34,10 @@ export class WalletIndex implements Contracts.State.WalletIndex {
     }
 
     public set(key: string, wallet: Contracts.State.Wallet): void {
-        // Key for wallet already exists
-        if (this.walletByKey.has(key)) {
-            const existingWallet = this.walletByKey.get(key)!;
+        const existingWallet = this.walletByKey.get(key)!;
 
-            // Remove given key in case where key points to different wallet
+        // Remove given key in case where key points to different wallet
+        if (existingWallet) {
             const existingKeys = this.keysByWallet.get(existingWallet)!;
             existingKeys.delete(key);
         }
@@ -57,9 +56,9 @@ export class WalletIndex implements Contracts.State.WalletIndex {
     }
 
     public forget(key: string): void {
-        if (this.walletByKey.has(key)) {
-            const wallet = this.walletByKey.get(key)!;
+        const wallet = this.walletByKey.get(key)!;
 
+        if (wallet) {
             const existingKeys = this.keysByWallet.get(wallet)!;
 
             existingKeys.delete(key);
@@ -69,9 +68,9 @@ export class WalletIndex implements Contracts.State.WalletIndex {
     }
 
     public forgetWallet(wallet: Contracts.State.Wallet): void {
-        if (this.keysByWallet.has(wallet)) {
-            const keys = this.keysByWallet.get(wallet)!;
+        const keys = this.keysByWallet.get(wallet)!;
 
+        if (keys) {
             for (const key of keys) {
                 this.walletByKey.delete(key);
             }

--- a/packages/core-state/src/wallets/wallet-repository.ts
+++ b/packages/core-state/src/wallets/wallet-repository.ts
@@ -21,11 +21,11 @@ export class WalletRepository implements Contracts.State.WalletRepository {
 
     @Container.postConstruct()
     public initialize(): void {
-        for (const { name, indexer } of this.indexerIndexes) {
+        for (const { name, indexer, autoIndex } of this.indexerIndexes) {
             if (this.indexes[name]) {
                 throw new WalletIndexAlreadyRegisteredError(name);
             }
-            this.indexes[name] = new WalletIndex(indexer);
+            this.indexes[name] = new WalletIndex(indexer, autoIndex);
         }
     }
 
@@ -209,7 +209,7 @@ export class WalletRepository implements Contracts.State.WalletRepository {
     }
 
     private indexWallet(wallet: Contracts.State.Wallet): void {
-        for (const index of Object.values(this.indexes)) {
+        for (const index of Object.values(this.indexes).filter((index) => index.autoIndex)) {
             index.forgetWallet(wallet);
             index.index(wallet);
         }


### PR DESCRIPTION
## Summary

Implements autoIndex option on indexes. When autoIndex is enabled, WalletRepository.index(wallet) method will remove all known index entries by wallet and will reindex wallet, otherwise developer is responsible to manually use index, set or delete methods directly on index. 

Disabling autoIndex option is useful in cases when index hold a lot of entries for the wallet and manual control over index will increase node performance. 

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged