### PR TITLE
chore(core-p2p): don't throw when receiving unchained block

### DIFF
--- a/packages/core-p2p/src/socket-server/controllers/blocks.ts
+++ b/packages/core-p2p/src/socket-server/controllers/blocks.ts
@@ -3,7 +3,7 @@ import { Container, Contracts, Providers, Utils } from "@arkecosystem/core-kerne
 import { Blocks, Interfaces, Managers } from "@arkecosystem/crypto";
 import Hapi from "@hapi/hapi";
 
-import { TooManyTransactionsError, UnchainedBlockError } from "../errors";
+import { TooManyTransactionsError } from "../errors";
 import { mapAddr } from "../utils/map-addr";
 import { Controller } from "./controller";
 
@@ -55,7 +55,7 @@ export class BlocksController extends Controller {
             const blockTimeLookup = await Utils.forgingInfoCalculator.getBlockTimeLookup(this.app, block.height);
 
             if (!Utils.isBlockChained(lastDownloadedBlock, block, blockTimeLookup)) {
-                throw new UnchainedBlockError(lastDownloadedBlock.height, block.height);
+                return false;
             }
         }
 


### PR DESCRIPTION
## Summary

Prevent punishing clients with connection drop for broadcasting unchained blocks.

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged