### PR TITLE
fix(core-api): add request.method in cache key

### DIFF
--- a/packages/core-api/src/plugins/cache.ts
+++ b/packages/core-api/src/plugins/cache.ts
@@ -9,6 +9,7 @@ const generateCacheKey = (request: Hapi.Request): string =>
             params: request.params || {},
             payload: request.payload || {},
             query: request.query,
+            method: request.method,
         }),
     ).toString("hex");
 


### PR DESCRIPTION
## Summary

Include request.method name into cache key generator. This fixes issue on some clients and create separate cache for OPTIONS and GET method on the same route path.

## Checklist

- [x] Ready to be merged