### PR TITLE
fix(core-database): set adequate autovacuum settings

### DIFF
--- a/packages/core-database/src/migrations/20201103000000-set-autovacuum-settings.ts
+++ b/packages/core-database/src/migrations/20201103000000-set-autovacuum-settings.ts
@@ -23,6 +23,13 @@ export class SetAutovacuumSettings20201103000000 implements MigrationInterface {
                 autovacuum_vacuum_threshold = 10000,
                 autovacuum_analyze_threshold = 10000
             );
+
+            ALTER TABLE rounds SET (
+                autovacuum_vacuum_scale_factor = 0,
+                autovacuum_analyze_scale_factor = 0,
+                autovacuum_vacuum_threshold = 10000,
+                autovacuum_analyze_threshold = 10000
+            );
         `);
     }
 
@@ -43,6 +50,13 @@ export class SetAutovacuumSettings20201103000000 implements MigrationInterface {
             );
 
             ALTER TABLE wallets SET (
+                autovacuum_vacuum_scale_factor = 0.2,
+                autovacuum_analyze_scale_factor = 0.1,
+                autovacuum_vacuum_threshold = 50,
+                autovacuum_analyze_threshold = 50
+            );
+
+            ALTER TABLE rounds SET (
                 autovacuum_vacuum_scale_factor = 0.2,
                 autovacuum_analyze_scale_factor = 0.1,
                 autovacuum_vacuum_threshold = 50,

--- a/packages/core-database/src/migrations/20201103000000-set-autovacuum-settings.ts
+++ b/packages/core-database/src/migrations/20201103000000-set-autovacuum-settings.ts
@@ -1,0 +1,53 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class SetAutovacuumSettings20201103000000 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query(`
+            ALTER TABLE blocks SET (
+                autovacuum_vacuum_scale_factor = 0,
+                autovacuum_analyze_scale_factor = 0,
+                autovacuum_vacuum_threshold = 10000,
+                autovacuum_analyze_threshold = 10000
+            );
+
+            ALTER TABLE transactions SET (
+                autovacuum_vacuum_scale_factor = 0,
+                autovacuum_analyze_scale_factor = 0,
+                autovacuum_vacuum_threshold = 10000,
+                autovacuum_analyze_threshold = 10000
+            );
+
+            ALTER TABLE wallets SET (
+                autovacuum_vacuum_scale_factor = 0,
+                autovacuum_analyze_scale_factor = 0,
+                autovacuum_vacuum_threshold = 10000,
+                autovacuum_analyze_threshold = 10000
+            );
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query(`
+            ALTER TABLE blocks SET (
+                autovacuum_vacuum_scale_factor = 0.2,
+                autovacuum_analyze_scale_factor = 0.1,
+                autovacuum_vacuum_threshold = 50,
+                autovacuum_analyze_threshold = 50
+            );
+
+            ALTER TABLE transactions SET (
+                autovacuum_vacuum_scale_factor = 0.2,
+                autovacuum_analyze_scale_factor = 0.1,
+                autovacuum_vacuum_threshold = 50,
+                autovacuum_analyze_threshold = 50
+            );
+
+            ALTER TABLE wallets SET (
+                autovacuum_vacuum_scale_factor = 0.2,
+                autovacuum_analyze_scale_factor = 0.1,
+                autovacuum_vacuum_threshold = 50,
+                autovacuum_analyze_threshold = 50
+            );
+        `);
+    }
+}


### PR DESCRIPTION
## Summary

Autovacuuming (and `ANALYZE`) wasn't performed frequently enough because default values of `autovacuum_vacuum_scale_factor` and `autovacuum_analyze_scale_factor` are to high.

## Checklist

- [x] Ready to be merged