### PR TITLE
refactor(core-manager): use dependencies only for manager process type

### DIFF
--- a/__tests__/unit/core-manager/service-provider.test.ts
+++ b/__tests__/unit/core-manager/service-provider.test.ts
@@ -61,12 +61,10 @@ describe("ServiceProvider", () => {
         ]);
     });
 
-    it("should contain optional core-snapshot dependency when processType is not equal manager", async () => {
+    it("should not contain dependencies when processType is not equal manager", async () => {
         app.rebind(Container.Identifiers.ConfigFlags).toConstantValue({ processType: "core" });
 
-        await expect(serviceProvider.dependencies()).toEqual([
-            { name: "@arkecosystem/core-snapshots", required: false },
-        ]);
+        await expect(serviceProvider.dependencies()).toEqual([]);
     });
 
     it("should register", async () => {

--- a/packages/core-manager/src/service-provider.ts
+++ b/packages/core-manager/src/service-provider.ts
@@ -96,12 +96,16 @@ export class ServiceProvider extends Providers.ServiceProvider {
     }
 
     public dependencies(): Contracts.Kernel.PluginDependency[] {
-        return [
-            {
-                name: "@arkecosystem/core-snapshots",
-                required: this.app.get<any>(Container.Identifiers.ConfigFlags).processType === "manager",
-            },
-        ];
+        if (this.app.get<any>(Container.Identifiers.ConfigFlags).processType === "manager") {
+            return [
+                {
+                    name: "@arkecosystem/core-snapshots",
+                    required: true,
+                },
+            ];
+        }
+
+        return [];
     }
 
     private async buildServer(type: string, id: symbol): Promise<void> {

--- a/packages/core-manager/src/service-provider.ts
+++ b/packages/core-manager/src/service-provider.ts
@@ -43,7 +43,7 @@ export class ServiceProvider extends Providers.ServiceProvider {
                 );
         }
 
-        if (this.app.get<any>(Container.Identifiers.ConfigFlags).processType === "manager") {
+        if (this.isProcessTypeManager()) {
             this.app.bind(Identifiers.ActionReader).to(ActionReader).inSingletonScope();
             this.app.bind(Identifiers.PluginFactory).to(PluginFactory).inSingletonScope();
             this.app.bind(Identifiers.BasicCredentialsValidator).to(Argon2id).inSingletonScope();
@@ -61,7 +61,7 @@ export class ServiceProvider extends Providers.ServiceProvider {
      * @memberof ServiceProvider
      */
     public async boot(): Promise<void> {
-        if (this.app.get<any>(Container.Identifiers.ConfigFlags).processType === "manager") {
+        if (this.isProcessTypeManager()) {
             if (this.config().get("server.http.enabled")) {
                 await this.buildServer("http", Identifiers.HTTP);
                 await this.app.get<Server>(Identifiers.HTTP).boot();
@@ -96,7 +96,7 @@ export class ServiceProvider extends Providers.ServiceProvider {
     }
 
     public dependencies(): Contracts.Kernel.PluginDependency[] {
-        if (this.app.get<any>(Container.Identifiers.ConfigFlags).processType === "manager") {
+        if (this.isProcessTypeManager()) {
             return [
                 {
                     name: "@arkecosystem/core-snapshots",
@@ -106,6 +106,10 @@ export class ServiceProvider extends Providers.ServiceProvider {
         }
 
         return [];
+    }
+
+    private isProcessTypeManager() {
+        return this.app.get<any>(Container.Identifiers.ConfigFlags).processType === "manager";
     }
 
     private async buildServer(type: string, id: symbol): Promise<void> {


### PR DESCRIPTION
## Summary

Use core-managers dependencies only for manager process type to prevent warnings and to include package. 

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged