### PR TITLE
fix(core-manager): await deamonizeProcess on start commnands

### DIFF
--- a/packages/core/src/commands/core-start.ts
+++ b/packages/core/src/commands/core-start.ts
@@ -64,7 +64,7 @@ export class Command extends Commands.Command {
 
         await buildBIP38(flags, this.app.getCorePath("config"));
 
-        this.actions.daemonizeProcess(
+        await this.actions.daemonizeProcess(
             {
                 name: `${flags.token}-core`,
                 script: resolve(__dirname, "../../bin/run"),

--- a/packages/core/src/commands/forger-start.ts
+++ b/packages/core/src/commands/forger-start.ts
@@ -62,7 +62,7 @@ export class Command extends Commands.Command {
 
         await buildBIP38(flags, this.app.getCorePath("config"));
 
-        this.actions.daemonizeProcess(
+        await this.actions.daemonizeProcess(
             {
                 name: `${flags.token}-forger`,
                 script: resolve(__dirname, "../../bin/run"),

--- a/packages/core/src/commands/manager-start.ts
+++ b/packages/core/src/commands/manager-start.ts
@@ -51,7 +51,7 @@ export class Command extends Commands.Command {
 
         this.actions.abortRunningProcess(`${flags.token}-manager`);
 
-        this.actions.daemonizeProcess(
+        await this.actions.daemonizeProcess(
             {
                 name: `${flags.token}-manager`,
                 script: resolve(__dirname, "../../bin/run"),

--- a/packages/core/src/commands/relay-start.ts
+++ b/packages/core/src/commands/relay-start.ts
@@ -56,7 +56,7 @@ export class Command extends Commands.Command {
 
         this.actions.abortRunningProcess(`${flags.token}-core`);
 
-        this.actions.daemonizeProcess(
+        await this.actions.daemonizeProcess(
             {
                 name: `${flags.token}-relay`,
                 script: resolve(__dirname, "../../bin/run"),

--- a/yarn.lock
+++ b/yarn.lock
@@ -5353,11 +5353,6 @@ babel-preset-jest@^26.0.0:
     babel-plugin-jest-hoist "^26.0.0"
     babel-preset-current-node-syntax "^0.1.2"
 
-backslash@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/backslash/-/backslash-0.2.0.tgz#6c3c1fce7e7e714ccfc10fd74f0f73410677375f"
-  integrity sha1-bDwfzn5+cUzPwQ/XTw9zQQZ3N18=
-
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"


### PR DESCRIPTION
## Summary

Await deamonizeProcess on :start commands. This fixes missing error logs when pm2 package is not installed. 

## Checklist
- [x] Ready to be merged