### PR TITLE
refactor(core-manager): separate HTTP and JSON-RPC server

### DIFF
--- a/__tests__/unit/core-manager/actions/log-archived.test.ts
+++ b/__tests__/unit/core-manager/actions/log-archived.test.ts
@@ -36,10 +36,10 @@ beforeEach(() => {
         .set("server.ip", "127.0.0.1");
     sandbox.app
         .get<Providers.PluginConfiguration>(Container.Identifiers.PluginConfiguration)
-        .set("server.http.port", "4005");
+        .set("server.http.port", 4005);
     sandbox.app
         .get<Providers.PluginConfiguration>(Container.Identifiers.PluginConfiguration)
-        .set("server.https.port", "8445");
+        .set("server.https.port", 8445);
 
     action = sandbox.app.resolve(Action);
 });
@@ -73,7 +73,7 @@ describe("Info:CoreVersion", () => {
         expect(result.length).toBe(1);
         expect(result[0].size).toBe(1);
         expect(result[0].name).toBe("2020-12-14_17-38-00.log.gz");
-        expect(result[0].downloadLink).toBe("http://127.0.0.1:4005/log/archived/2020-12-14_17-38-00.log.gz");
+        expect(result[0].downloadLink).toBe("http://127.0.0.1:4006/log/archived/2020-12-14_17-38-00.log.gz");
     });
 
     it("should return file info using HTTPS server", async () => {
@@ -87,7 +87,7 @@ describe("Info:CoreVersion", () => {
         expect(result.length).toBe(1);
         expect(result[0].size).toBe(1);
         expect(result[0].name).toBe("2020-12-14_17-38-00.log.gz");
-        expect(result[0].downloadLink).toBe("https://127.0.0.1:8445/log/archived/2020-12-14_17-38-00.log.gz");
+        expect(result[0].downloadLink).toBe("https://127.0.0.1:8446/log/archived/2020-12-14_17-38-00.log.gz");
     });
 
     it("should obtain public IP if IP is not set", async () => {
@@ -104,6 +104,6 @@ describe("Info:CoreVersion", () => {
         expect(result.length).toBe(1);
         expect(result[0].size).toBe(1);
         expect(result[0].name).toBe("2020-12-14_17-38-00.log.gz");
-        expect(result[0].downloadLink).toBe("http://127.0.0.5:4005/log/archived/2020-12-14_17-38-00.log.gz");
+        expect(result[0].downloadLink).toBe("http://127.0.0.5:4006/log/archived/2020-12-14_17-38-00.log.gz");
     });
 });

--- a/__tests__/unit/core-manager/actions/log-archived.test.ts
+++ b/__tests__/unit/core-manager/actions/log-archived.test.ts
@@ -79,7 +79,7 @@ describe("Info:CoreVersion", () => {
     it("should return file info using HTTPS server", async () => {
         // @ts-ignore
         pathExistsSync.mockReturnValue(true);
-        sandbox.app.bind(Identifiers.HTTPS).toConstantValue({});
+        sandbox.app.bind(Identifiers.HTTPS_JSON_RPC).toConstantValue({});
 
         const result = await action.execute({});
 

--- a/__tests__/unit/core-manager/server/http-server.test.ts
+++ b/__tests__/unit/core-manager/server/http-server.test.ts
@@ -1,0 +1,315 @@
+import "jest-extended";
+
+import { Container, Providers } from "@packages/core-kernel";
+import { ActionReader } from "@packages/core-manager/src/action-reader";
+import { Actions } from "@packages/core-manager/src/contracts";
+import { defaults } from "@packages/core-manager/src/defaults";
+import { Identifiers } from "@packages/core-manager/src/ioc";
+import { HttpServer } from "@packages/core-manager/src/server/http-server";
+import { PluginFactory } from "@packages/core-manager/src/server/plugins/plugin-factory";
+import { Argon2id, SimpleTokenValidator } from "@packages/core-manager/src/server/validators";
+import { Sandbox } from "@packages/core-test-framework";
+import { cloneDeep } from "lodash";
+
+import { Assets } from "../__fixtures__";
+
+let sandbox: Sandbox;
+let server: HttpServer;
+
+const logger = {
+    info: jest.fn(),
+    notice: jest.fn(),
+    error: jest.fn(),
+};
+
+let configuration;
+
+const registerRoute = async (server: any) => {
+    await server.server.route({
+        method: "GET",
+        path: "/",
+        handler: () => {
+            return {};
+        },
+    });
+};
+
+beforeEach(() => {
+    const dummyMethod = { ...Assets.dummyMethod };
+
+    const actionReader: Partial<ActionReader> = {
+        discoverActions(): Actions.Method[] {
+            return [dummyMethod];
+        },
+    };
+
+    configuration = cloneDeep(defaults);
+
+    configuration.plugins.basicAuthentication.enabled = false;
+    configuration.plugins.tokenAuthentication.enabled = false;
+
+    sandbox = new Sandbox();
+
+    sandbox.app.bind(Identifiers.HTTP).to(HttpServer).inSingletonScope();
+    sandbox.app.bind(Identifiers.ActionReader).toConstantValue(actionReader);
+    sandbox.app.bind(Identifiers.PluginFactory).to(PluginFactory).inSingletonScope();
+    sandbox.app.bind(Identifiers.BasicCredentialsValidator).to(Argon2id).inSingletonScope();
+    sandbox.app.bind(Identifiers.TokenValidator).to(SimpleTokenValidator).inSingletonScope();
+
+    sandbox.app.bind(Container.Identifiers.LogService).toConstantValue(logger);
+
+    sandbox.app.bind(Container.Identifiers.PluginConfiguration).to(Providers.PluginConfiguration).inSingletonScope();
+    sandbox.app
+        .get<Providers.PluginConfiguration>(Container.Identifiers.PluginConfiguration)
+        .from("@arkecosystem/core-monitor", configuration);
+
+    sandbox.app.terminate = jest.fn();
+
+    server = sandbox.app.get<HttpServer>(Identifiers.HTTP);
+});
+
+afterEach(async () => {
+    await server.dispose();
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+});
+
+describe("Server", () => {
+    describe("Whitelist", () => {
+        it("should return HTTP error if whitelisted", async () => {
+            configuration.plugins.whitelist = [];
+
+            await server.initialize("serverName", {});
+            registerRoute(server);
+            await server.boot();
+
+            const injectOptions = {
+                method: "GET",
+                url: "/",
+            };
+
+            const response = await server.inject(injectOptions);
+            const parsedResponse: Record<string, any> = { body: response.result, statusCode: response.statusCode };
+
+            expect(parsedResponse).toEqual({
+                body: {
+                    error: "Unauthorized",
+                    message: "Unauthorized",
+                    statusCode: 401,
+                },
+                statusCode: 401,
+            });
+        });
+    });
+
+    describe("Basic Authentication", () => {
+        let injectOptions;
+
+        beforeEach(() => {
+            configuration.plugins.tokenAuthentication.enabled = false;
+            configuration.plugins.basicAuthentication.enabled = true;
+            configuration.plugins.basicAuthentication.users = [
+                {
+                    username: "username",
+                    password:
+                        "$argon2id$v=19$m=4096,t=3,p=1$NiGA5Cy5vFWTxhBaZMG/3Q$TwEFlzTuIB0fDy+qozEas+GzEiBcLRkm5F+/ClVRCDY",
+                },
+            ];
+
+            injectOptions = {
+                method: "GET",
+                url: "/",
+                headers: {},
+            };
+        });
+
+        it("should be ok with valid username and password", async () => {
+            await server.initialize("serverName", {});
+            await registerRoute(server);
+            await server.boot();
+
+            // Data in header: { username: "username", password: "password" }
+            injectOptions.headers.Authorization = "Basic dXNlcm5hbWU6cGFzc3dvcmQ=";
+
+            const response = await server.inject(injectOptions);
+            const parsedResponse: Record<string, any> = { body: response.result, statusCode: response.statusCode };
+
+            expect(parsedResponse).toEqual({ body: {}, statusCode: 200 });
+        });
+
+        it("should return HTTP error if no username and password in header", async () => {
+            await server.initialize("serverName", {});
+            await registerRoute(server);
+            await server.boot();
+
+            const response = await server.inject(injectOptions);
+            const parsedResponse: Record<string, any> = { body: response.result, statusCode: response.statusCode };
+
+            expect(parsedResponse).toEqual({
+                body: {
+                    error: "Unauthorized",
+                    message: "Missing authentication",
+                    statusCode: 401,
+                },
+                statusCode: 401,
+            });
+        });
+
+        it("should return HTTP error if password is invalid", async () => {
+            await server.initialize("serverName", {});
+            await registerRoute(server);
+            await server.boot();
+
+            // Data in header: { username: "username", password: "invalid" }
+            injectOptions.headers.Authorization = "Basic dXNlcm5hbWU6aW52YWxpZA==";
+
+            const response = await server.inject(injectOptions);
+            const parsedResponse: Record<string, any> = { body: response.result, statusCode: response.statusCode };
+
+            expect(parsedResponse).toEqual({
+                body: {
+                    attributes: {
+                        error: "Bad username or password",
+                    },
+                    error: "Unauthorized",
+                    message: "Bad username or password",
+                    statusCode: 401,
+                },
+                statusCode: 401,
+            });
+        });
+
+        it("should return HTTP error user not found", async () => {
+            configuration.plugins.basicAuthentication.users = [];
+
+            await server.initialize("serverName", {});
+            await registerRoute(server);
+            await server.boot();
+
+            // Data in header: { username: "username", password: "password" }
+            injectOptions.headers.Authorization = "Basic dXNlcm5hbWU6cGFzc3dvcmQ=";
+
+            const response = await server.inject(injectOptions);
+            const parsedResponse: Record<string, any> = { body: response.result, statusCode: response.statusCode };
+
+            expect(parsedResponse).toEqual({
+                body: {
+                    attributes: {
+                        error: "Bad username or password",
+                    },
+                    error: "Unauthorized",
+                    message: "Bad username or password",
+                    statusCode: 401,
+                },
+                statusCode: 401,
+            });
+        });
+    });
+
+    describe("Token Authentication", () => {
+        let injectOptions;
+
+        beforeEach(() => {
+            configuration.plugins.tokenAuthentication.enabled = true;
+            configuration.plugins.tokenAuthentication.token = "secret_token";
+
+            injectOptions = {
+                method: "GET",
+                url: "/",
+                headers: {},
+            };
+        });
+
+        it("should be ok with valid token in headers", async () => {
+            await server.initialize("serverName", {});
+            await registerRoute(server);
+            await server.boot();
+
+            injectOptions.headers.Authorization = "Bearer secret_token";
+
+            const response = await server.inject(injectOptions);
+            const parsedResponse: Record<string, any> = { body: response.result, statusCode: response.statusCode };
+
+            expect(parsedResponse).toEqual({ body: {}, statusCode: 200 });
+        });
+
+        it("should be ok with valid token in params", async () => {
+            await server.initialize("serverName", {});
+            await registerRoute(server);
+            await server.boot();
+
+            injectOptions.url += "?token=secret_token";
+
+            const response = await server.inject(injectOptions);
+            const parsedResponse: Record<string, any> = { body: response.result, statusCode: response.statusCode };
+
+            expect(parsedResponse).toEqual({ body: {}, statusCode: 200 });
+        });
+
+        it("should return HTTP error if token in headers is not valid", async () => {
+            await server.initialize("serverName", {});
+            await registerRoute(server);
+            await server.boot();
+
+            injectOptions.headers.Authorization = "Bearer invalid_token";
+
+            const response = await server.inject(injectOptions);
+            const parsedResponse: Record<string, any> = { body: response.result, statusCode: response.statusCode };
+
+            expect(parsedResponse).toEqual({
+                body: {
+                    attributes: {
+                        error: "Bad token",
+                    },
+                    error: "Unauthorized",
+                    message: "Bad token",
+                    statusCode: 401,
+                },
+                statusCode: 401,
+            });
+        });
+
+        it("should return HTTP error if token in params is not valid", async () => {
+            await server.initialize("serverName", {});
+            await registerRoute(server);
+            await server.boot();
+
+            injectOptions.url += "?token=invalid_token";
+
+            const response = await server.inject(injectOptions);
+            const parsedResponse: Record<string, any> = { body: response.result, statusCode: response.statusCode };
+
+            expect(parsedResponse).toEqual({
+                body: {
+                    attributes: {
+                        error: "Bad token",
+                    },
+                    error: "Unauthorized",
+                    message: "Bad token",
+                    statusCode: 401,
+                },
+                statusCode: 401,
+            });
+        });
+
+        it("should return HTTP error if token configuration is missing", async () => {
+            delete configuration.plugins.tokenAuthentication.token;
+
+            await server.initialize("serverName", {});
+            await registerRoute(server);
+            await server.boot();
+
+            const response = await server.inject(injectOptions);
+            const parsedResponse: Record<string, any> = { body: response.result, statusCode: response.statusCode };
+
+            expect(parsedResponse).toEqual({
+                body: {
+                    error: "Unauthorized",
+                    message: "Missing authentication",
+                    statusCode: 401,
+                },
+                statusCode: 401,
+            });
+        });
+    });
+});

--- a/__tests__/unit/core-manager/server/plugins/rpc-response-handler.test.ts
+++ b/__tests__/unit/core-manager/server/plugins/rpc-response-handler.test.ts
@@ -94,13 +94,13 @@ beforeEach(() => {
 
     sandbox = new Sandbox();
 
-    sandbox.app.bind(Identifiers.HTTP).to(Server).inSingletonScope();
+    sandbox.app.bind(Identifiers.HTTP_JSON_RPC).to(Server).inSingletonScope();
     sandbox.app.bind(Identifiers.ActionReader).toConstantValue(actionReader);
     sandbox.app.bind(Identifiers.PluginFactory).toConstantValue(mockPluginFactory);
 
     sandbox.app.bind(Container.Identifiers.LogService).toConstantValue(logger);
 
-    server = sandbox.app.get<Server>(Identifiers.HTTP);
+    server = sandbox.app.get<Server>(Identifiers.HTTP_JSON_RPC);
 });
 
 afterEach(async () => {

--- a/__tests__/unit/core-manager/server/routes/log-achived.test.ts
+++ b/__tests__/unit/core-manager/server/routes/log-achived.test.ts
@@ -42,7 +42,7 @@ beforeEach(() => {
 
     sandbox = new Sandbox();
 
-    sandbox.app.bind(Identifiers.HTTP).to(Server).inSingletonScope();
+    sandbox.app.bind(Identifiers.HTTP_JSON_RPC).to(Server).inSingletonScope();
     sandbox.app.bind(Identifiers.ActionReader).toConstantValue(actionReader);
     sandbox.app.bind(Identifiers.PluginFactory).to(PluginFactory).inSingletonScope();
     sandbox.app.bind(Identifiers.BasicCredentialsValidator).to(Argon2id).inSingletonScope();
@@ -56,7 +56,7 @@ beforeEach(() => {
 
     sandbox.app.terminate = jest.fn();
 
-    server = sandbox.app.get<Server>(Identifiers.HTTP);
+    server = sandbox.app.get<Server>(Identifiers.HTTP_JSON_RPC);
 });
 
 afterEach(async () => {

--- a/__tests__/unit/core-manager/server/server-boot-dispose.test.ts
+++ b/__tests__/unit/core-manager/server/server-boot-dispose.test.ts
@@ -50,7 +50,7 @@ beforeEach(() => {
 
     sandbox = new Sandbox();
 
-    sandbox.app.bind(Identifiers.HTTP).to(Server).inSingletonScope();
+    sandbox.app.bind(Identifiers.HTTP_JSON_RPC).to(Server).inSingletonScope();
     sandbox.app.bind(Identifiers.ActionReader).to(ActionReader).inSingletonScope();
     sandbox.app.bind(Identifiers.PluginFactory).to(PluginFactory).inSingletonScope();
     sandbox.app.bind(Identifiers.BasicCredentialsValidator).toConstantValue({});
@@ -63,7 +63,7 @@ beforeEach(() => {
 
     sandbox.app.terminate = jest.fn();
 
-    server = sandbox.app.get<Server>(Identifiers.HTTP);
+    server = sandbox.app.get<Server>(Identifiers.HTTP_JSON_RPC);
 });
 
 afterEach(() => {

--- a/__tests__/unit/core-manager/server/server.test.ts
+++ b/__tests__/unit/core-manager/server/server.test.ts
@@ -44,7 +44,7 @@ beforeEach(() => {
 
     sandbox = new Sandbox();
 
-    sandbox.app.bind(Identifiers.HTTP).to(Server).inSingletonScope();
+    sandbox.app.bind(Identifiers.HTTP_JSON_RPC).to(Server).inSingletonScope();
     sandbox.app.bind(Identifiers.ActionReader).toConstantValue(actionReader);
     sandbox.app.bind(Identifiers.PluginFactory).to(PluginFactory).inSingletonScope();
     sandbox.app.bind(Identifiers.BasicCredentialsValidator).to(Argon2id).inSingletonScope();
@@ -59,7 +59,7 @@ beforeEach(() => {
 
     sandbox.app.terminate = jest.fn();
 
-    server = sandbox.app.get<Server>(Identifiers.HTTP);
+    server = sandbox.app.get<Server>(Identifiers.HTTP_JSON_RPC);
 });
 
 afterEach(async () => {

--- a/__tests__/unit/core-manager/service-provider.test.ts
+++ b/__tests__/unit/core-manager/service-provider.test.ts
@@ -86,8 +86,8 @@ describe("ServiceProvider", () => {
 
         await expect(serviceProvider.boot()).toResolve();
 
-        expect(app.isBound(Identifiers.HTTP)).toBeTrue();
-        expect(app.isBound(Identifiers.HTTPS)).not.toBeTrue();
+        expect(app.isBound(Identifiers.HTTP_JSON_RPC)).toBeTrue();
+        expect(app.isBound(Identifiers.HTTPS_JSON_RPC)).not.toBeTrue();
 
         await expect(serviceProvider.dispose()).toResolve();
     });
@@ -105,8 +105,8 @@ describe("ServiceProvider", () => {
 
         await expect(serviceProvider.boot()).toResolve();
 
-        expect(app.isBound(Identifiers.HTTP)).toBeFalse();
-        expect(app.isBound(Identifiers.HTTPS)).toBeFalse();
+        expect(app.isBound(Identifiers.HTTP_JSON_RPC)).toBeFalse();
+        expect(app.isBound(Identifiers.HTTPS_JSON_RPC)).toBeFalse();
         expect(app.isBound(Identifiers.ActionReader)).toBeFalse();
 
         await expect(serviceProvider.dispose()).toResolve();
@@ -124,8 +124,8 @@ describe("ServiceProvider", () => {
 
         await expect(serviceProvider.boot()).toResolve();
 
-        expect(app.isBound(Identifiers.HTTP)).not.toBeTrue();
-        expect(app.isBound(Identifiers.HTTPS)).toBeTrue();
+        expect(app.isBound(Identifiers.HTTP_JSON_RPC)).not.toBeTrue();
+        expect(app.isBound(Identifiers.HTTPS_JSON_RPC)).toBeTrue();
 
         await expect(serviceProvider.dispose()).toResolve();
     });
@@ -142,8 +142,8 @@ describe("ServiceProvider", () => {
 
         await expect(serviceProvider.boot()).toResolve();
 
-        expect(app.isBound(Identifiers.HTTP)).toBeTrue();
-        expect(app.isBound(Identifiers.HTTPS)).toBeTrue();
+        expect(app.isBound(Identifiers.HTTP_JSON_RPC)).toBeTrue();
+        expect(app.isBound(Identifiers.HTTPS_JSON_RPC)).toBeTrue();
 
         await expect(serviceProvider.dispose()).toResolve();
     });

--- a/__tests__/unit/core-manager/service-provider.test.ts
+++ b/__tests__/unit/core-manager/service-provider.test.ts
@@ -40,8 +40,8 @@ beforeEach(() => {
 
     defaults.watcher.storage = dirSync().name + "/events.sqlite";
     defaults.logs.storage = dirSync().name + "/logs.sqlite";
-    defaults.server.https.tls.key = path.resolve(__dirname, "./__fixtures__/key.pem");
-    defaults.server.https.tls.cert = path.resolve(__dirname, "./__fixtures__/server.crt");
+    defaults.server.https.tls.key = path.join(__dirname, "./__fixtures__/key.pem");
+    defaults.server.https.tls.cert = path.join(__dirname, "./__fixtures__/server.crt");
 });
 
 afterEach(() => {

--- a/packages/core-manager/package.json
+++ b/packages/core-manager/package.json
@@ -43,6 +43,7 @@
         "hapi-auth-bearer-token": "^6.1.6",
         "joi": "^17.3.0",
         "latest-version": "^5.1.0",
+        "lodash.clonedeep": "^4.5.0",
         "public-ip": "^4.0.3",
         "require-from-string": "^2.0.2",
         "systeminformation": "^4.30.4",

--- a/packages/core-manager/src/actions/log-archived.ts
+++ b/packages/core-manager/src/actions/log-archived.ts
@@ -53,7 +53,7 @@ export class Action implements Actions.Action {
             publicIp = await getPublicIp.v4();
         }
 
-        if (this.app.isBound(Identifiers.HTTPS)) {
+        if (this.app.isBound(Identifiers.HTTPS_JSON_RPC)) {
             return `https://${publicIp}:${this.configuration.getRequired<number>("server.https.port")}`;
         }
 

--- a/packages/core-manager/src/actions/log-archived.ts
+++ b/packages/core-manager/src/actions/log-archived.ts
@@ -54,9 +54,9 @@ export class Action implements Actions.Action {
         }
 
         if (this.app.isBound(Identifiers.HTTPS_JSON_RPC)) {
-            return `https://${publicIp}:${this.configuration.getRequired<number>("server.https.port")}`;
+            return `https://${publicIp}:${this.configuration.getRequired<number>("server.https.port") + 1}`;
         }
 
-        return `http://${publicIp}:${this.configuration.getRequired<number>("server.http.port")}`;
+        return `http://${publicIp}:${this.configuration.getRequired<number>("server.http.port") + 1}`;
     }
 }

--- a/packages/core-manager/src/contracts/plugins.ts
+++ b/packages/core-manager/src/contracts/plugins.ts
@@ -3,6 +3,10 @@ export interface RegisterPluginObject {
     options?: any;
 }
 
+export interface PluginFactoryOptions {
+    jsonRpcEnabled: boolean;
+}
+
 export interface PluginFactory {
-    preparePlugins(): Array<RegisterPluginObject>;
+    preparePlugins(options: PluginFactoryOptions): Array<RegisterPluginObject>;
 }

--- a/packages/core-manager/src/ioc/identifiers.ts
+++ b/packages/core-manager/src/ioc/identifiers.ts
@@ -1,6 +1,6 @@
 export const Identifiers = {
-    HTTP: Symbol.for("ManagerAPI<HTTP>"),
-    HTTPS: Symbol.for("ManagerAPI<HTTPS>"),
+    HTTP_JSON_RPC: Symbol.for("ManagerAPI<HTTP_JSON_RPC>"),
+    HTTPS_JSON_RPC: Symbol.for("ManagerAPI<HTTPS_JSON_RPC>"),
     CLI: Symbol.for("Application<Cli>"),
     ActionReader: Symbol.for("Discover<Action>"),
     PluginFactory: Symbol.for("Factory<Plugin>"),

--- a/packages/core-manager/src/ioc/identifiers.ts
+++ b/packages/core-manager/src/ioc/identifiers.ts
@@ -1,4 +1,6 @@
 export const Identifiers = {
+    HTTP: Symbol.for("ManagerAPI<HTTP"),
+    HTTPS: Symbol.for("ManagerAPI<HTTPS>"),
     HTTP_JSON_RPC: Symbol.for("ManagerAPI<HTTP_JSON_RPC>"),
     HTTPS_JSON_RPC: Symbol.for("ManagerAPI<HTTPS_JSON_RPC>"),
     CLI: Symbol.for("Application<Cli>"),

--- a/packages/core-manager/src/server/http-server.ts
+++ b/packages/core-manager/src/server/http-server.ts
@@ -1,0 +1,15 @@
+import { Container, Types } from "@arkecosystem/core-kernel";
+import { Server as HapiServer } from "@hapi/hapi";
+
+import { Server } from "./server";
+
+@Container.injectable()
+export class HttpServer extends Server {
+    public async initialize(name: string, serverOptions: Types.JsonObject): Promise<void> {
+        this.name = name;
+        this.server = new HapiServer(this.getServerOptions(serverOptions));
+        this.server.app.app = this.app;
+
+        await this.server.register(this.pluginFactory.preparePlugins());
+    }
+}

--- a/packages/core-manager/src/server/http-server.ts
+++ b/packages/core-manager/src/server/http-server.ts
@@ -10,6 +10,10 @@ export class HttpServer extends Server {
         this.server = new HapiServer(this.getServerOptions(serverOptions));
         this.server.app.app = this.app;
 
-        await this.server.register(this.pluginFactory.preparePlugins());
+        await this.server.register(
+            this.pluginFactory.preparePlugins({
+                jsonRpcEnabled: false,
+            }),
+        );
     }
 }

--- a/packages/core-manager/src/server/index.ts
+++ b/packages/core-manager/src/server/index.ts
@@ -1,0 +1,2 @@
+export * from "./server";
+export * from "./http-server";

--- a/packages/core-manager/src/server/plugins/plugin-factory.ts
+++ b/packages/core-manager/src/server/plugins/plugin-factory.ts
@@ -26,13 +26,10 @@ export class PluginFactory implements Plugins.PluginFactory {
     @Container.inject(Identifiers.TokenValidator)
     private readonly tokenValidator!: Authentication.TokenValidator;
 
-    public preparePlugins(): Array<Plugins.RegisterPluginObject> {
+    public preparePlugins(options: Plugins.PluginFactoryOptions): Array<Plugins.RegisterPluginObject> {
         const pluginConfig = this.configuration.get("plugins");
 
-        const plugins = [
-            {
-                plugin: rpcResponseHandler,
-            },
+        const plugins: Plugins.RegisterPluginObject[] = [
             {
                 plugin: whitelist,
                 options: {
@@ -40,42 +37,12 @@ export class PluginFactory implements Plugins.PluginFactory {
                     whitelist: pluginConfig.whitelist,
                 },
             },
-            {
-                plugin: rpc,
-                options: {
-                    methods: this.actionReader.discoverActions(),
-                    processor: {
-                        schema: {
-                            properties: {
-                                id: {
-                                    type: ["number", "string"],
-                                },
-                                jsonrpc: {
-                                    pattern: "2.0",
-                                    type: "string",
-                                },
-                                method: {
-                                    type: "string",
-                                },
-                                params: {
-                                    type: "object",
-                                },
-                            },
-                            required: ["jsonrpc", "method", "id"],
-                            type: "object",
-                        },
-                        validate(data: object, schema: object) {
-                            try {
-                                const { error } = Validation.validator.validate(schema, data);
-                                return { value: data, error: error ? error : null };
-                            } catch (error) {
-                                return { value: null, error: error.stack };
-                            }
-                        },
-                    },
-                },
-            },
         ];
+
+        if (options.jsonRpcEnabled) {
+            plugins.push(this.prepareJsonRpc());
+            plugins.push(this.prepareJsonRpcResponseHandler());
+        }
 
         // @ts-ignore
         if (pluginConfig.basicAuthentication.enabled) {
@@ -88,6 +55,50 @@ export class PluginFactory implements Plugins.PluginFactory {
         }
 
         return plugins;
+    }
+
+    private prepareJsonRpc(): Plugins.RegisterPluginObject {
+        return {
+            plugin: rpc,
+            options: {
+                methods: this.actionReader.discoverActions(),
+                processor: {
+                    schema: {
+                        properties: {
+                            id: {
+                                type: ["number", "string"],
+                            },
+                            jsonrpc: {
+                                pattern: "2.0",
+                                type: "string",
+                            },
+                            method: {
+                                type: "string",
+                            },
+                            params: {
+                                type: "object",
+                            },
+                        },
+                        required: ["jsonrpc", "method", "id"],
+                        type: "object",
+                    },
+                    validate(data: object, schema: object) {
+                        try {
+                            const { error } = Validation.validator.validate(schema, data);
+                            return { value: data, error: error ? error : null };
+                        } catch (error) {
+                            return { value: null, error: error.stack };
+                        }
+                    },
+                },
+            },
+        };
+    }
+
+    private prepareJsonRpcResponseHandler(): Plugins.RegisterPluginObject {
+        return {
+            plugin: rpcResponseHandler,
+        };
     }
 
     private prepareBasicAuthentication(): Plugins.RegisterPluginObject {

--- a/packages/core-manager/src/server/server.ts
+++ b/packages/core-manager/src/server/server.ts
@@ -1,6 +1,7 @@
 import { Container, Contracts, Types } from "@arkecosystem/core-kernel";
 import { Server as HapiServer, ServerInjectOptions, ServerInjectResponse, ServerRoute } from "@hapi/hapi";
 import { readFileSync } from "fs";
+import { cloneDeep } from "lodash";
 
 import { Plugins } from "../contracts";
 import { Identifiers } from "../ioc";
@@ -64,16 +65,16 @@ export class Server {
     }
 
     protected getServerOptions(options: Record<string, any>): object {
-        options = { ...options };
+        const tmpOptions = cloneDeep(options);
 
-        delete options.enabled;
+        delete tmpOptions.enabled;
 
-        if (options.tls) {
-            options.tls.key = readFileSync(options.tls.key).toString();
-            options.tls.cert = readFileSync(options.tls.cert).toString();
+        if (tmpOptions.tls) {
+            tmpOptions.tls.key = readFileSync(options.tls.key).toString();
+            tmpOptions.tls.cert = readFileSync(options.tls.cert).toString();
         }
 
-        return options;
+        return tmpOptions;
     }
 
     private getRoute(method: string, path: string): ServerRoute | undefined {

--- a/packages/core-manager/src/server/server.ts
+++ b/packages/core-manager/src/server/server.ts
@@ -12,7 +12,7 @@ export class Server {
     protected readonly app!: Contracts.Kernel.Application;
 
     @Container.inject(Container.Identifiers.LogService)
-    private readonly logger!: Contracts.Kernel.Logger;
+    protected readonly logger!: Contracts.Kernel.Logger;
 
     @Container.inject(Identifiers.PluginFactory)
     protected readonly pluginFactory!: Plugins.PluginFactory;

--- a/packages/core-manager/src/server/server.ts
+++ b/packages/core-manager/src/server/server.ts
@@ -25,7 +25,11 @@ export class Server {
         this.server = new HapiServer(this.getServerOptions(serverOptions));
         this.server.app.app = this.app;
 
-        await this.server.register(this.pluginFactory.preparePlugins());
+        await this.server.register(
+            this.pluginFactory.preparePlugins({
+                jsonRpcEnabled: true,
+            }),
+        );
 
         // Disable 2 minute socket timout
         this.getRoute("POST", "/").settings.timeout.socket = false;

--- a/packages/core-manager/src/server/server.ts
+++ b/packages/core-manager/src/server/server.ts
@@ -8,17 +8,17 @@ import { Identifiers } from "../ioc";
 @Container.injectable()
 export class Server {
     @Container.inject(Container.Identifiers.Application)
-    private readonly app!: Contracts.Kernel.Application;
+    protected readonly app!: Contracts.Kernel.Application;
 
     @Container.inject(Container.Identifiers.LogService)
     private readonly logger!: Contracts.Kernel.Logger;
 
     @Container.inject(Identifiers.PluginFactory)
-    private readonly pluginFactory!: Plugins.PluginFactory;
+    protected readonly pluginFactory!: Plugins.PluginFactory;
 
-    private server!: HapiServer;
+    protected server!: HapiServer;
 
-    private name!: string;
+    protected name!: string;
 
     public async initialize(name: string, serverOptions: Types.JsonObject): Promise<void> {
         this.name = name;
@@ -59,7 +59,7 @@ export class Server {
         }
     }
 
-    private getServerOptions(options: Record<string, any>): object {
+    protected getServerOptions(options: Record<string, any>): object {
         options = { ...options };
 
         delete options.enabled;

--- a/packages/core-manager/src/service-provider.ts
+++ b/packages/core-manager/src/service-provider.ts
@@ -133,7 +133,7 @@ export class ServiceProvider extends Providers.ServiceProvider {
 
         const server: HttpServer = this.app.get<HttpServer>(id);
 
-        const config = this.config().getRequired<{ port: number }>(`server.${type}`);
+        const config = { ...this.config().getRequired<{ port: number }>(`server.${type}`) };
         config.port++;
 
         await server.initialize(`Public API (${type.toUpperCase()})`, {

--- a/packages/core-manager/src/service-provider.ts
+++ b/packages/core-manager/src/service-provider.ts
@@ -65,13 +65,13 @@ export class ServiceProvider extends Providers.ServiceProvider {
     public async boot(): Promise<void> {
         if (this.isProcessTypeManager()) {
             if (this.config().get("server.http.enabled")) {
-                await this.buildServer("http", Identifiers.HTTP);
-                await this.app.get<Server>(Identifiers.HTTP).boot();
+                await this.buildServer("http", Identifiers.HTTP_JSON_RPC);
+                await this.app.get<Server>(Identifiers.HTTP_JSON_RPC).boot();
             }
 
             if (this.config().get("server.https.enabled")) {
-                await this.buildServer("https", Identifiers.HTTPS);
-                await this.app.get<Server>(Identifiers.HTTPS).boot();
+                await this.buildServer("https", Identifiers.HTTPS_JSON_RPC);
+                await this.app.get<Server>(Identifiers.HTTPS_JSON_RPC).boot();
             }
         }
 
@@ -81,12 +81,12 @@ export class ServiceProvider extends Providers.ServiceProvider {
     }
 
     public async dispose(): Promise<void> {
-        if (this.app.isBound(Identifiers.HTTP)) {
-            await this.app.get<Server>(Identifiers.HTTP).dispose();
+        if (this.app.isBound(Identifiers.HTTP_JSON_RPC)) {
+            await this.app.get<Server>(Identifiers.HTTP_JSON_RPC).dispose();
         }
 
-        if (this.app.isBound(Identifiers.HTTPS)) {
-            await this.app.get<Server>(Identifiers.HTTPS).dispose();
+        if (this.app.isBound(Identifiers.HTTPS_JSON_RPC)) {
+            await this.app.get<Server>(Identifiers.HTTPS_JSON_RPC).dispose();
         }
 
         this.app.get<EventsDatabaseService>(Identifiers.WatcherDatabaseService).dispose();

--- a/packages/core-manager/src/service-provider.ts
+++ b/packages/core-manager/src/service-provider.ts
@@ -1,5 +1,6 @@
 import { ApplicationFactory } from "@arkecosystem/core-cli";
 import { Container, Contracts, Providers, Types } from "@arkecosystem/core-kernel";
+import { cloneDeep } from "lodash";
 
 import { ActionReader } from "./action-reader";
 import { DatabaseLogger } from "./database-logger";
@@ -133,7 +134,7 @@ export class ServiceProvider extends Providers.ServiceProvider {
 
         const server: HttpServer = this.app.get<HttpServer>(id);
 
-        const config = { ...this.config().getRequired<{ port: number }>(`server.${type}`) };
+        const config = cloneDeep(this.config().getRequired<{ port: number }>(`server.${type}`));
         config.port++;
 
         await server.initialize(`Public API (${type.toUpperCase()})`, {


### PR DESCRIPTION
## Summary

Implements separate HTTP server for downloading logs to prevent overlapping with JSON-RPC server. 

HTTP port is offset by 1 from JSON_RPC server port. Defaults: HTTP: 4006, HTTPS: 8446

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged