### PR TITLE
chore(core-manager): full download link on `log.archived`

### DIFF
--- a/__tests__/unit/core-manager/actions/log-archived.test.ts
+++ b/__tests__/unit/core-manager/actions/log-archived.test.ts
@@ -1,12 +1,15 @@
 import "jest-extended";
 
-import { Container } from "@packages/core-kernel";
+import { Container, Providers } from "@packages/core-kernel";
 import { Action } from "@packages/core-manager/src/actions/log-archived";
+import { Identifiers } from "@packages/core-manager/src/ioc";
 import { Sandbox } from "@packages/core-test-framework";
-import { dirSync, setGracefulCleanup } from "tmp";
 import { pathExistsSync } from "fs-extra";
+import { v4 } from "public-ip";
+import { dirSync, setGracefulCleanup } from "tmp";
 
 jest.mock("fs-extra");
+jest.mock("public-ip");
 
 let sandbox: Sandbox;
 let action: Action;
@@ -26,6 +29,17 @@ beforeEach(() => {
 
     sandbox.app.bind(Container.Identifiers.ApplicationVersion).toConstantValue("dummyVersion");
     sandbox.app.bind(Container.Identifiers.FilesystemService).toConstantValue(mockFilesystem);
+    sandbox.app.bind(Container.Identifiers.PluginConfiguration).to(Providers.PluginConfiguration).inSingletonScope();
+
+    sandbox.app
+        .get<Providers.PluginConfiguration>(Container.Identifiers.PluginConfiguration)
+        .set("server.ip", "127.0.0.1");
+    sandbox.app
+        .get<Providers.PluginConfiguration>(Container.Identifiers.PluginConfiguration)
+        .set("server.http.port", "4005");
+    sandbox.app
+        .get<Providers.PluginConfiguration>(Container.Identifiers.PluginConfiguration)
+        .set("server.https.port", "8445");
 
     action = sandbox.app.resolve(Action);
 });
@@ -39,7 +53,17 @@ describe("Info:CoreVersion", () => {
         expect(action.name).toEqual("log.archived");
     });
 
-    it("should return file info", async () => {
+    it("should return empty array if folder doesn't exist", async () => {
+        // @ts-ignore
+        pathExistsSync.mockReturnValue(false);
+
+        const result = await action.execute({});
+
+        expect(result).toBeArray();
+        expect(result.length).toBe(0);
+    });
+
+    it("should return file info using HTTP server", async () => {
         // @ts-ignore
         pathExistsSync.mockReturnValue(true);
 
@@ -49,16 +73,37 @@ describe("Info:CoreVersion", () => {
         expect(result.length).toBe(1);
         expect(result[0].size).toBe(1);
         expect(result[0].name).toBe("2020-12-14_17-38-00.log.gz");
-        expect(result[0].downloadLink).toBe("/log/archived/2020-12-14_17-38-00.log.gz");
+        expect(result[0].downloadLink).toBe("http://127.0.0.1:4005/log/archived/2020-12-14_17-38-00.log.gz");
     });
 
-    it("should return empty array if folder doesn't exist", async () => {
+    it("should return file info using HTTPS server", async () => {
         // @ts-ignore
-        pathExistsSync.mockReturnValue(false);
+        pathExistsSync.mockReturnValue(true);
+        sandbox.app.bind(Identifiers.HTTPS).toConstantValue({});
 
         const result = await action.execute({});
 
         expect(result).toBeArray();
-        expect(result.length).toBe(0);
+        expect(result.length).toBe(1);
+        expect(result[0].size).toBe(1);
+        expect(result[0].name).toBe("2020-12-14_17-38-00.log.gz");
+        expect(result[0].downloadLink).toBe("https://127.0.0.1:8445/log/archived/2020-12-14_17-38-00.log.gz");
+    });
+
+    it("should obtain public IP if IP is not set", async () => {
+        // @ts-ignore
+        pathExistsSync.mockReturnValue(true);
+        // @ts-ignore
+        v4.mockReturnValue("127.0.0.5");
+
+        sandbox.app.get<Providers.PluginConfiguration>(Container.Identifiers.PluginConfiguration).unset("server.ip");
+
+        const result = await action.execute({});
+
+        expect(result).toBeArray();
+        expect(result.length).toBe(1);
+        expect(result[0].size).toBe(1);
+        expect(result[0].name).toBe("2020-12-14_17-38-00.log.gz");
+        expect(result[0].downloadLink).toBe("http://127.0.0.5:4005/log/archived/2020-12-14_17-38-00.log.gz");
     });
 });

--- a/packages/core-manager/package.json
+++ b/packages/core-manager/package.json
@@ -43,6 +43,7 @@
         "got": "^11.1.3",
         "hapi-auth-bearer-token": "^6.1.6",
         "latest-version": "^5.1.0",
+        "public-ip": "^4.0.3",
         "require-from-string": "^2.0.2",
         "systeminformation": "^4.30.4",
         "typeorm": "0.2.25",

--- a/packages/core-manager/src/defaults.ts
+++ b/packages/core-manager/src/defaults.ts
@@ -22,6 +22,7 @@ export const defaults = {
         history: 30, // Days
     },
     server: {
+        ip: process.env.CORE_MONITOR_PUBLIC_IP,
         http: {
             enabled: !process.env.CORE_MONITOR_DISABLED,
             host: process.env.CORE_MONITOR_HOST || "0.0.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7276,6 +7276,20 @@ dlv@^1.1.2:
   resolved "https://registry.yarnpkg.com/dlv/-/dlv-1.1.3.tgz#5c198a8a11453596e751494d49874bc7732f2e79"
   integrity sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==
 
+dns-packet@^5.1.2:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/dns-packet/-/dns-packet-5.2.1.tgz#26cec0be92252a1b97ed106482921192a7e08f72"
+  integrity sha512-JHj2yJeKOqlxzeuYpN1d56GfhzivAxavNwHj9co3qptECel27B1rLY5PifJAvubsInX5pGLDjAHuCfCUc2Zv/w==
+  dependencies:
+    ip "^1.1.5"
+
+dns-socket@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/dns-socket/-/dns-socket-4.2.1.tgz#c260f46e5649d1c2476763b78e2ee48f7abef531"
+  integrity sha512-fNvDq86lS522+zMbh31X8cQzYQd6xumCNlxsuZF5TKxQThF/e+rJbVM6K8mmlsdcSm6yNjKJQq3Sf38viAJj8g==
+  dependencies:
+    dns-packet "^5.1.2"
+
 doctrine@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-3.0.0.tgz#addebead72a6574db783639dc87a121773973961"
@@ -9389,6 +9403,11 @@ ip-regex@^2.1.0:
   resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-2.1.0.tgz#fa78bf5d2e6913c911ce9f819ee5146bb6d844e9"
   integrity sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=
 
+ip-regex@^4.0.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-4.2.0.tgz#a03f5eb661d9a154e3973a03de8b23dd0ad6892e"
+  integrity sha512-n5cDDeTWWRwK1EBoWwRti+8nP4NbytBBY0pldmnIkq6Z55KNFmWofh4rl9dPZpj+U/nVq7gweR3ylrvMt4YZ5A==
+
 ip@1.1.5, ip@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
@@ -9581,6 +9600,13 @@ is-interactive@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-interactive/-/is-interactive-1.0.0.tgz#cea6e6ae5c870a7b0a0004070b7b587e0252912e"
   integrity sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==
+
+is-ip@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/is-ip/-/is-ip-3.1.0.tgz#2ae5ddfafaf05cb8008a62093cf29734f657c5d8"
+  integrity sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==
+  dependencies:
+    ip-regex "^4.0.0"
 
 is-lambda@^1.0.1:
   version "1.0.1"
@@ -13255,6 +13281,15 @@ psl@^1.1.24, psl@^1.1.28:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.4.0.tgz#5dd26156cdb69fa1fdb8ab1991667d3f80ced7c2"
   integrity sha512-HZzqCGPecFLyoRj5HLfuDSKYTJkAfB5thKBIkRHtGjWwY7p1dAyveIbXIq4tO0KYfDF2tHqPUgY9SDnGm00uFw==
+
+public-ip@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/public-ip/-/public-ip-4.0.3.tgz#ca96979ddbd3e14d3378fd92b94a657b5696f288"
+  integrity sha512-IofiJJWoZ8hZHBk25l4ozLvcET0pjZSxocbUfh4sGkjidMOm4iZNzzWxezGqGsVY7HuxiK7SkyJKHNeT0YQ7uw==
+  dependencies:
+    dns-socket "^4.2.1"
+    got "^9.6.0"
+    is-ip "^3.1.0"
 
 pump@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
## Summary

Generate full download link on `log.archived` action. 

Path will use HTTPS settings if HTTPS server is running, otherwise it will use HTTP options. Optionally custom IP can be defined via CORE_MONITOR_PUBLIC_IP ENV variable.  If value is empty, public IP will be obtained via[ public-ip](https://www.npmjs.com/package/public-ip) package.

## Checklist

- [x] Tests _(if necessary)_
- [ ] Ready to be merged