### PR TITLE
feat(core-manager): store logs in sqlite database

### DIFF
--- a/__tests__/unit/core-manager/action-reader.test.ts
+++ b/__tests__/unit/core-manager/action-reader.test.ts
@@ -16,7 +16,9 @@ beforeEach(() => {
     sandbox.app.bind(Identifiers.CLI).toConstantValue({});
     sandbox.app.bind(Identifiers.SnapshotsManager).toConstantValue({});
     sandbox.app.bind(Identifiers.WatcherDatabaseService).toConstantValue({});
+    sandbox.app.bind(Identifiers.LogsDatabaseService).toConstantValue({});
     sandbox.app.bind(Container.Identifiers.PluginConfiguration).toConstantValue({});
+    sandbox.app.bind(Container.Identifiers.ConfigFlags).toConstantValue({});
     sandbox.app.bind(Container.Identifiers.FilesystemService).toConstantValue({});
 
     actionReader = sandbox.app.get<ActionReader>(Identifiers.ActionReader);

--- a/__tests__/unit/core-manager/actions/log-search.test.ts
+++ b/__tests__/unit/core-manager/actions/log-search.test.ts
@@ -1,52 +1,22 @@
 import "jest-extended";
 
-import { Container } from "@packages/core-kernel";
 import { Action } from "@packages/core-manager/src/actions/log-search";
+import { Identifiers } from "@packages/core-manager/src/ioc";
 import { Sandbox } from "@packages/core-test-framework";
-import fs from "fs";
-import readline from "readline";
 
 let sandbox: Sandbox;
 let action: Action;
 
-let logs;
-let mockFilesystem;
-let mockReadline;
+let logDatabaseService;
 
 beforeEach(() => {
-    logs = [
-        "[2020-11-17 14:11:50.689] [32mINFO [39m: [36mConnecting to database: ark_testnet[39m\n",
-        "[2020-11-17 14:11:50.796] [34mDEBUG[39m: [36mConnection established.[39m\n",
-        "[2020-11-18 14:11:51.238] [32mINFO [39m: [36mP2P Server P2P server started at http://127.0.0.1:4000[39m\n",
-    ];
-
-    mockFilesystem = {
-        exists: jest.fn().mockReturnValue(true),
+    logDatabaseService = {
+        search: jest.fn(),
     };
-
-    mockReadline = {
-        [Symbol.asyncIterator]() {
-            let i = 0;
-
-            return {
-                async next() {
-                    if (i < logs.length) {
-                        return { value: logs[i++] };
-                    }
-                    return { done: true };
-                },
-            };
-        },
-        close: jest.fn(),
-    };
-
-    // @ts-ignore
-    jest.spyOn(readline, "createInterface").mockReturnValue(mockReadline);
-    jest.spyOn(fs, "createReadStream").mockImplementation();
 
     sandbox = new Sandbox();
 
-    sandbox.app.bind(Container.Identifiers.FilesystemService).toConstantValue(mockFilesystem);
+    sandbox.app.bind(Identifiers.LogsDatabaseService).toConstantValue(logDatabaseService);
 
     action = sandbox.app.resolve(Action);
 });
@@ -56,102 +26,9 @@ describe("Log:Search", () => {
         expect(action.name).toEqual("log.search");
     });
 
-    it("should throw when log does not exist", async () => {
-        mockFilesystem.exists.mockReturnValue(false);
-
-        // @ts-ignore
-        await expect(action.execute({})).rejects.toThrowError("Cannot find log file");
-    });
-
     it("should return lines from out log", async () => {
-        // @ts-ignore
-        const result = await action.execute({});
+        await action.execute({});
 
-        await expect(result).toBeArray();
-        await expect(result.length).toEqual(3);
-        await expect(result[0]).toEqual({
-            timestamp: expect.toBeNumber(),
-            level: "INFO",
-            content: expect.toInclude("Connecting to database: ark_testnet"),
-        });
-
-        expect(mockFilesystem.exists).toHaveBeenCalledWith(expect.toInclude("ark-core-out.log"));
-    });
-
-    it("should return lines from error log", async () => {
-        // @ts-ignore
-        const result = await action.execute({ useErrorLog: true });
-
-        await expect(result).toBeArray();
-        await expect(result.length).toEqual(3);
-
-        expect(mockFilesystem.exists).toHaveBeenCalledWith(expect.toInclude("ark-core-error.log"));
-    });
-
-    it("should return lines when log line doesnt contains timestamp and log level", async () => {
-        logs = ["line to test"];
-
-        // @ts-ignore
-        const result = await action.execute({});
-
-        await expect(result).toBeArray();
-        await expect(result.length).toEqual(1);
-        await expect(result[0]).toEqual({
-            timestamp: undefined,
-            level: undefined,
-            content: "line to test",
-        });
-    });
-
-    it("should filter lines by log level", async () => {
-        // @ts-ignore
-        const result = await action.execute({ logLevel: "info" });
-
-        await expect(result).toBeArray();
-        await expect(result.length).toEqual(2);
-    });
-
-    it("should filter lines by dateFrom", async () => {
-        // @ts-ignore
-        const result = await action.execute({ dateFrom: 1605657600 });
-
-        await expect(result).toBeArray();
-        await expect(result.length).toEqual(1);
-    });
-
-    it("should filter lines by dateTo", async () => {
-        // @ts-ignore
-        const result = await action.execute({ dateTo: 1605657600 });
-
-        await expect(result).toBeArray();
-        await expect(result.length).toEqual(2);
-    });
-
-    it("should skip lines if date time is unrecognized", async () => {
-        logs = ["unrecognized datetime", "unrecognized datetime", "unrecognized datetime"];
-
-        // @ts-ignore
-        const result = await action.execute({ dateTo: 1605657600 });
-
-        await expect(result).toBeArray();
-        await expect(result.length).toEqual(0);
-    });
-
-    it("should filter lines by search string", async () => {
-        // @ts-ignore
-        const result = await action.execute({ contains: "database" });
-
-        await expect(result).toBeArray();
-        await expect(result.length).toEqual(1);
-    });
-
-    it("should limit response to 100 lines", async () => {
-        logs = new Array(200).fill(logs).flat();
-
-        // @ts-ignore
-        const result = await action.execute();
-
-        await expect(result).toBeArray();
-        await expect(result.length).toEqual(100);
+        expect(logDatabaseService.search).toHaveBeenCalledTimes(1);
     });
 });

--- a/__tests__/unit/core-manager/database/logs-database-service.test.ts
+++ b/__tests__/unit/core-manager/database/logs-database-service.test.ts
@@ -1,0 +1,169 @@
+import "jest-extended";
+
+import { Container } from "@arkecosystem/core-kernel";
+// import { Database } from "@arkecosystem/core-manager/src/database/database";
+import { LogsDatabaseService } from "@arkecosystem/core-manager/src/database/logs-database-service";
+import { Sandbox } from "@arkecosystem/core-test-framework";
+import { existsSync } from "fs-extra";
+import { dirSync, setGracefulCleanup } from "tmp";
+
+let database: LogsDatabaseService;
+let storagePath: string;
+let sandbox: Sandbox;
+let configuration: any;
+
+beforeEach(() => {
+    storagePath = dirSync().name + "/logs.sqlite";
+
+    configuration = {
+        getRequired: jest.fn().mockReturnValue({
+            storage: storagePath,
+            resetDatabase: false,
+        }),
+    };
+
+    sandbox = new Sandbox();
+
+    sandbox.app.bind(Container.Identifiers.PluginConfiguration).toConstantValue(configuration);
+
+    database = sandbox.app.resolve(LogsDatabaseService);
+});
+
+afterEach(() => {
+    setGracefulCleanup();
+
+    jest.clearAllMocks();
+    jest.resetAllMocks();
+});
+
+describe("LogsDatabaseService", () => {
+    describe("Boot", () => {
+        it("should boot and create file", async () => {
+            database.boot();
+            expect(existsSync(storagePath)).toBeTrue();
+        });
+
+        // it("should boot, create file and flush", async () => {
+        //     const spyOnFlush = jest.spyOn(Database.prototype, "flush");
+        //
+        //     configuration.getRequired = jest.fn().mockReturnValue({
+        //         storage: storagePath,
+        //         resetDatabase: true,
+        //     });
+        //
+        //     database.boot();
+        //     expect(existsSync(storagePath)).toBeTrue();
+        //
+        //     expect(spyOnFlush).toHaveBeenCalledTimes(1);
+        // });
+        //
+        // it("should boot without watcher storage in defaults", async () => {
+        //     configuration.getRequired = jest.fn().mockReturnValue({});
+        //
+        //     storagePath = dirSync().name;
+        //     process.env.CORE_PATH_DATA = storagePath;
+        //
+        //     database.boot();
+        //
+        //     expect(existsSync(storagePath + "/events.sqlite")).toBeTrue();
+        // });
+    });
+
+    describe("Dispose", () => {
+        it("should dispose", async () => {
+            database.boot();
+            database.dispose();
+
+            expect(() => {
+                database.add("info", "log content");
+            }).toThrowError();
+        });
+    });
+
+    describe("Add", () => {
+        it("should add log", async () => {
+            database.boot();
+            expect(existsSync(storagePath)).toBeTrue();
+
+            database.add("info", "content");
+
+            const result = database.find().data;
+
+            expect(result).toBeArray();
+            expect(result[0]).toMatchObject({
+                id: 1,
+                level: "info",
+                content: "content",
+            });
+
+            expect(result[0].timestamp).toBeDefined();
+        });
+    });
+
+    describe("Query", () => {
+        beforeEach(() => {
+            database.boot();
+
+            for (let i = 0; i < 100; i++) {
+                database.add("info", "info content");
+                database.add("warning", "warning content");
+            }
+        });
+
+        it("should return all", async () => {
+            const result = database.find({ $limit: 1000 });
+
+            expect(result.total).toBe(200);
+            expect(result.limit).toBe(1000);
+            expect(result.offset).toBe(0);
+            expect(result.data).toBeArray();
+            expect(result.data.length).toBe(200);
+        });
+
+        it("should filter by log type", async () => {
+            const result = database.find({ $limit: 1000, level: "info" });
+
+            expect(result.total).toBe(100);
+            expect(result.limit).toBe(1000);
+            expect(result.offset).toBe(0);
+            expect(result.data).toBeArray();
+            expect(result.data.length).toBe(100);
+        });
+
+        it("should filter by content", async () => {
+            const result = database.find({ $limit: 1000, content: "info content" });
+
+            expect(result.total).toBe(100);
+            expect(result.limit).toBe(1000);
+            expect(result.offset).toBe(0);
+            expect(result.data).toBeArray();
+            expect(result.data.length).toBe(100);
+        });
+
+        it("should search in content", async () => {
+            const result = database.find({ $limit: 1000, content: { $like: "%nfo%" } });
+
+            expect(result.total).toBe(100);
+            expect(result.limit).toBe(1000);
+            expect(result.offset).toBe(0);
+            expect(result.data).toBeArray();
+            expect(result.data.length).toBe(100);
+        });
+
+        it("should search by datetime", () => {
+            // @ts-ignore
+            database.database.exec(`UPDATE logs SET timestamp = '2016-01-02 00:00:00.000' WHERE id = 1`);
+
+            const result = database.find({
+                $limit: 1000,
+                timestamp: { $gte: "2016-01-01 00:00:00.000", $lte: "2016-01-03 00:00:00.000" },
+            });
+
+            expect(result.total).toBe(1);
+            expect(result.limit).toBe(1000);
+            expect(result.offset).toBe(0);
+            expect(result.data).toBeArray();
+            expect(result.data.length).toBe(1);
+        });
+    });
+});

--- a/__tests__/unit/core-manager/database/logs-database-service.test.ts
+++ b/__tests__/unit/core-manager/database/logs-database-service.test.ts
@@ -10,10 +10,15 @@ import { dirSync, setGracefulCleanup } from "tmp";
 let database: LogsDatabaseService;
 let storagePath: string;
 let sandbox: Sandbox;
+let configFlags: any;
 let configuration: any;
 
 beforeEach(() => {
     storagePath = dirSync().name + "/logs.sqlite";
+
+    configFlags = {
+        processType: "core",
+    };
 
     configuration = {
         getRequired: jest.fn().mockReturnValue({
@@ -24,6 +29,7 @@ beforeEach(() => {
 
     sandbox = new Sandbox();
 
+    sandbox.app.bind(Container.Identifiers.ConfigFlags).toConstantValue(configFlags);
     sandbox.app.bind(Container.Identifiers.PluginConfiguration).toConstantValue(configuration);
 
     database = sandbox.app.resolve(LogsDatabaseService);
@@ -92,6 +98,7 @@ describe("LogsDatabaseService", () => {
             expect(result).toBeArray();
             expect(result[0]).toMatchObject({
                 id: 1,
+                process: "core",
                 level: "info",
                 content: "content",
             });

--- a/__tests__/unit/core-manager/database/logs-database-service.test.ts
+++ b/__tests__/unit/core-manager/database/logs-database-service.test.ts
@@ -161,13 +161,18 @@ describe("LogsDatabaseService", () => {
             // @ts-ignore
             database.database.exec(`UPDATE logs SET timestamp = '2016-01-02 00:00:00.000' WHERE id = 1`);
 
-            const result = database.find({
-                $limit: 1000,
-                timestamp: { $gte: "2016-01-01 00:00:00.000", $lte: "2016-01-03 00:00:00.000" },
+            // const result = database.find({
+            //     $limit: 1000,
+            //     timestamp: { $gte: "2016-01-01 00:00:00.000", $lte: "2016-01-03 00:00:00.000" },
+            // });
+
+            const result = database.search({
+                dateFrom: "2016-01-01 00:00:00.000",
+                dateTo: "2016-01-03 00:00:00.000",
             });
 
             expect(result.total).toBe(1);
-            expect(result.limit).toBe(1000);
+            // expect(result.limit).toBe(1000);
             expect(result.offset).toBe(0);
             expect(result.data).toBeArray();
             expect(result.data.length).toBe(1);

--- a/__tests__/unit/core-manager/database/logs-database-service.test.ts
+++ b/__tests__/unit/core-manager/database/logs-database-service.test.ts
@@ -103,7 +103,7 @@ describe("LogsDatabaseService", () => {
                 content: "content",
             });
 
-            expect(result[0].timestamp).toBeDefined();
+            expect(result[0].timestamp).toBeNumber();
         });
     });
 
@@ -170,11 +170,11 @@ describe("LogsDatabaseService", () => {
 
         it("should search by datetime", () => {
             // @ts-ignore
-            database.database.exec(`UPDATE logs SET timestamp = '2016-01-02 00:00:00.000' WHERE id = 1`);
+            database.database.exec(`UPDATE logs SET timestamp = 1451696400 WHERE id = 1`);
 
             let result = database.search({
                 limit: 1000,
-                dateFrom: "2016-01-01 00:00:00.000",
+                dateFrom: 1451610000,
             });
 
             expect(result.total).toBe(200);
@@ -185,7 +185,7 @@ describe("LogsDatabaseService", () => {
 
             result = database.search({
                 limit: 1000,
-                dateTo: "2016-01-03 00:00:00.000",
+                dateTo: 1451782800,
             });
 
             expect(result.total).toBe(1);
@@ -196,8 +196,8 @@ describe("LogsDatabaseService", () => {
 
             result = database.search({
                 limit: 1000,
-                dateFrom: "2016-01-01 00:00:00.000",
-                dateTo: "2016-01-03 00:00:00.000",
+                dateFrom: 1451610000,
+                dateTo: 1451782800,
             });
 
             expect(result.total).toBe(1);

--- a/__tests__/unit/core-manager/service-provider.test.ts
+++ b/__tests__/unit/core-manager/service-provider.test.ts
@@ -14,6 +14,7 @@ const logger = {
     info: jest.fn(),
     debug: jest.fn(),
     error: jest.fn(),
+    notice: jest.fn(),
 };
 
 const mockEventDispatcher = {
@@ -32,11 +33,13 @@ beforeEach(() => {
 
     app.bind(Container.Identifiers.LogService).toConstantValue(logger);
     app.bind(Container.Identifiers.PluginConfiguration).to(Providers.PluginConfiguration).inSingletonScope();
+    app.bind(Container.Identifiers.ConfigFlags).toConstantValue({ processType: "core" });
     app.bind(Container.Identifiers.FilesystemService).toConstantValue({});
     app.bind(Container.Identifiers.EventDispatcherService).toConstantValue(mockEventDispatcher);
     app.bind(Container.Identifiers.WalletAttributes).toConstantValue({});
 
     defaults.watcher.storage = dirSync().name + "/events.sqlite";
+    defaults.logs.storage = dirSync().name + "/logs.sqlite";
     defaults.server.https.tls.key = path.resolve(__dirname, "./__fixtures__/key.pem");
     defaults.server.https.tls.cert = path.resolve(__dirname, "./__fixtures__/server.crt");
 });
@@ -148,8 +151,8 @@ describe("ServiceProvider", () => {
         usedDefaults.watcher.enabled = true;
 
         usedDefaults.watcher.watch.queries = false;
-        usedDefaults.watcher.watch.logs = false;
         usedDefaults.watcher.watch.wallets = false;
+        usedDefaults.logs.enabled = false;
 
         setPluginConfiguration(app, serviceProvider, usedDefaults);
 

--- a/packages/core-manager/package.json
+++ b/packages/core-manager/package.json
@@ -36,6 +36,7 @@
         "@sindresorhus/df": "^3.1.1",
         "argon2": "^0.26.2",
         "better-sqlite3": "^7.0.0",
+        "dayjs": "^1.9.6",
         "execa": "^3.4.0",
         "fs-extra": "^8.1.0",
         "got": "^11.1.3",

--- a/packages/core-manager/src/actions/log-search.ts
+++ b/packages/core-manager/src/actions/log-search.ts
@@ -1,215 +1,44 @@
-import { Container, Contracts } from "@arkecosystem/core-kernel";
-import dayjs from "dayjs";
-import fs from "fs";
-import { join } from "path";
-import readline from "readline";
+import { Container } from "@arkecosystem/core-kernel";
+import { Identifiers } from "../ioc";
+import { LogsDatabaseService, SearchParams } from "../database/logs-database-service";
 
 import { Actions } from "../contracts";
 
-interface Params {
-    name: string;
-    useErrorLog: boolean;
-    dateFrom?: number;
-    dateTo?: number;
-    logLevel?: string;
-    contains?: string;
-}
-
-interface Line {
-    timestamp?: number;
-    level?: string;
-    content: string;
-}
-
-enum CanIncludeLineResult {
-    ACCEPT,
-    SKIP,
-    END, // Prevent further search
-}
-
-type CanIncludeLineMethod = (line: string, params) => CanIncludeLineResult;
-
 @Container.injectable()
 export class Action implements Actions.Action {
-    @Container.inject(Container.Identifiers.FilesystemService)
-    private readonly filesystem!: Contracts.Kernel.Filesystem;
+    @Container.inject(Identifiers.LogsDatabaseService)
+    private readonly database!: LogsDatabaseService;
 
     public name = "log.search";
 
     public schema = {
         type: "object",
         properties: {
-            name: {
-                type: "string",
-            },
-            useErrorLog: {
-                type: "boolean",
-            },
             dateFrom: {
                 type: "number",
             },
             dateTo: {
                 type: "number",
             },
-            logLevel: {
+            level: {
                 type: "string",
             },
-            contains: {
+            process: {
                 type: "string",
+            },
+            searchTerm: {
+                type: "string",
+            },
+            limit: {
+                type: "number",
+            },
+            offset: {
+                type: "number",
             },
         },
     };
 
-    public async execute(params: Params): Promise<any> {
-        params = {
-            name: "ark-core",
-            useErrorLog: false,
-            ...params,
-        };
-
-        return this.queryLog(params);
-    }
-
-    private async getLogStream(params: Params): Promise<readline.Interface> {
-        const logsPath = `${process.env.HOME}/.pm2/logs`;
-        const filePath = join(logsPath, `${params.name}-${params.useErrorLog ? "error" : "out"}.log`);
-
-        if (!(await this.filesystem.exists(filePath))) {
-            throw new Error("Cannot find log file");
-        }
-
-        return readline.createInterface({
-            input: fs.createReadStream(filePath),
-        });
-    }
-
-    private async queryLog(params: Params): Promise<Line[]> {
-        const rl = await this.getLogStream(params);
-
-        let i = 0;
-        const limit = 100;
-
-        const result: Line[] = [];
-
-        for await (const line of rl) {
-            const canIncludeLine = this.canIncludeLine(line, params);
-
-            if (canIncludeLine === CanIncludeLineResult.ACCEPT) {
-                result.push(this.parseLine(line));
-            } else if (canIncludeLine === CanIncludeLineResult.SKIP) {
-                continue;
-            } else {
-                break;
-            }
-
-            if (++i === limit) {
-                break;
-            }
-        }
-
-        rl.close();
-
-        return result;
-    }
-
-    private canIncludeLine(line, params: Params): CanIncludeLineResult {
-        const canIncludeLineMethods: CanIncludeLineMethod[] = [
-            this.canIncludeLineByTimestamp,
-            this.canIncludeLineByLogType,
-            this.canIncludeLineBySearchTerm,
-        ];
-
-        for (const canIncludeLine of canIncludeLineMethods) {
-            const result = canIncludeLine(line, params);
-
-            if (result !== CanIncludeLineResult.ACCEPT) {
-                return result;
-            }
-        }
-
-        return CanIncludeLineResult.ACCEPT;
-    }
-
-    private canIncludeLineByTimestamp(line: string, params: Params): CanIncludeLineResult {
-        if (!params.dateFrom && !params.dateTo) {
-            return CanIncludeLineResult.ACCEPT;
-        }
-
-        const lineTimestamp = dayjs(line.substring(1, 24));
-
-        if (!lineTimestamp.isValid()) {
-            return CanIncludeLineResult.SKIP;
-        }
-
-        if (params.dateTo && params.dateTo < lineTimestamp.unix()) {
-            return CanIncludeLineResult.END;
-        }
-
-        if (params.dateFrom && params.dateFrom > lineTimestamp.unix()) {
-            return CanIncludeLineResult.SKIP;
-        }
-
-        return CanIncludeLineResult.ACCEPT;
-    }
-
-    private canIncludeLineByLogType(line: string, params: Params): CanIncludeLineResult {
-        if (!params.logLevel) {
-            return CanIncludeLineResult.ACCEPT;
-        }
-
-        const lineLogLevel = line.substring(31, 31 + params.logLevel.length);
-
-        if (params.logLevel.toUpperCase() !== lineLogLevel) {
-            return CanIncludeLineResult.SKIP;
-        }
-
-        return CanIncludeLineResult.ACCEPT;
-    }
-
-    private canIncludeLineBySearchTerm(line: string, params: Params): CanIncludeLineResult {
-        if (!params.contains) {
-            return CanIncludeLineResult.ACCEPT;
-        }
-
-        return line.includes(params.contains) ? CanIncludeLineResult.ACCEPT : CanIncludeLineResult.SKIP;
-    }
-
-    private parseLine(line: string): Line {
-        const result: Line = {
-            timestamp: undefined,
-            level: undefined,
-            content: "",
-        };
-
-        const timestampRaw = dayjs(line.substring(1, 24));
-        if (timestampRaw.isValid()) {
-            result.timestamp = timestampRaw.unix();
-        }
-
-        result.level = this.parseLevel(line);
-
-        if (result.timestamp && result.level) {
-            result.content = line.substring(31 + result.level.length + 12, line.length - 5);
-
-            result.level = result.level.trim();
-        } else {
-            result.content = line;
-        }
-
-        return result;
-    }
-
-    private parseLevel(line): string | undefined {
-        let level = "";
-
-        for (let i = 31; i < 41; i++) {
-            if (line.length > i && ((line[i] >= "A" && line[i] <= "Z") || line[i] === " ")) {
-                level += line[i];
-            } else {
-                break;
-            }
-        }
-
-        return level.length ? level : undefined;
+    public async execute(params: SearchParams): Promise<any> {
+        return this.database.search(params);
     }
 }

--- a/packages/core-manager/src/database/logs-database-service.ts
+++ b/packages/core-manager/src/database/logs-database-service.ts
@@ -4,6 +4,9 @@ import { Database, Result } from "./database";
 
 @Container.injectable()
 export class LogsDatabaseService {
+    @Container.inject(Container.Identifiers.ConfigFlags)
+    private readonly configFlags!: any;
+
     @Container.inject(Container.Identifiers.PluginConfiguration)
     @Container.tagged("plugin", "@arkecosystem/core-manager")
     private readonly configuration!: Providers.PluginConfiguration;
@@ -24,6 +27,10 @@ export class LogsDatabaseService {
                             type: "integer",
                             primary: true,
                             autoincrement: true,
+                        },
+                        {
+                            name: "process",
+                            type: "varchar(15)",
                         },
                         {
                             name: "level",
@@ -53,6 +60,7 @@ export class LogsDatabaseService {
 
     public add(level: string, content: string): void {
         this.database.add("logs", {
+            process: this.configFlags.processType,
             level,
             content,
         });

--- a/packages/core-manager/src/database/logs-database-service.ts
+++ b/packages/core-manager/src/database/logs-database-service.ts
@@ -2,7 +2,7 @@ import { Container, Providers } from "@arkecosystem/core-kernel";
 
 import { Database, Result } from "./database";
 
-interface SearchParams {
+export interface SearchParams {
     dateFrom?: string;
     dateTo?: string;
     searchTerm?: string;

--- a/packages/core-manager/src/database/logs-database-service.ts
+++ b/packages/core-manager/src/database/logs-database-service.ts
@@ -41,10 +41,12 @@ export class LogsDatabaseService {
                         {
                             name: "process",
                             type: "varchar(15)",
+                            index: true,
                         },
                         {
                             name: "level",
                             type: "varchar(15)",
+                            index: true,
                         },
                         {
                             name: "content",
@@ -53,6 +55,7 @@ export class LogsDatabaseService {
                         {
                             name: "timestamp",
                             type: "integer",
+                            index: true,
                         },
                     ],
                 },

--- a/packages/core-manager/src/database/logs-database-service.ts
+++ b/packages/core-manager/src/database/logs-database-service.ts
@@ -62,7 +62,7 @@ export class LogsDatabaseService {
             ],
         });
 
-        this.database.boot();
+        this.database.boot(this.configuration.getRequired<{ resetDatabase: boolean }>("logs").resetDatabase);
     }
 
     public dispose(): void {
@@ -76,6 +76,8 @@ export class LogsDatabaseService {
             content,
             timestamp: dayjs().unix(),
         });
+
+        this.removeOldRecords();
     }
 
     public search(searchParams: SearchParams): Result {
@@ -116,5 +118,14 @@ export class LogsDatabaseService {
         }
 
         return this.database.find("logs", conditions);
+    }
+
+    private removeOldRecords() {
+        this.database.remove("logs", {
+            timestamp: {
+                $lte:
+                    dayjs().unix() - this.configuration.getRequired<{ history: number }>("logs").history * 24 * 60 * 60,
+            },
+        });
     }
 }

--- a/packages/core-manager/src/database/logs-database-service.ts
+++ b/packages/core-manager/src/database/logs-database-service.ts
@@ -1,10 +1,11 @@
 import { Container, Providers } from "@arkecosystem/core-kernel";
+import dayjs from "dayjs";
 
 import { Database, Result } from "./database";
 
 export interface SearchParams {
-    dateFrom?: string;
-    dateTo?: string;
+    dateFrom?: number;
+    dateTo?: number;
     searchTerm?: string;
     level?: string;
     process?: string;
@@ -51,8 +52,7 @@ export class LogsDatabaseService {
                         },
                         {
                             name: "timestamp",
-                            type: "datetime",
-                            default: "CURRENT_TIMESTAMP",
+                            type: "integer",
                         },
                     ],
                 },
@@ -71,6 +71,7 @@ export class LogsDatabaseService {
             process: this.configFlags.processType,
             level,
             content,
+            timestamp: dayjs().unix(),
         });
     }
 

--- a/packages/core-manager/src/database/logs-database-service.ts
+++ b/packages/core-manager/src/database/logs-database-service.ts
@@ -2,6 +2,16 @@ import { Container, Providers } from "@arkecosystem/core-kernel";
 
 import { Database, Result } from "./database";
 
+interface SearchParams {
+    dateFrom?: string;
+    dateTo?: string;
+    searchTerm?: string;
+    level?: string;
+    process?: string;
+    limit?: number;
+    offset?: number;
+}
+
 @Container.injectable()
 export class LogsDatabaseService {
     @Container.inject(Container.Identifiers.ConfigFlags)
@@ -67,6 +77,24 @@ export class LogsDatabaseService {
     }
 
     public find(conditions?: any): Result {
+        return this.database.find("logs", conditions);
+    }
+
+    public search(searchParams: SearchParams): Result {
+        const conditions: any = {};
+
+        if (searchParams.dateFrom || searchParams.dateTo) {
+            conditions.timestamp = {};
+
+            if (searchParams.dateFrom) {
+                conditions.timestamp.$gte = searchParams.dateFrom;
+            }
+
+            if (searchParams.dateTo) {
+                conditions.timestamp.$lte = searchParams.dateTo;
+            }
+        }
+
         return this.database.find("logs", conditions);
     }
 }

--- a/packages/core-manager/src/database/logs-database-service.ts
+++ b/packages/core-manager/src/database/logs-database-service.ts
@@ -25,7 +25,6 @@ export class LogsDatabaseService {
 
     public boot(): void {
         const filename = this.configuration.getRequired<{ storage: string }>("logs").storage;
-        // `${process.env.CORE_PATH_DATA}/logs.sqlite`; TODO: Check
 
         this.database = new Database(filename, {
             tables: [
@@ -73,10 +72,6 @@ export class LogsDatabaseService {
             level,
             content,
         });
-    }
-
-    public find(conditions?: any): Result {
-        return this.database.find("logs", conditions);
     }
 
     public search(searchParams: SearchParams): Result {

--- a/packages/core-manager/src/database/logs-database-service.ts
+++ b/packages/core-manager/src/database/logs-database-service.ts
@@ -1,0 +1,64 @@
+import { Container, Providers } from "@arkecosystem/core-kernel";
+
+import { Database, Result } from "./database";
+
+@Container.injectable()
+export class LogsDatabaseService {
+    @Container.inject(Container.Identifiers.PluginConfiguration)
+    @Container.tagged("plugin", "@arkecosystem/core-manager")
+    private readonly configuration!: Providers.PluginConfiguration;
+
+    private database!: Database;
+
+    public boot(): void {
+        const filename = this.configuration.getRequired<{ storage: string }>("watcher").storage;
+        // `${process.env.CORE_PATH_DATA}/logs.sqlite`; TODO: Check
+
+        this.database = new Database(filename, {
+            tables: [
+                {
+                    name: "logs",
+                    columns: [
+                        {
+                            name: "id",
+                            type: "integer",
+                            primary: true,
+                            autoincrement: true,
+                        },
+                        {
+                            name: "level",
+                            type: "varchar(15)",
+                        },
+                        {
+                            name: "content",
+                            type: "text",
+                        },
+                        {
+                            name: "timestamp",
+                            type: "datetime",
+                            default: "CURRENT_TIMESTAMP",
+                        },
+                    ],
+                },
+            ],
+        });
+
+        // TODO: Check if requires flush
+        this.database.boot(this.configuration.getRequired<{ resetDatabase: boolean }>("watcher").resetDatabase);
+    }
+
+    public dispose(): void {
+        this.database.dispose();
+    }
+
+    public add(level: string, content: string): void {
+        this.database.add("logs", {
+            level,
+            content,
+        });
+    }
+
+    public find(conditions?: any): Result {
+        return this.database.find("logs", conditions);
+    }
+}

--- a/packages/core-manager/src/database/logs-database-service.ts
+++ b/packages/core-manager/src/database/logs-database-service.ts
@@ -60,8 +60,7 @@ export class LogsDatabaseService {
             ],
         });
 
-        // TODO: Check if requires flush
-        this.database.boot(this.configuration.getRequired<{ resetDatabase: boolean }>("watcher").resetDatabase);
+        this.database.boot();
     }
 
     public dispose(): void {
@@ -93,6 +92,28 @@ export class LogsDatabaseService {
             if (searchParams.dateTo) {
                 conditions.timestamp.$lte = searchParams.dateTo;
             }
+        }
+
+        if (searchParams.level) {
+            conditions.level = searchParams.level;
+        }
+
+        if (searchParams.process) {
+            conditions.process = searchParams.process;
+        }
+
+        if (searchParams.searchTerm) {
+            conditions.content = {
+                $like: `%${searchParams.searchTerm}%`,
+            };
+        }
+
+        if (searchParams.limit) {
+            conditions.$limit = searchParams.limit;
+        }
+
+        if (searchParams.offset) {
+            conditions.$offset = searchParams.offset;
         }
 
         return this.database.find("logs", conditions);

--- a/packages/core-manager/src/database/logs-database-service.ts
+++ b/packages/core-manager/src/database/logs-database-service.ts
@@ -11,7 +11,7 @@ export class LogsDatabaseService {
     private database!: Database;
 
     public boot(): void {
-        const filename = this.configuration.getRequired<{ storage: string }>("watcher").storage;
+        const filename = this.configuration.getRequired<{ storage: string }>("logs").storage;
         // `${process.env.CORE_PATH_DATA}/logs.sqlite`; TODO: Check
 
         this.database = new Database(filename, {

--- a/packages/core-manager/src/defaults.ts
+++ b/packages/core-manager/src/defaults.ts
@@ -18,6 +18,8 @@ export const defaults = {
     },
     logs: {
         storage: `${process.env.CORE_PATH_DATA}/logs.sqlite`,
+        resetDatabase: process.env.CORE_RESET_DATABASE,
+        history: 30, // Days
     },
     server: {
         http: {

--- a/packages/core-manager/src/defaults.ts
+++ b/packages/core-manager/src/defaults.ts
@@ -16,6 +16,9 @@ export const defaults = {
             webhooks: !process.env.CORE_WATCH_WEBHOOKS_DISABLED,
         },
     },
+    logs: {
+        storage: `${process.env.CORE_PATH_DATA}/logs.sqlite`,
+    },
     server: {
         http: {
             enabled: !process.env.CORE_MONITOR_DISABLED,

--- a/packages/core-manager/src/defaults.ts
+++ b/packages/core-manager/src/defaults.ts
@@ -6,7 +6,6 @@ export const defaults = {
         watch: {
             blocks: !process.env.CORE_WATCH_BLOCKS_DISABLED,
             errors: !process.env.CORE_WATCH_ERRORS_DISABLED,
-            logs: !process.env.CORE_WATCH_LOGS_DISABLED,
             queries: !process.env.CORE_WATCH_QUERIES_DISABLED,
             queues: !process.env.CORE_WATCH_QUEUES_DISABLED,
             rounds: !process.env.CORE_WATCH_ROUNDS_DISABLED,
@@ -17,8 +16,9 @@ export const defaults = {
         },
     },
     logs: {
-        storage: `${process.env.CORE_PATH_DATA}/logs.sqlite`,
+        enabled: !process.env.CORE_WATCH_LOGS_DISABLED,
         resetDatabase: process.env.CORE_RESET_DATABASE,
+        storage: `${process.env.CORE_PATH_DATA}/logs.sqlite`,
         history: 30, // Days
     },
     server: {

--- a/packages/core-manager/src/ioc/identifiers.ts
+++ b/packages/core-manager/src/ioc/identifiers.ts
@@ -10,5 +10,6 @@ export const Identifiers = {
     CliManager: Symbol.for("Manager<Cli>"),
 
     WatcherDatabaseService: Symbol.for("Watcher<DatabaseService>"),
+    LogsDatabaseService: Symbol.for("Logs<DatabaseService>"),
     EventsListener: Symbol.for("Listener<Events>"),
 };

--- a/packages/core-manager/src/log-service-wrapper.ts
+++ b/packages/core-manager/src/log-service-wrapper.ts
@@ -1,44 +1,44 @@
 import { Contracts } from "@arkecosystem/core-kernel";
 
-import { EventsDatabaseService } from "./database/events-database-service";
+import { LogsDatabaseService } from "./database/logs-database-service";
 
 export class LogServiceWrapper implements Contracts.Kernel.Logger {
-    public constructor(private logger: Contracts.Kernel.Logger, private databaseService: EventsDatabaseService) {}
+    public constructor(private logger: Contracts.Kernel.Logger, private databaseService: LogsDatabaseService) {}
 
     public async make(options?: any): Promise<Contracts.Kernel.Logger> {
         return this.logger.make(options);
     }
-    public emergency(message: any): void {
+    public emergency(message: string): void {
         this.logger.emergency(message);
-        this.databaseService.add("log.emergency", message);
+        this.databaseService.add("emergency", message);
     }
-    public alert(message: any): void {
+    public alert(message: string): void {
         this.logger.alert(message);
-        this.databaseService.add("log.alert", message);
+        this.databaseService.add("alert", message);
     }
-    public critical(message: any): void {
+    public critical(message: string): void {
         this.logger.critical(message);
-        this.databaseService.add("log.critical", message);
+        this.databaseService.add("critical", message);
     }
-    public error(message: any): void {
+    public error(message: string): void {
         this.logger.error(message);
-        this.databaseService.add("log.error", message);
+        this.databaseService.add("error", message);
     }
-    public warning(message: any): void {
+    public warning(message: string): void {
         this.logger.warning(message);
-        this.databaseService.add("log.warning", message);
+        this.databaseService.add("warning", message);
     }
-    public notice(message: any): void {
+    public notice(message: string): void {
         this.logger.notice(message);
-        this.databaseService.add("log.notice", message);
+        this.databaseService.add("notice", message);
     }
-    public info(message: any): void {
+    public info(message: string): void {
         this.logger.info(message);
-        this.databaseService.add("log.info", message);
+        this.databaseService.add("info", message);
     }
-    public debug(message: any): void {
+    public debug(message: string): void {
         this.logger.debug(message);
-        this.databaseService.add("log.debug", message);
+        this.databaseService.add("debug", message);
     }
     public suppressConsoleOutput(suppress: boolean): void {
         this.logger.suppressConsoleOutput(suppress);

--- a/packages/core-manager/src/service-provider.ts
+++ b/packages/core-manager/src/service-provider.ts
@@ -29,18 +29,18 @@ export class ServiceProvider extends Providers.ServiceProvider {
             if (this.config().getRequired<boolean>("watcher.watch.queries")) {
                 this.app.bind(Container.Identifiers.DatabaseLogger).to(DatabaseLogger).inSingletonScope();
             }
+        }
 
-            if (this.config().getRequired<boolean>("watcher.watch.logs")) {
-                const logService = this.app.get<Contracts.Kernel.Logger>(Container.Identifiers.LogService);
-                this.app
-                    .rebind(Container.Identifiers.LogService)
-                    .toConstantValue(
-                        new LogServiceWrapper(
-                            logService,
-                            this.app.get<LogsDatabaseService>(Identifiers.LogsDatabaseService),
-                        ),
-                    );
-            }
+        if (this.config().getRequired<boolean>("logs.enabled")) {
+            const logService = this.app.get<Contracts.Kernel.Logger>(Container.Identifiers.LogService);
+            this.app
+                .rebind(Container.Identifiers.LogService)
+                .toConstantValue(
+                    new LogServiceWrapper(
+                        logService,
+                        this.app.get<LogsDatabaseService>(Identifiers.LogsDatabaseService),
+                    ),
+                );
         }
 
         this.app.bind(Identifiers.ActionReader).to(ActionReader).inSingletonScope();

--- a/packages/core-manager/src/service-provider.ts
+++ b/packages/core-manager/src/service-provider.ts
@@ -4,6 +4,7 @@ import { Container, Contracts, Providers, Types } from "@arkecosystem/core-kerne
 import { ActionReader } from "./action-reader";
 import { DatabaseLogger } from "./database-logger";
 import { EventsDatabaseService } from "./database/events-database-service";
+import { LogsDatabaseService } from "./database/logs-database-service";
 import { Identifiers } from "./ioc";
 import { Listener } from "./listener";
 import { LogServiceWrapper } from "./log-service-wrapper";
@@ -18,6 +19,9 @@ export class ServiceProvider extends Providers.ServiceProvider {
     public async register(): Promise<void> {
         this.app.bind(Identifiers.WatcherDatabaseService).to(EventsDatabaseService).inSingletonScope();
         this.app.get<EventsDatabaseService>(Identifiers.WatcherDatabaseService).boot();
+
+        this.app.bind(Identifiers.LogsDatabaseService).to(LogsDatabaseService).inSingletonScope();
+        this.app.get<EventsDatabaseService>(Identifiers.LogsDatabaseService).boot();
 
         if (this.config().getRequired<{ enabled: boolean }>("watcher").enabled) {
             this.app.bind(Identifiers.EventsListener).to(Listener).inSingletonScope();
@@ -80,6 +84,7 @@ export class ServiceProvider extends Providers.ServiceProvider {
         }
 
         this.app.get<EventsDatabaseService>(Identifiers.WatcherDatabaseService).dispose();
+        this.app.get<EventsDatabaseService>(Identifiers.LogsDatabaseService).dispose();
     }
 
     public async required(): Promise<boolean> {

--- a/packages/core-manager/src/service-provider.ts
+++ b/packages/core-manager/src/service-provider.ts
@@ -37,7 +37,7 @@ export class ServiceProvider extends Providers.ServiceProvider {
                     .toConstantValue(
                         new LogServiceWrapper(
                             logService,
-                            this.app.get<EventsDatabaseService>(Identifiers.WatcherDatabaseService),
+                            this.app.get<LogsDatabaseService>(Identifiers.LogsDatabaseService),
                         ),
                     );
             }

--- a/packages/core/bin/config/testnet/app.json
+++ b/packages/core/bin/config/testnet/app.json
@@ -5,9 +5,6 @@
                 "package": "@arkecosystem/core-logger-pino"
             },
             {
-                "package": "@arkecosystem/core-manager"
-            },
-            {
                 "package": "@arkecosystem/core-state"
             },
             {

--- a/packages/core/bin/config/testnet/app.json
+++ b/packages/core/bin/config/testnet/app.json
@@ -5,6 +5,9 @@
                 "package": "@arkecosystem/core-logger-pino"
             },
             {
+                "package": "@arkecosystem/core-manager"
+            },
+            {
                 "package": "@arkecosystem/core-state"
             },
             {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6806,6 +6806,11 @@ dayjs@^1.8.35:
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.8.35.tgz#67118378f15d31623f3ee2992f5244b887606888"
   integrity sha512-isAbIEenO4ilm6f8cpqvgjZCsuerDAz2Kb7ri201AiNn58aqXuaLJEnCtfIMdCvERZHNGRY5lDMTr/jdAnKSWQ==
 
+dayjs@^1.9.6:
+  version "1.9.6"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.9.6.tgz#6f0c77d76ac1ff63720dd1197e5cb87b67943d70"
+  integrity sha512-HngNLtPEBWRo8EFVmHFmSXAjtCX8rGNqeXQI0Gh7wCTSqwaKgPIDqu9m07wABVopNwzvOeCb+2711vQhDlcIXw==
+
 de-indent@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/de-indent/-/de-indent-1.0.2.tgz#b2038e846dc33baa5796128d0804b455b8c1e21d"


### PR DESCRIPTION
## Summary

Store logs in sqlite database and use it on `log.search` action.
Keep logs history for 30 days. Different setting can be achieved via app.json.

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged
