### PR TITLE
feat(core-kernel): implement `Queue#isRunning/isStarted/onDrain/onError/onData` methods

### DIFF
--- a/__tests__/unit/core-kernel/services/queue/drivers/memory.test.ts
+++ b/__tests__/unit/core-kernel/services/queue/drivers/memory.test.ts
@@ -1,15 +1,17 @@
 import "jest-extended";
 
+import { performance } from "perf_hooks";
+
 import { sleep } from "@arkecosystem/utils";
-import { Container, Contracts, Enums } from "@packages/core-kernel/src";
+import { Container, Contracts } from "@packages/core-kernel/src";
 import { MemoryQueue } from "@packages/core-kernel/src/services/queue/drivers/memory";
 import { Sandbox } from "@packages/core-test-framework";
 
-class DummyClass implements Contracts.Kernel.QueueJob {
-    public constructor(private readonly method?) {}
+class DummyJob implements Contracts.Kernel.QueueJob {
+    public constructor(private readonly method) {}
 
-    public handle(): void {
-        this.method();
+    public async handle(): Promise<void> {
+        return await this.method();
     }
 }
 
@@ -31,143 +33,612 @@ afterEach(() => {
     jest.clearAllMocks();
 });
 
-const expectEventData = () => {
-    return expect.objectContaining({
-        driver: "memory",
-        executionTime: expect.toBeNumber(),
-    });
-};
+const jobMethod = jest.fn();
 
-const expectEventErrorData = () => {
-    return expect.objectContaining({
-        driver: "memory",
-        executionTime: expect.toBeNumber(),
-        error: expect.toBeObject(),
-    });
-};
+// const expectEventData = () => {
+//     return expect.objectContaining({
+//         driver: "memory",
+//         executionTime: expect.toBeNumber(),
+//     });
+// };
 
-const delay = async (timeout) => {
-    await new Promise((resolve) => {
-        setTimeout(() => {
-            resolve();
-        }, timeout);
-    });
-};
+// const expectEventErrorData = () => {
+//     return expect.objectContaining({
+//         driver: "memory",
+//         executionTime: expect.toBeNumber(),
+//         error: expect.toBeObject(),
+//     });
+// };
+//
+// const delay = async (timeout) => {
+//     await new Promise((resolve) => {
+//         setTimeout(() => {
+//             resolve();
+//         }, timeout);
+//     });
+// };
 
 describe("MemoryQueue", () => {
-    it("should start queue and process jobs", async () => {
-        const dummy: jest.Mock = jest.fn();
+    describe("Start", () => {
+        it("should process jobs start", async () => {
+            await driver.push(new DummyJob(jobMethod));
+            await sleep(50);
 
-        expect(driver.size()).toBe(0);
+            expect(jobMethod).not.toHaveBeenCalled();
 
-        await driver.push(new DummyClass(dummy));
+            await driver.start();
+            await sleep(50);
 
-        await driver.start();
+            expect(jobMethod).toHaveBeenCalledTimes(1);
 
-        expect(dummy).toHaveBeenCalled();
-
-        expect(mockEventDispatcher.dispatch).toHaveBeenCalledTimes(1);
-        expect(mockEventDispatcher.dispatch).toHaveBeenCalledWith(Enums.QueueEvent.Finished, expectEventData());
-    });
-
-    it("should stop queue and not process new jobs", async () => {
-        const dummy: jest.Mock = jest.fn();
-
-        expect(driver.size()).toBe(0);
-
-        await driver.push(new DummyClass(dummy));
-
-        await driver.start();
-
-        await driver.stop();
-
-        await driver.push(new DummyClass(dummy));
-
-        expect(dummy).toHaveBeenCalled();
-
-        expect(mockEventDispatcher.dispatch).toHaveBeenCalledTimes(1);
-        expect(mockEventDispatcher.dispatch).toHaveBeenCalledWith(Enums.QueueEvent.Finished, expectEventData());
-    });
-
-    it("should pause and resume queue", async () => {
-        const dummy: jest.Mock = jest.fn();
-
-        expect(driver.size()).toBe(0);
-
-        await driver.push(new DummyClass(dummy));
-
-        await driver.start();
-
-        await delay(100);
-
-        expect(dummy).toHaveBeenCalled();
-
-        await driver.pause();
-
-        await driver.bulk([new DummyClass(dummy), new DummyClass(dummy)]);
-
-        await driver.resume();
-
-        await delay(100);
-
-        expect(dummy).toHaveBeenCalledTimes(3);
-
-        expect(mockEventDispatcher.dispatch).toHaveBeenCalledTimes(3);
-        expect(mockEventDispatcher.dispatch).toHaveBeenCalledWith(Enums.QueueEvent.Finished, expectEventData());
-    });
-
-    it("should dipatch error if error in queue", async () => {
-        const dummy: jest.Mock = jest.fn().mockImplementation(() => {
-            throw new Error();
+            // expect(mockEventDispatcher.dispatch).toHaveBeenCalledTimes(1);
+            // expect(mockEventDispatcher.dispatch).toHaveBeenCalledWith(Enums.QueueEvent.Finished, expectEventData());
         });
 
-        await driver.push(new DummyClass(dummy));
+        it("should process on push if already started", async () => {
+            await driver.start();
 
-        driver.start();
+            await driver.push(new DummyJob(jobMethod));
+            await sleep(50);
 
-        // @ts-ignore
-        await expect(driver.lastQueue).rejects.toThrowError();
+            expect(jobMethod).toHaveBeenCalledTimes(1);
+        });
 
-        expect(dummy).toHaveBeenCalled();
-        expect(mockEventDispatcher.dispatch).toHaveBeenCalledTimes(1);
-        expect(mockEventDispatcher.dispatch).toHaveBeenCalledWith(Enums.QueueEvent.Failed, expectEventErrorData());
+        it("should remain started after all jobs are processed", async () => {
+            await driver.push(new DummyJob(jobMethod));
+
+            await driver.start();
+            await sleep(50);
+
+            expect(jobMethod).toHaveBeenCalledTimes(1);
+            expect(driver.isStarted()).toBe(true);
+        });
+
+        it("should not interfere with processing if called multiple times", async () => {
+            let methodFinish1;
+            let methodFinish2;
+
+            const jobMethod1 = jest.fn(async () => {
+                await sleep(50);
+                methodFinish1 = performance.now();
+            });
+
+            const jobMethod2 = jest.fn(async () => {
+                await sleep(50);
+                methodFinish2 = performance.now();
+            });
+
+            const onDrain = jest.fn();
+            driver.onDrain(onDrain);
+
+            await driver.push(new DummyJob(jobMethod1));
+            await driver.push(new DummyJob(jobMethod2));
+
+            const start1 = driver.start();
+            const start2 = driver.start();
+
+            await expect(start1).toResolve();
+            await expect(start2).toResolve();
+
+            await sleep(150);
+
+            expect(methodFinish2).toBeGreaterThan(methodFinish1);
+            expect(methodFinish2 - methodFinish1).toBeGreaterThan(45);
+            expect(methodFinish2 - methodFinish1).toBeLessThan(55);
+
+            expect(onDrain).toHaveBeenCalledTimes(1);
+        });
     });
 
-    it("should clear queue", async () => {
-        expect(driver.size()).toBe(0);
+    describe("Clear", () => {
+        it("should clear all jobs when stopped", async () => {
+            await driver.push(new DummyJob(jobMethod));
 
-        await driver.push(new DummyClass());
+            expect(driver.size()).toBe(1);
 
-        expect(driver.size()).toBe(1);
+            await driver.clear();
 
-        await driver.clear();
+            expect(driver.size()).toBe(0);
+        });
 
-        expect(driver.size()).toBe(0);
+        it("should clear all jobs when started and keep current job running", async () => {
+            jobMethod.mockImplementation(async () => {
+                await sleep(20);
+            });
+
+            await driver.push(new DummyJob(jobMethod));
+            await driver.push(new DummyJob(jobMethod));
+
+            expect(driver.size()).toBe(2);
+
+            await driver.start();
+            await driver.clear();
+
+            expect(driver.size()).toBe(0);
+            expect(driver.isRunning()).toBe(true);
+            expect(driver.isStarted()).toBe(true);
+            expect(jobMethod).toHaveBeenCalledTimes(1); // Fist job runs instantly
+
+            await sleep(50);
+            expect(driver.isRunning()).toBe(false);
+            expect(driver.isStarted()).toBe(true);
+        });
     });
 
-    it("should push the job onto queue", async () => {
-        expect(driver.size()).toBe(0);
+    describe("Stop", () => {
+        it("should clear all jobs when stopped", async () => {
+            await driver.push(new DummyJob(jobMethod));
 
-        await driver.push(new DummyClass());
+            expect(driver.size()).toBe(1);
 
-        expect(driver.size()).toBe(1);
+            await driver.stop();
+
+            expect(driver.size()).toBe(0);
+            expect(driver.isStarted()).toBe(false);
+        });
+
+        it("should clear all jobs when started and wait till current is processed", async () => {
+            jobMethod.mockImplementation(async () => {
+                await sleep(50);
+            });
+
+            await driver.push(new DummyJob(jobMethod));
+            await driver.push(new DummyJob(jobMethod));
+
+            expect(driver.size()).toBe(2);
+
+            await driver.start();
+            await driver.stop();
+
+            expect(driver.size()).toBe(0);
+            expect(driver.isRunning()).toBe(false);
+            expect(driver.isStarted()).toBe(false);
+            expect(jobMethod).toHaveBeenCalledTimes(1); // Fist job is run instantly
+        });
+
+        it("should resolve multiple stop promises", async () => {
+            jobMethod.mockImplementation(async () => {
+                await sleep(50);
+            });
+
+            await driver.push(new DummyJob(jobMethod));
+            await driver.push(new DummyJob(jobMethod));
+
+            expect(driver.size()).toBe(2);
+
+            await driver.start();
+            const stop1 = driver.stop();
+            const stop2 = driver.stop();
+
+            await driver.stop();
+
+            expect(driver.size()).toBe(0);
+            expect(driver.isRunning()).toBe(false);
+            expect(driver.isStarted()).toBe(false);
+            expect(jobMethod).toHaveBeenCalledTimes(1); // Fist job is run instantly
+
+            await expect(stop1).toResolve();
+            await expect(stop2).toResolve();
+        });
+
+        it("should not process new jobs after stop", async () => {
+            await driver.start();
+            await driver.stop();
+
+            await driver.push(new DummyJob(jobMethod));
+            await driver.push(new DummyJob(jobMethod));
+
+            await sleep(50);
+
+            expect(driver.size()).toBe(2);
+            expect(driver.isRunning()).toBe(false);
+            expect(driver.isStarted()).toBe(false);
+            expect(jobMethod).not.toHaveBeenCalled();
+        });
     });
 
-    it("should push the job onto queue with a 2 second delay", async () => {
-        expect(driver.size()).toBe(0);
+    describe("Pause", () => {
+        it("should pause after current job is processed", async () => {
+            const jobMethod1 = jest.fn(async () => {
+                await sleep(50);
+            });
 
-        await driver.later(2000, new DummyClass());
+            const jobMethod2 = jest.fn(async () => {
+                await sleep(50);
+            });
 
-        await sleep(2000);
+            await driver.push(new DummyJob(jobMethod1));
+            await driver.push(new DummyJob(jobMethod2));
 
-        expect(driver.size()).toBe(1);
+            expect(driver.size()).toBe(2);
+
+            await driver.start();
+
+            await driver.pause();
+
+            expect(jobMethod1).toHaveBeenCalled();
+            expect(jobMethod2).not.toHaveBeenCalled();
+
+            expect(driver.size()).toBe(1);
+            expect(driver.isRunning()).toBe(false);
+            expect(driver.isStarted()).toBe(false);
+        });
+
+        it("should pause after current job is processed with error", async () => {
+            const jobMethod1 = jest.fn(async () => {
+                await sleep(50);
+                throw new Error();
+            });
+
+            const jobMethod2 = jest.fn(async () => {
+                await sleep(50);
+            });
+
+            await driver.push(new DummyJob(jobMethod1));
+            await driver.push(new DummyJob(jobMethod2));
+
+            expect(driver.size()).toBe(2);
+
+            await driver.start();
+
+            await driver.pause();
+
+            expect(jobMethod1).toHaveBeenCalled();
+            expect(jobMethod2).not.toHaveBeenCalled();
+
+            expect(driver.size()).toBe(1);
+            expect(driver.isRunning()).toBe(false);
+            expect(driver.isStarted()).toBe(false);
+        });
+
+        it("should not process new jobs after pause", async () => {
+            await driver.push(new DummyJob(jobMethod));
+
+            expect(driver.size()).toBe(1);
+
+            await driver.start();
+            await driver.pause();
+
+            expect(driver.size()).toBe(0);
+            expect(driver.isRunning()).toBe(false);
+            expect(driver.isStarted()).toBe(false);
+
+            await driver.push(new DummyJob(jobMethod));
+
+            expect(driver.size()).toBe(1);
+            expect(driver.isRunning()).toBe(false);
+            expect(driver.isStarted()).toBe(false);
+        });
+
+        it("should resolve all if called multiple times", async () => {
+            const jobMethod1 = jest.fn(async () => {
+                await sleep(50);
+            });
+
+            const jobMethod2 = jest.fn(async () => {
+                await sleep(50);
+            });
+
+            await driver.push(new DummyJob(jobMethod1));
+            await driver.push(new DummyJob(jobMethod2));
+
+            expect(driver.size()).toBe(2);
+
+            await driver.start();
+
+            const pause1 = driver.pause();
+            await driver.pause();
+
+            await expect(pause1).toResolve();
+
+            expect(jobMethod1).toHaveBeenCalled();
+            expect(jobMethod2).not.toHaveBeenCalled();
+
+            expect(driver.size()).toBe(1);
+            expect(driver.isRunning()).toBe(false);
+            expect(driver.isStarted()).toBe(false);
+        });
     });
 
-    it("should push the job onto queue", async () => {
-        expect(driver.size()).toBe(0);
+    describe("Resume", () => {
+        it("should resume processing after pause", async () => {
+            await driver.pause();
 
-        await driver.bulk([new DummyClass(), new DummyClass()]);
+            await driver.push(new DummyJob(jobMethod));
 
-        expect(driver.size()).toBe(2);
+            expect(driver.size()).toBe(1);
+            expect(driver.isStarted()).toBe(false);
+
+            await driver.resume();
+
+            await sleep(10);
+
+            expect(driver.size()).toBe(0);
+            expect(driver.isStarted()).toBe(true);
+        });
+
+        it("should resume processing after stop", async () => {
+            await driver.stop();
+
+            await driver.push(new DummyJob(jobMethod));
+
+            expect(driver.size()).toBe(1);
+            expect(driver.isStarted()).toBe(false);
+
+            await driver.resume();
+
+            await sleep(10);
+
+            expect(driver.size()).toBe(0);
+            expect(driver.isStarted()).toBe(true);
+        });
+
+        it("should not interfere with start", async () => {
+            let methodFinish1;
+            let methodFinish2;
+
+            const jobMethod1 = jest.fn(async () => {
+                await sleep(50);
+                methodFinish1 = performance.now();
+            });
+
+            const jobMethod2 = jest.fn(async () => {
+                await sleep(50);
+                methodFinish2 = performance.now();
+            });
+
+            const onDrain = jest.fn();
+            driver.onDrain(onDrain);
+
+            await driver.push(new DummyJob(jobMethod1));
+            await driver.push(new DummyJob(jobMethod2));
+
+            const start1 = driver.start();
+            const resume1 = driver.resume();
+
+            await expect(start1).toResolve();
+            await expect(resume1).toResolve();
+
+            await sleep(150);
+
+            expect(methodFinish2).toBeGreaterThan(methodFinish1);
+            expect(methodFinish2 - methodFinish1).toBeGreaterThan(45);
+            expect(methodFinish2 - methodFinish1).toBeLessThan(55);
+
+            expect(onDrain).toHaveBeenCalledTimes(1);
+        });
+
+        it("should not interfere with another resume", async () => {
+            let methodFinish1;
+            let methodFinish2;
+
+            const jobMethod1 = jest.fn(async () => {
+                await sleep(50);
+                methodFinish1 = performance.now();
+            });
+
+            const jobMethod2 = jest.fn(async () => {
+                await sleep(50);
+                methodFinish2 = performance.now();
+            });
+
+            const onDrain = jest.fn();
+            driver.onDrain(onDrain);
+
+            await driver.push(new DummyJob(jobMethod1));
+            await driver.push(new DummyJob(jobMethod2));
+
+            const resume1 = driver.resume();
+            const resume2 = driver.resume();
+
+            await expect(resume1).toResolve();
+            await expect(resume2).toResolve();
+
+            await sleep(150);
+
+            expect(methodFinish2).toBeGreaterThan(methodFinish1);
+            expect(methodFinish2 - methodFinish1).toBeGreaterThan(45);
+            expect(methodFinish2 - methodFinish1).toBeLessThan(55);
+
+            expect(onDrain).toHaveBeenCalledTimes(1);
+        });
     });
+
+    describe("Later", () => {
+        it("should push job with delay", async () => {
+            await driver.later(50, new DummyJob(jobMethod));
+
+            expect(driver.size()).toBe(0);
+
+            await sleep(60);
+
+            expect(driver.size()).toBe(1);
+        });
+    });
+
+    describe("Bulk", () => {
+        it("should push multiple jobs", async () => {
+            await driver.bulk([new DummyJob(jobMethod), new DummyJob(jobMethod)]);
+
+            expect(driver.size()).toBe(2);
+        });
+    });
+
+    describe("Callbacks", () => {
+        it("should call onData", async () => {
+            const onData = jest.fn();
+            driver.onData(onData);
+
+            jobMethod.mockResolvedValue("dummy_data");
+            const job1 = new DummyJob(jobMethod);
+            const job2 = new DummyJob(jobMethod);
+
+            await driver.push(job1);
+            await driver.push(job2);
+            await driver.start();
+
+            await sleep(50);
+
+            expect(jobMethod).toHaveBeenCalledTimes(2);
+            expect(onData).toHaveBeenCalledTimes(2);
+            expect(onData).toHaveBeenCalledWith(job1, "dummy_data");
+            expect(onData).toHaveBeenCalledWith(job2, "dummy_data");
+        });
+
+        it("should call onError and continue processing", async () => {
+            const onData = jest.fn();
+            driver.onData(onData);
+
+            const onError = jest.fn();
+            driver.onError(onError);
+
+            jobMethod.mockResolvedValue("dummy_data");
+
+            const error = new Error("dummy_error");
+            const errorMethod = jest.fn().mockImplementation(async () => {
+                throw error;
+            });
+
+            const job1 = new DummyJob(errorMethod);
+            const job2 = new DummyJob(jobMethod);
+
+            await driver.push(job1);
+            await driver.push(job2);
+            await driver.start();
+
+            await sleep(50);
+
+            expect(errorMethod).toHaveBeenCalledTimes(1);
+            expect(jobMethod).toHaveBeenCalledTimes(1);
+
+            expect(onError).toHaveBeenCalledTimes(1);
+            expect(onError).toHaveBeenCalledWith(job1, error);
+
+            expect(onData).toHaveBeenCalledTimes(1);
+            expect(onData).toHaveBeenCalledWith(job2, "dummy_data");
+        });
+
+        it("should call onDrain", async () => {
+            const onDrain = jest.fn();
+            driver.onDrain(onDrain);
+
+            await driver.push(new DummyJob(jobMethod));
+            await driver.start();
+
+            await sleep(50);
+
+            // Second iteration
+            expect(jobMethod).toHaveBeenCalledTimes(1);
+            expect(onDrain).toHaveBeenCalledTimes(1);
+
+            await driver.push(new DummyJob(jobMethod));
+            await driver.start();
+
+            await sleep(50);
+
+            expect(jobMethod).toHaveBeenCalledTimes(2);
+            expect(onDrain).toHaveBeenCalledTimes(2);
+        });
+    });
+
+    // it("should stop queue and not process new jobs", async () => {
+    //     const dummy: jest.Mock = jest.fn();
+    //
+    //     expect(driver.size()).toBe(0);
+    //
+    //     await driver.push(new DummyClass(dummy));
+    //
+    //     await driver.start();
+    //
+    //     await driver.stop();
+    //
+    //     await driver.push(new DummyClass(dummy));
+    //
+    //     expect(dummy).toHaveBeenCalled();
+    //
+    //     expect(mockEventDispatcher.dispatch).toHaveBeenCalledTimes(1);
+    //     expect(mockEventDispatcher.dispatch).toHaveBeenCalledWith(Enums.QueueEvent.Finished, expectEventData());
+    // });
+    //
+    // it("should pause and resume queue", async () => {
+    //     const dummy: jest.Mock = jest.fn();
+    //
+    //     expect(driver.size()).toBe(0);
+    //
+    //     await driver.push(new DummyClass(dummy));
+    //
+    //     await driver.start();
+    //
+    //     await delay(100);
+    //
+    //     expect(dummy).toHaveBeenCalled();
+    //
+    //     await driver.pause();
+    //
+    //     await driver.bulk([new DummyClass(dummy), new DummyClass(dummy)]);
+    //
+    //     await driver.resume();
+    //
+    //     await delay(100);
+    //
+    //     expect(dummy).toHaveBeenCalledTimes(3);
+    //
+    //     expect(mockEventDispatcher.dispatch).toHaveBeenCalledTimes(3);
+    //     expect(mockEventDispatcher.dispatch).toHaveBeenCalledWith(Enums.QueueEvent.Finished, expectEventData());
+    // });
+    //
+    // it("should dipatch error if error in queue", async () => {
+    //     const dummy: jest.Mock = jest.fn().mockImplementation(() => {
+    //         throw new Error();
+    //     });
+    //
+    //     await driver.push(new DummyClass(dummy));
+    //
+    //     driver.start();
+    //
+    //     // @ts-ignore
+    //     await expect(driver.lastQueue).rejects.toThrowError();
+    //
+    //     expect(dummy).toHaveBeenCalled();
+    //     expect(mockEventDispatcher.dispatch).toHaveBeenCalledTimes(1);
+    //     expect(mockEventDispatcher.dispatch).toHaveBeenCalledWith(Enums.QueueEvent.Failed, expectEventErrorData());
+    // });
+    //
+    // it("should clear queue", async () => {
+    //     expect(driver.size()).toBe(0);
+    //
+    //     await driver.push(new DummyClass());
+    //
+    //     expect(driver.size()).toBe(1);
+    //
+    //     await driver.clear();
+    //
+    //     expect(driver.size()).toBe(0);
+    // });
+    //
+    // it("should push the job onto queue", async () => {
+    //     expect(driver.size()).toBe(0);
+    //
+    //     await driver.push(new DummyClass());
+    //
+    //     expect(driver.size()).toBe(1);
+    // });
+    //
+    // it("should push the job onto queue with a 2 second delay", async () => {
+    //     expect(driver.size()).toBe(0);
+    //
+    //     await driver.later(2000, new DummyClass());
+    //
+    //     await sleep(2000);
+    //
+    //     expect(driver.size()).toBe(1);
+    // });
+    //
+    // it("should push the job onto queue", async () => {
+    //     expect(driver.size()).toBe(0);
+    //
+    //     await driver.bulk([new DummyClass(), new DummyClass()]);
+    //
+    //     expect(driver.size()).toBe(2);
+    // });
 });

--- a/__tests__/unit/core-kernel/services/queue/drivers/memory.test.ts
+++ b/__tests__/unit/core-kernel/services/queue/drivers/memory.test.ts
@@ -3,7 +3,7 @@ import "jest-extended";
 import { performance } from "perf_hooks";
 
 import { sleep } from "@arkecosystem/utils";
-import { Container, Contracts } from "@packages/core-kernel/src";
+import { Container, Contracts, Enums } from "@packages/core-kernel";
 import { MemoryQueue } from "@packages/core-kernel/src/services/queue/drivers/memory";
 import { Sandbox } from "@packages/core-test-framework";
 
@@ -35,32 +35,9 @@ afterEach(() => {
 
 const jobMethod = jest.fn();
 
-// const expectEventData = () => {
-//     return expect.objectContaining({
-//         driver: "memory",
-//         executionTime: expect.toBeNumber(),
-//     });
-// };
-
-// const expectEventErrorData = () => {
-//     return expect.objectContaining({
-//         driver: "memory",
-//         executionTime: expect.toBeNumber(),
-//         error: expect.toBeObject(),
-//     });
-// };
-//
-// const delay = async (timeout) => {
-//     await new Promise((resolve) => {
-//         setTimeout(() => {
-//             resolve();
-//         }, timeout);
-//     });
-// };
-
 describe("MemoryQueue", () => {
     describe("Start", () => {
-        it("should process jobs start", async () => {
+        it("should process job", async () => {
             await driver.push(new DummyJob(jobMethod));
             await sleep(50);
 
@@ -70,9 +47,6 @@ describe("MemoryQueue", () => {
             await sleep(50);
 
             expect(jobMethod).toHaveBeenCalledTimes(1);
-
-            // expect(mockEventDispatcher.dispatch).toHaveBeenCalledTimes(1);
-            // expect(mockEventDispatcher.dispatch).toHaveBeenCalledWith(Enums.QueueEvent.Finished, expectEventData());
         });
 
         it("should process on push if already started", async () => {
@@ -123,8 +97,8 @@ describe("MemoryQueue", () => {
             await sleep(150);
 
             expect(methodFinish2).toBeGreaterThan(methodFinish1);
-            expect(methodFinish2 - methodFinish1).toBeGreaterThan(45);
-            expect(methodFinish2 - methodFinish1).toBeLessThan(55);
+            expect(methodFinish2 - methodFinish1).toBeGreaterThan(40);
+            expect(methodFinish2 - methodFinish1).toBeLessThan(60);
 
             expect(onDrain).toHaveBeenCalledTimes(1);
         });
@@ -193,7 +167,7 @@ describe("MemoryQueue", () => {
             expect(driver.size()).toBe(0);
             expect(driver.isRunning()).toBe(false);
             expect(driver.isStarted()).toBe(false);
-            expect(jobMethod).toHaveBeenCalledTimes(1); // Fist job is run instantly
+            expect(jobMethod).toHaveBeenCalledTimes(1); // Fist job is run after start
         });
 
         it("should resolve multiple stop promises", async () => {
@@ -215,7 +189,7 @@ describe("MemoryQueue", () => {
             expect(driver.size()).toBe(0);
             expect(driver.isRunning()).toBe(false);
             expect(driver.isStarted()).toBe(false);
-            expect(jobMethod).toHaveBeenCalledTimes(1); // Fist job is run instantly
+            expect(jobMethod).toHaveBeenCalledTimes(1); // Fist job is run after start
 
             await expect(stop1).toResolve();
             await expect(stop2).toResolve();
@@ -228,7 +202,7 @@ describe("MemoryQueue", () => {
             await driver.push(new DummyJob(jobMethod));
             await driver.push(new DummyJob(jobMethod));
 
-            await sleep(50);
+            await sleep(10);
 
             expect(driver.size()).toBe(2);
             expect(driver.isRunning()).toBe(false);
@@ -402,8 +376,8 @@ describe("MemoryQueue", () => {
             await sleep(150);
 
             expect(methodFinish2).toBeGreaterThan(methodFinish1);
-            expect(methodFinish2 - methodFinish1).toBeGreaterThan(45);
-            expect(methodFinish2 - methodFinish1).toBeLessThan(55);
+            expect(methodFinish2 - methodFinish1).toBeGreaterThan(40);
+            expect(methodFinish2 - methodFinish1).toBeLessThan(60);
 
             expect(onDrain).toHaveBeenCalledTimes(1);
         });
@@ -437,8 +411,8 @@ describe("MemoryQueue", () => {
             await sleep(150);
 
             expect(methodFinish2).toBeGreaterThan(methodFinish1);
-            expect(methodFinish2 - methodFinish1).toBeGreaterThan(45);
-            expect(methodFinish2 - methodFinish1).toBeLessThan(55);
+            expect(methodFinish2 - methodFinish1).toBeGreaterThan(40);
+            expect(methodFinish2 - methodFinish1).toBeLessThan(60);
 
             expect(onDrain).toHaveBeenCalledTimes(1);
         });
@@ -477,7 +451,7 @@ describe("MemoryQueue", () => {
             await driver.push(job2);
             await driver.start();
 
-            await sleep(50);
+            await sleep(10);
 
             expect(jobMethod).toHaveBeenCalledTimes(2);
             expect(onData).toHaveBeenCalledTimes(2);
@@ -506,7 +480,7 @@ describe("MemoryQueue", () => {
             await driver.push(job2);
             await driver.start();
 
-            await sleep(50);
+            await sleep(10);
 
             expect(errorMethod).toHaveBeenCalledTimes(1);
             expect(jobMethod).toHaveBeenCalledTimes(1);
@@ -525,7 +499,7 @@ describe("MemoryQueue", () => {
             await driver.push(new DummyJob(jobMethod));
             await driver.start();
 
-            await sleep(50);
+            await sleep(10);
 
             // Second iteration
             expect(jobMethod).toHaveBeenCalledTimes(1);
@@ -534,111 +508,62 @@ describe("MemoryQueue", () => {
             await driver.push(new DummyJob(jobMethod));
             await driver.start();
 
-            await sleep(50);
+            await sleep(10);
 
             expect(jobMethod).toHaveBeenCalledTimes(2);
             expect(onDrain).toHaveBeenCalledTimes(2);
         });
     });
 
-    // it("should stop queue and not process new jobs", async () => {
-    //     const dummy: jest.Mock = jest.fn();
-    //
-    //     expect(driver.size()).toBe(0);
-    //
-    //     await driver.push(new DummyClass(dummy));
-    //
-    //     await driver.start();
-    //
-    //     await driver.stop();
-    //
-    //     await driver.push(new DummyClass(dummy));
-    //
-    //     expect(dummy).toHaveBeenCalled();
-    //
-    //     expect(mockEventDispatcher.dispatch).toHaveBeenCalledTimes(1);
-    //     expect(mockEventDispatcher.dispatch).toHaveBeenCalledWith(Enums.QueueEvent.Finished, expectEventData());
-    // });
-    //
-    // it("should pause and resume queue", async () => {
-    //     const dummy: jest.Mock = jest.fn();
-    //
-    //     expect(driver.size()).toBe(0);
-    //
-    //     await driver.push(new DummyClass(dummy));
-    //
-    //     await driver.start();
-    //
-    //     await delay(100);
-    //
-    //     expect(dummy).toHaveBeenCalled();
-    //
-    //     await driver.pause();
-    //
-    //     await driver.bulk([new DummyClass(dummy), new DummyClass(dummy)]);
-    //
-    //     await driver.resume();
-    //
-    //     await delay(100);
-    //
-    //     expect(dummy).toHaveBeenCalledTimes(3);
-    //
-    //     expect(mockEventDispatcher.dispatch).toHaveBeenCalledTimes(3);
-    //     expect(mockEventDispatcher.dispatch).toHaveBeenCalledWith(Enums.QueueEvent.Finished, expectEventData());
-    // });
-    //
-    // it("should dipatch error if error in queue", async () => {
-    //     const dummy: jest.Mock = jest.fn().mockImplementation(() => {
-    //         throw new Error();
-    //     });
-    //
-    //     await driver.push(new DummyClass(dummy));
-    //
-    //     driver.start();
-    //
-    //     // @ts-ignore
-    //     await expect(driver.lastQueue).rejects.toThrowError();
-    //
-    //     expect(dummy).toHaveBeenCalled();
-    //     expect(mockEventDispatcher.dispatch).toHaveBeenCalledTimes(1);
-    //     expect(mockEventDispatcher.dispatch).toHaveBeenCalledWith(Enums.QueueEvent.Failed, expectEventErrorData());
-    // });
-    //
-    // it("should clear queue", async () => {
-    //     expect(driver.size()).toBe(0);
-    //
-    //     await driver.push(new DummyClass());
-    //
-    //     expect(driver.size()).toBe(1);
-    //
-    //     await driver.clear();
-    //
-    //     expect(driver.size()).toBe(0);
-    // });
-    //
-    // it("should push the job onto queue", async () => {
-    //     expect(driver.size()).toBe(0);
-    //
-    //     await driver.push(new DummyClass());
-    //
-    //     expect(driver.size()).toBe(1);
-    // });
-    //
-    // it("should push the job onto queue with a 2 second delay", async () => {
-    //     expect(driver.size()).toBe(0);
-    //
-    //     await driver.later(2000, new DummyClass());
-    //
-    //     await sleep(2000);
-    //
-    //     expect(driver.size()).toBe(1);
-    // });
-    //
-    // it("should push the job onto queue", async () => {
-    //     expect(driver.size()).toBe(0);
-    //
-    //     await driver.bulk([new DummyClass(), new DummyClass()]);
-    //
-    //     expect(driver.size()).toBe(2);
-    // });
+    describe("DispatchEvents", () => {
+        const error = new Error("dummy_error")
+
+        const expectEventData = () => {
+            return expect.objectContaining({
+                driver: "memory",
+                executionTime: expect.toBeNumber(),
+                data: "dummy_data",
+            });
+        };
+
+        const expectEventErrorData = () => {
+            return expect.objectContaining({
+                driver: "memory",
+                executionTime: expect.toBeNumber(),
+                error: expect.toBeOneOf([error]),
+            });
+        };
+
+        it("should dispatch 'queue.finished' after every processed job", async () => {
+            jobMethod.mockResolvedValue("dummy_data");
+
+            await driver.push(new DummyJob(jobMethod));
+            await driver.push(new DummyJob(jobMethod));
+
+            await driver.start();
+            await sleep(10);
+
+            expect(jobMethod).toHaveBeenCalledTimes(2);
+
+            expect(mockEventDispatcher.dispatch).toHaveBeenCalledTimes(2);
+            expect(mockEventDispatcher.dispatch).toHaveBeenCalledWith(Enums.QueueEvent.Finished, expectEventData());
+        });
+
+        it("should dispatch 'queue.failed' after every failed job", async () => {
+            jobMethod.mockImplementation(async () => {
+                throw error;
+            });
+
+            await driver.push(new DummyJob(jobMethod));
+            await driver.push(new DummyJob(jobMethod));
+
+            await driver.start();
+            await sleep(10);
+
+            expect(jobMethod).toHaveBeenCalledTimes(2);
+
+            expect(mockEventDispatcher.dispatch).toHaveBeenCalledTimes(2);
+            expect(mockEventDispatcher.dispatch).toHaveBeenCalledWith(Enums.QueueEvent.Failed, expectEventErrorData());
+        });
+    });
 });

--- a/__tests__/unit/core-kernel/services/queue/drivers/null.test.ts
+++ b/__tests__/unit/core-kernel/services/queue/drivers/null.test.ts
@@ -100,3 +100,27 @@ describe("NullQueue.isRunning", () => {
         expect(result).toBe(false);
     });
 });
+
+describe("NullQueue.onData", () => {
+    it("should accept function", async () => {
+        const driver = new NullQueue();
+        const onData = jest.fn();
+        driver.onData(onData);
+    });
+});
+
+describe("NullQueue.onError", () => {
+    it("should accept function", async () => {
+        const driver = new NullQueue();
+        const onError = jest.fn();
+        driver.onError(onError);
+    });
+});
+
+describe("NullQueue.onDrain", () => {
+    it("should accept function", async () => {
+        const driver = new NullQueue();
+        const onDrain = jest.fn();
+        driver.onDrain(onDrain);
+    });
+});

--- a/__tests__/unit/core-kernel/services/queue/drivers/null.test.ts
+++ b/__tests__/unit/core-kernel/services/queue/drivers/null.test.ts
@@ -1,8 +1,8 @@
-import { NullQueue } from "../../../../../../packages/core-kernel/src/services/queue/drivers/null";
-import { QueueJob } from "../../../../../../packages/core-kernel/src/contracts/kernel/queue";
+import { QueueJob } from "@packages/core-kernel/src/contracts/kernel/queue";
+import { NullQueue } from "@packages/core-kernel/src/services/queue/drivers/null";
 
 class MyQueueJob implements QueueJob {
-    handle(): void {}
+    public async handle(): Promise<void> {}
 }
 
 describe("NullQueue.make", () => {
@@ -82,5 +82,21 @@ describe("NullQueue.size", () => {
         const driver = new NullQueue();
         const result = await driver.size();
         expect(result).toBe(0);
+    });
+});
+
+describe("NullQueue.isStarted", () => {
+    it("should return false", async () => {
+        const driver = new NullQueue();
+        const result = await driver.isStarted();
+        expect(result).toBe(false);
+    });
+});
+
+describe("NullQueue.isRunning", () => {
+    it("should return false", async () => {
+        const driver = new NullQueue();
+        const result = await driver.isRunning();
+        expect(result).toBe(false);
     });
 });

--- a/__tests__/unit/core-kernel/services/queue/service-provider.test.ts
+++ b/__tests__/unit/core-kernel/services/queue/service-provider.test.ts
@@ -2,7 +2,6 @@ import "jest-extended";
 
 import { Application } from "@packages/core-kernel/src/application";
 import { Container, Identifiers } from "@packages/core-kernel/src/ioc";
-import { MemoryEventDispatcher } from "@packages/core-kernel/src/services/events/drivers/memory";
 import { ServiceProvider } from "@packages/core-kernel/src/services/queue";
 import { MemoryQueue } from "@packages/core-kernel/src/services/queue/drivers/memory";
 import { QueueFactory } from "@packages/core-kernel/src/types";
@@ -11,7 +10,8 @@ let app: Application;
 
 beforeEach(() => {
     app = new Application(new Container());
-    app.bind(Identifiers.EventDispatcherService).to(MemoryEventDispatcher);
+    app.bind(Identifiers.EventDispatcherService).toConstantValue({});
+    app.bind(Identifiers.LogService).toConstantValue({});
 });
 
 describe("QueueServiceProvider", () => {

--- a/packages/core-kernel/src/contracts/kernel/queue.ts
+++ b/packages/core-kernel/src/contracts/kernel/queue.ts
@@ -7,9 +7,9 @@ export interface QueueJob {
 
 export type QueueOnDrainFunction = () => void;
 
-export type QueueOnErrorFunction = () => { error: Error; job: QueueJob };
+export type QueueOnErrorFunction = (job: QueueJob, error: Error) => void;
 
-export type QueueOnDataFunction = () => { data: any; job: QueueJob };
+export type QueueOnDataFunction = (job: QueueJob, data: any) => void;
 
 /**
  * @export

--- a/packages/core-kernel/src/contracts/kernel/queue.ts
+++ b/packages/core-kernel/src/contracts/kernel/queue.ts
@@ -1,15 +1,17 @@
+import { EventEmitter } from "events";
+
 /**
  * @interface QueueJob
  */
 export interface QueueJob {
-    handle(): void;
+    handle(): Promise<void>;
 }
 
 /**
  * @export
  * @interface Queue
  */
-export interface Queue {
+export interface Queue extends EventEmitter {
     /**
      * Create a new instance of the queue.
      *
@@ -99,4 +101,8 @@ export interface Queue {
      * @memberof Queue
      */
     size(): number;
+
+    isStarted(): boolean;
+
+    isRunning(): boolean;
 }

--- a/packages/core-kernel/src/contracts/kernel/queue.ts
+++ b/packages/core-kernel/src/contracts/kernel/queue.ts
@@ -1,5 +1,3 @@
-import { EventEmitter } from "events";
-
 /**
  * @interface QueueJob
  */
@@ -7,11 +5,17 @@ export interface QueueJob {
     handle(): Promise<void>;
 }
 
+export type QueueOnDrainFunction = () => void;
+
+export type QueueOnErrorFunction = () => { error: Error; job: QueueJob };
+
+export type QueueOnDataFunction = () => { data: any; job: QueueJob };
+
 /**
  * @export
  * @interface Queue
  */
-export interface Queue extends EventEmitter {
+export interface Queue {
     /**
      * Create a new instance of the queue.
      *
@@ -105,4 +109,10 @@ export interface Queue extends EventEmitter {
     isStarted(): boolean;
 
     isRunning(): boolean;
+
+    onData(callback: QueueOnDataFunction): void;
+
+    onError(callback: QueueOnErrorFunction): void;
+
+    onDrain(callback: QueueOnDrainFunction): void;
 }

--- a/packages/core-kernel/src/enums/events.ts
+++ b/packages/core-kernel/src/enums/events.ts
@@ -124,5 +124,5 @@ export enum ScheduleEvent {
  */
 export enum QueueEvent {
     Finished = "queue.finished",
-    Failed = "queue.finished",
+    Failed = "queue.failed",
 }

--- a/packages/core-kernel/src/services/queue/drivers/memory.ts
+++ b/packages/core-kernel/src/services/queue/drivers/memory.ts
@@ -1,6 +1,7 @@
 import { performance } from "perf_hooks";
 
 import { EventDispatcher } from "../../../contracts/kernel/events";
+import { Logger } from "../../../contracts/kernel/log";
 import {
     Queue,
     QueueJob,
@@ -20,6 +21,9 @@ import { Identifiers, inject, injectable } from "../../../ioc";
 export class MemoryQueue implements Queue {
     @inject(Identifiers.EventDispatcherService)
     private readonly events!: EventDispatcher;
+
+    @inject(Identifiers.LogService)
+    private readonly logger!: Logger;
 
     /**
      * @private
@@ -239,6 +243,8 @@ export class MemoryQueue implements Queue {
                     executionTime: performance.now() - start,
                     error: error,
                 });
+
+                this.logger.warning(`Queue error occurs when handling job: ${job}`);
 
                 if (this.onErrorCallback) {
                     this.onErrorCallback(job, error);

--- a/packages/core-kernel/src/services/queue/drivers/null.ts
+++ b/packages/core-kernel/src/services/queue/drivers/null.ts
@@ -1,6 +1,10 @@
-import { EventEmitter } from "events";
-
-import { Queue, QueueJob } from "../../../contracts/kernel/queue";
+import {
+    Queue,
+    QueueJob,
+    QueueOnDataFunction,
+    QueueOnDrainFunction,
+    QueueOnErrorFunction,
+} from "../../../contracts/kernel/queue";
 import { injectable } from "../../../ioc";
 
 /**
@@ -9,7 +13,7 @@ import { injectable } from "../../../ioc";
  * @implements {Queue}
  */
 @injectable()
-export class NullQueue extends EventEmitter implements Queue {
+export class NullQueue implements Queue {
     /**
      * Create a new instance of the queue.
      *
@@ -123,4 +127,10 @@ export class NullQueue extends EventEmitter implements Queue {
     public isRunning(): boolean {
         return false;
     }
+
+    public onData(callback: QueueOnDataFunction): void {}
+
+    public onError(callback: QueueOnErrorFunction): void {}
+
+    public onDrain(callback: QueueOnDrainFunction): void {}
 }

--- a/packages/core-kernel/src/services/queue/drivers/null.ts
+++ b/packages/core-kernel/src/services/queue/drivers/null.ts
@@ -1,3 +1,5 @@
+import { EventEmitter } from "events";
+
 import { Queue, QueueJob } from "../../../contracts/kernel/queue";
 import { injectable } from "../../../ioc";
 
@@ -7,7 +9,7 @@ import { injectable } from "../../../ioc";
  * @implements {Queue}
  */
 @injectable()
-export class NullQueue implements Queue {
+export class NullQueue extends EventEmitter implements Queue {
     /**
      * Create a new instance of the queue.
      *
@@ -112,5 +114,13 @@ export class NullQueue implements Queue {
      */
     public size(): number {
         return 0;
+    }
+
+    public isStarted(): boolean {
+        return false;
+    }
+
+    public isRunning(): boolean {
+        return false;
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -15326,7 +15326,7 @@ typeforce@^1.11.5:
   resolved "https://registry.yarnpkg.com/typeforce/-/typeforce-1.18.0.tgz#d7416a2c5845e085034d70fcc5b6cc4a90edbfdc"
   integrity sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g==
 
-typeorm@^0.2.25:
+typeorm@0.2.25:
   version "0.2.25"
   resolved "https://registry.yarnpkg.com/typeorm/-/typeorm-0.2.25.tgz#1a33513b375b78cc7740d2405202208b918d7dde"
   integrity sha512-yzQ995fyDy5wolSLK9cmjUNcmQdixaeEm2TnXB5HN++uKbs9TiR6Y7eYAHpDlAE8s9J1uniDBgytecCZVFergQ==


### PR DESCRIPTION
## Summary

Refactor Queue from core-kernel with corresponding MemoryQueue and NullQueue implementations. 

MemoryQueue will be used in the core-blockchain logic and that is why it implements additional methods:
- isRunning
- isStarted
- onDrain
- onError
- onData

## Checklist

- [x] Tests
- [x] Ready to be merged