### PR TITLE
chore(core-test-framework): resolve .env and app.json file path from package name

### DIFF
--- a/packages/core-test-framework/package.json
+++ b/packages/core-test-framework/package.json
@@ -21,6 +21,7 @@
         "prepublishOnly": "yarn build"
     },
     "dependencies": {
+        "@arkecosystem/core": "^3.0.0-alpha.2",
         "@arkecosystem/core-api": "^3.0.0-alpha.2",
         "@arkecosystem/core-blockchain": "^3.0.0-alpha.2",
         "@arkecosystem/core-cli": "^3.0.0-alpha.2",

--- a/packages/core-test-framework/src/app/generators/core.ts
+++ b/packages/core-test-framework/src/app/generators/core.ts
@@ -89,7 +89,7 @@ export class CoreGenerator extends Generator {
         if (this.options.core.environment) {
             writeFileSync(filePath, this.options.core.environment);
         } else {
-            copyFileSync(resolve(__dirname, "../../../../core/bin/config/testnet/.env"), filePath);
+            copyFileSync(require.resolve("@arkecosystem/core/bin/config/testnet/.env"), filePath);
         }
     }
 
@@ -103,7 +103,7 @@ export class CoreGenerator extends Generator {
         if (this.options.core.app) {
             writeJSONSync(filePath, this.options.core.app, { spaces: 4 });
         } else {
-            copyFileSync(resolve(__dirname, "../../../../core/bin/config/testnet/app.json"), filePath);
+            copyFileSync(require.resolve("@arkecosystem/core/bin/config/testnet/app.json"), filePath);
         }
     }
 }


### PR DESCRIPTION
## Summary

Use file path resolving based on package name rather than using relative structure used in packages/. Fixes problem which occur on booting sandbox.app when using published @arkecosystem/core-test-framework package.

## Checklist

- [x] Ready to be merged