### PR TITLE
chore(core-p2p): improve block download when above maxPayload

### DIFF
--- a/packages/core-p2p/src/hapi-nes/client.ts
+++ b/packages/core-p2p/src/hapi-nes/client.ts
@@ -202,7 +202,9 @@ export class Client {
     }
 
     public setMaxPayload(maxPayload: number) {
-        this._ws._receiver._maxPayload = maxPayload;
+        if (this._ws?.receiver) {
+            this._ws._receiver._maxPayload = maxPayload;
+        }
     }
 
     private _connect(options, initial, next) {

--- a/packages/core-p2p/src/network-monitor.ts
+++ b/packages/core-p2p/src/network-monitor.ts
@@ -402,18 +402,15 @@ export class NetworkMonitor implements Contracts.P2P.NetworkMonitor {
                             blockLimit: this.downloadChunkSize,
                         });
 
-                        if (blocks.length === this.downloadChunkSize || (isLastChunk && blocks.length > 0)) {
+                        if (blocks.length > 0 || isLastChunk) {
+                            // when `isLastChunk` it can be normal that the peer does not send any block (when none were forged)
                             this.logger.debug(
                                 `Downloaded blocks ${blocksRange} (${blocks.length}) ` + `from ${peerPrint}`,
                             );
                             downloadResults[i] = blocks;
                             return;
-                        } else if (isLastChunk && blocks.length === 0) {
-                            // Peer returned no block, but it is probably fine (when no new blocks are forged for example)
-                            downloadResults[i] = [];
-                            return;
                         } else {
-                            throw new Error("Received blocks length does not match asked length");
+                            throw new Error("Peer did not return any block");
                         }
                     } catch (error) {
                         this.logger.info(


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
We currently have a basic way of dealing with blocks that collectively exceed the max payload value : we try to download a whole chunk, if that does not work we reduce the chunk until it works.

This PR improves it a bit : when we are requested a chunk of blocks, we will only return a chunk of blocks that fits the max payload value (so it can be a sub-interval of what is asked).
This way we don't generate errors sending data exceeding max payload, and the client will handle fine receiving a sub-interval of what it asked.
<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
