### PR TITLE
refactor(crypto): use `@arkecosystem/crypto-identities`

### DIFF
--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -31,6 +31,7 @@
         "prepublishOnly": "yarn build:rollup"
     },
     "dependencies": {
+        "@arkecosystem/crypto-identities": "^1.0.0",
         "@arkecosystem/utils": "^1.2.0",
         "ajv": "^6.10.2",
         "ajv-keywords": "^3.4.1",

--- a/packages/crypto/src/crypto/message.ts
+++ b/packages/crypto/src/crypto/message.ts
@@ -1,7 +1,6 @@
 import { Keys } from "../identities";
 import { IKeyPair, IMessage } from "../interfaces";
 import { Network } from "../interfaces/networks";
-import { configManager } from "../managers";
 import { Hash } from "./hash";
 import { HashAlgorithms } from "./hash-algorithms";
 
@@ -17,10 +16,6 @@ export class Message {
     }
 
     public static signWithWif(message: string, wif: string, network?: Network): IMessage {
-        if (!network) {
-            network = configManager.get("network");
-        }
-
         const keys: IKeyPair = Keys.fromWIF(wif, network);
 
         return {

--- a/packages/crypto/src/identities/address.ts
+++ b/packages/crypto/src/identities/address.ts
@@ -10,7 +10,7 @@ export class Address {
             networkVersion = configManager.get("network.pubKeyHash");
         }
 
-        return BaseAddress.fromPublicKey(passphrase, { pubKeyHash: (networkVersion as unknown) as number });
+        return BaseAddress.fromPassphrase(passphrase, { pubKeyHash: (networkVersion as unknown) as number });
     }
 
     public static fromPublicKey(publicKey: string, networkVersion?: number): string {

--- a/packages/crypto/src/identities/keys.ts
+++ b/packages/crypto/src/identities/keys.ts
@@ -1,46 +1,23 @@
-import { secp256k1 } from "bcrypto";
-import wif from "wif";
+import { Keys as BaseKeys } from "@arkecosystem/crypto-identities";
 
-import { HashAlgorithms } from "../crypto";
-import { NetworkVersionError } from "../errors";
 import { IKeyPair } from "../interfaces";
 import { Network } from "../interfaces/networks";
 import { configManager } from "../managers";
 
 export class Keys {
     public static fromPassphrase(passphrase: string, compressed = true): IKeyPair {
-        return Keys.fromPrivateKey(HashAlgorithms.sha256(Buffer.from(passphrase, "utf8")), compressed);
+        return BaseKeys.fromPassphrase(passphrase, compressed);
     }
 
     public static fromPrivateKey(privateKey: Buffer | string, compressed = true): IKeyPair {
-        privateKey = privateKey instanceof Buffer ? privateKey : Buffer.from(privateKey, "hex");
-
-        return {
-            publicKey: secp256k1.publicKeyCreate(privateKey, compressed).toString("hex"),
-            privateKey: privateKey.toString("hex"),
-            compressed,
-        };
+        return BaseKeys.fromPrivateKey(privateKey, compressed);
     }
 
     public static fromWIF(wifKey: string, network?: Network): IKeyPair {
         if (!network) {
-            network = configManager.get("network");
+            network = configManager.get("network.wif");
         }
 
-        if (!network) {
-            throw new Error();
-        }
-
-        const { version, compressed, privateKey } = wif.decode(wifKey, network.wif);
-
-        if (version !== network.wif) {
-            throw new NetworkVersionError(network.wif, version);
-        }
-
-        return {
-            publicKey: secp256k1.publicKeyCreate(privateKey, compressed).toString("hex"),
-            privateKey: privateKey.toString("hex"),
-            compressed,
-        };
+        return BaseKeys.fromWIF(wifKey, { wif: (network as unknown) as number });
     }
 }

--- a/packages/crypto/src/identities/private-key.ts
+++ b/packages/crypto/src/identities/private-key.ts
@@ -1,12 +1,18 @@
+import { PrivateKey as BasePrivateKey } from "@arkecosystem/crypto-identities";
+
+import { configManager } from "../managers";
 import { NetworkType } from "../types";
-import { Keys } from "./keys";
 
 export class PrivateKey {
     public static fromPassphrase(passphrase: string): string {
-        return Keys.fromPassphrase(passphrase).privateKey;
+        return BasePrivateKey.fromPassphrase(passphrase);
     }
 
     public static fromWIF(wif: string, network?: NetworkType): string {
-        return Keys.fromWIF(wif, network).privateKey;
+        if (!network) {
+            network = configManager.get("network.wif");
+        }
+
+        return BasePrivateKey.fromWIF(wif, { wif: (network as unknown) as number });
     }
 }

--- a/packages/crypto/src/identities/public-key.ts
+++ b/packages/crypto/src/identities/public-key.ts
@@ -1,42 +1,27 @@
-import { secp256k1 } from "bcrypto";
+import { PublicKey as BasePublicKey } from "@arkecosystem/crypto-identities";
 
-import { InvalidMultiSignatureAssetError, PublicKeyError } from "../errors";
 import { IMultiSignatureAsset } from "../interfaces";
+import { configManager } from "../managers";
 import { NetworkType } from "../types";
-import { numberToHex } from "../utils";
-import { Keys } from "./keys";
 
 export class PublicKey {
     public static fromPassphrase(passphrase: string): string {
-        return Keys.fromPassphrase(passphrase).publicKey;
+        return BasePublicKey.fromPassphrase(passphrase);
     }
 
     public static fromWIF(wif: string, network?: NetworkType): string {
-        return Keys.fromWIF(wif, network).publicKey;
+        if (!network) {
+            network = configManager.get("network.wif");
+        }
+
+        return BasePublicKey.fromWIF(wif, { wif: (network as unknown) as number });
     }
 
     public static fromMultiSignatureAsset(asset: IMultiSignatureAsset): string {
-        const { min, publicKeys }: IMultiSignatureAsset = asset;
-
-        for (const publicKey of publicKeys) {
-            if (!this.verify(publicKey)) {
-                throw new PublicKeyError(publicKey);
-            }
-        }
-
-        if (min < 1 || min > publicKeys.length) {
-            throw new InvalidMultiSignatureAssetError();
-        }
-
-        const minKey: string = PublicKey.fromPassphrase(numberToHex(min));
-        const keys: string[] = [minKey, ...publicKeys];
-
-        return secp256k1
-            .publicKeyCombine(keys.map((publicKey: string) => Buffer.from(publicKey, "hex")))
-            .toString("hex");
+        return BasePublicKey.fromMultiSignatureAsset(asset);
     }
 
     public static verify(publicKey: string): boolean {
-        return secp256k1.publicKeyVerify(Buffer.from(publicKey, "hex"));
+        return BasePublicKey.verify(publicKey);
     }
 }

--- a/packages/crypto/src/identities/wif.ts
+++ b/packages/crypto/src/identities/wif.ts
@@ -1,34 +1,23 @@
-import wif from "wif";
+import { WIF as BaseWIF } from "@arkecosystem/crypto-identities";
 
 import { IKeyPair } from "../interfaces";
 import { Network } from "../interfaces/networks";
 import { configManager } from "../managers";
-import { Keys } from "./keys";
 
 export class WIF {
     public static fromPassphrase(passphrase: string, network?: Network): string {
-        const keys: IKeyPair = Keys.fromPassphrase(passphrase);
-
         if (!network) {
-            network = configManager.get("network");
+            network = configManager.get("network.wif");
         }
 
-        if (!network) {
-            throw new Error();
-        }
-
-        return wif.encode(network.wif, Buffer.from(keys.privateKey, "hex"), keys.compressed);
+        return BaseWIF.fromPassphrase(passphrase, { wif: (network as unknown) as number });
     }
 
     public static fromKeys(keys: IKeyPair, network?: Network): string {
         if (!network) {
-            network = configManager.get("network");
+            network = configManager.get("network.wif");
         }
 
-        if (!network) {
-            throw new Error();
-        }
-
-        return wif.encode(network.wif, Buffer.from(keys.privateKey, "hex"), keys.compressed);
+        return BaseWIF.fromKeys(keys, { wif: (network as unknown) as number });
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,19 @@
 # yarn lockfile v1
 
 
+"@arkecosystem/crypto-identities@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@arkecosystem/crypto-identities/-/crypto-identities-1.0.0.tgz#c5a58a0d8c0005484ed923db1409c199f34d32df"
+  integrity sha512-QQT3QHaNukcjbXybtNRbZ0fP0nuGMTcIfmm8pFuBJHwSZk+MElT+DD4oykD/xnDXW6f5TFKNjOUe/TzCw1kffg==
+  dependencies:
+    "@arkecosystem/utils" "^1.2.0"
+    bcrypto "^5.3.0"
+    browserify-aes "^1.2.0"
+    bstring "^0.3.9"
+    builtin-modules "^3.1.0"
+    fast-memoize "^2.5.1"
+    wif "^2.0.6"
+
 "@arkecosystem/utils@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@arkecosystem/utils/-/utils-1.2.0.tgz#f58e9dca0e4478503e996c5f276bb210ab142e92"
@@ -11288,6 +11301,7 @@ minipass-fetch@^1.3.0:
   resolved "https://registry.yarnpkg.com/minipass-fetch/-/minipass-fetch-1.3.1.tgz#6d09556764474119ed79e270bc98b9c76d12c8e2"
   integrity sha512-N0ddPAD8OZnoAHUYj1ZH4ZJVna+ucy7if777LrdeIV1ko8f46af4jbyM5EC1gN4xc9Wq5c3C38GnxRJ2gneXRA==
   dependencies:
+    encoding "^0.1.12"
     minipass "^3.1.0"
     minipass-sized "^1.0.3"
     minizlib "^2.0.0"


### PR DESCRIPTION
~Follow up to https://github.com/ArkEcosystem/core/pull/3742. More split-ups into separate packages will follow as I have time for it.~

Skipping this in favor of the complete removal of identities from the crypto package.