### PR TITLE
fix(core-blockchain): broadcast only new blocks

### DIFF
--- a/__tests__/unit/core-blockchain/state-machine/state-machine.test.ts
+++ b/__tests__/unit/core-blockchain/state-machine/state-machine.test.ts
@@ -1,7 +1,7 @@
-import delay from "delay";
 import { Container } from "@arkecosystem/core-kernel";
-import { StateMachine } from "../../../../packages/core-blockchain/src/state-machine/state-machine";
-import { blockchainMachine } from "../../../../packages/core-blockchain/src/state-machine/machine";
+import { blockchainMachine } from "@packages/core-blockchain/src/state-machine/machine";
+import { StateMachine } from "@packages/core-blockchain/src/state-machine/state-machine";
+import delay from "delay";
 
 describe("State machine", () => {
     const container = new Container.Container();
@@ -62,6 +62,26 @@ describe("State machine", () => {
                 expect(nextState).toEqual(mockNextState);
                 expect(handle).toHaveBeenCalledTimes(1);
             });
+        });
+    });
+
+    describe("getState", () => {
+        it("should return state if defined", () => {
+            stateStore.blockchain = {
+                // @ts-ignore
+                value: "dummy_state",
+            };
+            const stateMachine = container.resolve<StateMachine>(StateMachine);
+
+            expect(stateMachine.getState()).toEqual("dummy_state");
+        });
+
+        it("should return undefined if state is not set", () => {
+            // @ts-ignore
+            stateStore.blockchain = {};
+            const stateMachine = container.resolve<StateMachine>(StateMachine);
+
+            expect(stateMachine.getState()).toEqual(undefined);
         });
     });
 });

--- a/packages/core-blockchain/src/process-blocks-job.ts
+++ b/packages/core-blockchain/src/process-blocks-job.ts
@@ -5,6 +5,7 @@ import { Blocks, Crypto, Interfaces, Utils as CryptoUtils } from "@arkecosystem/
 
 import { BlockProcessor, BlockProcessorResult } from "./processor";
 import { RevertBlockHandler } from "./processor/handlers";
+import { StateMachine } from "@packages/core-blockchain/src/state-machine";
 
 @Container.injectable()
 export class ProcessBlocksJob implements Contracts.Kernel.QueueJob {
@@ -13,6 +14,9 @@ export class ProcessBlocksJob implements Contracts.Kernel.QueueJob {
 
     @Container.inject(Container.Identifiers.BlockchainService)
     private readonly blockchain!: Contracts.Blockchain.Blockchain;
+
+    @Container.inject(Container.Identifiers.StateMachine)
+    private readonly stateMachine!: StateMachine;
 
     @Container.inject(Container.Identifiers.StateStore)
     private readonly stateStore!: Contracts.State.StateStore;
@@ -157,7 +161,7 @@ export class ProcessBlocksJob implements Contracts.Kernel.QueueJob {
                 lastProcessResult === BlockProcessorResult.DiscardedButCanBeBroadcasted) &&
             lastProcessedBlock
         ) {
-            if (this.stateStore.started) {
+            if (this.stateStore.started && this.stateMachine.getState() === "newBlock") {
                 this.networkMonitor.broadcastBlock(lastProcessedBlock);
             }
         } else if (forkBlock) {

--- a/packages/core-blockchain/src/state-machine/state-machine.ts
+++ b/packages/core-blockchain/src/state-machine/state-machine.ts
@@ -52,4 +52,8 @@ export class StateMachine {
 
         return nextState;
     }
+
+    public getState(): string | undefined {
+        return this.stateStore.blockchain.value;
+    }
 }


### PR DESCRIPTION
## Summary

New getState() method on stateMachine. 

Broadcast only new blocks. Skip broadcasting downloaded blocks, to prevent diconnectiong from other peers.

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged