### PR TITLE
fix: replace micromatch with nanomatch

### DIFF
--- a/packages/core-api/package.json
+++ b/packages/core-api/package.json
@@ -31,6 +31,7 @@
         "@hapi/joi": "^17.1.0",
         "ajv": "^6.10.2",
         "ip": "^1.1.5",
+        "nanomatch": "^1.2.13",
         "node-cache": "^5.0.2",
         "rate-limiter-flexible": "^1.1.6",
         "semver": "^6.3.0"

--- a/packages/core-api/src/plugins/rate-limit.ts
+++ b/packages/core-api/src/plugins/rate-limit.ts
@@ -1,6 +1,6 @@
 import Boom from "@hapi/boom";
 import Hapi from "@hapi/hapi";
-import mm from "micromatch";
+import mm from "nanomatch";
 import { RateLimiterMemory, RLWrapperBlackAndWhite } from "rate-limiter-flexible";
 
 interface RateLimitResult {

--- a/packages/core-kernel/src/services/events/drivers/memory.ts
+++ b/packages/core-kernel/src/services/events/drivers/memory.ts
@@ -1,4 +1,4 @@
-import mm from "micromatch";
+import mm from "nanomatch";
 
 import { EventDispatcher as EventDispatcherContract, EventListener, EventName } from "../../../contracts/kernel/events";
 import { injectable } from "../../../ioc";


### PR DESCRIPTION
## Summary

Replace micromatch with nanomatch. PR fixes missing dependancy when using core* packages form npm. 

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged