### PR TITLE
fix(core-api): fix delegate.lastBlock.timestamp property

### DIFF
--- a/packages/core-api/src/services/delegate-search-service.ts
+++ b/packages/core-api/src/services/delegate-search-service.ts
@@ -45,7 +45,7 @@ export class DelegateSearchService {
             delegateLastBlock = {
                 id: delegateAttribute.lastBlock.id,
                 height: delegateAttribute.lastBlock.height,
-                timestamp: delegateAttribute.lastBlock.timestamp,
+                timestamp: AppUtils.formatTimestamp(delegateAttribute.lastBlock.timestamp),
             };
         }
 


### PR DESCRIPTION
## Summary

Follow up to #3931 that fixes `delegate.lastBlock.timestamp` response property.

## Checklist

- [x] Ready to be merged