### PR TITLE
fix(core): generate genesis block with id full sha256

### DIFF
--- a/__tests__/unit/crypto/validation/keywords.test.ts
+++ b/__tests__/unit/crypto/validation/keywords.test.ts
@@ -101,10 +101,10 @@ describe("keyword blockId", () => {
         expect(validate({ height: 1, previousBlock: "" })).toBeTrue();
         expect(validate({ height: 1, previousBlock: undefined })).toBeTrue();
         expect(validate({ height: 1, previousBlock: 0 })).toBeTrue();
+        expect(validate({ height: 1, previousBlock: "1234" })).toBeTrue();
 
         expect(validate({ height: 1, previousBlock: "abc" })).toBeFalse();
         expect(validate({ height: 1, previousBlock: {} })).toBeFalse();
-        expect(validate({ height: 1, previousBlock: "1234" })).toBeFalse();
 
         expect(validate({ height: 2, previousBlock: "" })).toBeFalse();
         expect(validate({ height: 2, previousBlock: 0 })).toBeFalse();

--- a/packages/crypto/src/blocks/block.ts
+++ b/packages/crypto/src/blocks/block.ts
@@ -292,6 +292,6 @@ export class Block implements IBlock {
 
     private applyGenesisBlockFix(id: string): void {
         this.data.id = id;
-        this.data.idHex = Block.toBytesHex(id);
+        this.data.idHex = id.length === 64 ? id : Block.toBytesHex(id); // if id.length is 64 it's already hex
     }
 }

--- a/packages/crypto/src/validation/keywords.ts
+++ b/packages/crypto/src/validation/keywords.ts
@@ -135,7 +135,9 @@ const blockId = (ajv: Ajv) => {
         compile(schema) {
             return (data, dataPath, parentObject: any) => {
                 if (parentObject && parentObject.height === 1 && schema.allowNullWhenGenesis) {
-                    return !data || Number(data) === 0;
+                    if (!data || Number(data) === 0) {
+                        return true;
+                    }
                 }
 
                 if (typeof data !== "string") {
@@ -149,7 +151,7 @@ const blockId = (ajv: Ajv) => {
 
                 if (parentObject && parentObject.height) {
                     const height = schema.isPreviousBlock ? parentObject.height - 1 : parentObject.height;
-                    const constants = configManager.getMilestone(height);
+                    const constants = configManager.getMilestone(height ?? 1); // if height === 0 set it to 1
                     return constants.block.idFullSha256 ? isFullSha256 : isPartial;
                 }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
Generate a genesis block with full sha256 is now that `idFullSha256` is set from height 1.

Needed some adjustments in crypto too.

Changed schema so that genesis block can be allowed to have a previous block : can seem weird but actually can make sense in my opinion so that we can build and serialize a genesis block like a normal block. In `network:generate` command as an example we set the previous block to `00000...` and we can then serialize with crypto methods without issue.
<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
