### PR TITLE
fix(core-cli): log fatal errors

### DIFF
--- a/__tests__/unit/core-cli/components/fatal.test.ts
+++ b/__tests__/unit/core-cli/components/fatal.test.ts
@@ -1,6 +1,7 @@
 import { Container } from "@arkecosystem/core-cli";
 import { Console } from "@arkecosystem/core-test-framework";
 import { Fatal } from "@packages/core-cli/src/components";
+import { white } from "kleur";
 
 let cli;
 let component;
@@ -15,6 +16,10 @@ beforeEach(() => {
 
 describe("Fatal", () => {
     it("should render the component", () => {
+        const spyLogger = jest.spyOn(cli.app.get(Container.Identifiers.Logger), "error");
+
         expect(() => component.render("Hello World")).toThrow("Hello World");
+
+        expect(spyLogger).toHaveBeenCalledWith(white().bgRed(`[ERROR] Hello World`));
     });
 });

--- a/__tests__/unit/core/commands/config-publish.test.ts
+++ b/__tests__/unit/core/commands/config-publish.test.ts
@@ -20,7 +20,7 @@ afterAll(() => setGracefulCleanup());
 describe("PublishCommand", () => {
     it("should throw if the network is invalid", async () => {
         await expect(cli.withFlags({ network: "invalid" }).execute(Command)).rejects.toThrow(
-            '[ERROR] "network" must be one of [devnet, mainnet, testnet]',
+            '"network" must be one of [devnet, mainnet, testnet]',
         );
     });
 
@@ -28,7 +28,7 @@ describe("PublishCommand", () => {
         jest.spyOn(fs, "existsSync").mockReturnValueOnce(true);
 
         await expect(cli.execute(Command)).rejects.toThrow(
-            "[ERROR] Please use the --reset flag if you wish to reset your configuration.",
+            "Please use the --reset flag if you wish to reset your configuration.",
         );
     });
 
@@ -105,7 +105,7 @@ describe("PublishCommand", () => {
         });
 
         await expect(cli.withFlags({ network: undefined }).execute(Command)).rejects.toThrow(
-            "[ERROR] You'll need to select the network to continue.",
+            "You'll need to select the network to continue.",
         );
 
         expect(spyEnsure).not.toHaveBeenCalled();
@@ -125,7 +125,7 @@ describe("PublishCommand", () => {
         });
 
         await expect(cli.withFlags({ network: undefined }).execute(Command)).rejects.toThrow(
-            "[ERROR] You'll need to confirm the network to continue.",
+            "You'll need to confirm the network to continue.",
         );
 
         expect(spyEnsure).not.toHaveBeenCalled();

--- a/__tests__/unit/core/commands/core-log.test.ts
+++ b/__tests__/unit/core/commands/core-log.test.ts
@@ -6,6 +6,6 @@ beforeEach(() => (cli = new Console()));
 
 describe("LogCommand", () => {
     it("should throw if the process does not exist", async () => {
-        await expect(cli.execute(Command)).rejects.toThrow('[ERROR] The "ark-core" process does not exist.');
+        await expect(cli.execute(Command)).rejects.toThrow('The "ark-core" process does not exist.');
     });
 });

--- a/__tests__/unit/core/commands/core-restart.test.ts
+++ b/__tests__/unit/core/commands/core-restart.test.ts
@@ -14,7 +14,7 @@ describe("RestartCommand", () => {
         const missing = jest.spyOn(processManager, "missing").mockReturnValue(true);
         const isStopped = jest.spyOn(processManager, "isStopped").mockReturnValue(false);
 
-        await expect(cli.execute(Command)).rejects.toThrowError('[ERROR] The "ark-core" process does not exist.');
+        await expect(cli.execute(Command)).rejects.toThrowError('The "ark-core" process does not exist.');
 
         missing.mockReset();
         isStopped.mockReset();
@@ -24,7 +24,7 @@ describe("RestartCommand", () => {
         const missing = jest.spyOn(processManager, "missing").mockReturnValue(false);
         const isStopped = jest.spyOn(processManager, "isStopped").mockReturnValue(true);
 
-        await expect(cli.execute(Command)).rejects.toThrowError('[ERROR] The "ark-core" process is not running.');
+        await expect(cli.execute(Command)).rejects.toThrowError('The "ark-core" process is not running.');
 
         missing.mockReset();
         isStopped.mockReset();

--- a/__tests__/unit/core/commands/core-status.test.ts
+++ b/__tests__/unit/core/commands/core-status.test.ts
@@ -13,7 +13,7 @@ beforeEach(() => {
 
 describe("StatusCommand", () => {
     it("should throw if the process does not exist", async () => {
-        await expect(cli.execute(Command)).rejects.toThrow('[ERROR] The "ark-core" process does not exist.');
+        await expect(cli.execute(Command)).rejects.toThrow('The "ark-core" process does not exist.');
     });
 
     it("should render a table with the process information", async () => {

--- a/__tests__/unit/core/commands/core-stop.test.ts
+++ b/__tests__/unit/core/commands/core-stop.test.ts
@@ -15,7 +15,7 @@ describe("StopCommand", () => {
         const isUnknown = jest.spyOn(processManager, "isUnknown").mockReturnValue(false);
         const isStopped = jest.spyOn(processManager, "isStopped").mockReturnValue(false);
 
-        await expect(cli.execute(Command)).rejects.toThrowError('[ERROR] The "ark-core" process does not exist.');
+        await expect(cli.execute(Command)).rejects.toThrowError('The "ark-core" process does not exist.');
 
         missing.mockReset();
         isUnknown.mockReset();
@@ -28,7 +28,7 @@ describe("StopCommand", () => {
         const isStopped = jest.spyOn(processManager, "isStopped").mockReturnValue(false);
 
         await expect(cli.execute(Command)).rejects.toThrowError(
-            '[ERROR] The "ark-core" process has entered an unknown state.',
+            'The "ark-core" process has entered an unknown state.',
         );
 
         missing.mockReset();
@@ -41,7 +41,7 @@ describe("StopCommand", () => {
         const isUnknown = jest.spyOn(processManager, "isUnknown").mockReturnValue(false);
         const isStopped = jest.spyOn(processManager, "isStopped").mockReturnValue(true);
 
-        await expect(cli.execute(Command)).rejects.toThrowError('[ERROR] The "ark-core" process is not running.');
+        await expect(cli.execute(Command)).rejects.toThrowError('The "ark-core" process is not running.');
 
         missing.mockReset();
         isUnknown.mockReset();

--- a/__tests__/unit/core/commands/env-list.test.ts
+++ b/__tests__/unit/core/commands/env-list.test.ts
@@ -15,7 +15,7 @@ afterAll(() => setGracefulCleanup());
 describe("ListCommand", () => {
     it("should fail if the environment configuration doesn't exist", async () => {
         await expect(cli.execute(Command)).rejects.toThrow(
-            `[ERROR] No environment file found at ${process.env.CORE_PATH_CONFIG}/.env`,
+            `No environment file found at ${process.env.CORE_PATH_CONFIG}/.env`,
         );
     });
 

--- a/__tests__/unit/core/commands/forger-log.test.ts
+++ b/__tests__/unit/core/commands/forger-log.test.ts
@@ -6,6 +6,6 @@ beforeEach(() => (cli = new Console()));
 
 describe("LogCommand", () => {
     it("should throw if the process does not exist", async () => {
-        await expect(cli.execute(Command)).rejects.toThrow('[ERROR] The "ark-forger" process does not exist.');
+        await expect(cli.execute(Command)).rejects.toThrow('The "ark-forger" process does not exist.');
     });
 });

--- a/__tests__/unit/core/commands/forger-restart.test.ts
+++ b/__tests__/unit/core/commands/forger-restart.test.ts
@@ -14,7 +14,7 @@ describe("RestartCommand", () => {
         const missing = jest.spyOn(processManager, "missing").mockReturnValue(true);
         const isStopped = jest.spyOn(processManager, "isStopped").mockReturnValue(false);
 
-        await expect(cli.execute(Command)).rejects.toThrowError('[ERROR] The "ark-forger" process does not exist.');
+        await expect(cli.execute(Command)).rejects.toThrowError('The "ark-forger" process does not exist.');
 
         missing.mockReset();
         isStopped.mockReset();
@@ -24,7 +24,7 @@ describe("RestartCommand", () => {
         const missing = jest.spyOn(processManager, "missing").mockReturnValue(false);
         const isStopped = jest.spyOn(processManager, "isStopped").mockReturnValue(true);
 
-        await expect(cli.execute(Command)).rejects.toThrowError('[ERROR] The "ark-forger" process is not running.');
+        await expect(cli.execute(Command)).rejects.toThrowError('The "ark-forger" process is not running.');
 
         missing.mockReset();
         isStopped.mockReset();

--- a/__tests__/unit/core/commands/forger-status.test.ts
+++ b/__tests__/unit/core/commands/forger-status.test.ts
@@ -13,7 +13,7 @@ beforeEach(() => {
 
 describe("StatusCommand", () => {
     it("should throw if the process does not exist", async () => {
-        await expect(cli.execute(Command)).rejects.toThrow('[ERROR] The "ark-forger" process does not exist.');
+        await expect(cli.execute(Command)).rejects.toThrow('The "ark-forger" process does not exist.');
     });
 
     it("should render a table with the process information", async () => {

--- a/__tests__/unit/core/commands/forger-stop.test.ts
+++ b/__tests__/unit/core/commands/forger-stop.test.ts
@@ -15,7 +15,7 @@ describe("StopCommand", () => {
         const isUnknown = jest.spyOn(processManager, "isUnknown").mockReturnValue(false);
         const isStopped = jest.spyOn(processManager, "isStopped").mockReturnValue(false);
 
-        await expect(cli.execute(Command)).rejects.toThrowError('[ERROR] The "ark-forger" process does not exist.');
+        await expect(cli.execute(Command)).rejects.toThrowError('The "ark-forger" process does not exist.');
 
         missing.mockReset();
         isUnknown.mockReset();
@@ -28,7 +28,7 @@ describe("StopCommand", () => {
         const isStopped = jest.spyOn(processManager, "isStopped").mockReturnValue(false);
 
         await expect(cli.execute(Command)).rejects.toThrowError(
-            '[ERROR] The "ark-forger" process has entered an unknown state.',
+            'The "ark-forger" process has entered an unknown state.',
         );
 
         missing.mockReset();
@@ -41,7 +41,7 @@ describe("StopCommand", () => {
         const isUnknown = jest.spyOn(processManager, "isUnknown").mockReturnValue(false);
         const isStopped = jest.spyOn(processManager, "isStopped").mockReturnValue(true);
 
-        await expect(cli.execute(Command)).rejects.toThrowError('[ERROR] The "ark-forger" process is not running.');
+        await expect(cli.execute(Command)).rejects.toThrowError('The "ark-forger" process is not running.');
 
         missing.mockReset();
         isUnknown.mockReset();

--- a/__tests__/unit/core/commands/manager-stop.test.ts
+++ b/__tests__/unit/core/commands/manager-stop.test.ts
@@ -15,7 +15,7 @@ describe("StopCommand", () => {
         const isUnknown = jest.spyOn(processManager, "isUnknown").mockReturnValue(false);
         const isStopped = jest.spyOn(processManager, "isStopped").mockReturnValue(false);
 
-        await expect(cli.execute(Command)).rejects.toThrowError('[ERROR] The "ark-manager" process does not exist.');
+        await expect(cli.execute(Command)).rejects.toThrowError('The "ark-manager" process does not exist.');
 
         missing.mockReset();
         isUnknown.mockReset();
@@ -28,7 +28,7 @@ describe("StopCommand", () => {
         const isStopped = jest.spyOn(processManager, "isStopped").mockReturnValue(false);
 
         await expect(cli.execute(Command)).rejects.toThrowError(
-            '[ERROR] The "ark-manager" process has entered an unknown state.',
+            'The "ark-manager" process has entered an unknown state.',
         );
 
         missing.mockReset();
@@ -41,7 +41,7 @@ describe("StopCommand", () => {
         const isUnknown = jest.spyOn(processManager, "isUnknown").mockReturnValue(false);
         const isStopped = jest.spyOn(processManager, "isStopped").mockReturnValue(true);
 
-        await expect(cli.execute(Command)).rejects.toThrowError('[ERROR] The "ark-manager" process is not running.');
+        await expect(cli.execute(Command)).rejects.toThrowError('The "ark-manager" process is not running.');
 
         missing.mockReset();
         isUnknown.mockReset();

--- a/__tests__/unit/core/commands/reinstall.test.ts
+++ b/__tests__/unit/core/commands/reinstall.test.ts
@@ -51,7 +51,7 @@ describe("ReinstallCommand", () => {
 
         prompts.inject([false]);
 
-        await expect(cli.execute(Command)).rejects.toThrow("[ERROR] You'll need to confirm the reinstall to continue.");
+        await expect(cli.execute(Command)).rejects.toThrow("You'll need to confirm the reinstall to continue.");
 
         expect(sync).not.toHaveBeenCalled();
 

--- a/__tests__/unit/core/commands/relay-log.test.ts
+++ b/__tests__/unit/core/commands/relay-log.test.ts
@@ -18,7 +18,7 @@ afterAll(() => setGracefulCleanup());
 
 describe("LogCommand", () => {
     it("should throw if the process does not exist", async () => {
-        await expect(cli.execute(Command)).rejects.toThrow('[ERROR] The "ark-relay" process does not exist.');
+        await expect(cli.execute(Command)).rejects.toThrow('The "ark-relay" process does not exist.');
     });
 
     it("should log to pm_out_log_path", async () => {

--- a/__tests__/unit/core/commands/relay-restart.test.ts
+++ b/__tests__/unit/core/commands/relay-restart.test.ts
@@ -14,7 +14,7 @@ describe("RestartCommand", () => {
         const missing = jest.spyOn(processManager, "missing").mockReturnValue(true);
         const isStopped = jest.spyOn(processManager, "isStopped").mockReturnValue(false);
 
-        await expect(cli.execute(Command)).rejects.toThrowError('[ERROR] The "ark-relay" process does not exist.');
+        await expect(cli.execute(Command)).rejects.toThrowError('The "ark-relay" process does not exist.');
 
         missing.mockReset();
         isStopped.mockReset();
@@ -24,7 +24,7 @@ describe("RestartCommand", () => {
         const missing = jest.spyOn(processManager, "missing").mockReturnValue(false);
         const isStopped = jest.spyOn(processManager, "isStopped").mockReturnValue(true);
 
-        await expect(cli.execute(Command)).rejects.toThrowError('[ERROR] The "ark-relay" process is not running.');
+        await expect(cli.execute(Command)).rejects.toThrowError('The "ark-relay" process is not running.');
 
         missing.mockReset();
         isStopped.mockReset();

--- a/__tests__/unit/core/commands/relay-status.test.ts
+++ b/__tests__/unit/core/commands/relay-status.test.ts
@@ -13,7 +13,7 @@ beforeEach(() => {
 
 describe("StatusCommand", () => {
     it("should throw if the process does not exist", async () => {
-        await expect(cli.execute(Command)).rejects.toThrow('[ERROR] The "ark-relay" process does not exist.');
+        await expect(cli.execute(Command)).rejects.toThrow('The "ark-relay" process does not exist.');
     });
 
     it("should render a table with the process information", async () => {

--- a/__tests__/unit/core/commands/relay-stop.test.ts
+++ b/__tests__/unit/core/commands/relay-stop.test.ts
@@ -15,7 +15,7 @@ describe("StopCommand", () => {
         const isUnknown = jest.spyOn(processManager, "isUnknown").mockReturnValue(false);
         const isStopped = jest.spyOn(processManager, "isStopped").mockReturnValue(false);
 
-        await expect(cli.execute(Command)).rejects.toThrow('[ERROR] The "ark-relay" process does not exist.');
+        await expect(cli.execute(Command)).rejects.toThrow('The "ark-relay" process does not exist.');
 
         missing.mockReset();
         isUnknown.mockReset();
@@ -28,7 +28,7 @@ describe("StopCommand", () => {
         const isStopped = jest.spyOn(processManager, "isStopped").mockReturnValue(false);
 
         await expect(cli.execute(Command)).rejects.toThrow(
-            '[ERROR] The "ark-relay" process has entered an unknown state.',
+            'The "ark-relay" process has entered an unknown state.',
         );
 
         missing.mockReset();
@@ -41,7 +41,7 @@ describe("StopCommand", () => {
         const isUnknown = jest.spyOn(processManager, "isUnknown").mockReturnValue(false);
         const isStopped = jest.spyOn(processManager, "isStopped").mockReturnValue(true);
 
-        await expect(cli.execute(Command)).rejects.toThrow('[ERROR] The "ark-relay" process is not running.');
+        await expect(cli.execute(Command)).rejects.toThrow('The "ark-relay" process is not running.');
 
         missing.mockReset();
         isUnknown.mockReset();

--- a/__tests__/unit/core/commands/uninstall.test.ts
+++ b/__tests__/unit/core/commands/uninstall.test.ts
@@ -6,6 +6,6 @@ beforeEach(() => (cli = new Console()));
 
 describe("UninstallCommand", () => {
     it("should throw since the command is not implemented", async () => {
-        await expect(cli.execute(Command)).rejects.toThrow("[ERROR] This command has not been implemented.");
+        await expect(cli.execute(Command)).rejects.toThrow("This command has not been implemented.");
     });
 });

--- a/packages/core-cli/src/components/fatal.ts
+++ b/packages/core-cli/src/components/fatal.ts
@@ -1,6 +1,8 @@
 import { white } from "kleur";
 
-import { injectable } from "../ioc";
+import { Identifiers, inject, injectable } from "../ioc";
+import { Logger } from "../services";
+import { Runtime } from "../exceptions";
 
 /**
  * @export
@@ -9,11 +11,21 @@ import { injectable } from "../ioc";
 @injectable()
 export class Fatal {
     /**
+     * @private
+     * @type {Logger}
+     * @memberof Command
+     */
+    @inject(Identifiers.Logger)
+    private readonly logger!: Logger;
+
+    /**
      * @static
      * @param {string} message
      * @memberof Fatal
      */
     public render(message: string): void {
-        throw new Error(white().bgRed(`[ERROR] ${message}`));
+        this.logger.error(white().bgRed(`[ERROR] ${message}`));
+
+        throw new Runtime.FatalException(message);
     }
 }

--- a/packages/core-cli/src/exceptions/base.ts
+++ b/packages/core-cli/src/exceptions/base.ts
@@ -1,0 +1,29 @@
+/**
+ * @export
+ * @class Exception
+ * @extends {Error}
+ */
+export class Exception extends Error {
+    /**
+     * Creates an instance of Exception.
+     *
+     * @param {string} message
+     * @param {string} [code]
+     * @memberof Exception
+     */
+    public constructor(message: string, code?: string) {
+        super(message);
+
+        Object.defineProperty(this, "message", {
+            enumerable: false,
+            value: code ? `${code}: ${message}` : message,
+        });
+
+        Object.defineProperty(this, "name", {
+            enumerable: false,
+            value: this.constructor.name,
+        });
+
+        Error.captureStackTrace(this, this.constructor);
+    }
+}

--- a/packages/core-cli/src/exceptions/index.ts
+++ b/packages/core-cli/src/exceptions/index.ts
@@ -1,0 +1,2 @@
+export * as Base from "./base";
+export * as Runtime from "./runtime";

--- a/packages/core-cli/src/exceptions/runtime.ts
+++ b/packages/core-cli/src/exceptions/runtime.ts
@@ -1,0 +1,15 @@
+import { Exception } from "./base";
+
+/**
+ * @export
+ * @class RuntimeException
+ * @extends {Exception}
+ */
+export class RuntimeException extends Exception {}
+
+/**
+ * @export
+ * @class OverflowException
+ * @extends {Exception}
+ */
+export class FatalException extends RuntimeException {}

--- a/packages/core/bin/run
+++ b/packages/core/bin/run
@@ -23,6 +23,19 @@ try {
     //
 }
 
-const CommandLineInterface = new (require("../dist").CommandLineInterface)(process.argv.slice(2));
+const main = async () => {
+    try {
+        const CommandLineInterface = new (require("../dist").CommandLineInterface)(process.argv.slice(2));
 
-CommandLineInterface.execute();
+        await CommandLineInterface.execute();
+    } catch (error) {
+        if (error.name !== "FatalException") {
+            console.error(error)
+        }
+
+        process.exit(1)
+    }
+}
+
+main()
+

--- a/packages/core/src/commands/env-get.ts
+++ b/packages/core/src/commands/env-get.ts
@@ -37,7 +37,11 @@ export class Command extends Commands.Command {
         this.definition
             .setFlag("token", "The name of the token.", Joi.string().default("ark"))
             .setFlag("network", "The name of the network.", Joi.string().valid(...Object.keys(Networks)))
-            .setFlag("key", "The name of the environment variable that you wish to get the value of.", Joi.string());
+            .setFlag(
+                "key",
+                "The name of the environment variable that you wish to get the value of.",
+                Joi.string().required(),
+            );
     }
 
     /**


### PR DESCRIPTION
## Summary

Fix for issue #4094.

- Log fatal errors from core-cli then throw error. 
- Require key on env:get command
- ./bin/run entry file now uses main function and exit process with status code 1 when error occurs. 

## Checklist

- [x]  Tests (if necessary)
- [x] Ready to be merged