### PR TITLE
feat(core-manager): support custom tokens

### DIFF
--- a/__tests__/unit/core-manager/actions/info-current-delegate.test.ts
+++ b/__tests__/unit/core-manager/actions/info-current-delegate.test.ts
@@ -1,5 +1,6 @@
 import "jest-extended";
 
+import { Container } from "@arkecosystem/core-kernel";
 import { Action } from "@packages/core-manager/src/actions/info-current-delegate";
 import { Identifiers } from "@packages/core-manager/src/ioc";
 import * as Utils from "@packages/core-manager/src/utils";
@@ -12,9 +13,10 @@ let action: Action;
 
 let mockCli;
 let mockTrigger;
+let spyOnGetCoreOrForgerProcessName;
 
 beforeEach(() => {
-    jest.spyOn(Utils, "getCoreOrForgerProcessName").mockReturnValue("ark-core");
+    spyOnGetCoreOrForgerProcessName = jest.spyOn(Utils, "getCoreOrForgerProcessName").mockReturnValue("ark-core");
     jest.spyOn(Utils, "getOnlineProcesses").mockReturnValue([]);
 
     mockTrigger = jest.fn().mockReturnValue({
@@ -29,6 +31,7 @@ beforeEach(() => {
 
     sandbox = new Sandbox();
 
+    sandbox.app.bind(Container.Identifiers.ApplicationToken).toConstantValue("ark");
     sandbox.app.bind(Identifiers.CLI).toConstantValue(mockCli);
 
     action = sandbox.app.resolve(Action);
@@ -48,6 +51,16 @@ describe("Info:CurrentDelegate", () => {
         const result = await action.execute({});
 
         expect(result).toEqual({ rank: 16, username: "genesis_25" });
+
+        expect(spyOnGetCoreOrForgerProcessName).toHaveBeenCalledWith([], "ark");
+    });
+
+    it("should return current delegate using token in params", async () => {
+        const result = await action.execute({ token: "customToken" });
+
+        expect(result).toEqual({ rank: 16, username: "genesis_25" });
+
+        expect(spyOnGetCoreOrForgerProcessName).toHaveBeenCalledWith([], "customToken");
     });
 
     it("should throw error if trigger responded with error", async () => {

--- a/__tests__/unit/core-manager/actions/info-last-forged-block.test.ts
+++ b/__tests__/unit/core-manager/actions/info-last-forged-block.test.ts
@@ -13,9 +13,10 @@ let action: Action;
 
 let mockCli;
 let mockTrigger;
+let spyOnGetCoreOrForgerProcessName;
 
 beforeEach(() => {
-    jest.spyOn(Utils, "getCoreOrForgerProcessName").mockReturnValue("ark-core");
+    spyOnGetCoreOrForgerProcessName = jest.spyOn(Utils, "getCoreOrForgerProcessName").mockReturnValue("ark-core");
     jest.spyOn(Utils, "getOnlineProcesses").mockReturnValue([]);
 
     mockTrigger = jest.fn().mockReturnValue({
@@ -51,6 +52,17 @@ describe("Info:CurrentDelegate", () => {
 
         expect(result.data).toBeDefined();
         expect(result.serialized).toBeDefined();
+
+        expect(spyOnGetCoreOrForgerProcessName).toHaveBeenCalledWith([], "ark");
+    });
+
+    it("should return last block using token in params", async () => {
+        const result = await action.execute({ token: "customToken" });
+
+        expect(result.data).toBeDefined();
+        expect(result.serialized).toBeDefined();
+
+        expect(spyOnGetCoreOrForgerProcessName).toHaveBeenCalledWith([], "customToken");
     });
 
     it("should throw error if trigger responded with error", async () => {

--- a/__tests__/unit/core-manager/actions/info-last-forged-block.test.ts
+++ b/__tests__/unit/core-manager/actions/info-last-forged-block.test.ts
@@ -6,6 +6,7 @@ import * as Utils from "@packages/core-manager/src/utils";
 import { Sandbox } from "@packages/core-test-framework";
 
 import { TriggerResponses } from "../__fixtures__";
+import { Container } from "@arkecosystem/core-kernel";
 
 let sandbox: Sandbox;
 let action: Action;
@@ -29,6 +30,7 @@ beforeEach(() => {
 
     sandbox = new Sandbox();
 
+    sandbox.app.bind(Container.Identifiers.ApplicationToken).toConstantValue("ark");
     sandbox.app.bind(Identifiers.CLI).toConstantValue(mockCli);
 
     action = sandbox.app.resolve(Action);

--- a/__tests__/unit/core-manager/actions/info-next-forging-slot.test.ts
+++ b/__tests__/unit/core-manager/actions/info-next-forging-slot.test.ts
@@ -1,5 +1,6 @@
 import "jest-extended";
 
+import { Container } from "@arkecosystem/core-kernel";
 import { Action } from "@packages/core-manager/src/actions/info-next-forging-slot";
 import { Identifiers } from "@packages/core-manager/src/ioc";
 import * as Utils from "@packages/core-manager/src/utils";
@@ -12,9 +13,10 @@ let action: Action;
 
 let mockCli;
 let mockTrigger;
+let spyOnGetCoreOrForgerProcessName;
 
 beforeEach(() => {
-    jest.spyOn(Utils, "getCoreOrForgerProcessName").mockReturnValue("ark-core");
+    spyOnGetCoreOrForgerProcessName = jest.spyOn(Utils, "getCoreOrForgerProcessName").mockReturnValue("ark-core");
     jest.spyOn(Utils, "getOnlineProcesses").mockReturnValue([]);
 
     mockTrigger = jest.fn().mockReturnValue({
@@ -29,6 +31,7 @@ beforeEach(() => {
 
     sandbox = new Sandbox();
 
+    sandbox.app.bind(Container.Identifiers.ApplicationToken).toConstantValue("ark");
     sandbox.app.bind(Identifiers.CLI).toConstantValue(mockCli);
 
     action = sandbox.app.resolve(Action);
@@ -48,6 +51,16 @@ describe("Info:NextForgingSlot", () => {
         const result = await action.execute({});
 
         expect(result).toEqual({ remainingTime: 6000 });
+
+        expect(spyOnGetCoreOrForgerProcessName).toHaveBeenCalledWith([], "ark");
+    });
+
+    it("should return remainingTime using token in params", async () => {
+        const result = await action.execute({ token: "customToken" });
+
+        expect(result).toEqual({ remainingTime: 6000 });
+
+        expect(spyOnGetCoreOrForgerProcessName).toHaveBeenCalledWith([], "customToken");
     });
 
     it("should throw error if trigger responded with error", async () => {

--- a/packages/core-manager/src/actions/info-core-status.ts
+++ b/packages/core-manager/src/actions/info-core-status.ts
@@ -5,6 +5,11 @@ import { Actions } from "../contracts";
 import { Identifiers } from "../ioc";
 import { getConnectionData, HttpClient } from "../utils";
 
+interface Params {
+    token: string;
+    process: string;
+}
+
 @Container.injectable()
 export class Action implements Actions.Action {
     @Container.inject(Container.Identifiers.Application)
@@ -24,7 +29,13 @@ export class Action implements Actions.Action {
         },
     };
 
-    public async execute(params: any): Promise<any> {
+    public async execute(params: Params): Promise<any> {
+        params = {
+            token: this.app.token(),
+            process: "core",
+            ...params,
+        };
+
         return {
             processStatus: this.getProcessStatus(params.token, params.process) || "undefined",
             syncing: await this.getSyncingStatus(),

--- a/packages/core-manager/src/actions/info-core-status.ts
+++ b/packages/core-manager/src/actions/info-core-status.ts
@@ -29,7 +29,7 @@ export class Action implements Actions.Action {
         },
     };
 
-    public async execute(params: Params): Promise<any> {
+    public async execute(params: Partial<Params>): Promise<any> {
         params = {
             token: this.app.token(),
             process: "core",
@@ -37,12 +37,12 @@ export class Action implements Actions.Action {
         };
 
         return {
-            processStatus: this.getProcessStatus(params.token, params.process) || "undefined",
+            processStatus: this.getProcessStatus(params.token!, params.process!) || "undefined",
             syncing: await this.getSyncingStatus(),
         };
     }
 
-    private getProcessStatus(token: string = "ark", process: string = "core"): Contracts.ProcessState | undefined {
+    private getProcessStatus(token: string, process: string): Contracts.ProcessState | undefined {
         const cli = this.app.get<Cli>(Identifiers.CLI);
 
         const processManager = cli.get<Services.ProcessManager>(CliContainer.Identifiers.ProcessManager);

--- a/packages/core-manager/src/actions/info-current-delegate.ts
+++ b/packages/core-manager/src/actions/info-current-delegate.ts
@@ -5,6 +5,10 @@ import { Actions } from "../contracts";
 import { Identifiers } from "../ioc";
 import { getCoreOrForgerProcessName, getOnlineProcesses, parseProcessActionResponse } from "../utils";
 
+interface Params {
+    token: string;
+}
+
 @Container.injectable()
 export class Action implements Actions.Action {
     @Container.inject(Container.Identifiers.Application)
@@ -12,16 +16,30 @@ export class Action implements Actions.Action {
 
     public name = "info.currentDelegate";
 
-    public async execute(params: object): Promise<any> {
-        return await this.getCurrentDelegate();
+    public schema = {
+        type: "object",
+        properties: {
+            token: {
+                type: "string",
+            },
+        },
+    };
+
+    public async execute(params: Params): Promise<any> {
+        params = {
+            token: this.app.token(),
+            ...params,
+        };
+
+        return await this.getCurrentDelegate(params.token);
     }
 
-    private async getCurrentDelegate(): Promise<any> {
+    private async getCurrentDelegate(token: string): Promise<any> {
         const cli = this.app.get<Cli>(Identifiers.CLI);
 
         const processManager = cli.get<Services.ProcessManager>(CliContainer.Identifiers.ProcessManager);
 
-        const processName = getCoreOrForgerProcessName(getOnlineProcesses(processManager));
+        const processName = getCoreOrForgerProcessName(getOnlineProcesses(processManager), token);
 
         const response = processManager.trigger(processName, "forger.currentDelegate");
 

--- a/packages/core-manager/src/actions/info-current-delegate.ts
+++ b/packages/core-manager/src/actions/info-current-delegate.ts
@@ -25,13 +25,13 @@ export class Action implements Actions.Action {
         },
     };
 
-    public async execute(params: Params): Promise<any> {
+    public async execute(params: Partial<Params>): Promise<any> {
         params = {
             token: this.app.token(),
             ...params,
         };
 
-        return await this.getCurrentDelegate(params.token);
+        return await this.getCurrentDelegate(params.token!);
     }
 
     private async getCurrentDelegate(token: string): Promise<any> {

--- a/packages/core-manager/src/actions/info-last-forged-block.ts
+++ b/packages/core-manager/src/actions/info-last-forged-block.ts
@@ -5,6 +5,10 @@ import { Actions } from "../contracts";
 import { Identifiers } from "../ioc";
 import { getCoreOrForgerProcessName, getOnlineProcesses, parseProcessActionResponse } from "../utils";
 
+interface Params {
+    token: string;
+}
+
 @Container.injectable()
 export class Action implements Actions.Action {
     @Container.inject(Container.Identifiers.Application)
@@ -12,16 +16,30 @@ export class Action implements Actions.Action {
 
     public name = "info.lastForgedBlock";
 
-    public async execute(params: object): Promise<any> {
-        return await this.getLastForgedBlock();
+    public schema = {
+        type: "object",
+        properties: {
+            token: {
+                type: "string",
+            },
+        },
+    };
+
+    public async execute(params: Params): Promise<any> {
+        params = {
+            token: this.app.token(),
+            ...params,
+        };
+
+        return await this.getLastForgedBlock(params.token);
     }
 
-    private async getLastForgedBlock(): Promise<any> {
+    private async getLastForgedBlock(token: string): Promise<any> {
         const cli = this.app.get<Cli>(Identifiers.CLI);
 
         const processManager = cli.get<Services.ProcessManager>(CliContainer.Identifiers.ProcessManager);
 
-        const processName = getCoreOrForgerProcessName(getOnlineProcesses(processManager));
+        const processName = getCoreOrForgerProcessName(getOnlineProcesses(processManager), token);
 
         const response = processManager.trigger(processName, "forger.lastForgedBlock");
 

--- a/packages/core-manager/src/actions/info-last-forged-block.ts
+++ b/packages/core-manager/src/actions/info-last-forged-block.ts
@@ -25,13 +25,13 @@ export class Action implements Actions.Action {
         },
     };
 
-    public async execute(params: Params): Promise<any> {
+    public async execute(params: Partial<Params>): Promise<any> {
         params = {
             token: this.app.token(),
             ...params,
         };
 
-        return await this.getLastForgedBlock(params.token);
+        return await this.getLastForgedBlock(params.token!);
     }
 
     private async getLastForgedBlock(token: string): Promise<any> {

--- a/packages/core-manager/src/actions/info-next-forging-slot.ts
+++ b/packages/core-manager/src/actions/info-next-forging-slot.ts
@@ -25,13 +25,13 @@ export class Action implements Actions.Action {
         },
     };
 
-    public async execute(params: Params): Promise<any> {
+    public async execute(params: Partial<Params>): Promise<any> {
         params = {
             token: this.app.token(),
             ...params,
         };
 
-        return await this.getNextForgingSlot(params.token);
+        return await this.getNextForgingSlot(params.token!);
     }
 
     private async getNextForgingSlot(token: string): Promise<any> {

--- a/packages/core-manager/src/actions/info-next-forging-slot.ts
+++ b/packages/core-manager/src/actions/info-next-forging-slot.ts
@@ -5,6 +5,10 @@ import { Actions } from "../contracts";
 import { Identifiers } from "../ioc";
 import { getCoreOrForgerProcessName, getOnlineProcesses, parseProcessActionResponse } from "../utils";
 
+interface Params {
+    token: string;
+}
+
 @Container.injectable()
 export class Action implements Actions.Action {
     @Container.inject(Container.Identifiers.Application)
@@ -12,16 +16,30 @@ export class Action implements Actions.Action {
 
     public name = "info.nextForgingSlot";
 
-    public async execute(params: object): Promise<any> {
-        return await this.getNextForgingSlot();
+    public schema = {
+        type: "object",
+        properties: {
+            token: {
+                type: "string",
+            },
+        },
+    };
+
+    public async execute(params: Params): Promise<any> {
+        params = {
+            token: this.app.token(),
+            ...params,
+        };
+
+        return await this.getNextForgingSlot(params.token);
     }
 
-    private async getNextForgingSlot(): Promise<any> {
+    private async getNextForgingSlot(token: string): Promise<any> {
         const cli = this.app.get<Cli>(Identifiers.CLI);
 
         const processManager = cli.get<Services.ProcessManager>(CliContainer.Identifiers.ProcessManager);
 
-        const processName = getCoreOrForgerProcessName(getOnlineProcesses(processManager));
+        const processName = getCoreOrForgerProcessName(getOnlineProcesses(processManager), token);
 
         // ! it's sync trigger, but NextSlotProcessAction.handler is async
         const response = processManager.trigger(processName, "forger.nextSlot");

--- a/packages/core-manager/src/utils/process.ts
+++ b/packages/core-manager/src/utils/process.ts
@@ -4,8 +4,8 @@ export const getOnlineProcesses = (processManager: Services.ProcessManager): { n
     return processManager.list().filter((x) => processManager.isOnline(x.name)) as [{ name: string }];
 };
 
-export const getCoreOrForgerProcessName = (processes: { name: string }[]) => {
-    const process = processes.find((x) => x.name === "ark-forger" || x.name === "ark-core");
+export const getCoreOrForgerProcessName = (processes: { name: string }[], token: string = "ark") => {
+    const process = processes.find((x) => x.name === `${token}-forger` || x.name === `${token}-core`);
 
     if (!process) {
         throw new Error("Process with name ark-forger or ark-core is not online");


### PR DESCRIPTION
## Summary

Support custom tokens. Token name is read from app.token() and is the same as defined in flags. Custom token can also be set in params to override default app.token() option. 

Change supports processes with custom token like [cusomTokeName]-[core/relay/forger]. 

Affected endpoints:
- info.coreStatus
- info.nextForgingSlot
- info.currnetDelegate
- info.lastForgedBlock

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged