### PR TITLE
feat: partial windows support

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "name": "core",
     "description": "The packages that make up the ARK Core",
     "scripts": {
-        "lerna": "./node_modules/lerna/cli.js",
+        "lerna": "node ./node_modules/lerna/cli.js",
         "setup": "yarn && yarn bootstrap && yarn build",
         "setup:clean": "yarn && yarn clean && yarn bootstrap && yarn build",
         "bootstrap": "yarn lerna bootstrap",

--- a/packages/core-api/package.json
+++ b/packages/core-api/package.json
@@ -16,8 +16,8 @@
         "build": "yarn clean && yarn compile",
         "build:watch": "yarn clean && yarn compile -w",
         "build:docs": "../../node_modules/typedoc/bin/typedoc --out docs src",
-        "clean": "del dist",
-        "compile": "../../node_modules/typescript/bin/tsc",
+        "clean": "rimraf dist",
+        "compile": "node ../../node_modules/typescript/bin/tsc",
         "prepublishOnly": "yarn build",
         "pretest": "bash ../../scripts/pre-test.sh"
     },

--- a/packages/core-api/package.json
+++ b/packages/core-api/package.json
@@ -28,7 +28,7 @@
         "@arkecosystem/core-transactions": "^3.0.0-next.18",
         "@arkecosystem/crypto": "^3.0.0-next.18",
         "@hapi/boom": "^9.0.0",
-        "@hapi/hapi": "^19.0.0",
+        "@hapi/hapi": "^20.0.3",
         "@hapi/hoek": "^9.1.0",
         "@hapi/joi": "^17.1.0",
         "ajv": "^6.10.2",

--- a/packages/core-blockchain/package.json
+++ b/packages/core-blockchain/package.json
@@ -17,8 +17,8 @@
         "build": "yarn clean && yarn compile",
         "build:watch": "yarn clean && yarn compile -w",
         "build:docs": "../../node_modules/typedoc/bin/typedoc --out docs src",
-        "clean": "del dist",
-        "compile": "../../node_modules/typescript/bin/tsc",
+        "clean": "rimraf dist",
+        "compile": "node ../../node_modules/typescript/bin/tsc",
         "prepublishOnly": "yarn build",
         "pretest": "bash ../../scripts/pre-test.sh"
     },

--- a/packages/core-cli/package.json
+++ b/packages/core-cli/package.json
@@ -12,12 +12,12 @@
     "main": "dist/index",
     "types": "dist/index",
     "scripts": {
-        "ark": "./bin/run",
+        "ark": "node ./bin/run",
         "build": "yarn clean && yarn compile",
         "build:watch": "yarn clean && yarn compile -w",
         "build:docs": "../../node_modules/typedoc/bin/typedoc --out docs src",
-        "clean": "del dist",
-        "compile": "../../node_modules/typescript/bin/tsc",
+        "clean": "rimraf dist",
+        "compile": "node ../../node_modules/typescript/bin/tsc",
         "prepublishOnly": "yarn build"
     },
     "dependencies": {

--- a/packages/core-database/package.json
+++ b/packages/core-database/package.json
@@ -16,8 +16,8 @@
         "build": "yarn clean && yarn compile",
         "build:watch": "yarn clean && yarn compile -w",
         "build:docs": "../../node_modules/typedoc/bin/typedoc --out docs src",
-        "clean": "del dist",
-        "compile": "../../node_modules/typescript/bin/tsc",
+        "clean": "rimraf dist",
+        "compile": "node ../../node_modules/typescript/bin/tsc",
         "prepublishOnly": "yarn build",
         "pretest": "bash ../../scripts/pre-test.sh"
     },

--- a/packages/core-forger/package.json
+++ b/packages/core-forger/package.json
@@ -16,8 +16,8 @@
         "build": "yarn clean && yarn compile",
         "build:watch": "yarn clean && yarn compile -w",
         "build:docs": "../../node_modules/typedoc/bin/typedoc --out docs src",
-        "clean": "del dist",
-        "compile": "../../node_modules/typescript/bin/tsc",
+        "clean": "rimraf dist",
+        "compile": "node ../../node_modules/typescript/bin/tsc",
         "prepublishOnly": "yarn build",
         "pretest": "bash ../../scripts/pre-test.sh"
     },

--- a/packages/core-forger/package.json
+++ b/packages/core-forger/package.json
@@ -25,7 +25,7 @@
         "@arkecosystem/core-kernel": "^3.0.0-next.18",
         "@arkecosystem/core-p2p": "^3.0.0-next.18",
         "@arkecosystem/crypto": "^3.0.0-next.18",
-        "@hapi/hapi": "^19.0.0",
+        "@hapi/hapi": "^20.0.3",
         "node-forge": "^0.9.1",
         "otplib": "^12.0.0",
         "wif": "^2.0.6"

--- a/packages/core-kernel/package.json
+++ b/packages/core-kernel/package.json
@@ -14,11 +14,11 @@
     "scripts": {
         "prepublishOnly": "yarn build",
         "pretest": "yarn lint && yarn build",
-        "compile": "../../node_modules/typescript/bin/tsc",
+        "compile": "node ../../node_modules/typescript/bin/tsc",
         "build": "yarn clean && yarn compile",
         "build:watch": "yarn clean && yarn compile -w",
         "build:docs": "../../node_modules/typedoc/bin/typedoc --out docs src",
-        "clean": "del dist"
+        "clean": "rimraf dist"
     },
     "dependencies": {
         "@arkecosystem/crypto": "^3.0.0-next.18",

--- a/packages/core-logger-pino/package.json
+++ b/packages/core-logger-pino/package.json
@@ -14,8 +14,8 @@
         "build": "yarn clean && yarn compile",
         "build:watch": "yarn clean && yarn compile -w",
         "build:docs": "../../node_modules/typedoc/bin/typedoc --out docs src",
-        "clean": "del dist",
-        "compile": "../../node_modules/typescript/bin/tsc",
+        "clean": "rimraf dist",
+        "compile": "node ../../node_modules/typescript/bin/tsc",
         "prepublishOnly": "yarn build",
         "pretest": "bash ../../scripts/pre-test.sh"
     },

--- a/packages/core-magistrate-api/package.json
+++ b/packages/core-magistrate-api/package.json
@@ -16,8 +16,8 @@
         "build": "yarn clean && yarn compile",
         "build:watch": "yarn clean && yarn compile -w",
         "build:docs": "../../node_modules/typedoc/bin/typedoc --out docs src",
-        "clean": "del dist",
-        "compile": "../../node_modules/typescript/bin/tsc",
+        "clean": "rimraf dist",
+        "compile": "node ../../node_modules/typescript/bin/tsc",
         "prepublishOnly": "yarn build",
         "pretest": "bash ../../scripts/pre-test.sh"
     },

--- a/packages/core-magistrate-api/package.json
+++ b/packages/core-magistrate-api/package.json
@@ -27,7 +27,7 @@
         "@arkecosystem/core-magistrate-crypto": "^3.0.0-next.18",
         "@arkecosystem/core-magistrate-transactions": "^3.0.0-next.18",
         "@hapi/boom": "^9.0.0",
-        "@hapi/hapi": "^19.0.0",
+        "@hapi/hapi": "^20.0.3",
         "@hapi/joi": "^17.1.0"
     },
     "devDependencies": {

--- a/packages/core-magistrate-crypto/package.json
+++ b/packages/core-magistrate-crypto/package.json
@@ -16,8 +16,8 @@
     "scripts": {
         "build": "yarn clean && tsc",
         "build:watch": "yarn clean && yarn compile -w",
-        "clean": "del dist",
-        "compile": "../../node_modules/typescript/bin/tsc",
+        "clean": "rimraf dist",
+        "compile": "node ../../node_modules/typescript/bin/tsc",
         "prepublishOnly": "yarn build"
     },
     "dependencies": {

--- a/packages/core-magistrate-transactions/package.json
+++ b/packages/core-magistrate-transactions/package.json
@@ -16,8 +16,8 @@
     "scripts": {
         "build": "yarn clean && tsc",
         "build:watch": "yarn clean && yarn compile -w",
-        "clean": "del dist",
-        "compile": "../../node_modules/typescript/bin/tsc",
+        "clean": "rimraf dist",
+        "compile": "node ../../node_modules/typescript/bin/tsc",
         "prepublishOnly": "yarn build"
     },
     "dependencies": {

--- a/packages/core-manager/package.json
+++ b/packages/core-manager/package.json
@@ -15,8 +15,8 @@
         "build": "yarn clean && yarn compile",
         "build:watch": "yarn clean && yarn compile -w",
         "build:docs": "../../node_modules/typedoc/bin/typedoc --out docs src",
-        "clean": "del dist",
-        "compile": "../../node_modules/typescript/bin/tsc",
+        "clean": "rimraf dist",
+        "compile": "node ../../node_modules/typescript/bin/tsc",
         "prepublishOnly": "yarn build",
         "pretest": "bash ../../scripts/pre-test.sh"
     },

--- a/packages/core-manager/package.json
+++ b/packages/core-manager/package.json
@@ -30,7 +30,7 @@
         "@arkecosystem/utils": "^1.2.1",
         "@hapi/basic": "^6.0.0",
         "@hapi/boom": "^9.0.0",
-        "@hapi/hapi": "^19.0.0",
+        "@hapi/hapi": "^20.0.3",
         "@hapi/joi": "^17.1.1",
         "@hapist/json-rpc": "^0.2.0",
         "@hapist/whitelist": "^0.1.0",

--- a/packages/core-p2p/package.json
+++ b/packages/core-p2p/package.json
@@ -21,8 +21,8 @@
         "pbjs": "../../node_modules/protobufjs/cli/bin/pbjs -t static-module -w commonjs src/socket-server/codecs/proto/*.proto -o src/socket-server/codecs/proto/protos.js",
         "pbts": "../../node_modules/protobufjs/cli/bin/pbts src/socket-server/codecs/proto/protos.js -o src/socket-server/codecs/proto/protos.d.ts",
         "build:proto": "yarn pbjs && yarn pbts",
-        "clean": "del dist",
-        "compile": "../../node_modules/typescript/bin/tsc",
+        "clean": "rimraf dist",
+        "compile": "node ../../node_modules/typescript/bin/tsc",
         "prepublishOnly": "yarn build",
         "pretest": "bash ../../scripts/pre-test.sh"
     },

--- a/packages/core-p2p/package.json
+++ b/packages/core-p2p/package.json
@@ -35,7 +35,7 @@
         "@hapi/boom": "^9.0.0",
         "@hapi/bounce": "2.x.x",
         "@hapi/cryptiles": "5.x.x",
-        "@hapi/hapi": "^19.0.0",
+        "@hapi/hapi": "^20.0.3",
         "@hapi/hoek": "9.x.x",
         "@hapi/joi": "^17.1.1",
         "@hapi/sntp": "^4.0.0",

--- a/packages/core-snapshots/package.json
+++ b/packages/core-snapshots/package.json
@@ -15,8 +15,8 @@
         "build": "yarn clean && yarn compile",
         "build:watch": "yarn clean && yarn compile -w",
         "build:docs": "../../node_modules/typedoc/bin/typedoc --out docs src",
-        "clean": "del dist",
-        "compile": "../../node_modules/typescript/bin/tsc",
+        "clean": "rimraf dist",
+        "compile": "node ../../node_modules/typescript/bin/tsc",
         "prepublishOnly": "yarn build"
     },
     "dependencies": {

--- a/packages/core-state/package.json
+++ b/packages/core-state/package.json
@@ -16,8 +16,8 @@
         "build": "yarn clean && yarn compile",
         "build:watch": "yarn clean && yarn compile -w",
         "build:docs": "../../node_modules/typedoc/bin/typedoc --out docs src",
-        "clean": "del dist",
-        "compile": "../../node_modules/typescript/bin/tsc",
+        "clean": "rimraf dist",
+        "compile": "node ../../node_modules/typescript/bin/tsc",
         "prepublishOnly": "yarn build",
         "pretest": "bash ../../scripts/pre-test.sh"
     },

--- a/packages/core-test-framework/package.json
+++ b/packages/core-test-framework/package.json
@@ -16,8 +16,8 @@
         "build": "yarn clean && yarn compile",
         "build:watch": "yarn clean && yarn compile -w",
         "build:docs": "../../node_modules/typedoc/bin/typedoc --out docs src",
-        "clean": "del dist",
-        "compile": "../../node_modules/typescript/bin/tsc",
+        "clean": "rimraf dist",
+        "compile": "node ../../node_modules/typescript/bin/tsc",
         "prepublishOnly": "yarn build"
     },
     "dependencies": {

--- a/packages/core-transaction-pool/package.json
+++ b/packages/core-transaction-pool/package.json
@@ -19,8 +19,8 @@
         "build": "yarn clean && yarn compile",
         "build:watch": "yarn clean && yarn compile -w",
         "build:docs": "../../node_modules/typedoc/bin/typedoc --out docs src",
-        "clean": "del dist",
-        "compile": "../../node_modules/typescript/bin/tsc",
+        "clean": "rimraf dist",
+        "compile": "node ../../node_modules/typescript/bin/tsc",
         "prepublishOnly": "yarn build",
         "pretest": "bash ../../scripts/pre-test.sh"
     },

--- a/packages/core-transactions/package.json
+++ b/packages/core-transactions/package.json
@@ -15,8 +15,8 @@
         "build": "yarn clean && yarn compile",
         "build:watch": "yarn clean && yarn compile -w",
         "build:docs": "../../node_modules/typedoc/bin/typedoc --out docs src",
-        "clean": "del dist",
-        "compile": "../../node_modules/typescript/bin/tsc",
+        "clean": "rimraf dist",
+        "compile": "node ../../node_modules/typescript/bin/tsc",
         "prepublishOnly": "yarn build"
     },
     "dependencies": {

--- a/packages/core-webhooks/package.json
+++ b/packages/core-webhooks/package.json
@@ -23,7 +23,7 @@
         "@arkecosystem/core-kernel": "^3.0.0-next.18",
         "@arkecosystem/crypto": "^3.0.0-next.18",
         "@hapi/boom": "^9.0.0",
-        "@hapi/hapi": "^19.0.0",
+        "@hapi/hapi": "^20.0.3",
         "@hapi/joi": "^17.1.0",
         "fs-extra": "^8.1.0",
         "lowdb": "^1.0.0",

--- a/packages/core-webhooks/package.json
+++ b/packages/core-webhooks/package.json
@@ -14,8 +14,8 @@
         "build": "yarn clean && yarn compile",
         "build:watch": "yarn clean && yarn compile -w",
         "build:docs": "../../node_modules/typedoc/bin/typedoc --out docs src",
-        "clean": "del dist",
-        "compile": "../../node_modules/typescript/bin/tsc",
+        "clean": "rimraf dist",
+        "compile": "node ../../node_modules/typescript/bin/tsc",
         "prepublishOnly": "yarn build",
         "pretest": "bash ../../scripts/pre-test.sh"
     },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,12 +19,12 @@
         "ark": "./bin/run"
     },
     "scripts": {
-        "ark": "./bin/run",
+        "ark": "node ./bin/run",
         "build": "yarn clean && yarn compile",
         "build:watch": "yarn clean && yarn compile -w",
         "build:docs": "../../node_modules/typedoc/bin/typedoc --out docs src",
-        "clean": "del dist",
-        "compile": "../../node_modules/typescript/bin/tsc",
+        "clean": "rimraf dist",
+        "compile": "node ../../node_modules/typescript/bin/tsc",
         "debug:forger": "node --inspect-brk yarn ark forger:run",
         "debug:relay": "node --inspect-brk yarn ark relay:run",
         "debug:start": "node --inspect-brk yarn ark core:run",

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -26,8 +26,8 @@
         "build:rollup": "yarn clean && tsc && rollup -c",
         "build:watch": "yarn clean && yarn compile -w",
         "build:docs": "../../node_modules/typedoc/bin/typedoc --out docs src",
-        "clean": "del dist",
-        "compile": "../../node_modules/typescript/bin/tsc",
+        "clean": "rimraf dist",
+        "compile": "node ../../node_modules/typescript/bin/tsc",
         "prepublishOnly": "yarn build:rollup"
     },
     "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2171,15 +2171,15 @@
     "@hapi/joi" "16.x.x"
     "@hapi/podium" "3.x.x"
 
-"@hapi/catbox@11.x.x":
-  version "11.0.1"
-  resolved "https://registry.yarnpkg.com/@hapi/catbox/-/catbox-11.0.1.tgz#c3a1ce5c7a5aa587471e16914745fd27ae861571"
-  integrity sha512-CsdannMSzWqLcJ7rXT55JGAzoR+BPXesKn9POOrF0A0wsumbUwHP7vxBUH/21YitcM/dLxjUfphkRAQT+XaoyQ==
+"@hapi/catbox@^11.1.1":
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/@hapi/catbox/-/catbox-11.1.1.tgz#d277e2d5023fd69cddb33d05b224ea03065fec0c"
+  integrity sha512-u/8HvB7dD/6X8hsZIpskSDo4yMKpHxFd7NluoylhGrL6cUfYxdQPnvUp9YU2C6F9hsyBVLGulBd9vBN1ebfXOQ==
   dependencies:
     "@hapi/boom" "9.x.x"
     "@hapi/hoek" "9.x.x"
-    "@hapi/joi" "17.x.x"
     "@hapi/podium" "4.x.x"
+    "@hapi/validate" "1.x.x"
 
 "@hapi/content@^4.1.1":
   version "4.1.1"
@@ -2253,29 +2253,29 @@
     "@hapi/teamwork" "3.x.x"
     "@hapi/topo" "3.x.x"
 
-"@hapi/hapi@^19.0.0":
-  version "19.1.1"
-  resolved "https://registry.yarnpkg.com/@hapi/hapi/-/hapi-19.1.1.tgz#d3b73777194b2229be81dd237b23b06711a781ca"
-  integrity sha512-rpQzSs0XsHSF7usM4qdJJ0Bcmhs9stWhUW3OiamW33bw4qL8q3uEgUKB9KH8ODmluCAkkXOQ0X0Dh9t94E5VIw==
+"@hapi/hapi@^20.0.3":
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/@hapi/hapi/-/hapi-20.0.3.tgz#e72cad460394e6d2c15f9c57abb5d3332dea27e3"
+  integrity sha512-aqJVHVjoY3phiZsgsGjDRG15CoUNIs1azScqLZDOCZUSKYGTbzPi+K0QP+RUjUJ0m8L9dRuTZ27c8HKxG3wEhA==
   dependencies:
     "@hapi/accept" "^5.0.1"
     "@hapi/ammo" "^5.0.1"
     "@hapi/boom" "9.x.x"
     "@hapi/bounce" "2.x.x"
     "@hapi/call" "8.x.x"
-    "@hapi/catbox" "11.x.x"
+    "@hapi/catbox" "^11.1.1"
     "@hapi/catbox-memory" "5.x.x"
-    "@hapi/heavy" "7.x.x"
+    "@hapi/heavy" "^7.0.1"
     "@hapi/hoek" "9.x.x"
-    "@hapi/joi" "17.x.x"
     "@hapi/mimos" "5.x.x"
-    "@hapi/podium" "4.x.x"
-    "@hapi/shot" "5.x.x"
+    "@hapi/podium" "^4.1.1"
+    "@hapi/shot" "^5.0.1"
     "@hapi/somever" "3.x.x"
-    "@hapi/statehood" "^7.0.2"
+    "@hapi/statehood" "^7.0.3"
     "@hapi/subtext" "^7.0.3"
-    "@hapi/teamwork" "4.x.x"
+    "@hapi/teamwork" "5.x.x"
     "@hapi/topo" "5.x.x"
+    "@hapi/validate" "^1.1.0"
 
 "@hapi/heavy@6.x.x":
   version "6.2.2"
@@ -2286,14 +2286,14 @@
     "@hapi/hoek" "8.x.x"
     "@hapi/joi" "16.x.x"
 
-"@hapi/heavy@7.x.x":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@hapi/heavy/-/heavy-7.0.0.tgz#711b06be6c77a30c7a302d1a41f6edc400025d48"
-  integrity sha512-n/nheUG6zNleWkjY+3fzV3VJIAumUCaa/WoTmurjqlYY5JgC5ZKOpvP7tWi8rXmKZhbcXgjH3fHFoM55LoBT7g==
+"@hapi/heavy@^7.0.1":
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/@hapi/heavy/-/heavy-7.0.1.tgz#73315ae33b6e7682a0906b7a11e8ca70e3045874"
+  integrity sha512-vJ/vzRQ13MtRzz6Qd4zRHWS3FaUc/5uivV2TIuExGTM9Qk+7Zzqj0e2G7EpE6KztO9SalTbiIkTh7qFKj/33cA==
   dependencies:
     "@hapi/boom" "9.x.x"
     "@hapi/hoek" "9.x.x"
-    "@hapi/joi" "17.x.x"
+    "@hapi/validate" "1.x.x"
 
 "@hapi/hoek@8.x.x", "@hapi/hoek@^8.2.4", "@hapi/hoek@^8.3.0", "@hapi/hoek@^8.3.1":
   version "8.5.1"
@@ -2461,6 +2461,15 @@
     "@hapi/joi" "17.x.x"
     "@hapi/teamwork" "4.x.x"
 
+"@hapi/podium@^4.1.1":
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/@hapi/podium/-/podium-4.1.1.tgz#106e5849f2cb19b8767cc16007e0107f27c3c791"
+  integrity sha512-jh7a6+5Z4FUWzx8fgmxjaAa1DTBu+Qfg+NbVdo0f++rE5DgsVidUYrLDp3db65+QjDLleA2MfKQXkpT8ylBDXA==
+  dependencies:
+    "@hapi/hoek" "9.x.x"
+    "@hapi/teamwork" "5.x.x"
+    "@hapi/validate" "1.x.x"
+
 "@hapi/shot@4.x.x":
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/@hapi/shot/-/shot-4.1.2.tgz#69f999956041fe468701a89a413175a521dabed5"
@@ -2469,13 +2478,13 @@
     "@hapi/hoek" "8.x.x"
     "@hapi/joi" "16.x.x"
 
-"@hapi/shot@5.x.x":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@hapi/shot/-/shot-5.0.0.tgz#64c908398295c1b4bd10f471b3a83b4e1410f342"
-  integrity sha512-JXddnJkRh3Xhv9lY1tA+TSIUaoODKbdNIPL/M8WFvFQKOttmGaDeqTW5e8Gf01LtLI7L5DraLMULHjrK1+YNFg==
+"@hapi/shot@^5.0.1":
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/@hapi/shot/-/shot-5.0.4.tgz#6c978314f21a054c041f4becc50095dd78d3d775"
+  integrity sha512-PcEz0WJgFDA3xNSMeONgQmothFr7jhbbRRSAKaDh7chN7zOXBlhl13bvKZW6CMb2xVfJUmt34CW3e/oExMgBhQ==
   dependencies:
     "@hapi/hoek" "9.x.x"
-    "@hapi/joi" "17.x.x"
+    "@hapi/validate" "1.x.x"
 
 "@hapi/sntp@^4.0.0":
   version "4.0.0"
@@ -2516,10 +2525,10 @@
     "@hapi/iron" "5.x.x"
     "@hapi/joi" "16.x.x"
 
-"@hapi/statehood@^7.0.2":
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/@hapi/statehood/-/statehood-7.0.2.tgz#e797c7e6d8cdcdf6900e9ea69612181fe5553db6"
-  integrity sha512-+0VNxysQu+UYzkfvAXq3X4aN65TnUwiR7gsq2cQ/4Rq26nCJjHAfrkYReEeshU2hPmJ3m5QuaBzyDqRm8WOpyg==
+"@hapi/statehood@^7.0.3":
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/@hapi/statehood/-/statehood-7.0.3.tgz#655166f3768344ed3c3b50375a303cdeca8040d9"
+  integrity sha512-pYB+pyCHkf2Amh67QAXz7e/DN9jcMplIL7Z6N8h0K+ZTy0b404JKPEYkbWHSnDtxLjJB/OtgElxocr2fMH4G7w==
   dependencies:
     "@hapi/boom" "9.x.x"
     "@hapi/bounce" "2.x.x"
@@ -2527,7 +2536,7 @@
     "@hapi/cryptiles" "5.x.x"
     "@hapi/hoek" "9.x.x"
     "@hapi/iron" "6.x.x"
-    "@hapi/joi" "17.x.x"
+    "@hapi/validate" "1.x.x"
 
 "@hapi/subtext@^6.1.3":
   version "6.1.3"
@@ -2583,6 +2592,14 @@
   integrity sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==
   dependencies:
     "@hapi/hoek" "^9.0.0"
+
+"@hapi/validate@1.x.x", "@hapi/validate@^1.1.0":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@hapi/validate/-/validate-1.1.3.tgz#f750a07283929e09b51aa16be34affb44e1931ad"
+  integrity sha512-/XMR0N0wjw0Twzq2pQOzPBZlDzkekGcoCtzO314BpIEsbXdYGthQUbxgkGDf4nhk1+IPDAsXqWjMohRQYO06UA==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+    "@hapi/topo" "^5.0.0"
 
 "@hapi/vise@3.x.x":
   version "3.1.1"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

**Note:**
Windows build tools are required to successfully build and run Ark Core and can be installed using opening PowerShell as Administrator and running a command `yarn global add windows-build-tools`
I didn't amend all the scripts just the ones that are required to successfully build and run ark core on windows, hence development & debugging are now working.

**What changes are being made?**
Amend scripts (required to build and run the project) which should now run under windows.
Bump hapi dependencies to resolve `Topo is not a constructor error`.

**Why are these changes necessary?**
To allow building and running ark core on windows without using docker or wsl.

<!-- How were these changes implemented? -->


## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
