### PR TITLE
refactor(core-state): test every wallet vote balance

### DIFF
--- a/__tests__/integration/core-state/__support__/utils.ts
+++ b/__tests__/integration/core-state/__support__/utils.ts
@@ -1,0 +1,44 @@
+import { Contracts, Utils as AppUtils } from "@arkecosystem/core-kernel";
+import { Utils } from "@arkecosystem/crypto";
+
+export const getExpectedVoteBalances = (
+    walletRepository: Contracts.State.WalletRepository,
+): Record<string, Utils.BigNumber> => {
+    const expectedVoteBalances: Record<string, Utils.BigNumber> = {};
+
+    for (const wallet of walletRepository.allByAddress()) {
+        if (wallet.hasAttribute("vote")) {
+            const publicKey = wallet.getAttribute("vote");
+            const voteBalance = wallet
+                .getAttribute("htlc.lockedBalance", Utils.BigNumber.ZERO)
+                .plus(wallet.balance)
+                .plus(expectedVoteBalances[publicKey] ?? Utils.BigNumber.ZERO);
+
+            if (voteBalance.isZero()) {
+                delete expectedVoteBalances[publicKey];
+            } else {
+                expectedVoteBalances[publicKey] = voteBalance;
+            }
+        }
+    }
+
+    return expectedVoteBalances;
+};
+
+export const getActualVoteBalances = (
+    walletRepository: Contracts.State.WalletRepository,
+): Record<string, Utils.BigNumber> => {
+    const actualVoteBalances: Record<string, Utils.BigNumber> = {};
+
+    for (const wallet of walletRepository.allByAddress()) {
+        if (wallet.hasAttribute("delegate.voteBalance")) {
+            const voteBalance = wallet.getAttribute("delegate.voteBalance");
+            if (!voteBalance.isZero()) {
+                AppUtils.assert.defined<string>(wallet.publicKey);
+                actualVoteBalances[wallet.publicKey] = voteBalance;
+            }
+        }
+    }
+
+    return actualVoteBalances;
+};

--- a/__tests__/integration/core-state/block-state/lock-then-claim.test.ts
+++ b/__tests__/integration/core-state/block-state/lock-then-claim.test.ts
@@ -1,12 +1,12 @@
 import { createHash } from "crypto";
 import { Application, Container, Contracts } from "@arkecosystem/core-kernel";
-import { Utils, Transactions, Identities } from "@arkecosystem/crypto";
+import { Utils, Transactions, Identities, Enums } from "@arkecosystem/crypto";
 import { Repositories } from "@arkecosystem/core-database";
 import { delegates } from "@arkecosystem/core-test-framework";
 import { BIP39 } from "../../../../packages/core-forger/src/methods/bip39";
 
 import { setUp, tearDown } from "../__support__/setup";
-import { HtlcLockExpirationType } from "@arkecosystem/crypto/dist/enums";
+import { getActualVoteBalances, getExpectedVoteBalances } from "../__support__/utils";
 
 let app: Application;
 
@@ -42,7 +42,7 @@ test("BlockState handling [lock], [claim] blocks", async () => {
 
     const lockTransaction = Transactions.BuilderFactory.htlcLock()
         .htlcLockAsset({
-            expiration: { type: HtlcLockExpirationType.BlockHeight, value: 3 },
+            expiration: { type: Enums.HtlcLockExpirationType.BlockHeight, value: 3 },
             secretHash: lockSecretHash.toString("hex"),
         })
         .recipientId(Identities.Address.fromPublicKey(delegates[3].publicKey))
@@ -78,37 +78,23 @@ test("BlockState handling [lock], [claim] blocks", async () => {
         reward: Utils.BigNumber.make("100"),
     });
 
-    const delegate1 = walletRepository.findByPublicKey(delegates[1].publicKey);
-    const delegate2 = walletRepository.findByPublicKey(delegates[2].publicKey);
-    const delegate3 = walletRepository.findByPublicKey(delegates[3].publicKey);
-
-    expect(delegate1.getAttribute("delegate.voteBalance").toFixed()).toBe("300000000000000");
-    expect(delegate2.getAttribute("delegate.voteBalance").toFixed()).toBe("300000000000000");
-    expect(delegate3.getAttribute("delegate.voteBalance").toFixed()).toBe("300000000000000");
+    expect(getActualVoteBalances(walletRepository)).toEqual(getExpectedVoteBalances(walletRepository));
 
     await blockState.applyBlock(block2);
 
-    expect(delegate1.getAttribute("delegate.voteBalance").toFixed()).toBe("300000000000200");
-    expect(delegate2.getAttribute("delegate.voteBalance").toFixed()).toBe("299999999999900");
-    expect(delegate3.getAttribute("delegate.voteBalance").toFixed()).toBe("300000000000000");
+    expect(getActualVoteBalances(walletRepository)).toEqual(getExpectedVoteBalances(walletRepository));
 
     await blockState.applyBlock(block3);
 
-    expect(delegate1.getAttribute("delegate.voteBalance").toFixed()).toBe("300000000000300");
-    expect(delegate2.getAttribute("delegate.voteBalance").toFixed()).toBe("299999999999800");
-    expect(delegate3.getAttribute("delegate.voteBalance").toFixed()).toBe("300000000000100");
+    expect(getActualVoteBalances(walletRepository)).toEqual(getExpectedVoteBalances(walletRepository));
 
     jest.spyOn(transactionRepository, "findByIds").mockResolvedValueOnce([lockTransaction.data as any]);
 
     await blockState.revertBlock(block3);
 
-    expect(delegate1.getAttribute("delegate.voteBalance").toFixed()).toBe("300000000000200");
-    expect(delegate2.getAttribute("delegate.voteBalance").toFixed()).toBe("299999999999900");
-    expect(delegate3.getAttribute("delegate.voteBalance").toFixed()).toBe("300000000000000");
+    expect(getActualVoteBalances(walletRepository)).toEqual(getExpectedVoteBalances(walletRepository));
 
     await blockState.revertBlock(block2);
 
-    expect(delegate1.getAttribute("delegate.voteBalance").toFixed()).toBe("300000000000000");
-    expect(delegate2.getAttribute("delegate.voteBalance").toFixed()).toBe("300000000000000");
-    expect(delegate3.getAttribute("delegate.voteBalance").toFixed()).toBe("300000000000000");
+    expect(getActualVoteBalances(walletRepository)).toEqual(getExpectedVoteBalances(walletRepository));
 });

--- a/__tests__/integration/core-state/block-state/multi-payment.test.ts
+++ b/__tests__/integration/core-state/block-state/multi-payment.test.ts
@@ -4,6 +4,7 @@ import { delegates } from "@arkecosystem/core-test-framework";
 import { BIP39 } from "../../../../packages/core-forger/src/methods/bip39";
 
 import { setUp, tearDown } from "../__support__/setup";
+import { getActualVoteBalances, getExpectedVoteBalances } from "../__support__/utils";
 
 let app: Application;
 
@@ -48,27 +49,13 @@ test("BlockState handling [multi-payment] block", async () => {
         reward: Utils.BigNumber.make("100"),
     });
 
-    const delegate1 = walletRepository.findByPublicKey(delegates[1].publicKey);
-    const delegate2 = walletRepository.findByPublicKey(delegates[2].publicKey);
-    const delegate3 = walletRepository.findByPublicKey(delegates[3].publicKey);
-    const delegate4 = walletRepository.findByPublicKey(delegates[4].publicKey);
-
-    expect(delegate1.getAttribute("delegate.voteBalance").toFixed()).toBe("300000000000000");
-    expect(delegate2.getAttribute("delegate.voteBalance").toFixed()).toBe("300000000000000");
-    expect(delegate3.getAttribute("delegate.voteBalance").toFixed()).toBe("300000000000000");
-    expect(delegate4.getAttribute("delegate.voteBalance").toFixed()).toBe("300000000000000");
+    expect(getActualVoteBalances(walletRepository)).toEqual(getExpectedVoteBalances(walletRepository));
 
     await blockState.applyBlock(block2);
 
-    expect(delegate1.getAttribute("delegate.voteBalance").toFixed()).toBe("300000000000200");
-    expect(delegate2.getAttribute("delegate.voteBalance").toFixed()).toBe("299999999999600");
-    expect(delegate3.getAttribute("delegate.voteBalance").toFixed()).toBe("300000000000100");
-    expect(delegate4.getAttribute("delegate.voteBalance").toFixed()).toBe("300000000000200");
+    expect(getActualVoteBalances(walletRepository)).toEqual(getExpectedVoteBalances(walletRepository));
 
     await blockState.revertBlock(block2);
 
-    expect(delegate1.getAttribute("delegate.voteBalance").toFixed()).toBe("300000000000000");
-    expect(delegate2.getAttribute("delegate.voteBalance").toFixed()).toBe("300000000000000");
-    expect(delegate3.getAttribute("delegate.voteBalance").toFixed()).toBe("300000000000000");
-    expect(delegate4.getAttribute("delegate.voteBalance").toFixed()).toBe("300000000000000");
+    expect(getActualVoteBalances(walletRepository)).toEqual(getExpectedVoteBalances(walletRepository));
 });

--- a/__tests__/integration/core-state/block-state/transfer.test.ts
+++ b/__tests__/integration/core-state/block-state/transfer.test.ts
@@ -4,6 +4,7 @@ import { delegates } from "@arkecosystem/core-test-framework";
 import { BIP39 } from "../../../../packages/core-forger/src/methods/bip39";
 
 import { setUp, tearDown } from "../__support__/setup";
+import { getActualVoteBalances, getExpectedVoteBalances } from "../__support__/utils";
 
 let app: Application;
 
@@ -48,23 +49,13 @@ test("BlockState handling [transfer] block", async () => {
         reward: Utils.BigNumber.make("100"),
     });
 
-    const delegate1 = walletRepository.findByPublicKey(delegates[1].publicKey);
-    const delegate2 = walletRepository.findByPublicKey(delegates[2].publicKey);
-    const delegate3 = walletRepository.findByPublicKey(delegates[3].publicKey);
-
-    expect(delegate1.getAttribute("delegate.voteBalance").toFixed()).toBe("300000000000000");
-    expect(delegate2.getAttribute("delegate.voteBalance").toFixed()).toBe("300000000000000");
-    expect(delegate3.getAttribute("delegate.voteBalance").toFixed()).toBe("300000000000000");
+    expect(getActualVoteBalances(walletRepository)).toEqual(getExpectedVoteBalances(walletRepository));
 
     await blockState.applyBlock(block2);
 
-    expect(delegate1.getAttribute("delegate.voteBalance").toFixed()).toBe("300000000000200");
-    expect(delegate2.getAttribute("delegate.voteBalance").toFixed()).toBe("299999999999800");
-    expect(delegate3.getAttribute("delegate.voteBalance").toFixed()).toBe("300000000000100");
+    expect(getActualVoteBalances(walletRepository)).toEqual(getExpectedVoteBalances(walletRepository));
 
     await blockState.revertBlock(block2);
 
-    expect(delegate1.getAttribute("delegate.voteBalance").toFixed()).toBe("300000000000000");
-    expect(delegate2.getAttribute("delegate.voteBalance").toFixed()).toBe("300000000000000");
-    expect(delegate3.getAttribute("delegate.voteBalance").toFixed()).toBe("300000000000000");
+    expect(getActualVoteBalances(walletRepository)).toEqual(getExpectedVoteBalances(walletRepository));
 });

--- a/__tests__/integration/core-state/block-state/unvote-by-forger-then-vote-by-forger.test.ts
+++ b/__tests__/integration/core-state/block-state/unvote-by-forger-then-vote-by-forger.test.ts
@@ -4,6 +4,7 @@ import { delegates } from "@arkecosystem/core-test-framework";
 import { BIP39 } from "../../../../packages/core-forger/src/methods/bip39";
 
 import { setUp, tearDown } from "../__support__/setup";
+import { getActualVoteBalances, getExpectedVoteBalances } from "../__support__/utils";
 
 let app: Application;
 
@@ -60,29 +61,21 @@ test("BlockState handling [unvote by forger], [vote by forger] blocks", async ()
         reward: Utils.BigNumber.make("200"),
     });
 
-    const delegate1 = walletRepository.findByPublicKey(delegates[1].publicKey);
-    const delegate2 = walletRepository.findByPublicKey(delegates[2].publicKey);
-
-    expect(delegate1.getAttribute("delegate.voteBalance").toFixed()).toBe("300000000000000");
-    expect(delegate2.getAttribute("delegate.voteBalance").toFixed()).toBe("300000000000000");
+    expect(getActualVoteBalances(walletRepository)).toEqual(getExpectedVoteBalances(walletRepository));
 
     await blockState.applyBlock(block2);
 
-    expect(delegate1.getAttribute("delegate.voteBalance").toFixed()).toBe("0");
-    expect(delegate2.getAttribute("delegate.voteBalance").toFixed()).toBe("300000000000000");
+    expect(getActualVoteBalances(walletRepository)).toEqual(getExpectedVoteBalances(walletRepository));
 
     await blockState.applyBlock(block3);
 
-    expect(delegate1.getAttribute("delegate.voteBalance").toFixed()).toBe("0");
-    expect(delegate2.getAttribute("delegate.voteBalance").toFixed()).toBe("600000000000300");
+    expect(getActualVoteBalances(walletRepository)).toEqual(getExpectedVoteBalances(walletRepository));
 
     await blockState.revertBlock(block3);
 
-    expect(delegate1.getAttribute("delegate.voteBalance").toFixed()).toBe("0");
-    expect(delegate2.getAttribute("delegate.voteBalance").toFixed()).toBe("300000000000000");
+    expect(getActualVoteBalances(walletRepository)).toEqual(getExpectedVoteBalances(walletRepository));
 
     await blockState.revertBlock(block2);
 
-    expect(delegate1.getAttribute("delegate.voteBalance").toFixed()).toBe("300000000000000");
-    expect(delegate2.getAttribute("delegate.voteBalance").toFixed()).toBe("300000000000000");
+    expect(getActualVoteBalances(walletRepository)).toEqual(getExpectedVoteBalances(walletRepository));
 });

--- a/__tests__/integration/core-state/block-state/unvote-by-forger-vote-by-forger-twice.test.ts
+++ b/__tests__/integration/core-state/block-state/unvote-by-forger-vote-by-forger-twice.test.ts
@@ -4,6 +4,7 @@ import { delegates } from "@arkecosystem/core-test-framework";
 import { BIP39 } from "../../../../packages/core-forger/src/methods/bip39";
 
 import { setUp, tearDown } from "../__support__/setup";
+import { getActualVoteBalances, getExpectedVoteBalances } from "../__support__/utils";
 
 let app: Application;
 
@@ -71,23 +72,13 @@ test("BlockState handling [unvote by forger, vote by forger, unvote by forger, v
         },
     );
 
-    const delegate1 = walletRepository.findByPublicKey(delegates[1].publicKey);
-    const delegate2 = walletRepository.findByPublicKey(delegates[2].publicKey);
-    const delegate3 = walletRepository.findByPublicKey(delegates[3].publicKey);
-
-    expect(delegate1.getAttribute("delegate.voteBalance").toFixed()).toBe("300000000000000");
-    expect(delegate2.getAttribute("delegate.voteBalance").toFixed()).toBe("300000000000000");
-    expect(delegate3.getAttribute("delegate.voteBalance").toFixed()).toBe("300000000000000");
+    expect(getActualVoteBalances(walletRepository)).toEqual(getExpectedVoteBalances(walletRepository));
 
     await blockState.applyBlock(block2);
 
-    expect(delegate1.getAttribute("delegate.voteBalance").toFixed()).toBe("0");
-    expect(delegate2.getAttribute("delegate.voteBalance").toFixed()).toBe("300000000000000");
-    expect(delegate3.getAttribute("delegate.voteBalance").toFixed()).toBe("600000000000100");
+    expect(getActualVoteBalances(walletRepository)).toEqual(getExpectedVoteBalances(walletRepository));
 
     await blockState.revertBlock(block2);
 
-    expect(delegate1.getAttribute("delegate.voteBalance").toFixed()).toBe("300000000000000");
-    expect(delegate2.getAttribute("delegate.voteBalance").toFixed()).toBe("300000000000000");
-    expect(delegate3.getAttribute("delegate.voteBalance").toFixed()).toBe("300000000000000");
+    expect(getActualVoteBalances(walletRepository)).toEqual(getExpectedVoteBalances(walletRepository));
 });

--- a/__tests__/integration/core-state/block-state/unvote-then-vote-unvote.test.ts
+++ b/__tests__/integration/core-state/block-state/unvote-then-vote-unvote.test.ts
@@ -4,6 +4,7 @@ import { delegates } from "@arkecosystem/core-test-framework";
 import { BIP39 } from "../../../../packages/core-forger/src/methods/bip39";
 
 import { setUp, tearDown } from "../__support__/setup";
+import { getActualVoteBalances, getExpectedVoteBalances } from "../__support__/utils";
 
 let app: Application;
 
@@ -60,23 +61,21 @@ test("BlockState handling [unvote], [vote+unvote] blocks", async () => {
         reward: Utils.BigNumber.make("100"),
     });
 
-    const delegate2 = walletRepository.findByPublicKey(delegates[2].publicKey);
-
-    expect(delegate2.getAttribute("delegate.voteBalance").toFixed()).toBe("300000000000000");
+    expect(getActualVoteBalances(walletRepository)).toEqual(getExpectedVoteBalances(walletRepository));
 
     await blockState.applyBlock(block2);
 
-    expect(delegate2.getAttribute("delegate.voteBalance").toFixed()).toBe("0");
+    expect(getActualVoteBalances(walletRepository)).toEqual(getExpectedVoteBalances(walletRepository));
 
     await blockState.applyBlock(block3);
 
-    expect(delegate2.getAttribute("delegate.voteBalance").toFixed()).toBe("0");
+    expect(getActualVoteBalances(walletRepository)).toEqual(getExpectedVoteBalances(walletRepository));
 
     await blockState.revertBlock(block3);
 
-    expect(delegate2.getAttribute("delegate.voteBalance").toFixed()).toBe("0");
+    expect(getActualVoteBalances(walletRepository)).toEqual(getExpectedVoteBalances(walletRepository));
 
     await blockState.revertBlock(block2);
 
-    expect(delegate2.getAttribute("delegate.voteBalance").toFixed()).toBe("300000000000000");
+    expect(getActualVoteBalances(walletRepository)).toEqual(getExpectedVoteBalances(walletRepository));
 });

--- a/__tests__/integration/core-state/block-state/unvote-then-vote.test.ts
+++ b/__tests__/integration/core-state/block-state/unvote-then-vote.test.ts
@@ -4,6 +4,7 @@ import { delegates } from "@arkecosystem/core-test-framework";
 import { BIP39 } from "../../../../packages/core-forger/src/methods/bip39";
 
 import { setUp, tearDown } from "../__support__/setup";
+import { getActualVoteBalances, getExpectedVoteBalances } from "../__support__/utils";
 
 let app: Application;
 
@@ -60,23 +61,21 @@ test("BlockState handling [unvote], [vote] blocks", async () => {
         reward: Utils.BigNumber.make("100"),
     });
 
-    const delegate2 = walletRepository.findByPublicKey(delegates[2].publicKey);
-
-    expect(delegate2.getAttribute("delegate.voteBalance").toFixed()).toBe("300000000000000");
+    expect(getActualVoteBalances(walletRepository)).toEqual(getExpectedVoteBalances(walletRepository));
 
     await blockState.applyBlock(block2);
 
-    expect(delegate2.getAttribute("delegate.voteBalance").toFixed()).toBe("0");
+    expect(getActualVoteBalances(walletRepository)).toEqual(getExpectedVoteBalances(walletRepository));
 
     await blockState.applyBlock(block3);
 
-    expect(delegate2.getAttribute("delegate.voteBalance").toFixed()).toBe("299999999999800");
+    expect(getActualVoteBalances(walletRepository)).toEqual(getExpectedVoteBalances(walletRepository));
 
     await blockState.revertBlock(block3);
 
-    expect(delegate2.getAttribute("delegate.voteBalance").toFixed()).toBe("0");
+    expect(getActualVoteBalances(walletRepository)).toEqual(getExpectedVoteBalances(walletRepository));
 
     await blockState.revertBlock(block2);
 
-    expect(delegate2.getAttribute("delegate.voteBalance").toFixed()).toBe("300000000000000");
+    expect(getActualVoteBalances(walletRepository)).toEqual(getExpectedVoteBalances(walletRepository));
 });

--- a/__tests__/integration/core-state/block-state/unvote-vote-by-forger.test.ts
+++ b/__tests__/integration/core-state/block-state/unvote-vote-by-forger.test.ts
@@ -4,6 +4,7 @@ import { delegates } from "@arkecosystem/core-test-framework";
 import { BIP39 } from "../../../../packages/core-forger/src/methods/bip39";
 
 import { setUp, tearDown } from "../__support__/setup";
+import { getActualVoteBalances, getExpectedVoteBalances } from "../__support__/utils";
 
 let app: Application;
 
@@ -47,19 +48,13 @@ test("BlockState handling [unvote+vote by forger] block", async () => {
         reward: Utils.BigNumber.make("100"),
     });
 
-    const delegate1 = walletRepository.findByPublicKey(delegates[1].publicKey);
-    const delegate2 = walletRepository.findByPublicKey(delegates[2].publicKey);
-
-    expect(delegate1.getAttribute("delegate.voteBalance").toFixed()).toBe("300000000000000");
-    expect(delegate2.getAttribute("delegate.voteBalance").toFixed()).toBe("300000000000000");
+    expect(getActualVoteBalances(walletRepository)).toEqual(getExpectedVoteBalances(walletRepository));
 
     await blockState.applyBlock(block2);
 
-    expect(delegate1.getAttribute("delegate.voteBalance").toFixed()).toBe("0");
-    expect(delegate2.getAttribute("delegate.voteBalance").toFixed()).toBe("600000000000100");
+    expect(getActualVoteBalances(walletRepository)).toEqual(getExpectedVoteBalances(walletRepository));
 
     await blockState.revertBlock(block2);
 
-    expect(delegate1.getAttribute("delegate.voteBalance").toFixed()).toBe("300000000000000");
-    expect(delegate2.getAttribute("delegate.voteBalance").toFixed()).toBe("300000000000000");
+    expect(getActualVoteBalances(walletRepository)).toEqual(getExpectedVoteBalances(walletRepository));
 });

--- a/__tests__/integration/core-state/block-state/unvote-vote.test.ts
+++ b/__tests__/integration/core-state/block-state/unvote-vote.test.ts
@@ -4,6 +4,7 @@ import { delegates } from "@arkecosystem/core-test-framework";
 import { BIP39 } from "../../../../packages/core-forger/src/methods/bip39";
 
 import { setUp, tearDown } from "../__support__/setup";
+import { getActualVoteBalances, getExpectedVoteBalances } from "../__support__/utils";
 
 let app: Application;
 
@@ -47,15 +48,13 @@ test("BlockState handling [unvote+vote] block", async () => {
         reward: Utils.BigNumber.make("100"),
     });
 
-    const delegate2 = walletRepository.findByPublicKey(delegates[2].publicKey);
-
-    expect(delegate2.getAttribute("delegate.voteBalance").toFixed()).toBe("300000000000000");
+    expect(getActualVoteBalances(walletRepository)).toEqual(getExpectedVoteBalances(walletRepository));
 
     await blockState.applyBlock(block2);
 
-    expect(delegate2.getAttribute("delegate.voteBalance").toFixed()).toBe("299999999999900");
+    expect(getActualVoteBalances(walletRepository)).toEqual(getExpectedVoteBalances(walletRepository));
 
     await blockState.revertBlock(block2);
 
-    expect(delegate2.getAttribute("delegate.voteBalance").toFixed()).toBe("300000000000000");
+    expect(getActualVoteBalances(walletRepository)).toEqual(getExpectedVoteBalances(walletRepository));
 });


### PR DESCRIPTION
## Summary

Tests are now comparing results of two functions to check vote balances:
- `getExpectedVoteBalances` that returns calculated vote balance values.
- `getActualVoteBalances` that returns actual `delegate.voteBalance` values.

## Checklist

- [x] Tests
- [x] Ready to be merged
