### PR TITLE
fix(core-state): don't throw forgetting undefined attribute

### DIFF
--- a/packages/core-kernel/src/services/attributes/attribute-map.ts
+++ b/packages/core-kernel/src/services/attributes/attribute-map.ts
@@ -38,9 +38,9 @@ export class AttributeMap {
     public get<T>(key: string, defaultValue?: T): T {
         this.assertKnown(key);
 
-        const value: T | undefined = get(this.attributes, key, defaultValue);
+        const value: T | undefined = get(this.attributes, key) ?? defaultValue;
 
-        assert.defined<AttributeMap>(value);
+        assert.defined<T>(value);
 
         return value;
     }

--- a/packages/core-state/src/wallets/wallet.ts
+++ b/packages/core-state/src/wallets/wallet.ts
@@ -95,13 +95,14 @@ export class Wallet implements Contracts.State.Wallet {
      * @memberof Wallet
      */
     public forgetAttribute(key: string): boolean {
-        const previousValue = this.attributes.has(key) ? this.attributes.get(key) : undefined;
+        const na = Symbol();
+        const previousValue = this.attributes.get(key, na);
         const wasSet = this.attributes.forget(key);
 
         this.events?.dispatchSync(WalletEvent.PropertySet, {
             publicKey: this.publicKey,
             key,
-            previousValue,
+            previousValue: previousValue === na ? undefined : previousValue,
             wallet: this,
         });
 


### PR DESCRIPTION
Including `previousValue` into event that is fired during `forgetAttribute`﻿ requires workaround to avoid error if it is `undefined`.
