### PR TITLE
feat(core-api): return block height in API response headers

### DIFF
--- a/__tests__/unit/core-api/plugins/response-headers.test.ts
+++ b/__tests__/unit/core-api/plugins/response-headers.test.ts
@@ -1,0 +1,61 @@
+import { responseHeaders } from "@packages/core-api/src/plugins/response-headers";
+
+const getLastHeight = jest.fn();
+const app = { get: (id) => ({ getLastHeight }) };
+
+describe("responseHeaders.register", () => {
+    it("should register onPreResponse extension", () => {
+        const server = {
+            ext: jest.fn(),
+            app: { app },
+        };
+
+        responseHeaders.register(server);
+
+        expect(server.ext).toBeCalledWith("onPreResponse", expect.any(Function));
+    });
+});
+
+describe("responseHeaders.getOnPreResponse", () => {
+    it("should add header X-Block-Height with last block height from app blockchain getLastHeight()", () => {
+        const onPreResponse = responseHeaders.getOnPreResponseHandler(app as any);
+        const height = 2346;
+        getLastHeight.mockReturnValueOnce(height);
+
+        const request = {
+            query: {},
+            response: { headers: {} },
+        };
+
+        const h = {
+            continue: Symbol,
+        };
+
+        const ret = onPreResponse(request, h);
+
+        expect(request.response.headers["X-Block-Height"]).toEqual(height);
+
+        expect(ret).toBe(h.continue);
+    });
+
+    it("should add header X-Block-Height to response.output headers when response is error", () => {
+        const onPreResponse = responseHeaders.getOnPreResponseHandler(app as any);
+        const height = 2346;
+        getLastHeight.mockReturnValueOnce(height);
+
+        const request = {
+            query: {},
+            response: { headers: {}, isBoom: true, output: { headers: undefined } },
+        };
+
+        const h = {
+            continue: Symbol,
+        };
+
+        const ret = onPreResponse(request, h);
+
+        expect(request.response.output.headers["X-Block-Height"]).toEqual(height);
+
+        expect(ret).toBe(h.continue);
+    });
+});

--- a/packages/core-api/src/plugins/index.ts
+++ b/packages/core-api/src/plugins/index.ts
@@ -2,6 +2,7 @@ import { dotSeparatedQuery } from "./dot-separated-query";
 import { commaArrayQuery } from "./comma-array-query";
 import { hapiAjv } from "./hapi-ajv";
 import { whitelist } from "./whitelist";
+import { responseHeaders } from "./response-headers";
 
 export const preparePlugins = (config) => [
     {
@@ -31,4 +32,5 @@ export const preparePlugins = (config) => [
             },
         },
     },
+    { plugin: responseHeaders },
 ];

--- a/packages/core-api/src/plugins/response-headers.ts
+++ b/packages/core-api/src/plugins/response-headers.ts
@@ -1,0 +1,25 @@
+import { Container, Contracts } from "@arkecosystem/core-kernel";
+import Hapi from "@hapi/hapi";
+
+export const responseHeaders = {
+    name: "response-headers",
+    version: "1.0.0",
+
+    register(server: Hapi.Server): void {
+        server.ext("onPreResponse", this.getOnPreResponseHandler(server.app.app));
+    },
+
+    getOnPreResponseHandler(app: Contracts.Kernel.Application) {
+        return (request: Hapi.Request, h: Hapi.ResponseToolkit): Hapi.Lifecycle.ReturnValue => {
+            const blockHeight = app
+                .get<Contracts.Blockchain.Blockchain>(Container.Identifiers.BlockchainService)
+                .getLastHeight();
+
+            const responsePropToUpdate = request.response.isBoom ? request.response.output : request.response;
+            responsePropToUpdate.headers = responsePropToUpdate.headers ?? {};
+            responsePropToUpdate.headers["X-Block-Height"] = blockHeight;
+
+            return h.continue;
+        }
+    },
+};


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
Return block height as `X-Block-Height` header in API response.
<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
