### PR TITLE
fix(core-p2p): remove `transactions` field from block when requesting with `headersOnly`

### DIFF
--- a/packages/core-p2p/src/peer-communicator.ts
+++ b/packages/core-p2p/src/peer-communicator.ts
@@ -175,7 +175,10 @@ export class PeerCommunicator implements Contracts.P2P.PeerCommunicator {
         }
 
         for (const block of peerBlocks) {
-            if (!block.transactions) {
+            if (headersOnly) {
+                // with headersOnly we still get block.transactions as empty array (protobuf deser) but in this case we actually
+                // don't want the transactions as a property at all (because it would make validation fail)
+                delete block.transactions;
                 continue;
             }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
Fixes #4167 .

Remove `transactions` field from block when requesting with `headersOnly`, as now ser/deserializing with protobuf sets default `transactions` field to empty array when we expect it to be undefined.
<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
