### PR TITLE
fix(core-manager): optional core-snapshots dependency when process is not manager

### DIFF
--- a/__tests__/unit/core-manager/service-provider.test.ts
+++ b/__tests__/unit/core-manager/service-provider.test.ts
@@ -55,8 +55,18 @@ describe("ServiceProvider", () => {
         serviceProvider = app.resolve<ServiceProvider>(ServiceProvider);
     });
 
-    it("should contain core-snapshot dependency", async () => {
-        await expect(serviceProvider.dependencies().length).toEqual(1);
+    it("should contain required core-snapshot dependency when processType is equal manager", async () => {
+        await expect(serviceProvider.dependencies()).toEqual([
+            { name: "@arkecosystem/core-snapshots", required: true },
+        ]);
+    });
+
+    it("should contain optional core-snapshot dependency when processType is not equal manager", async () => {
+        app.rebind(Container.Identifiers.ConfigFlags).toConstantValue({ processType: "core" });
+
+        await expect(serviceProvider.dependencies()).toEqual([
+            { name: "@arkecosystem/core-snapshots", required: false },
+        ]);
     });
 
     it("should register", async () => {

--- a/packages/core-manager/src/service-provider.ts
+++ b/packages/core-manager/src/service-provider.ts
@@ -99,7 +99,7 @@ export class ServiceProvider extends Providers.ServiceProvider {
         return [
             {
                 name: "@arkecosystem/core-snapshots",
-                required: true,
+                required: this.app.get<any>(Container.Identifiers.ConfigFlags).processType === "manager",
             },
         ];
     }

--- a/packages/core/bin/config/devnet/app.json
+++ b/packages/core/bin/config/devnet/app.json
@@ -39,9 +39,6 @@
             },
             {
                 "package": "@arkecosystem/core-forger"
-            },
-            {
-                "package": "@arkecosystem/core-snapshots"
             }
         ]
     },

--- a/packages/core/bin/config/testnet/app.json
+++ b/packages/core/bin/config/testnet/app.json
@@ -39,9 +39,6 @@
             },
             {
                 "package": "@arkecosystem/core-forger"
-            },
-            {
-                "package": "@arkecosystem/core-snapshots"
             }
         ]
     },


### PR DESCRIPTION
## Summary

Require core-snspshots dependency only when processType is manager. For other types (core, forger) this dependency is optional because actions are not loaded and https server is not booted. 

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged