### PR TITLE
chore(core-p2p): set up a rate limit on `postTransactions`

### DIFF
--- a/packages/core-p2p/src/defaults.ts
+++ b/packages/core-p2p/src/defaults.ts
@@ -71,4 +71,5 @@ export const defaults = {
      * Rate limit config
      */
     rateLimit: process.env.CORE_P2P_RATE_LIMIT || 100, // max number of messages per second per socket connection
+    rateLimitPostTransactions: process.env.CORE_P2P_RATE_LIMIT_POST_TRANSACTIONS || 25, // postTransactions endpoint
 };

--- a/packages/core-p2p/src/peer-communicator.ts
+++ b/packages/core-p2p/src/peer-communicator.ts
@@ -39,7 +39,8 @@ export class PeerCommunicator implements Contracts.P2P.PeerCommunicator {
             // them requests, ie we could spam them.
             whitelist: [],
             remoteAccess: [],
-            rateLimit: this.configuration.getOptional<boolean>("rateLimit", false),
+            rateLimit: this.configuration.getOptional<number>("rateLimit", 100),
+            rateLimitPostTransactions: this.configuration.getOptional<number>("rateLimitPostTransactions", 25),
         });
     }
 

--- a/packages/core-p2p/src/service-provider.ts
+++ b/packages/core-p2p/src/service-provider.ts
@@ -85,6 +85,7 @@ export class ServiceProvider extends Providers.ServiceProvider {
                 .required(),
             ntp: Joi.array().items(Joi.string()).required(),
             rateLimit: Joi.number().min(0).required(),
+            rateLimitPostTransactions: Joi.number().min(1),
             networkStart: Joi.bool(),
             disableDiscovery: Joi.bool(),
             skipDiscovery: Joi.bool(),

--- a/packages/core-p2p/src/socket-server/plugins/rate-limit.ts
+++ b/packages/core-p2p/src/socket-server/plugins/rate-limit.ts
@@ -23,6 +23,7 @@ export class RateLimitPlugin {
             whitelist: [],
             remoteAccess: this.configuration.getOptional<Array<string>>("remoteAccess", []),
             rateLimit: this.configuration.getOptional<number>("rateLimit", 100),
+            rateLimitPostTransactions: this.configuration.getOptional<number>("rateLimitPostTransactions", 25),
         });
 
         const allRoutesConfigByPath = {

--- a/packages/core-p2p/src/utils/build-rate-limiter.ts
+++ b/packages/core-p2p/src/utils/build-rate-limiter.ts
@@ -31,6 +31,10 @@ export const buildRateLimiter = (options) =>
                     rateLimit: 9,
                     endpoint: "p2p.peer.getCommonBlocks",
                 },
+                {
+                    rateLimit: 25,
+                    endpoint: "p2p.transactions.postTransactions",
+                },
             ],
         },
     });

--- a/packages/core-p2p/src/utils/build-rate-limiter.ts
+++ b/packages/core-p2p/src/utils/build-rate-limiter.ts
@@ -6,7 +6,6 @@ export const buildRateLimiter = (options) =>
         configurations: {
             global: {
                 rateLimit: options.rateLimit,
-                blockDuration: 60 * 1, // 1 minute ban for now
             },
             endpoints: [
                 {
@@ -32,7 +31,7 @@ export const buildRateLimiter = (options) =>
                     endpoint: "p2p.peer.getCommonBlocks",
                 },
                 {
-                    rateLimit: 25,
+                    rateLimit: options.rateLimitPostTransactions || 25,
                     endpoint: "p2p.transactions.postTransactions",
                 },
             ],


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
Set up a logic rate limit on `postTransactions` as currently there is not (it is limited by the global limit of 100/sec). 25/sec looks more than enough : even if using the endpoint sending 1 transaction each time, we'd be able to send 200 txs in 8 seconds (which is the block time, so it would fill the block). At any moment if there is more transactions to be processed, the txs will still be sent to other nodes but it will just be throttled.

This specific rate limit on `postTransactions` can be customized from app.json / env.
<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
