### PR TITLE
refactor(core-manager): single database path setting

### DIFF
--- a/__tests__/unit/core-manager/database/events-database-service.test.ts
+++ b/__tests__/unit/core-manager/database/events-database-service.test.ts
@@ -56,17 +56,6 @@ describe("EventsDatabaseService", () => {
 
             expect(spyOnFlush).toHaveBeenCalledTimes(1);
         });
-
-        it("should boot without watcher storage in defaults", async () => {
-            configuration.getRequired = jest.fn().mockReturnValue({});
-
-            storagePath = dirSync().name;
-            process.env.CORE_PATH_DATA = storagePath;
-
-            database.boot();
-
-            expect(existsSync(storagePath + "/events.sqlite")).toBeTrue();
-        });
     });
 
     describe("Dispose", () => {

--- a/packages/core-manager/src/database/events-database-service.ts
+++ b/packages/core-manager/src/database/events-database-service.ts
@@ -11,9 +11,7 @@ export class EventsDatabaseService {
     private database!: Database;
 
     public boot(): void {
-        const filename =
-            this.configuration.getRequired<{ storage: string }>("watcher").storage ||
-            `${process.env.CORE_PATH_DATA}/events.sqlite`;
+        const filename = this.configuration.getRequired<{ storage: string }>("watcher").storage;
 
         this.database = new Database(filename, {
             tables: [


### PR DESCRIPTION
## Summary

Database file path should be set in the single setting from defaults.

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged