### PR TITLE
chore: enable core-manager on all processes

### DIFF
--- a/__tests__/unit/core-manager/database/logs-database-service.test.ts
+++ b/__tests__/unit/core-manager/database/logs-database-service.test.ts
@@ -70,10 +70,15 @@ describe("LogsDatabaseService", () => {
         it("should dispose", async () => {
             database.boot();
             database.dispose();
+        });
+
+        it("should not throw if add is called after dispose", async () => {
+            database.boot();
+            database.dispose();
 
             expect(() => {
                 database.add("info", "log content");
-            }).toThrowError();
+            }).not.toThrowError();
         });
     });
 

--- a/packages/core-manager/src/database/database.ts
+++ b/packages/core-manager/src/database/database.ts
@@ -51,6 +51,10 @@ export class Database {
         this.database = new BetterSqlite3(filename);
     }
 
+    public isOpen(): boolean {
+        return this.database.open;
+    }
+
     public boot(flush: boolean = false): void {
         this.exec(this.createDatabaseSQL());
 

--- a/packages/core-manager/src/database/logs-database-service.ts
+++ b/packages/core-manager/src/database/logs-database-service.ts
@@ -70,6 +70,10 @@ export class LogsDatabaseService {
     }
 
     public add(level: string, content: string): void {
+        if (!this.database.isOpen()) {
+            return;
+        }
+
         this.database.add("logs", {
             process: this.configFlags.processType,
             level,

--- a/packages/core/bin/config/devnet/app.json
+++ b/packages/core/bin/config/devnet/app.json
@@ -5,6 +5,9 @@
                 "package": "@arkecosystem/core-logger-pino"
             },
             {
+                "package": "@arkecosystem/core-manager"
+            },
+            {
                 "package": "@arkecosystem/core-state"
             },
             {
@@ -48,6 +51,9 @@
                 "package": "@arkecosystem/core-logger-pino"
             },
             {
+                "package": "@arkecosystem/core-manager"
+            },
+            {
                 "package": "@arkecosystem/core-state"
             },
             {
@@ -85,6 +91,9 @@
                 "package": "@arkecosystem/core-logger-pino"
             },
             {
+                "package": "@arkecosystem/core-manager"
+            },
+            {
                 "package": "@arkecosystem/core-forger"
             }
         ]
@@ -93,6 +102,9 @@
         "plugins": [
             {
                 "package": "@arkecosystem/core-logger-pino"
+            },
+            {
+                "package": "@arkecosystem/core-manager"
             },
             {
                 "package": "@arkecosystem/core-snapshots"

--- a/packages/core/bin/config/mainnet/app.json
+++ b/packages/core/bin/config/mainnet/app.json
@@ -5,6 +5,9 @@
                 "package": "@arkecosystem/core-logger-pino"
             },
             {
+                "package": "@arkecosystem/core-manager"
+            },
+            {
                 "package": "@arkecosystem/core-state"
             },
             {
@@ -45,6 +48,9 @@
                 "package": "@arkecosystem/core-logger-pino"
             },
             {
+                "package": "@arkecosystem/core-manager"
+            },
+            {
                 "package": "@arkecosystem/core-state"
             },
             {
@@ -82,6 +88,9 @@
                 "package": "@arkecosystem/core-logger-pino"
             },
             {
+                "package": "@arkecosystem/core-manager"
+            },
+            {
                 "package": "@arkecosystem/core-forger"
             }
         ]
@@ -90,6 +99,9 @@
         "plugins": [
             {
                 "package": "@arkecosystem/core-logger-pino"
+            },
+            {
+                "package": "@arkecosystem/core-manager"
             },
             {
                 "package": "@arkecosystem/core-snapshots"

--- a/packages/core/bin/config/testnet/app.json
+++ b/packages/core/bin/config/testnet/app.json
@@ -5,6 +5,9 @@
                 "package": "@arkecosystem/core-logger-pino"
             },
             {
+                "package": "@arkecosystem/core-manager"
+            },
+            {
                 "package": "@arkecosystem/core-state"
             },
             {
@@ -48,6 +51,9 @@
                 "package": "@arkecosystem/core-logger-pino"
             },
             {
+                "package": "@arkecosystem/core-manager"
+            },
+            {
                 "package": "@arkecosystem/core-state"
             },
             {
@@ -85,6 +91,9 @@
                 "package": "@arkecosystem/core-logger-pino"
             },
             {
+                "package": "@arkecosystem/core-manager"
+            },
+            {
                 "package": "@arkecosystem/core-forger"
             }
         ]
@@ -93,6 +102,9 @@
         "plugins": [
             {
                 "package": "@arkecosystem/core-logger-pino"
+            },
+            {
+                "package": "@arkecosystem/core-manager"
             },
             {
                 "package": "@arkecosystem/core-snapshots"

--- a/packages/core/src/commands/core-run.ts
+++ b/packages/core/src/commands/core-run.ts
@@ -66,16 +66,6 @@ export class Command extends Commands.Command {
                     networkStart: flags.networkStart,
                 },
                 "@arkecosystem/core-forger": await buildBIP38(flags, this.app.getCorePath("config")),
-                "@arkecosystem/core-manager": {
-                    server: {
-                        http: {
-                            enabled: false,
-                        },
-                        https: {
-                            enabled: false,
-                        },
-                    },
-                },
             },
         });
 

--- a/packages/core/src/commands/manager-run.ts
+++ b/packages/core/src/commands/manager-run.ts
@@ -51,14 +51,7 @@ export class Command extends Commands.Command {
 
         await Utils.buildApplication({
             flags,
-            plugins: {
-                "@arkecosystem/core-manager": {
-                    watcher: {
-                        enabled: false,
-                        resetDatabase: process.env.CORE_RESET_DATABASE,
-                    },
-                },
-            },
+            plugins: {},
         });
 
         // Prevent resolving execute method


### PR DESCRIPTION
## Summary

Enable core manager on all processes to enable logging to database. Prevent booting http and https servers when process is not manager.

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged