### PR TITLE
chore(core-p2p): add delay on multiple reconnections (client socket)

### DIFF
--- a/__tests__/unit/core-p2p/peer-connector.test.ts
+++ b/__tests__/unit/core-p2p/peer-connector.test.ts
@@ -7,6 +7,8 @@ import { Peer } from "../../../packages/core-p2p/src/peer";
 import { PeerConnector } from "../../../packages/core-p2p/src/peer-connector";
 import { NesClient } from "./mocks/nes";
 
+jest.setTimeout(60000);
+
 const spyOnClient = jest.spyOn(Nes, "Client").mockImplementation((url) => new (NesClient as any)());
 
 describe("PeerConnector", () => {
@@ -93,6 +95,17 @@ describe("PeerConnector", () => {
 
             expect(peerConnection).toBeInstanceOf(NesClient);
             expect(logger.debug).toHaveBeenCalled();
+        });
+
+        it("should delay connection create if re-connecting within 10 seconds", async () => {
+            const peer = new Peer("178.165.55.11", 4000);
+            await peerConnector.connect(peer);
+
+            peerConnector.disconnect(peer);
+
+            const before = Date.now();
+            await peerConnector.connect(peer);
+            expect((Date.now() - before)/1000).toBeCloseTo(10, 1); // close to 10 seconds
         });
     });
 

--- a/packages/core-p2p/src/peer-connector.ts
+++ b/packages/core-p2p/src/peer-connector.ts
@@ -51,6 +51,16 @@ export class PeerConnector implements Contracts.P2P.PeerConnector {
 
             this.connections.delete(`${peer.ip}`);
         }
+
+        const timeSinceLastConnectionCreate = Date.now() - (this.lastConnectionCreate.get(peer.ip) ?? 0);
+        setTimeout(
+            () => {
+                if (!this.connection(peer)) {
+                    this.lastConnectionCreate.delete(peer.ip);
+                }
+            },
+            Math.max(TEN_SECONDS_IN_MILLISECONDS - timeSinceLastConnectionCreate, 0), // always between 0-10 seconds
+        );
     }
 
     public async emit(peer: Contracts.P2P.Peer, event: string, payload: any): Promise<any> {

--- a/packages/core-p2p/src/peer-connector.ts
+++ b/packages/core-p2p/src/peer-connector.ts
@@ -1,6 +1,9 @@
 import { Container, Contracts, Utils } from "@arkecosystem/core-kernel";
+import delay from "delay";
 
 import { Client } from "./hapi-nes";
+
+const TEN_SECONDS_IN_MILLISECONDS = 10000;
 
 @Container.injectable()
 export class PeerConnector implements Contracts.P2P.PeerConnector {
@@ -9,6 +12,7 @@ export class PeerConnector implements Contracts.P2P.PeerConnector {
 
     private readonly connections: Map<string, Client> = new Map<string, Client>();
     private readonly errors: Map<string, string> = new Map<string, string>();
+    private readonly lastConnectionCreate: Map<string, number> = new Map<string, number>();
 
     public all(): Client[] {
         return Array.from(this.connections, ([key, value]) => value);
@@ -21,6 +25,13 @@ export class PeerConnector implements Contracts.P2P.PeerConnector {
     }
 
     public async connect(peer: Contracts.P2P.Peer, maxPayload?: number): Promise<Client> {
+        if (!this.connection(peer)) {
+            // delay a bit if last connection create was less than 10 sec ago to prevent possible abuse of reconnection
+            const timeSinceLastConnectionCreate = Date.now() - (this.lastConnectionCreate.get(peer.ip) ?? 0);
+            if (timeSinceLastConnectionCreate < TEN_SECONDS_IN_MILLISECONDS) {
+                await delay(TEN_SECONDS_IN_MILLISECONDS - timeSinceLastConnectionCreate);
+            }
+        }
         const connection = this.connection(peer) || (await this.create(peer));
         
         if (maxPayload) {
@@ -74,6 +85,7 @@ export class PeerConnector implements Contracts.P2P.PeerConnector {
         const connection = new Client(`ws://${Utils.IpAddress.normalizeAddress(peer.ip)}:${peer.port}`, {
             timeout: 10000,
         });
+        this.lastConnectionCreate.set(peer.ip, Date.now());
 
         connection.onError = (error) => {
             this.logger.debug(`Socket error (peer ${Utils.IpAddress.normalizeAddress(peer.ip)}) : ${error.message}`);


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
Add a 10 seconds delay on multiple reconnections to same peer to prevent possible abuse. Under normal conditions we should not need to connect twice (creating new socket) within 10 seconds.
<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
