### PR TITLE
chore(core-api): allow array query parameter in all schemas

### DIFF
--- a/__tests__/integration/core-api/handlers/delegates.test.ts
+++ b/__tests__/integration/core-api/handlers/delegates.test.ts
@@ -47,6 +47,23 @@ beforeEach(() => {
 });
 
 describe("API 2.0 - Delegates", () => {
+    describe("GET /delegates", () => {
+        it("should GET all delegates", async () => {
+            const response = await api.request("GET", `delegates`);
+            expect(response).toBeSuccessfulResponse();
+            expect(response.data.data).toBeArray();
+            expect(response.data.data).toHaveLength(51);
+        });
+
+        it("should GET the delegates for the specified addresses", async () => {
+            const address = ["APRiwbs17FdbaF8DYU9js2jChRehQc2e6P", "AReCSCQRssLGF4XyhTjxhQm6mBFAWTaDTz"];
+            const response = await api.request("GET", `delegates`, { address });
+            expect(response).toBeSuccessfulResponse();
+            expect(response.data.data).toBeArray();
+            expect(response.data.data.map(d => d.address).sort()).toEqual(address.sort());
+        });
+    });
+
     describe("GET /delegates/:id/blocks", () => {
         it("should GET all blocks for a delegate by the given identifier", async () => {
             const block2: Interfaces.IBlock = Factories.factory("Block")

--- a/__tests__/integration/core-api/handlers/wallets.test.ts
+++ b/__tests__/integration/core-api/handlers/wallets.test.ts
@@ -32,6 +32,24 @@ beforeAll(async () => {
 afterAll(async () => await tearDown());
 
 describe("API 2.0 - Wallets", () => {
+    describe("GET /wallets", () => {
+        it("should GET all the wallets", async () => {
+            const response = await api.request("GET", `wallets`);
+            expect(response).toBeSuccessfulResponse();
+            expect(response.data.data).toBeArray();
+            expect(response.data.data).toHaveLength(52);
+        });
+
+        it("should GET the wallets for the specified addresses", async () => {
+            const address = ["APRiwbs17FdbaF8DYU9js2jChRehQc2e6P", "AReCSCQRssLGF4XyhTjxhQm6mBFAWTaDTz"];
+            const response = await api.request("GET", `wallets`, { address });
+            expect(response).toBeSuccessfulResponse();
+            expect(response.data.data).toBeArray();
+            expect(response.data.data).toHaveLength(2);
+            expect(response.data.data.map(w => w.address).sort()).toEqual(address.sort());
+        });
+    });
+
     describe("GET /wallets/:id/transactions", () => {
         it("should GET all the transactions for the given wallet by id", async () => {
             const response = await api.request("GET", `wallets/${address}/transactions`);

--- a/__tests__/unit/core-magistrate-api/controllers/entities.test.ts
+++ b/__tests__/unit/core-magistrate-api/controllers/entities.test.ts
@@ -68,36 +68,6 @@ describe("EntityController.index", () => {
     });
 });
 
-describe("EntityController.search", () => {
-    it("should get criteria from payload and return page from EntitySearchService", () => {
-        const entitiesPage: Contracts.Search.ResultsPage<Resources.EntityResource> = {
-            results: [entityResource1],
-            totalCount: 1,
-            meta: { totalCountIsEstimate: false },
-        };
-
-        entitySearchService.getEntitiesPage.mockReturnValueOnce(entitiesPage);
-
-        const entityController = container.resolve(EntityController);
-        const result = entityController.search({
-            query: {
-                page: 1,
-                limit: 100,
-                orderBy: ["data.name", "address"],
-            },
-            payload: [{ type: Enums.EntityType.Business }, { type: Enums.EntityType.Plugin }],
-        });
-
-        expect(entitySearchService.getEntitiesPage).toBeCalledWith(
-            { offset: 0, limit: 100 },
-            ["data.name", "address"],
-            [{ type: Enums.EntityType.Business }, { type: Enums.EntityType.Plugin }],
-        );
-
-        expect(result).toBe(entitiesPage);
-    });
-});
-
 describe("EntityController.show", () => {
     it("should get entity id from path and return entity from EntitySearchService", () => {
         entitySearchService.getEntity.mockReturnValueOnce(entityResource1);

--- a/packages/core-api/src/resources-new/delegate.ts
+++ b/packages/core-api/src/resources-new/delegate.ts
@@ -68,5 +68,5 @@ export const delegateCriteriaSchemaObject = {
     },
 };
 
-export const delegateCriteriaQuerySchema = Joi.object(delegateCriteriaSchemaObject);
+export const delegateCriteriaSchema = Schemas.createCriteriaSchema(delegateCriteriaSchemaObject);
 export const delegateSortingSchema = Schemas.createSortingSchema(delegateCriteriaSchemaObject);

--- a/packages/core-api/src/resources-new/lock.ts
+++ b/packages/core-api/src/resources-new/lock.ts
@@ -51,5 +51,5 @@ export const lockCriteriaSchemaObject = {
 };
 
 export const lockParamSchema = transactionIdSchema;
-export const lockCriteriaQuerySchema = Joi.object(lockCriteriaSchemaObject);
+export const lockCriteriaSchema = Schemas.createCriteriaSchema(lockCriteriaSchemaObject);
 export const lockSortingSchema = Schemas.createSortingSchema(lockCriteriaSchemaObject);

--- a/packages/core-api/src/resources-new/wallet.ts
+++ b/packages/core-api/src/resources-new/wallet.ts
@@ -37,5 +37,5 @@ export const walletCriteriaSchemaObject = {
 };
 
 export const walletParamSchema = Joi.alternatives(walletAddressSchema, walletPublicKeySchema, walletUsernameSchema);
-export const walletCriteriaQuerySchema = Joi.object(walletCriteriaSchemaObject);
+export const walletCriteriaSchema = Schemas.createCriteriaSchema(walletCriteriaSchemaObject);
 export const walletSortingSchema = Schemas.createSortingSchema(walletCriteriaSchemaObject, ["attributes"]);

--- a/packages/core-api/src/routes/delegates.ts
+++ b/packages/core-api/src/routes/delegates.ts
@@ -3,9 +3,9 @@ import Joi from "@hapi/joi";
 
 import { DelegatesController } from "../controllers/delegates";
 import {
-    delegateCriteriaQuerySchema,
+    delegateCriteriaSchema,
     delegateSortingSchema,
-    walletCriteriaQuerySchema,
+    walletCriteriaSchema,
     walletParamSchema,
     walletSortingSchema,
 } from "../resources-new";
@@ -22,7 +22,7 @@ export const register = (server: Hapi.Server): void => {
         options: {
             validate: {
                 query: Joi.object()
-                    .concat(delegateCriteriaQuerySchema)
+                    .concat(delegateCriteriaSchema)
                     .concat(delegateSortingSchema)
                     .concat(Schemas.pagination),
             },
@@ -54,10 +54,7 @@ export const register = (server: Hapi.Server): void => {
                 params: Joi.object({
                     id: walletParamSchema,
                 }),
-                query: Joi.object()
-                    .concat(walletCriteriaQuerySchema)
-                    .concat(walletSortingSchema)
-                    .concat(Schemas.pagination),
+                query: Joi.object().concat(walletCriteriaSchema).concat(walletSortingSchema).concat(Schemas.pagination),
             },
             plugins: {
                 pagination: { enabled: true },

--- a/packages/core-api/src/routes/locks.ts
+++ b/packages/core-api/src/routes/locks.ts
@@ -2,11 +2,7 @@ import Hapi from "@hapi/hapi";
 import Joi from "@hapi/joi";
 
 import { LocksController } from "../controllers/locks";
-import {
-    lockCriteriaQuerySchema,
-    lockParamSchema,
-    lockSortingSchema,
-} from "../resources-new";
+import { lockCriteriaSchema, lockParamSchema, lockSortingSchema } from "../resources-new";
 import * as Schemas from "../schemas";
 
 export const register = (server: Hapi.Server): void => {
@@ -19,10 +15,7 @@ export const register = (server: Hapi.Server): void => {
         handler: (request: Hapi.Request) => controller.index(request),
         options: {
             validate: {
-                query: Joi.object()
-                    .concat(lockCriteriaQuerySchema)
-                    .concat(lockSortingSchema)
-                    .concat(Schemas.pagination),
+                query: Joi.object().concat(lockCriteriaSchema).concat(lockSortingSchema).concat(Schemas.pagination),
             },
             plugins: {
                 pagination: { enabled: true },

--- a/packages/core-api/src/routes/wallets.ts
+++ b/packages/core-api/src/routes/wallets.ts
@@ -3,9 +3,9 @@ import Joi from "@hapi/joi";
 
 import { WalletsController } from "../controllers/wallets";
 import {
-    lockCriteriaQuerySchema,
+    lockCriteriaSchema,
     lockSortingSchema,
-    walletCriteriaQuerySchema,
+    walletCriteriaSchema,
     walletParamSchema,
     walletSortingSchema,
 } from "../resources-new";
@@ -21,10 +21,7 @@ export const register = (server: Hapi.Server): void => {
         handler: (request: Hapi.Request) => controller.index(request),
         options: {
             validate: {
-                query: Joi.object()
-                    .concat(walletCriteriaQuerySchema)
-                    .concat(walletSortingSchema)
-                    .concat(Schemas.pagination),
+                query: Joi.object().concat(walletCriteriaSchema).concat(walletSortingSchema).concat(Schemas.pagination),
             },
             plugins: {
                 pagination: { enabled: true },
@@ -38,10 +35,7 @@ export const register = (server: Hapi.Server): void => {
         handler: (request: Hapi.Request) => controller.top(request),
         options: {
             validate: {
-                query: Joi.object()
-                    .concat(walletCriteriaQuerySchema)
-                    .concat(walletSortingSchema)
-                    .concat(Schemas.pagination),
+                query: Joi.object().concat(walletCriteriaSchema).concat(walletSortingSchema).concat(Schemas.pagination),
             },
             plugins: {
                 pagination: { enabled: true },
@@ -71,10 +65,7 @@ export const register = (server: Hapi.Server): void => {
                 params: Joi.object({
                     id: server.app.schemas.walletId,
                 }),
-                query: Joi.object()
-                    .concat(lockCriteriaQuerySchema)
-                    .concat(lockSortingSchema)
-                    .concat(Schemas.pagination),
+                query: Joi.object().concat(lockCriteriaSchema).concat(lockSortingSchema).concat(Schemas.pagination),
             },
             plugins: {
                 pagination: { enabled: true },

--- a/packages/core-api/src/schemas.ts
+++ b/packages/core-api/src/schemas.ts
@@ -26,18 +26,16 @@ export type SchemaObject = {
     [x: string]: Joi.Schema | SchemaObject;
 };
 
-export const createCriteriaPayloadSchema = (schemaObject: SchemaObject): Joi.ArraySchema => {
-    const item = {};
+export const createCriteriaSchema = (schemaObject: SchemaObject): Joi.ObjectSchema => {
+    const schema = {};
 
     for (const [key, value] of Object.entries(schemaObject)) {
-        if (isSchema(value)) {
-            item[key] = Joi.array().single().items(value);
-        } else {
-            item[key] = createCriteriaPayloadSchema(value);
-        }
+        schema[key] = Joi.array()
+            .single()
+            .items(isSchema(value) ? value : createCriteriaSchema(value));
     }
 
-    return Joi.array().single().items(Joi.object(item));
+    return Joi.object(schema);
 };
 
 export const createRangeCriteriaSchema = (item: Joi.Schema): Joi.Schema => {

--- a/packages/core-magistrate-api/src/controllers/entities.ts
+++ b/packages/core-magistrate-api/src/controllers/entities.ts
@@ -20,14 +20,6 @@ export class EntityController extends Controller {
         return this.entitySearchService.getEntitiesPage(pagination, sorting, criteria);
     }
 
-    public search(request: Hapi.Request): Contracts.Search.ResultsPage<EntityResource> {
-        const pagination = this.getQueryPagination(request.query);
-        const sorting = request.query.orderBy as Contracts.Search.Sorting;
-        const criteria = request.payload as EntityCriteria;
-
-        return this.entitySearchService.getEntitiesPage(pagination, sorting, criteria);
-    }
-
     public show(request: Hapi.Request): { data: EntityResource } | Boom {
         const entityId = request.params.id as string;
         const entityResource = this.entitySearchService.getEntity(entityId);

--- a/packages/core-magistrate-api/src/resources/entity.ts
+++ b/packages/core-magistrate-api/src/resources/entity.ts
@@ -29,6 +29,5 @@ export const entityCriteriaSchemaObject = {
 };
 
 export const entityParamSchema = CoreResources.transactionIdSchema;
-export const entityCriteriaQuerySchema = Joi.object(entityCriteriaSchemaObject);
-export const entityCriteriaPayloadSchema = Schemas.createCriteriaPayloadSchema(entityCriteriaSchemaObject);
+export const entityCriteriaSchema = Schemas.createCriteriaSchema(entityCriteriaSchemaObject);
 export const entitySortingSchema = Schemas.createSortingSchema(entityCriteriaSchemaObject);

--- a/packages/core-magistrate-api/src/routes/entities.ts
+++ b/packages/core-magistrate-api/src/routes/entities.ts
@@ -3,12 +3,7 @@ import Hapi from "@hapi/hapi";
 import Joi from "@hapi/joi";
 
 import { EntityController } from "../controllers/entities";
-import {
-    entityCriteriaPayloadSchema,
-    entityCriteriaQuerySchema,
-    entityParamSchema,
-    entitySortingSchema,
-} from "../resources";
+import { entityCriteriaSchema, entityParamSchema, entitySortingSchema } from "../resources";
 
 export const register = (server: Hapi.Server): void => {
     const controller = server.app.app.resolve(EntityController);
@@ -20,25 +15,7 @@ export const register = (server: Hapi.Server): void => {
         handler: controller.index,
         options: {
             validate: {
-                query: Joi.object()
-                    .concat(entityCriteriaQuerySchema)
-                    .concat(entitySortingSchema)
-                    .concat(Schemas.pagination),
-            },
-            plugins: {
-                pagination: { enabled: true },
-            },
-        },
-    });
-
-    server.route({
-        method: "POST",
-        path: "/entities/search",
-        handler: controller.search,
-        options: {
-            validate: {
-                query: Joi.object().concat(entitySortingSchema).concat(Schemas.pagination),
-                payload: entityCriteriaPayloadSchema,
+                query: Joi.object().concat(entityCriteriaSchema).concat(entitySortingSchema).concat(Schemas.pagination),
             },
             plugins: {
                 pagination: { enabled: true },


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
Follow-up on #4068 to allow comma-separated api query parameter (OR) on more endpoints. (was only on transactions and blocks).
Credits to @rainydio for the changes.

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
