### PR TITLE
fix(magistrate): delegate check only needed on entity register

### DIFF
--- a/packages/core-magistrate-transactions/src/handlers/entity.ts
+++ b/packages/core-magistrate-transactions/src/handlers/entity.ts
@@ -96,6 +96,16 @@ export class EntityTransactionHandler extends IHandlers.TransactionHandler {
                     }
                 }
             }
+
+            // specific check for Delegate entity to ensure that the sender delegate username matches the entity name
+            if (transaction.data.asset.type === Enums.EntityType.Delegate) {
+                if (!wallet.hasAttribute("delegate.username")) {
+                    throw new EntitySenderIsNotDelegateError();
+                }
+                if (wallet.getAttribute("delegate.username") !== transaction.data.asset.data.name) {
+                    throw new EntityNameDoesNotMatchDelegateError();
+                }
+            }
         } else {
             // Resign or update share the same checks
             if (!walletEntities[transaction.data.asset.registrationId]) {
@@ -109,15 +119,6 @@ export class EntityTransactionHandler extends IHandlers.TransactionHandler {
             }
             if (walletEntities[transaction.data.asset.registrationId].subType !== transaction.data.asset.subType) {
                 throw new EntityWrongSubTypeError();
-            }
-        }
-
-        if (transaction.data.asset.type === Enums.EntityType.Delegate) {
-            if (!wallet.hasAttribute("delegate.username")) {
-                throw new EntitySenderIsNotDelegateError();
-            }
-            if (wallet.getAttribute("delegate.username") !== transaction.data.asset.data.name) {
-                throw new EntityNameDoesNotMatchDelegateError();
             }
         }
     }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
Entity delegate transactions have a specific check against the sender wallet which needs to be a delegate and username must match entity name.

But this check is only needed for register : as an update or resign needs first a register tx where the delegate check was already done.

This also fixes an issue with current implementation where update or resign entity delegate tx would not be accepted because of the name check which was incorrectly implemented.
<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
