### PR TITLE
fix(core-api): fix block returned by api by either id or height

### DIFF
--- a/packages/core-api/src/controllers/blocks.ts
+++ b/packages/core-api/src/controllers/blocks.ts
@@ -106,7 +106,7 @@ export class BlocksController extends Controller {
     }
 
     private getBlockCriteriaByIdOrHeight(idOrHeight: string): Contracts.Shared.OrBlockCriteria {
-        const asHeight = parseFloat(idOrHeight);
+        const asHeight = Number(idOrHeight);
         return asHeight && asHeight <= this.blockchain.getLastHeight() ? { height: asHeight } : { id: idOrHeight };
     }
 }


### PR DESCRIPTION
Use `Number()` to determine if parameter is block height﻿
