### PR TITLE
fix(core-state): clone wallet on mempool wallet-repository

### DIFF
--- a/__tests__/unit/core-state/wallets/wallet-index.test.ts
+++ b/__tests__/unit/core-state/wallets/wallet-index.test.ts
@@ -42,6 +42,13 @@ describe("WalletIndex", () => {
         expect(walletIndex.keys()).toContain(wallet.address);
     });
 
+    it("should return walletKeys", () => {
+        expect(walletIndex.walletKeys(wallet)).toEqual([]);
+
+        walletIndex.index(wallet);
+        expect(walletIndex.walletKeys(wallet)).toEqual([wallet.address]);
+    });
+
     describe("set", () => {
         it("should set and get addresses", () => {
             expect(walletIndex.has(wallet.address)).toBeFalse();

--- a/packages/core-kernel/src/contracts/state/wallets.ts
+++ b/packages/core-kernel/src/contracts/state/wallets.ts
@@ -16,6 +16,7 @@ export interface WalletIndex {
     entries(): ReadonlyArray<[string, Wallet]>;
     values(): ReadonlyArray<Wallet>;
     keys(): string[];
+    walletKeys(wallet: Wallet): string[];
     clear(): void;
     clone(): WalletIndex;
 }

--- a/packages/core-state/src/wallets/wallet-index.ts
+++ b/packages/core-state/src/wallets/wallet-index.ts
@@ -17,6 +17,12 @@ export class WalletIndex implements Contracts.State.WalletIndex {
         return [...this.walletByKey.keys()];
     }
 
+    public walletKeys(wallet: Contracts.State.Wallet): string[] {
+        const walletKeys = this.keysByWallet.get(wallet);
+
+        return walletKeys ? [...walletKeys.keys()] : [];
+    }
+
     public values(): ReadonlyArray<Contracts.State.Wallet> {
         return [...this.walletByKey.values()];
     }
@@ -81,6 +87,7 @@ export class WalletIndex implements Contracts.State.WalletIndex {
 
     public clear(): void {
         this.walletByKey = new Map<string, Contracts.State.Wallet>();
+        this.keysByWallet = new Map<Contracts.State.Wallet, Set<string>>();
     }
 
     public clone(): Contracts.State.WalletIndex {


### PR DESCRIPTION
## Summary

Extend wallet-index with walletKeys method. Clone wallet by walletKeys insted using index. This approach copy exactly stored keys and copy wallet from indexes even if autoIndex is set to false.

## Checklist

- [x] Test
- [x] Ready to be merged