### PR TITLE
fix(core-state): wallet repository clone instantiation

### DIFF
--- a/__tests__/unit/core-state/wallets/wallet-index.test.ts
+++ b/__tests__/unit/core-state/wallets/wallet-index.test.ts
@@ -22,13 +22,6 @@ beforeEach(() => {
 });
 
 describe("WalletIndex", () => {
-    it("should be cloneable", () => {
-        walletIndex.index(wallet);
-        walletIndex.set(wallet.address, wallet);
-        const clonedWalletIndex = walletIndex.clone();
-        expect(walletIndex).toEqual(clonedWalletIndex);
-    });
-
     it("should return entries", () => {
         walletIndex.index(wallet);
         const entries = walletIndex.entries();

--- a/__tests__/unit/core-state/wallets/wallet-repository-clone.test.ts
+++ b/__tests__/unit/core-state/wallets/wallet-repository-clone.test.ts
@@ -31,6 +31,7 @@ beforeEach(() => {
 describe("Wallet Repository Clone", () => {
     it("should create a wallet", () => {
         const wallet = walletRepoClone.createWallet("abcd");
+
         expect(wallet.address).toEqual("abcd");
         expect(wallet).toBeInstanceOf(Wallet);
     });
@@ -174,10 +175,27 @@ describe("Wallet Repository Clone", () => {
 
     describe("indexing", () => {
         it("should index wallet", () => {
-            const wallet = walletRepoClone.createWallet("abcdef");
-            walletRepoClone.index(wallet);
+            const wallet1 = walletRepoClone.createWallet("wallet1");
+            walletRepoClone.index(wallet1);
 
-            expect(walletRepoClone.findByAddress("abcdef")).toBe(wallet);
+            expect(walletRepoClone.findByAddress("wallet1")).toBe(wallet1);
+        });
+
+        it("should index array of wallets", () => {
+            const wallet1 = walletRepoClone.createWallet("wallet1");
+            const wallet2 = walletRepoClone.createWallet("wallet2");
+            walletRepoClone.index([wallet1, wallet2]);
+
+            expect(walletRepoClone.findByAddress("wallet1")).toBe(wallet1);
+            expect(walletRepoClone.findByAddress("wallet2")).toBe(wallet2);
+        });
+
+        it("should re-index wallet", () => {
+            const wallet = walletRepo.createWallet("abcdef");
+            const clone = wallet.clone();
+            walletRepoClone.index(clone);
+
+            expect(walletRepoClone.findByAddress("abcdef")).toBe(clone);
         });
 
         it("should throw error when attempting to index state=blockchain wallet", () => {

--- a/__tests__/unit/core-state/wallets/wallet-repository-clone.test.ts
+++ b/__tests__/unit/core-state/wallets/wallet-repository-clone.test.ts
@@ -192,6 +192,7 @@ describe("Wallet Repository Clone", () => {
 
         it("should re-index wallet", () => {
             const wallet = walletRepo.createWallet("abcdef");
+            walletRepo.index(wallet);
             const clone = wallet.clone();
             walletRepoClone.index(clone);
 

--- a/__tests__/unit/core-state/wallets/wallet-repository-clone.test.ts
+++ b/__tests__/unit/core-state/wallets/wallet-repository-clone.test.ts
@@ -173,6 +173,13 @@ describe("Wallet Repository Clone", () => {
     });
 
     describe("indexing", () => {
+        it("should index wallet", () => {
+            const wallet = walletRepoClone.createWallet("abcdef");
+            walletRepoClone.index(wallet);
+
+            expect(walletRepoClone.findByAddress("abcdef")).toBe(wallet);
+        });
+
         it("should throw error when attempting to index state=blockchain wallet", () => {
             const wallet = walletRepo.createWallet("abcdef");
             walletRepo.index(wallet);

--- a/__tests__/unit/core-state/wallets/wallet-repository-clone.test.ts
+++ b/__tests__/unit/core-state/wallets/wallet-repository-clone.test.ts
@@ -173,13 +173,11 @@ describe("Wallet Repository Clone", () => {
     });
 
     describe("indexing", () => {
-        it("should not affect the original", () => {
+        it("should throw error when attempting to index state=blockchain wallet", () => {
             const wallet = walletRepo.createWallet("abcdef");
             walletRepo.index(wallet);
 
-            walletRepoClone.index(wallet);
-
-            expect(walletRepo.findByAddress(wallet.address)).not.toBe(walletRepoClone.findByAddress(wallet.address));
+            expect(() => walletRepoClone.index(wallet)).toThrowError("Can't index state=blockchain wallet");
         });
     });
 

--- a/packages/core-kernel/src/contracts/state/wallets.ts
+++ b/packages/core-kernel/src/contracts/state/wallets.ts
@@ -18,7 +18,6 @@ export interface WalletIndex {
     keys(): string[];
     walletKeys(wallet: Wallet): string[];
     clear(): void;
-    clone(): WalletIndex;
 }
 
 export type WalletIndexer = (index: WalletIndex, wallet: Wallet) => void;

--- a/packages/core-state/src/wallets/wallet-index.ts
+++ b/packages/core-state/src/wallets/wallet-index.ts
@@ -89,14 +89,4 @@ export class WalletIndex implements Contracts.State.WalletIndex {
         this.walletByKey = new Map<string, Contracts.State.Wallet>();
         this.keysByWallet = new Map<Contracts.State.Wallet, Set<string>>();
     }
-
-    public clone(): Contracts.State.WalletIndex {
-        const walletIndex = new WalletIndex(this.indexer, this.autoIndex);
-
-        for (const [key, value] of this.entries()) {
-            walletIndex.set(key, value.clone());
-        }
-
-        return walletIndex;
-    }
 }

--- a/packages/core-state/src/wallets/wallet-repository.ts
+++ b/packages/core-state/src/wallets/wallet-repository.ts
@@ -126,7 +126,7 @@ export class WalletRepository implements Contracts.State.WalletRepository {
         return Utils.BigNumber.ZERO;
     }
 
-    public index(wallets: Contracts.State.Wallet | ReadonlyArray<Contracts.State.Wallet>): void {
+    public index(wallets: Contracts.State.Wallet | Contracts.State.Wallet[]): void {
         if (!Array.isArray(wallets)) {
             this.indexWallet(wallets as Contracts.State.Wallet);
         } else {


### PR DESCRIPTION
## Summary

Clone of wallet repository was instantiated incorrectly:

```typescript
public initialize(): void {
  for (const index of this.blockchainWalletRepository.getIndexNames()) {
    this.indexes[index] = this.blockchainWalletRepository.getIndex(index).clone();
  }
}
```

This error was actually made by me back in the days when I had little understanding of its internals. The issue is with the wallet index `clone` method:

```typescript
public clone(): Contracts.State.WalletIndex {
  const walletIndex = new WalletIndex(this.indexer, this.autoIndex);

  for (const [key, value] of this.entries()) {
    walletIndex.set(key, value.clone());
  }

  return walletIndex;
}
```

It performs deep clone and as result cloned wallet repository will contain separate but identical wallet copies in all of its indexes:

```typescript
const walletByPublicKey = walletRepositoryClone.findByPublicKey(tx.senderPublicKey);
const walletByAddress = walletRepositoryClone.findByAddress(walletByPublicKey.address);

assert(walletByPublicKey === walletByAddress); // throws
```

Fixed `initialize` by taking every wallet from `"addresses"` index (it's analogous to primary key) and then cloning and re-indexing them. This slows down initialization. If wallet indexes were storing address as value instead of wallet reference, then it would be possible to clone them and avoid re-indexing.

---

Now also throwing error when attempting to index `state=blockchain` wallet into it. Previously `index` automatically cloned wallet which meant that caller was left with wallet reference that wasn't actually indexed. Now caller is required to clone wallet himself if he has to transfer wallet between wallet repositories.

## Checklist

- [ ] Ready to be merged