### PR TITLE
feat(core-manager): allow bearer token in URL

### DIFF
--- a/__tests__/unit/core-manager/server/server.test.ts
+++ b/__tests__/unit/core-manager/server/server.test.ts
@@ -363,7 +363,7 @@ describe("Server", () => {
             };
         });
 
-        it("should be ok with valid token", async () => {
+        it("should be ok with valid token in headers", async () => {
             await server.initialize("serverName", {});
             await server.boot();
 
@@ -375,11 +375,42 @@ describe("Server", () => {
             expect(parsedResponse).toEqual({ body: { id: "1", jsonrpc: "2.0", result: {} }, statusCode: 200 });
         });
 
-        it("should return RCP error if token is not valid", async () => {
+        it("should be ok with valid token in params", async () => {
+            await server.initialize("serverName", {});
+            await server.boot();
+
+            injectOptions.url += "?token=secret_token";
+
+            const response = await server.inject(injectOptions);
+            const parsedResponse: Record<string, any> = { body: response.result, statusCode: response.statusCode };
+
+            expect(parsedResponse).toEqual({ body: { id: "1", jsonrpc: "2.0", result: {} }, statusCode: 200 });
+        });
+
+        it("should return RCP error if token in headers is not valid", async () => {
             await server.initialize("serverName", {});
             await server.boot();
 
             injectOptions.headers.Authorization = "Bearer invalid_token";
+
+            const response = await server.inject(injectOptions);
+            const parsedResponse: Record<string, any> = { body: response.result, statusCode: response.statusCode };
+
+            expect(parsedResponse).toEqual({
+                body: {
+                    jsonrpc: "2.0",
+                    error: { code: -32001, message: "These credentials do not match our records" },
+                    id: null,
+                },
+                statusCode: 200,
+            });
+        });
+
+        it("should return RCP error if token in params is not valid", async () => {
+            await server.initialize("serverName", {});
+            await server.boot();
+
+            injectOptions.url += "?token=invalid_token";
 
             const response = await server.inject(injectOptions);
             const parsedResponse: Record<string, any> = { body: response.result, statusCode: response.statusCode };

--- a/packages/core-manager/src/server/plugins/plugin-factory.ts
+++ b/packages/core-manager/src/server/plugins/plugin-factory.ts
@@ -125,6 +125,8 @@ export class PluginFactory implements Plugins.PluginFactory {
                     await server.register(tokenAuthenticationPlugin);
 
                     server.auth.strategy("simple", "bearer-access-token", {
+                        allowQueryToken: true,
+                        accessTokenName: "token",
                         validate: async (...params) => {
                             // @ts-ignore
                             return this.validateToken(...params);


### PR DESCRIPTION
## Summary

Allow beaer token in URL.

Example:
http://127.0.0.1:4005/log/archived/2021-01-21_03-05-51.log.gz `?token=secret_token`

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged