### PR TITLE
fix(core-database): don't rollback transaction that failed to start

### DIFF
--- a/packages/core-database/src/wallets-table-service.ts
+++ b/packages/core-database/src/wallets-table-service.ts
@@ -46,14 +46,14 @@ export class WalletsTableService implements Contracts.Database.WalletsTableServi
                         .join(", ");
 
                     const query = `
-                                    INSERT INTO wallets(address, public_key, balance, nonce, attributes) VALUES
-                                        ${values}
-                                    ON CONFLICT (address) DO UPDATE SET
-                                        public_key = EXCLUDED.public_key,
-                                        balance = EXCLUDED.balance,
-                                        nonce = EXCLUDED.nonce,
-                                        attributes = EXCLUDED.attributes
-                                `;
+                        INSERT INTO wallets(address, public_key, balance, nonce, attributes) VALUES
+                            ${values}
+                        ON CONFLICT (address) DO UPDATE SET
+                            public_key = EXCLUDED.public_key,
+                            balance = EXCLUDED.balance,
+                            nonce = EXCLUDED.nonce,
+                            attributes = EXCLUDED.attributes
+                    `;
 
                     await queryRunner.query(query, params);
                 }

--- a/packages/core-database/src/wallets-table-service.ts
+++ b/packages/core-database/src/wallets-table-service.ts
@@ -11,11 +11,14 @@ export class WalletsTableService implements Contracts.Database.WalletsTableServi
 
         try {
             await queryRunner.startTransaction("SERIALIZABLE");
-            await queryRunner.query(`TRUNCATE TABLE wallets`);
-            await queryRunner.commitTransaction();
-        } catch (error) {
-            await queryRunner.rollbackTransaction();
-            throw error;
+
+            try {
+                await queryRunner.query(`TRUNCATE TABLE wallets`);
+                await queryRunner.commitTransaction();
+            } catch (error) {
+                await queryRunner.rollbackTransaction();
+                throw error;
+            }
         } finally {
             await queryRunner.release();
         }
@@ -30,34 +33,36 @@ export class WalletsTableService implements Contracts.Database.WalletsTableServi
         try {
             await queryRunner.startTransaction("SERIALIZABLE");
 
-            for (let i = 0; i < wallets.length; i += batchSize) {
-                const batchWallets = wallets.slice(i, i + batchSize);
+            try {
+                for (let i = 0; i < wallets.length; i += batchSize) {
+                    const batchWallets = wallets.slice(i, i + batchSize);
 
-                const params = batchWallets
-                    .map((w) => [w.address, w.publicKey, w.balance.toFixed(), w.nonce.toFixed(), w.getAttributes()])
-                    .flat();
+                    const params = batchWallets
+                        .map((w) => [w.address, w.publicKey, w.balance.toFixed(), w.nonce.toFixed(), w.getAttributes()])
+                        .flat();
 
-                const values = batchWallets
-                    .map((_, y) => `($${y * 5 + 1}, $${y * 5 + 2}, $${y * 5 + 3}, $${y * 5 + 4}, $${y * 5 + 5})`)
-                    .join(", ");
+                    const values = batchWallets
+                        .map((_, y) => `($${y * 5 + 1}, $${y * 5 + 2}, $${y * 5 + 3}, $${y * 5 + 4}, $${y * 5 + 5})`)
+                        .join(", ");
 
-                const query = `
-                    INSERT INTO wallets(address, public_key, balance, nonce, attributes) VALUES
-                        ${values}
-                    ON CONFLICT (address) DO UPDATE SET
-                        public_key = EXCLUDED.public_key,
-                        balance = EXCLUDED.balance,
-                        nonce = EXCLUDED.nonce,
-                        attributes = EXCLUDED.attributes
-                `;
+                    const query = `
+                                    INSERT INTO wallets(address, public_key, balance, nonce, attributes) VALUES
+                                        ${values}
+                                    ON CONFLICT (address) DO UPDATE SET
+                                        public_key = EXCLUDED.public_key,
+                                        balance = EXCLUDED.balance,
+                                        nonce = EXCLUDED.nonce,
+                                        attributes = EXCLUDED.attributes
+                                `;
 
-                await queryRunner.query(query, params);
+                    await queryRunner.query(query, params);
+                }
+
+                await queryRunner.commitTransaction();
+            } catch (error) {
+                await queryRunner.rollbackTransaction();
+                throw error;
             }
-
-            await queryRunner.commitTransaction();
-        } catch (error) {
-            await queryRunner.rollbackTransaction();
-            throw error;
         } finally {
             await queryRunner.release();
         }


### PR DESCRIPTION
## Summary

Not a real issue. `ROLLBACK TRANSACTION` was sent if `START TRANSACTION` somehow failed (it can't). Creating/releasing query runner is extracted into separate `try...finally` from commit/rollback `try...catch`.

## Checklist

- [x] Ready to be merged