### PR TITLE
refactor(core-p2p): re-organize plugins in hapi lifecycle

### DIFF
--- a/__tests__/unit/core-p2p/socket-server/plugins/is-app-ready.test.ts
+++ b/__tests__/unit/core-p2p/socket-server/plugins/is-app-ready.test.ts
@@ -54,7 +54,7 @@ describe("IsAppReadyPlugin", () => {
 
         isAppReadyPlugin.register(server);
 
-        expect(spyExt).toBeCalledWith(expect.objectContaining({ type: "onPreHandler" }));
+        expect(spyExt).toBeCalledWith(expect.objectContaining({ type: "onRequest" }));
 
         // try the route with a valid payload
         const remoteAddress = "187.166.55.44";
@@ -129,7 +129,7 @@ describe("IsAppReadyPlugin", () => {
 
         isAppReadyPlugin.register(server);
 
-        expect(spyExt).toBeCalledWith(expect.objectContaining({ type: "onPreHandler" }));
+        expect(spyExt).toBeCalledWith(expect.objectContaining({ type: "onRequest" }));
 
         // try the route with a valid payload
         const remoteAddress = "187.166.55.44";

--- a/__tests__/unit/core-p2p/socket-server/plugins/whitelist-forger.test.ts
+++ b/__tests__/unit/core-p2p/socket-server/plugins/whitelist-forger.test.ts
@@ -61,7 +61,7 @@ describe("WhitelistForgerPlugin", () => {
 
         whitelistForgerPlugin.register(server);
 
-        expect(spyExt).toBeCalledWith(expect.objectContaining({ type: "onPreHandler" }));
+        expect(spyExt).toBeCalledWith(expect.objectContaining({ type: "onPreAuth" }));
     });
 
     it("should authorize default whitelisted IPs", async () => {
@@ -72,7 +72,7 @@ describe("WhitelistForgerPlugin", () => {
 
         whitelistForgerPlugin.register(server);
 
-        expect(spyExt).toBeCalledWith(expect.objectContaining({ type: "onPreHandler" }));
+        expect(spyExt).toBeCalledWith(expect.objectContaining({ type: "onPreAuth" }));
 
         // try the route with a valid remoteAddress
         const remoteAddress = defaults.remoteAccess[0];
@@ -96,7 +96,7 @@ describe("WhitelistForgerPlugin", () => {
 
         whitelistForgerPlugin.register(server);
 
-        expect(spyExt).toBeCalledWith(expect.objectContaining({ type: "onPreHandler" }));
+        expect(spyExt).toBeCalledWith(expect.objectContaining({ type: "onPreAuth" }));
 
         // try the route with an invalid remoteAddress
         const remoteAddress = "187.166.55.44";
@@ -137,7 +137,7 @@ describe("WhitelistForgerPlugin", () => {
 
         whitelistForgerPlugin.register(server);
 
-        expect(spyExt).toBeCalledWith(expect.objectContaining({ type: "onPreHandler" }));
+        expect(spyExt).toBeCalledWith(expect.objectContaining({ type: "onPreAuth" }));
 
         // try the route with a valid remoteAddress
         const remoteAddress = defaults.remoteAccess[0];

--- a/packages/core-p2p/src/socket-server/plugins/accept-peer.ts
+++ b/packages/core-p2p/src/socket-server/plugins/accept-peer.ts
@@ -23,7 +23,7 @@ export class AcceptPeerPlugin {
         const peerProcessor = this.peerProcessor;
 
         server.ext({
-            type: "onPostResponse",
+            type: "onPostAuth",
             async method(request, h) {
                 if (routesConfigByPath[request.path]) {
                     const peerIp = request.socket ? getPeerIp(request.socket) : request.info.remoteAddress;

--- a/packages/core-p2p/src/socket-server/plugins/accept-peer.ts
+++ b/packages/core-p2p/src/socket-server/plugins/accept-peer.ts
@@ -23,7 +23,7 @@ export class AcceptPeerPlugin {
         const peerProcessor = this.peerProcessor;
 
         server.ext({
-            type: "onPostAuth",
+            type: "onPreHandler",
             async method(request, h) {
                 if (routesConfigByPath[request.path]) {
                     const peerIp = request.socket ? getPeerIp(request.socket) : request.info.remoteAddress;

--- a/packages/core-p2p/src/socket-server/plugins/accept-peer.ts
+++ b/packages/core-p2p/src/socket-server/plugins/accept-peer.ts
@@ -2,6 +2,8 @@ import { Container, Contracts } from "@arkecosystem/core-kernel";
 
 import { PeerRoute } from "../routes/peer";
 import { getPeerIp } from "../../utils/get-peer-ip";
+import { BlocksRoute } from "../routes/blocks";
+import { TransactionsRoute } from "../routes/transactions";
 
 @Container.injectable()
 export class AcceptPeerPlugin {
@@ -12,13 +14,18 @@ export class AcceptPeerPlugin {
     private readonly peerProcessor!: Contracts.P2P.PeerProcessor;
 
     public register(server) {
-        const peerRoutesConfigByPath = this.app.resolve(PeerRoute).getRoutesConfigByPath();
+        // try to add peer when receiving request on all routes except internal
+        const routesConfigByPath = {
+            ...this.app.resolve(PeerRoute).getRoutesConfigByPath(),
+            ...this.app.resolve(BlocksRoute).getRoutesConfigByPath(),
+            ...this.app.resolve(TransactionsRoute).getRoutesConfigByPath(),
+        };
         const peerProcessor = this.peerProcessor;
 
         server.ext({
-            type: "onPreHandler",
+            type: "onPostResponse",
             async method(request, h) {
-                if (peerRoutesConfigByPath[request.path]) {
+                if (routesConfigByPath[request.path]) {
                     const peerIp = request.socket ? getPeerIp(request.socket) : request.info.remoteAddress;
                     peerProcessor.validateAndAcceptPeer({ ip: peerIp } as Contracts.P2P.Peer);
                 }

--- a/packages/core-p2p/src/socket-server/plugins/is-app-ready.ts
+++ b/packages/core-p2p/src/socket-server/plugins/is-app-ready.ts
@@ -8,7 +8,7 @@ export class IsAppReadyPlugin {
 
     public register(server) {
         server.ext({
-            type: "onPreHandler",
+            type: "onRequest",
             method: async (request, h) => {
                 if (
                     this.app.isBound(Container.Identifiers.BlockchainService) &&

--- a/packages/core-p2p/src/socket-server/plugins/whitelist-forger.ts
+++ b/packages/core-p2p/src/socket-server/plugins/whitelist-forger.ts
@@ -16,7 +16,7 @@ export class WhitelistForgerPlugin {
         const peerProcessor = this.peerProcessor;
 
         server.ext({
-            type: "onPreHandler",
+            type: "onPreAuth",
             async method(request, h) {
                 if (peerRoutesConfigByPath[request.path]) {
                     if (peerProcessor.isWhitelisted({ ip: request.info.remoteAddress } as Contracts.P2P.Peer)) {

--- a/packages/core-p2p/src/socket-server/server.ts
+++ b/packages/core-p2p/src/socket-server/server.ts
@@ -80,6 +80,8 @@ export class Server {
         // onPostAuth
         this.app.resolve(CodecPlugin).register(this.server);
         this.app.resolve(ValidatePlugin).register(this.server);
+
+        // onPreHandler
         this.app.resolve(AcceptPeerPlugin).register(this.server);
     }
 

--- a/packages/core-p2p/src/socket-server/server.ts
+++ b/packages/core-p2p/src/socket-server/server.ts
@@ -66,16 +66,22 @@ export class Server {
             }
         });
 
-        this.app.resolve(IsAppReadyPlugin).register(this.server);
-        this.app.resolve(CodecPlugin).register(this.server);
-        this.app.resolve(ValidatePlugin).register(this.server);
-
         this.app.resolve(InternalRoute).register(this.server);
         this.app.resolve(PeerRoute).register(this.server);
         this.app.resolve(BlocksRoute).register(this.server);
         this.app.resolve(TransactionsRoute).register(this.server);
 
+        // onRequest
+        this.app.resolve(IsAppReadyPlugin).register(this.server);
+
+        // onPreAuth
         this.app.resolve(WhitelistForgerPlugin).register(this.server);
+
+        // onPostAuth
+        this.app.resolve(CodecPlugin).register(this.server);
+        this.app.resolve(ValidatePlugin).register(this.server);
+
+        // onPostResponse
         this.app.resolve(AcceptPeerPlugin).register(this.server);
     }
 

--- a/packages/core-p2p/src/socket-server/server.ts
+++ b/packages/core-p2p/src/socket-server/server.ts
@@ -80,8 +80,6 @@ export class Server {
         // onPostAuth
         this.app.resolve(CodecPlugin).register(this.server);
         this.app.resolve(ValidatePlugin).register(this.server);
-
-        // onPostResponse
         this.app.resolve(AcceptPeerPlugin).register(this.server);
     }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
Re-organize plugins in hapi lifecycle so that it makes more sense.

Also updated a bit AcceptPeerPlugin to be triggered on peer, blocks and transactions routes (all except internal). Might resolve #4124 .
<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
