### PR TITLE
refactor(core-manager): get version channel from core-cli config

### DIFF
--- a/__tests__/unit/core-manager/action-reader.test.ts
+++ b/__tests__/unit/core-manager/action-reader.test.ts
@@ -13,6 +13,7 @@ beforeEach(() => {
 
     sandbox.app.bind(Identifiers.ActionReader).to(ActionReader).inSingletonScope();
     sandbox.app.bind(Identifiers.CliManager).toConstantValue({});
+    sandbox.app.bind(Identifiers.CLI).toConstantValue({});
     sandbox.app.bind(Identifiers.SnapshotsManager).toConstantValue({});
     sandbox.app.bind(Identifiers.WatcherDatabaseService).toConstantValue({});
     sandbox.app.bind(Container.Identifiers.PluginConfiguration).toConstantValue({});

--- a/__tests__/unit/core-manager/actions/info-core-version.test.ts
+++ b/__tests__/unit/core-manager/actions/info-core-version.test.ts
@@ -3,14 +3,24 @@ import "jest-extended";
 import { Sandbox } from "@packages/core-test-framework";
 import { Container } from "@packages/core-kernel";
 import { Action } from "@packages/core-manager/src/actions/info-core-version";
+import { Identifiers } from "@packages/core-manager/src/ioc";
 
 let sandbox: Sandbox;
 let action: Action;
 
+const mockCliConfig = {
+    get: jest.fn().mockReturnValue("next"),
+};
+
+const mockCli = {
+    resolve: jest.fn().mockReturnValue(mockCliConfig),
+};
+
 beforeEach(() => {
     sandbox = new Sandbox();
 
-    sandbox.app.bind(Container.Identifiers.ApplicationVersion).toConstantValue("@arkecosystem/core");
+    sandbox.app.bind(Container.Identifiers.ApplicationVersion).toConstantValue("3.0.0");
+    sandbox.app.bind(Identifiers.CLI).toConstantValue(mockCli);
 
     action = sandbox.app.resolve(Action);
 });
@@ -27,20 +37,7 @@ describe("Info:CoreVersion", () => {
 
         const result = await promise;
 
-        await expect(result.currentVersion).toBe("@arkecosystem/core");
-        await expect(result.latestVersion).toBeString();
-    });
-
-    it("should return current and latest version using channel", async () => {
-        sandbox.app.rebind(Container.Identifiers.ApplicationVersion).toConstantValue("@arkecosystem/core-next");
-
-        const promise = action.execute({});
-
-        await expect(promise).toResolve();
-
-        const result = await promise;
-
-        await expect(result.currentVersion).toBe("@arkecosystem/core-next");
+        await expect(result.currentVersion).toBe("3.0.0");
         await expect(result.latestVersion).toBeString();
     });
 });

--- a/packages/core-manager/src/actions/info-core-version.ts
+++ b/packages/core-manager/src/actions/info-core-version.ts
@@ -1,12 +1,17 @@
+import * as Cli from "@arkecosystem/core-cli";
 import { Application, Container } from "@arkecosystem/core-kernel";
 import latestVersion from "latest-version";
 
 import { Actions } from "../contracts";
+import { Identifiers } from "../ioc";
 
 @Container.injectable()
 export class Action implements Actions.Action {
     @Container.inject(Container.Identifiers.Application)
     private readonly app!: Application;
+
+    @Container.inject(Identifiers.CLI)
+    private readonly cli!: Cli.Application;
 
     public name = "info.coreVersion";
 
@@ -24,15 +29,7 @@ export class Action implements Actions.Action {
     }
 
     private getChannel(): string {
-        const channels: string[] = ["next"];
-
-        let channel = "latest";
-        for (const item of channels) {
-            if (this.app.version().includes(`-${item}`)) {
-                channel = item;
-            }
-        }
-
-        return channel;
+        const config = this.cli.resolve(Cli.Services.Config);
+        return config.get("channel");
     }
 }

--- a/packages/core-manager/src/actions/info-core-version.ts
+++ b/packages/core-manager/src/actions/info-core-version.ts
@@ -29,7 +29,6 @@ export class Action implements Actions.Action {
     }
 
     private getChannel(): string {
-        const config = this.cli.resolve(Cli.Services.Config);
-        return config.get("channel");
+        return this.cli.resolve(Cli.Services.Config).get("channel");
     }
 }


### PR DESCRIPTION
## Summary

Get version channel from core-cli config to remove code duplication.

## Checklist
- [x] Tests
- [x] Ready to be merged