### PR TITLE
fix(core-state): detect missed blocks

### DIFF
--- a/packages/core-state/src/database-interactions.ts
+++ b/packages/core-state/src/database-interactions.ts
@@ -96,11 +96,11 @@ export class DatabaseInteraction {
     }
 
     public async applyBlock(block: Interfaces.IBlock): Promise<void> {
+        await this.detectMissedBlocks(block);
+
         await this.blockState.applyBlock(block);
 
         this.blocksInCurrentRound.push(block);
-
-        await this.detectMissedBlocks(block);
 
         await this.applyRound(block.data.height);
 


### PR DESCRIPTION
## Summary

Fix issue #4089

Detect missed blocks before applying block. After latest changes in core-state blocks are set in apply method and check needs to execute before applying. 

## Checklist
- [x] Ready to be merged