### PR TITLE
fix(core-p2p): clear hapi-nes request on timeout

### DIFF
--- a/packages/core-p2p/src/hapi-nes/client.ts
+++ b/packages/core-p2p/src/hapi-nes/client.ts
@@ -429,6 +429,7 @@ export class Client {
         if (this._settings.timeout) {
             record.timeout = setTimeout(() => {
                 record.timeout = null;
+                delete this._requests[request.id];
                 return record.reject(NesError("Request timed out", errorTypes.TIMEOUT));
             }, this._settings.timeout);
         }


### PR DESCRIPTION
## Summary

Fix for issue #4114.

Clear hapi-nes request from request list on timeout. If server response with after timeout the error is logged. 

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged