### PR TITLE
feat(core-manager): sort logs descending by defaut on `log.search`

### DIFF
--- a/__tests__/unit/core-manager/database/logs-database-service.test.ts
+++ b/__tests__/unit/core-manager/database/logs-database-service.test.ts
@@ -233,7 +233,7 @@ describe("LogsDatabaseService", () => {
             expect(result.offset).toBe(0);
             expect(result.data).toBeArray();
             expect(result.data.length).toBe(1);
-            expect(result.data[0].id).toBe(1);
+            expect(result.data[0].id).toBe(200);
 
             result = database.search({
                 limit: 1,
@@ -245,7 +245,29 @@ describe("LogsDatabaseService", () => {
             expect(result.offset).toBe(10);
             expect(result.data).toBeArray();
             expect(result.data.length).toBe(1);
-            expect(result.data[0].id).toBe(11);
+            expect(result.data[0].id).toBe(190);
+        });
+
+        it("should sort by order", () => {
+            let result = database.search({});
+
+            expect(result.total).toBe(200);
+            expect(result.limit).toBe(100);
+            expect(result.offset).toBe(0);
+            expect(result.data).toBeArray();
+            expect(result.data.length).toBe(100);
+            expect(result.data[0].id).toBe(200);
+
+            result = database.search({
+                order: "ASC",
+            });
+
+            expect(result.total).toBe(200);
+            expect(result.limit).toBe(100);
+            expect(result.offset).toBe(0);
+            expect(result.data).toBeArray();
+            expect(result.data.length).toBe(100);
+            expect(result.data[0].id).toBe(1);
         });
     });
 });

--- a/packages/core-manager/src/actions/log-search.ts
+++ b/packages/core-manager/src/actions/log-search.ts
@@ -35,6 +35,9 @@ export class Action implements Actions.Action {
             offset: {
                 type: "number",
             },
+            order: {
+                type: "string",
+            },
         },
     };
 

--- a/packages/core-manager/src/database/logs-database-service.ts
+++ b/packages/core-manager/src/database/logs-database-service.ts
@@ -19,6 +19,7 @@ export interface SearchParams {
     process?: string;
     limit?: number;
     offset?: number;
+    order?: string;
 }
 
 @Container.injectable()
@@ -99,7 +100,9 @@ export class LogsDatabaseService {
     }
 
     public search(searchParams: SearchParams): Result {
-        const conditions: any = {};
+        const conditions: any = {
+            $order: { id: "DESC" },
+        };
 
         if (searchParams.dateFrom || searchParams.dateTo) {
             conditions.timestamp = {};
@@ -133,6 +136,10 @@ export class LogsDatabaseService {
 
         if (searchParams.offset) {
             conditions.$offset = searchParams.offset;
+        }
+
+        if (searchParams.order && searchParams.order.toUpperCase() === "ASC") {
+            conditions.$order.id = "ASC";
         }
 
         return this.database.find("logs", conditions);


### PR DESCRIPTION
## Summary

Sort logs by time descending on `log.search` action.

Added optional parameter `order` which accepts values `DESC` (default) or `ASC`. 

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged