### PR TITLE
refactor(core-api): do not bind directly handler to class method to allow extending response

### DIFF
--- a/__tests__/unit/core-p2p/socket-server/controllers/blocks.test.ts
+++ b/__tests__/unit/core-p2p/socket-server/controllers/blocks.test.ts
@@ -140,8 +140,8 @@ describe("BlocksController", () => {
                 // probably some unreachable code though...
                 const milestone = Managers.configManager.getMilestone();
                 const spyGetMilestone = jest.spyOn(Managers.configManager, "getMilestone");
-                for (let i = 0; i < 113; i++) {
-                    // yeah 113 times :wtf: before the one we are interested to mock kicks in
+                for (let i = 0; i < 87; i++) {
+                    // yeah 87 times :wtf: before the one we are interested to mock kicks in
                     spyGetMilestone.mockReturnValueOnce({
                         ...milestone,
                         block: {

--- a/packages/core-api/src/routes/blockchain.ts
+++ b/packages/core-api/src/routes/blockchain.ts
@@ -9,6 +9,6 @@ export const register = (server: Hapi.Server): void => {
     server.route({
         method: "GET",
         path: "/blockchain",
-        handler: controller.index,
+        handler: (request: Hapi.Request) => controller.index(request),
     });
 };

--- a/packages/core-api/src/routes/blocks.ts
+++ b/packages/core-api/src/routes/blocks.ts
@@ -11,7 +11,7 @@ export const register = (server: Hapi.Server): void => {
     server.route({
         method: "GET",
         path: "/blocks",
-        handler: controller.index,
+        handler: (request: Hapi.Request) => controller.index(request),
         options: {
             validate: {
                 query: Joi.object({
@@ -31,7 +31,7 @@ export const register = (server: Hapi.Server): void => {
     server.route({
         method: "GET",
         path: "/blocks/first",
-        handler: controller.first,
+        handler: (request: Hapi.Request) => controller.first(request),
         options: {
             validate: {
                 query: Joi.object({
@@ -44,7 +44,7 @@ export const register = (server: Hapi.Server): void => {
     server.route({
         method: "GET",
         path: "/blocks/last",
-        handler: controller.last,
+        handler: (request: Hapi.Request) => controller.last(request),
         options: {
             validate: {
                 query: Joi.object({
@@ -57,7 +57,7 @@ export const register = (server: Hapi.Server): void => {
     server.route({
         method: "GET",
         path: "/blocks/{id}",
-        handler: controller.show,
+        handler: (request: Hapi.Request) => controller.show(request),
         options: {
             validate: {
                 params: Joi.object({
@@ -73,7 +73,7 @@ export const register = (server: Hapi.Server): void => {
     server.route({
         method: "GET",
         path: "/blocks/{id}/transactions",
-        handler: controller.transactions,
+        handler: (request: Hapi.Request) => controller.transactions(request),
         options: {
             validate: {
                 params: Joi.object({
@@ -96,7 +96,7 @@ export const register = (server: Hapi.Server): void => {
     server.route({
         method: "POST",
         path: "/blocks/search",
-        handler: controller.search,
+        handler: (request: Hapi.Request) => controller.search(request),
         options: {
             validate: {
                 query: Joi.object({

--- a/packages/core-api/src/routes/delegates.ts
+++ b/packages/core-api/src/routes/delegates.ts
@@ -19,7 +19,7 @@ export const register = (server: Hapi.Server): void => {
     server.route({
         method: "GET",
         path: "/delegates",
-        handler: controller.index,
+        handler: (request: Hapi.Request) => controller.index(request),
         options: {
             validate: {
                 query: Joi.object()
@@ -36,7 +36,7 @@ export const register = (server: Hapi.Server): void => {
     server.route({
         method: "POST",
         path: "/delegates/search",
-        handler: controller.search,
+        handler: (request: Hapi.Request) => controller.search(request),
         options: {
             validate: {
                 query: Joi.object().concat(delegateSortingSchema).concat(Schemas.pagination),
@@ -51,7 +51,7 @@ export const register = (server: Hapi.Server): void => {
     server.route({
         method: "GET",
         path: "/delegates/{id}",
-        handler: controller.show,
+        handler: (request: Hapi.Request) => controller.show(request),
         options: {
             validate: {
                 params: Joi.object({
@@ -64,7 +64,7 @@ export const register = (server: Hapi.Server): void => {
     server.route({
         method: "GET",
         path: "/delegates/{id}/voters",
-        handler: controller.voters,
+        handler: (request: Hapi.Request) => controller.voters(request),
         options: {
             validate: {
                 params: Joi.object({
@@ -84,7 +84,7 @@ export const register = (server: Hapi.Server): void => {
     server.route({
         method: "GET",
         path: "/delegates/{id}/blocks",
-        handler: controller.blocks,
+        handler: (request: Hapi.Request) => controller.blocks(request),
         options: {
             validate: {
                 params: Joi.object({

--- a/packages/core-api/src/routes/locks.ts
+++ b/packages/core-api/src/routes/locks.ts
@@ -17,7 +17,7 @@ export const register = (server: Hapi.Server): void => {
     server.route({
         method: "GET",
         path: "/locks",
-        handler: controller.index,
+        handler: (request: Hapi.Request) => controller.index(request),
         options: {
             validate: {
                 query: Joi.object()
@@ -34,7 +34,7 @@ export const register = (server: Hapi.Server): void => {
     server.route({
         method: "POST",
         path: "/locks/search",
-        handler: controller.search,
+        handler: (request: Hapi.Request) => controller.search(request),
         options: {
             validate: {
                 query: Joi.object().concat(lockSortingSchema).concat(Schemas.pagination),
@@ -49,7 +49,7 @@ export const register = (server: Hapi.Server): void => {
     server.route({
         method: "GET",
         path: "/locks/{id}",
-        handler: controller.show,
+        handler: (request: Hapi.Request) => controller.show(request),
         options: {
             validate: {
                 params: Joi.object({
@@ -62,7 +62,7 @@ export const register = (server: Hapi.Server): void => {
     server.route({
         method: "POST",
         path: "/locks/unlocked",
-        handler: controller.unlocked,
+        handler: (request: Hapi.Request) => controller.unlocked(request),
         options: {
             validate: {
                 query: Joi.object({

--- a/packages/core-api/src/routes/node.ts
+++ b/packages/core-api/src/routes/node.ts
@@ -10,31 +10,31 @@ export const register = (server: Hapi.Server): void => {
     server.route({
         method: "GET",
         path: "/node/status",
-        handler: controller.status,
+        handler: (request: Hapi.Request) => controller.status(request),
     });
 
     server.route({
         method: "GET",
         path: "/node/syncing",
-        handler: controller.syncing,
+        handler: (request: Hapi.Request) => controller.syncing(request),
     });
 
     server.route({
         method: "GET",
         path: "/node/configuration",
-        handler: controller.configuration,
+        handler: (request: Hapi.Request) => controller.configuration(request),
     });
 
     server.route({
         method: "GET",
         path: "/node/configuration/crypto",
-        handler: controller.configurationCrypto,
+        handler: (request: Hapi.Request) => controller.configurationCrypto(request),
     });
 
     server.route({
         method: "GET",
         path: "/node/fees",
-        handler: controller.fees,
+        handler: (request: Hapi.Request) => controller.fees(request),
         options: {
             validate: {
                 query: Joi.object({

--- a/packages/core-api/src/routes/peers.ts
+++ b/packages/core-api/src/routes/peers.ts
@@ -11,7 +11,7 @@ export const register = (server: Hapi.Server): void => {
     server.route({
         method: "GET",
         path: "/peers",
-        handler: controller.index,
+        handler: (request: Hapi.Request) => controller.index(request),
         options: {
             validate: {
                 query: Joi.object({
@@ -31,7 +31,7 @@ export const register = (server: Hapi.Server): void => {
     server.route({
         method: "GET",
         path: "/peers/{ip}",
-        handler: controller.show,
+        handler: (request: Hapi.Request) => controller.show(request),
         options: {
             validate: {
                 params: Joi.object({

--- a/packages/core-api/src/routes/rounds.ts
+++ b/packages/core-api/src/routes/rounds.ts
@@ -10,7 +10,7 @@ export const register = (server: Hapi.Server): void => {
     server.route({
         method: "GET",
         path: "/rounds/{id}/delegates",
-        handler: controller.delegates,
+        handler: (request: Hapi.Request) => controller.delegates(request),
         options: {
             validate: {
                 params: Joi.object({

--- a/packages/core-api/src/routes/transactions.ts
+++ b/packages/core-api/src/routes/transactions.ts
@@ -12,7 +12,7 @@ export const register = (server: Hapi.Server): void => {
     server.route({
         method: "GET",
         path: "/transactions",
-        handler: controller.index,
+        handler: (request: Hapi.Request) => controller.index(request),
         options: {
             validate: {
                 query: Joi.object({
@@ -32,7 +32,7 @@ export const register = (server: Hapi.Server): void => {
     server.route({
         method: "POST",
         path: "/transactions",
-        handler: controller.store,
+        handler: (request: Hapi.Request) => controller.store(request),
         options: {
             plugins: {
                 "hapi-ajv": {
@@ -62,7 +62,7 @@ export const register = (server: Hapi.Server): void => {
     server.route({
         method: "GET",
         path: "/transactions/{id}",
-        handler: controller.show,
+        handler: (request: Hapi.Request) => controller.show(request),
         options: {
             validate: {
                 params: Joi.object({
@@ -78,7 +78,7 @@ export const register = (server: Hapi.Server): void => {
     server.route({
         method: "GET",
         path: "/transactions/unconfirmed",
-        handler: controller.unconfirmed,
+        handler: (request: Hapi.Request) => controller.unconfirmed(request),
         options: {
             validate: {
                 query: Joi.object({
@@ -96,7 +96,7 @@ export const register = (server: Hapi.Server): void => {
     server.route({
         method: "GET",
         path: "/transactions/unconfirmed/{id}",
-        handler: controller.showUnconfirmed,
+        handler: (request: Hapi.Request) => controller.showUnconfirmed(request),
         options: {
             validate: {
                 params: Joi.object({
@@ -109,7 +109,7 @@ export const register = (server: Hapi.Server): void => {
     server.route({
         method: "POST",
         path: "/transactions/search",
-        handler: controller.search,
+        handler: (request: Hapi.Request) => controller.search(request),
         options: {
             validate: {
                 query: Joi.object({
@@ -131,18 +131,18 @@ export const register = (server: Hapi.Server): void => {
     server.route({
         method: "GET",
         path: "/transactions/types",
-        handler: controller.types,
+        handler: (request: Hapi.Request) => controller.types(request),
     });
 
     server.route({
         method: "GET",
         path: "/transactions/schemas",
-        handler: controller.schemas,
+        handler: (request: Hapi.Request) => controller.schemas(request),
     });
 
     server.route({
         method: "GET",
         path: "/transactions/fees",
-        handler: controller.fees,
+        handler: (request: Hapi.Request) => controller.fees(request),
     });
 };

--- a/packages/core-api/src/routes/votes.ts
+++ b/packages/core-api/src/routes/votes.ts
@@ -11,7 +11,7 @@ export const register = (server: Hapi.Server): void => {
     server.route({
         method: "GET",
         path: "/votes",
-        handler: controller.index,
+        handler: (request: Hapi.Request) => controller.index(request),
         options: {
             validate: {
                 query: Joi.object({
@@ -31,7 +31,7 @@ export const register = (server: Hapi.Server): void => {
     server.route({
         method: "GET",
         path: "/votes/{id}",
-        handler: controller.show,
+        handler: (request: Hapi.Request) => controller.show(request),
         options: {
             validate: {
                 params: Joi.object({

--- a/packages/core-api/src/routes/wallets.ts
+++ b/packages/core-api/src/routes/wallets.ts
@@ -20,7 +20,7 @@ export const register = (server: Hapi.Server): void => {
     server.route({
         method: "GET",
         path: "/wallets",
-        handler: controller.index,
+        handler: (request: Hapi.Request) => controller.index(request),
         options: {
             validate: {
                 query: Joi.object()
@@ -37,7 +37,7 @@ export const register = (server: Hapi.Server): void => {
     server.route({
         method: "GET",
         path: "/wallets/top",
-        handler: controller.top,
+        handler: (request: Hapi.Request) => controller.top(request),
         options: {
             validate: {
                 query: Joi.object()
@@ -54,7 +54,7 @@ export const register = (server: Hapi.Server): void => {
     server.route({
         method: "POST",
         path: "/wallets/search",
-        handler: controller.search,
+        handler: (request: Hapi.Request) => controller.search(request),
         options: {
             validate: {
                 query: Joi.object().concat(walletSortingSchema).concat(Schemas.pagination),
@@ -69,7 +69,7 @@ export const register = (server: Hapi.Server): void => {
     server.route({
         method: "GET",
         path: "/wallets/{id}",
-        handler: controller.show,
+        handler: (request: Hapi.Request) => controller.show(request),
         options: {
             validate: {
                 params: Joi.object({
@@ -82,7 +82,7 @@ export const register = (server: Hapi.Server): void => {
     server.route({
         method: "GET",
         path: "/wallets/{id}/locks",
-        handler: controller.locks,
+        handler: (request: Hapi.Request) => controller.locks(request),
         options: {
             validate: {
                 params: Joi.object({
@@ -102,7 +102,7 @@ export const register = (server: Hapi.Server): void => {
     server.route({
         method: "GET",
         path: "/wallets/{id}/transactions",
-        handler: controller.transactions,
+        handler: (request: Hapi.Request) => controller.transactions(request),
         options: {
             validate: {
                 params: Joi.object({
@@ -125,7 +125,7 @@ export const register = (server: Hapi.Server): void => {
     server.route({
         method: "GET",
         path: "/wallets/{id}/transactions/sent",
-        handler: controller.transactionsSent,
+        handler: (request: Hapi.Request) => controller.transactionsSent(request),
         options: {
             validate: {
                 params: Joi.object({
@@ -148,7 +148,7 @@ export const register = (server: Hapi.Server): void => {
     server.route({
         method: "GET",
         path: "/wallets/{id}/transactions/received",
-        handler: controller.transactionsReceived,
+        handler: (request: Hapi.Request) => controller.transactionsReceived(request),
         options: {
             validate: {
                 params: Joi.object({
@@ -171,7 +171,7 @@ export const register = (server: Hapi.Server): void => {
     server.route({
         method: "GET",
         path: "/wallets/{id}/votes",
-        handler: controller.votes,
+        handler: (request: Hapi.Request) => controller.votes(request),
         options: {
             validate: {
                 params: Joi.object({


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
Following up issue #3571 and PR #3928 which allowed to extend api response by getting the registered handler : 

Refactor existing core-api routes handlers, using an arrow function to call the class method handler instead of directly binding the handler to the class method. This allow to easily extend the api response as shown in tests in PR #3928 .
(without using the arrow function, we would get issues with `this` when extending api response and calling the original handler)

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
