### PR TITLE
refactor(core-p2p): rename peer storage into repository

### DIFF
--- a/__tests__/integration/core-api/handlers/peers.test.ts
+++ b/__tests__/integration/core-api/handlers/peers.test.ts
@@ -45,7 +45,7 @@ beforeAll(async () => {
 
     for (const peerMock of Object.values(peerMocks)) {
         // @ts-ignore
-        app.get<Contracts.P2P.PeerStorage>(Container.Identifiers.PeerStorage).setPeer(peerMock);
+        app.get<Contracts.P2P.PeerRepository>(Container.Identifiers.PeerRepository).setPeer(peerMock);
     }
 });
 

--- a/__tests__/integration/core-state/__support__/setup.ts
+++ b/__tests__/integration/core-state/__support__/setup.ts
@@ -10,7 +10,7 @@ const peerNetworkMonitor = {
     boot: jest.fn(),
     cleansePeers: jest.fn(),
 };
-const peerStorage = null;
+const peerRepository = null;
 
 export const setUp = async (): Promise<Application> => {
     jest.setTimeout(60000);
@@ -45,7 +45,7 @@ export const setUp = async (): Promise<Application> => {
             app.bind(Container.Identifiers.TransactionPoolQuery).toConstantValue(transactionPoolQuery);
             app.bind(Container.Identifiers.TransactionPoolService).toConstantValue(transactionPoolService);
             app.bind(Container.Identifiers.PeerNetworkMonitor).toConstantValue(peerNetworkMonitor);
-            app.bind(Container.Identifiers.PeerStorage).toConstantValue(peerStorage);
+            app.bind(Container.Identifiers.PeerRepository).toConstantValue(peerRepository);
 
             await app.bootstrap({
                 flags: {

--- a/__tests__/unit/core-api/__support__/app.ts
+++ b/__tests__/unit/core-api/__support__/app.ts
@@ -69,7 +69,7 @@ export const initApp = (): Application => {
 
     app.bind(Container.Identifiers.PeerNetworkMonitor).toConstantValue(Mocks.NetworkMonitor.instance);
 
-    app.bind(Container.Identifiers.PeerStorage).toConstantValue(Mocks.PeerStorage.instance);
+    app.bind(Container.Identifiers.PeerRepository).toConstantValue(Mocks.PeerRepository.instance);
 
     app.bind(Container.Identifiers.DatabaseRoundRepository).toConstantValue(Mocks.RoundRepository.instance);
 

--- a/__tests__/unit/core-api/controllers/peers.test.ts
+++ b/__tests__/unit/core-api/controllers/peers.test.ts
@@ -23,7 +23,7 @@ beforeEach(() => {
 
     controller = app.resolve<PeersController>(PeersController);
 
-    Mocks.PeerStorage.setPeers([]);
+    Mocks.PeerRepository.setPeers([]);
 });
 
 afterEach(() => {
@@ -77,7 +77,7 @@ describe("PeersController", () => {
 
     describe("index", () => {
         it("should return list of peers", async () => {
-            Mocks.PeerStorage.setPeers([peer, anotherPeer]);
+            Mocks.PeerRepository.setPeers([peer, anotherPeer]);
 
             const request: Hapi.Request = {
                 query: {
@@ -101,7 +101,7 @@ describe("PeersController", () => {
         });
 
         it("should return list of peers if version in request is not set", async () => {
-            Mocks.PeerStorage.setPeers([peer, anotherPeer]);
+            Mocks.PeerRepository.setPeers([peer, anotherPeer]);
 
             const request: Hapi.Request = {
                 query: {
@@ -137,7 +137,7 @@ describe("PeersController", () => {
         });
 
         it("should return error when offset is negative", async () => {
-            Mocks.PeerStorage.setPeers([peer]);
+            Mocks.PeerRepository.setPeers([peer]);
 
             const request: Hapi.Request = {
                 query: {
@@ -157,7 +157,7 @@ describe("PeersController", () => {
         });
 
         it("should return paginated response when offset is not a number", async () => {
-            Mocks.PeerStorage.setPeers([peer]);
+            Mocks.PeerRepository.setPeers([peer]);
 
             const request: Hapi.Request = {
                 query: {
@@ -177,7 +177,7 @@ describe("PeersController", () => {
         });
 
         it("should return paginated response when limit is not defined", async () => {
-            Mocks.PeerStorage.setPeers([peer]);
+            Mocks.PeerRepository.setPeers([peer]);
 
             const request: Hapi.Request = {
                 query: {
@@ -196,7 +196,7 @@ describe("PeersController", () => {
         });
 
         it("should return list of peers ordered by version ascending", async () => {
-            Mocks.PeerStorage.setPeers([peer, anotherPeer]);
+            Mocks.PeerRepository.setPeers([peer, anotherPeer]);
 
             const request: Hapi.Request = {
                 query: {
@@ -226,7 +226,7 @@ describe("PeersController", () => {
         });
 
         it("should return list of peers ordered by version descending", async () => {
-            Mocks.PeerStorage.setPeers([peer, anotherPeer]);
+            Mocks.PeerRepository.setPeers([peer, anotherPeer]);
 
             const request: Hapi.Request = {
                 query: {
@@ -256,7 +256,7 @@ describe("PeersController", () => {
         });
 
         it("should return list of peers ordered by height ascending", async () => {
-            Mocks.PeerStorage.setPeers([peer, anotherPeer]);
+            Mocks.PeerRepository.setPeers([peer, anotherPeer]);
 
             const request: Hapi.Request = {
                 query: {
@@ -286,7 +286,7 @@ describe("PeersController", () => {
         });
 
         it("should return list of peers ordered by height descending", async () => {
-            Mocks.PeerStorage.setPeers([peer, anotherPeer]);
+            Mocks.PeerRepository.setPeers([peer, anotherPeer]);
 
             const request: Hapi.Request = {
                 query: {
@@ -316,7 +316,7 @@ describe("PeersController", () => {
         });
 
         it("should return list of peers ordered by latency ascending", async () => {
-            Mocks.PeerStorage.setPeers([peer, anotherPeer]);
+            Mocks.PeerRepository.setPeers([peer, anotherPeer]);
 
             const request: Hapi.Request = {
                 query: {
@@ -346,7 +346,7 @@ describe("PeersController", () => {
         });
 
         it("should return list of peers ordered by latency descending", async () => {
-            Mocks.PeerStorage.setPeers([peer, anotherPeer]);
+            Mocks.PeerRepository.setPeers([peer, anotherPeer]);
 
             const request: Hapi.Request = {
                 query: {
@@ -376,7 +376,7 @@ describe("PeersController", () => {
         });
 
         it("should return list of peers ordered by other descending", async () => {
-            Mocks.PeerStorage.setPeers([peer, anotherPeer]);
+            Mocks.PeerRepository.setPeers([peer, anotherPeer]);
 
             const request: Hapi.Request = {
                 query: {
@@ -408,7 +408,7 @@ describe("PeersController", () => {
 
     describe("show", () => {
         it("should return peer", async () => {
-            Mocks.PeerStorage.setPeers([peer]);
+            Mocks.PeerRepository.setPeers([peer]);
 
             const request: Hapi.Request = {
                 params: {

--- a/__tests__/unit/core-api/service-provider.test.ts
+++ b/__tests__/unit/core-api/service-provider.test.ts
@@ -33,7 +33,7 @@ beforeEach(() => {
 
     app.bind(Container.Identifiers.PeerNetworkMonitor).toConstantValue({});
 
-    app.bind(Container.Identifiers.PeerStorage).toConstantValue({});
+    app.bind(Container.Identifiers.PeerRepository).toConstantValue({});
 
     app.bind(Container.Identifiers.DatabaseRoundRepository).toConstantValue({});
 

--- a/__tests__/unit/core-blockchain/blockchain.test.ts
+++ b/__tests__/unit/core-blockchain/blockchain.test.ts
@@ -24,7 +24,7 @@ describe("Blockchain", () => {
     const stateMachine: any = {};
     const eventDispatcherService: any = {};
     const peerNetworkMonitor: any = {};
-    const peerStorage: any = {};
+    const peerRepository: any = {};
     const blockProcessor: any = {};
     const databaseInteractions: any = {};
 
@@ -41,7 +41,7 @@ describe("Blockchain", () => {
         sandbox.app.bind(Container.Identifiers.StateMachine).toConstantValue(stateMachine);
         sandbox.app.bind(Container.Identifiers.EventDispatcherService).toConstantValue(eventDispatcherService);
         sandbox.app.bind(Container.Identifiers.PeerNetworkMonitor).toConstantValue(peerNetworkMonitor);
-        sandbox.app.bind(Container.Identifiers.PeerStorage).toConstantValue(peerStorage);
+        sandbox.app.bind(Container.Identifiers.PeerRepository).toConstantValue(peerRepository);
         sandbox.app.bind(Container.Identifiers.BlockchainService).to(Blockchain).inSingletonScope();
         sandbox.app.bind(Container.Identifiers.BlockProcessor).toConstantValue(blockProcessor);
         sandbox.app.bind(Container.Identifiers.DatabaseTransactionRepository).toConstantValue({});
@@ -112,7 +112,7 @@ describe("Blockchain", () => {
         peerNetworkMonitor.broadcastBlock = jest.fn();
         peerNetworkMonitor.checkNetworkHealth = jest.fn();
 
-        peerStorage.hasPeers = jest.fn();
+        peerRepository.hasPeers = jest.fn();
 
         blockProcessor.process = jest.fn();
 
@@ -756,7 +756,7 @@ describe("Blockchain", () => {
         it("should return true if we have no peer", () => {
             const blockchain = sandbox.app.resolve<Blockchain>(Blockchain);
 
-            peerStorage.hasPeers = jest.fn().mockReturnValue(false);
+            peerRepository.hasPeers = jest.fn().mockReturnValue(false);
 
             expect(blockchain.isSynced()).toBeTrue();
         });
@@ -764,7 +764,7 @@ describe("Blockchain", () => {
         it("should return true if last block is less than 3 blocktimes away from current slot time", () => {
             const blockchain = sandbox.app.resolve<Blockchain>(Blockchain);
 
-            peerStorage.hasPeers = jest.fn().mockReturnValue(true);
+            peerRepository.hasPeers = jest.fn().mockReturnValue(true);
             const mockBlock = { data: { id: "123", height: 444, timestamp: Crypto.Slots.getTime() - 16 } };
             stateStore.getLastBlock = jest.fn().mockReturnValue(mockBlock);
 
@@ -774,7 +774,7 @@ describe("Blockchain", () => {
         it("should return false if last block is more than 3 blocktimes away from current slot time", () => {
             const blockchain = sandbox.app.resolve<Blockchain>(Blockchain);
 
-            peerStorage.hasPeers = jest.fn().mockReturnValue(true);
+            peerRepository.hasPeers = jest.fn().mockReturnValue(true);
             const mockBlock = { data: { id: "123", height: 444, timestamp: Crypto.Slots.getTime() - 25 } };
             stateStore.getLastBlock = jest.fn().mockReturnValue(mockBlock);
 

--- a/__tests__/unit/core-magistrate-api/__support__/index.ts
+++ b/__tests__/unit/core-magistrate-api/__support__/index.ts
@@ -59,7 +59,7 @@ export const initApp = (): Application => {
     app.bind(Container.Identifiers.DatabaseTransactionRepository).toConstantValue({});
     app.bind(Container.Identifiers.DatabaseRoundRepository).toConstantValue({});
     app.bind(Container.Identifiers.PeerNetworkMonitor).toConstantValue({});
-    app.bind(Container.Identifiers.PeerStorage).toConstantValue({});
+    app.bind(Container.Identifiers.PeerRepository).toConstantValue({});
     app.bind(Container.Identifiers.TransactionPoolQuery).toConstantValue({});
     app.bind(Container.Identifiers.TransactionPoolProcessorFactory).toConstantValue({});
     app.bind(Container.Identifiers.TransactionHistoryService).toConstantValue({});

--- a/__tests__/unit/core-magistrate-api/service-provider.test.ts
+++ b/__tests__/unit/core-magistrate-api/service-provider.test.ts
@@ -24,7 +24,7 @@ beforeEach(() => {
 
     app.bind(Container.Identifiers.PeerNetworkMonitor).toConstantValue({});
 
-    app.bind(Container.Identifiers.PeerStorage).toConstantValue({});
+    app.bind(Container.Identifiers.PeerRepository).toConstantValue({});
 
     app.bind(Container.Identifiers.DatabaseRoundRepository).toConstantValue({});
 

--- a/__tests__/unit/core-p2p/listeners.test.ts
+++ b/__tests__/unit/core-p2p/listeners.test.ts
@@ -8,7 +8,7 @@ describe("DisconnectInvalidPeers", () => {
     const container = new Container.Container();
 
     const logger = { warning: jest.fn(), debug: jest.fn() };
-    const storage = { getPeers: jest.fn() };
+    const repository = { getPeers: jest.fn() };
     const app = {
         getTagged: () => ({
             getOptional: () => ["^3.0.0", "^3.0.0-next.0"], // minimumVersions
@@ -19,7 +19,7 @@ describe("DisconnectInvalidPeers", () => {
     beforeAll(() => {
         container.unbindAll();
         container.bind(Container.Identifiers.LogService).toConstantValue(logger);
-        container.bind(Container.Identifiers.PeerStorage).toConstantValue(storage);
+        container.bind(Container.Identifiers.PeerRepository).toConstantValue(repository);
         container.bind(Container.Identifiers.Application).toConstantValue(app);
         container.bind(Container.Identifiers.EventDispatcherService).toConstantValue(emitter);
     });
@@ -38,10 +38,10 @@ describe("DisconnectInvalidPeers", () => {
     peers[4].version = "3.0.1"; // valid
     beforeEach(() => {
         disconnectInvalidPeers = container.resolve<DisconnectInvalidPeers>(DisconnectInvalidPeers);
-        storage.getPeers = jest.fn().mockReturnValue(peers);
+        repository.getPeers = jest.fn().mockReturnValue(peers);
     });
     afterEach(() => {
-        storage.getPeers = jest.fn();
+        repository.getPeers = jest.fn();
     });
 
     describe("handle", () => {
@@ -59,13 +59,13 @@ describe("DisconnectPeer", () => {
     const container = new Container.Container();
 
     const logger = { warning: jest.fn(), debug: jest.fn() };
-    const storage = { forgetPeer: jest.fn() };
+    const repository = { forgetPeer: jest.fn() };
     const connector = { disconnect: jest.fn() };
 
     beforeAll(() => {
         container.unbindAll();
         container.bind(Container.Identifiers.LogService).toConstantValue(logger);
-        container.bind(Container.Identifiers.PeerStorage).toConstantValue(storage);
+        container.bind(Container.Identifiers.PeerRepository).toConstantValue(repository);
         container.bind(Container.Identifiers.PeerConnector).toConstantValue(connector);
     });
 
@@ -78,8 +78,8 @@ describe("DisconnectPeer", () => {
             const peer = new Peer("187.176.1.1", 4000);
             await disconnectPeer.handle({ data: { peer: peer, port: 4000 } });
 
-            expect(storage.forgetPeer).toBeCalledTimes(1);
-            expect(storage.forgetPeer).toBeCalledWith(peer);
+            expect(repository.forgetPeer).toBeCalledTimes(1);
+            expect(repository.forgetPeer).toBeCalledWith(peer);
             expect(connector.disconnect).toBeCalledTimes(1);
             expect(connector.disconnect).toBeCalledWith(peer);
         });

--- a/__tests__/unit/core-p2p/peer-processor.test.ts
+++ b/__tests__/unit/core-p2p/peer-processor.test.ts
@@ -20,7 +20,7 @@ describe("PeerProcessor", () => {
     const eventDispatcher = { listen: jest.fn(), dispatch: jest.fn() };
     const peerCommunicator = { ping: jest.fn() };
     const peerConnector = { disconnect: jest.fn() };
-    const peerStorage = {
+    const peerRepository = {
         hasPendingPeer: jest.fn(),
         getSameSubnetPeers: jest.fn(),
         hasPeer: jest.fn(),
@@ -39,7 +39,7 @@ describe("PeerProcessor", () => {
         container.bind(Container.Identifiers.EventDispatcherService).toConstantValue(eventDispatcher);
         container.bind(Container.Identifiers.PeerCommunicator).toConstantValue(peerCommunicator);
         container.bind(Container.Identifiers.PeerConnector).toConstantValue(peerConnector);
-        container.bind(Container.Identifiers.PeerStorage).toConstantValue(peerStorage);
+        container.bind(Container.Identifiers.PeerRepository).toConstantValue(peerRepository);
         container.bind(Container.Identifiers.Application).toConstantValue(app);
 
         container.bind(Container.Identifiers.PeerProcessor).to(PeerProcessor);
@@ -60,19 +60,19 @@ describe("PeerProcessor", () => {
 
             expect(eventDispatcher.listen).toBeCalledTimes(1);
             expect(eventDispatcher.listen).toBeCalledWith(Enums.CryptoEvent.MilestoneChanged, expect.anything());
-        })
-    })
+        });
+    });
 
     describe("validateAndAcceptPeer", () => {
         it("should accept a new peer if its ip is validated", async () => {
             const peer = new Peer("178.165.55.55", 4000);
-            peerStorage.getSameSubnetPeers = jest.fn().mockReturnValueOnce([]);
+            peerRepository.getSameSubnetPeers = jest.fn().mockReturnValueOnce([]);
 
             await peerProcessor.validateAndAcceptPeer(peer);
 
-            expect(peerStorage.setPendingPeer).toBeCalledTimes(1);
+            expect(peerRepository.setPendingPeer).toBeCalledTimes(1);
             expect(peerCommunicator.ping).toBeCalledTimes(1);
-            expect(peerStorage.setPeer).toBeCalledTimes(1);
+            expect(peerRepository.setPeer).toBeCalledTimes(1);
         });
 
         it("should accept a new peer if whitelist is undefined", async () => {
@@ -80,13 +80,13 @@ describe("PeerProcessor", () => {
             configGet.whitelist = undefined;
 
             const peer = new Peer("178.165.55.55", 4000);
-            peerStorage.getSameSubnetPeers = jest.fn().mockReturnValueOnce([]);
+            peerRepository.getSameSubnetPeers = jest.fn().mockReturnValueOnce([]);
 
             await peerProcessor.validateAndAcceptPeer(peer);
 
-            expect(peerStorage.setPendingPeer).toBeCalledTimes(1);
+            expect(peerRepository.setPendingPeer).toBeCalledTimes(1);
             expect(peerCommunicator.ping).toBeCalledTimes(1);
-            expect(peerStorage.setPeer).toBeCalledTimes(1);
+            expect(peerRepository.setPeer).toBeCalledTimes(1);
         });
 
         it("should accept a new peer if blacklist is undefined", async () => {
@@ -94,38 +94,38 @@ describe("PeerProcessor", () => {
             configGet.blacklist = undefined;
 
             const peer = new Peer("178.165.55.55", 4000);
-            peerStorage.getSameSubnetPeers = jest.fn().mockReturnValueOnce([]);
+            peerRepository.getSameSubnetPeers = jest.fn().mockReturnValueOnce([]);
 
             await peerProcessor.validateAndAcceptPeer(peer);
 
-            expect(peerStorage.setPendingPeer).toBeCalledTimes(1);
+            expect(peerRepository.setPendingPeer).toBeCalledTimes(1);
             expect(peerCommunicator.ping).toBeCalledTimes(1);
-            expect(peerStorage.setPeer).toBeCalledTimes(1);
+            expect(peerRepository.setPeer).toBeCalledTimes(1);
         });
 
         it("should disconnect the peer on any error", async () => {
             const peer = new Peer("178.165.55.55", 4000);
-            peerStorage.getSameSubnetPeers = jest.fn().mockReturnValueOnce([]);
+            peerRepository.getSameSubnetPeers = jest.fn().mockReturnValueOnce([]);
             peerCommunicator.ping = jest.fn().mockRejectedValueOnce(new Error("ping threw"));
 
             await peerProcessor.validateAndAcceptPeer(peer);
 
-            expect(peerStorage.setPendingPeer).toBeCalledTimes(1);
+            expect(peerRepository.setPendingPeer).toBeCalledTimes(1);
             expect(peerCommunicator.ping).toBeCalledTimes(1);
-            expect(peerStorage.setPeer).toBeCalledTimes(0);
+            expect(peerRepository.setPeer).toBeCalledTimes(0);
             expect(peerConnector.disconnect).toBeCalledTimes(1);
         });
 
         it("should not do anything if peer is already added", async () => {
             const peer = new Peer("178.165.55.55", 4000);
-            peerStorage.getSameSubnetPeers = jest.fn().mockReturnValueOnce([]);
-            peerStorage.hasPeer = jest.fn().mockReturnValueOnce(true);
+            peerRepository.getSameSubnetPeers = jest.fn().mockReturnValueOnce([]);
+            peerRepository.hasPeer = jest.fn().mockReturnValueOnce(true);
 
             await peerProcessor.validateAndAcceptPeer(peer);
 
-            expect(peerStorage.setPendingPeer).toBeCalledTimes(0);
+            expect(peerRepository.setPendingPeer).toBeCalledTimes(0);
             expect(peerCommunicator.ping).toBeCalledTimes(0);
-            expect(peerStorage.setPeer).toBeCalledTimes(0);
+            expect(peerRepository.setPeer).toBeCalledTimes(0);
         });
     });
 
@@ -148,7 +148,7 @@ describe("PeerProcessor", () => {
         });
 
         it("should return false when peer is already in pending peers", () => {
-            peerStorage.hasPendingPeer = jest.fn().mockReturnValueOnce(true);
+            peerRepository.hasPendingPeer = jest.fn().mockReturnValueOnce(true);
             expect(peerProcessor.validatePeerIp(peer)).toBeFalse();
         });
 
@@ -166,12 +166,12 @@ describe("PeerProcessor", () => {
 
         it("should return false when there are already too many peers on the peer subnet and not in seed mode", () => {
             const sameSubnetPeers = [new Peer("178.165.55.50", 4000), new Peer("178.165.55.51", 4000)];
-            peerStorage.getSameSubnetPeers = jest.fn().mockReturnValueOnce(sameSubnetPeers);
+            peerRepository.getSameSubnetPeers = jest.fn().mockReturnValueOnce(sameSubnetPeers);
             expect(peerProcessor.validatePeerIp(peer)).toBeFalse();
         });
 
         it("should return true otherwise", () => {
-            peerStorage.getSameSubnetPeers = jest.fn().mockReturnValueOnce([]);
+            peerRepository.getSameSubnetPeers = jest.fn().mockReturnValueOnce([]);
 
             expect(peerProcessor.validatePeerIp(peer)).toBeTrue();
         });

--- a/__tests__/unit/core-p2p/peer-repository.test.ts
+++ b/__tests__/unit/core-p2p/peer-repository.test.ts
@@ -1,10 +1,10 @@
 import { Container } from "@arkecosystem/core-kernel";
 
-import { PeerStorage } from "@arkecosystem/core-p2p/src/peer-storage";
+import { PeerRepository } from "@arkecosystem/core-p2p/src/peer-repository";
 import { Peer } from "@arkecosystem/core-p2p/src/peer";
 
-describe("PeerStorage", () => {
-    let peerStorage: PeerStorage;
+describe("PeerRepository", () => {
+    let peerStorage: PeerRepository;
 
     beforeEach(() => {
         const container = new Container.Container();
@@ -13,9 +13,9 @@ describe("PeerStorage", () => {
 
         container.unbindAll();
         container.bind(Container.Identifiers.LogService).toConstantValue(logger);
-        container.bind(Container.Identifiers.PeerStorage).to(PeerStorage);
+        container.bind(Container.Identifiers.PeerRepository).to(PeerRepository);
 
-        peerStorage = container.get<PeerStorage>(Container.Identifiers.PeerStorage);
+        peerStorage = container.get<PeerRepository>(Container.Identifiers.PeerRepository);
     });
 
     describe("getPeers", () => {

--- a/__tests__/unit/core-p2p/service-provider.test.ts
+++ b/__tests__/unit/core-p2p/service-provider.test.ts
@@ -72,7 +72,7 @@ describe("ServiceProvider", () => {
             const Identifiers = Container.Identifiers;
             for (const identifier of [
                 Identifiers.PeerFactory,
-                Identifiers.PeerStorage,
+                Identifiers.PeerRepository,
                 Identifiers.PeerConnector,
                 Identifiers.PeerCommunicator,
                 Identifiers.PeerProcessor,

--- a/__tests__/unit/core-p2p/socket-server/controllers/blocks.test.ts
+++ b/__tests__/unit/core-p2p/socket-server/controllers/blocks.test.ts
@@ -11,7 +11,7 @@ describe("BlocksController", () => {
     const container = new Container.Container();
 
     const logger = { warning: jest.fn(), debug: jest.fn(), info: jest.fn() };
-    const peerStorage = { getPeers: jest.fn() };
+    const peerRepository = { getPeers: jest.fn() };
     const database = { getCommonBlocks: jest.fn(), getBlocksForDownload: jest.fn() };
     const blockchain = {
         getLastBlock: jest.fn(),
@@ -59,7 +59,7 @@ describe("BlocksController", () => {
     beforeAll(() => {
         container.unbindAll();
         container.bind(Container.Identifiers.LogService).toConstantValue(logger);
-        container.bind(Container.Identifiers.PeerStorage).toConstantValue(peerStorage);
+        container.bind(Container.Identifiers.PeerRepository).toConstantValue(peerRepository);
         container.bind(Container.Identifiers.DatabaseService).toConstantValue(database);
         container.bind(Container.Identifiers.Application).toConstantValue(app);
     });

--- a/__tests__/unit/core-p2p/socket-server/controllers/peer.test.ts
+++ b/__tests__/unit/core-p2p/socket-server/controllers/peer.test.ts
@@ -13,7 +13,7 @@ describe("PeerController", () => {
     const container = new Container.Container();
 
     const logger = { warning: jest.fn(), debug: jest.fn(), info: jest.fn() };
-    const peerStorage = { getPeers: jest.fn() };
+    const peerRepository = { getPeers: jest.fn() };
     const database = { getCommonBlocks: jest.fn(), getBlocksForDownload: jest.fn() };
     const databaseInteractions = {
         getCommonBlocks: jest.fn(),
@@ -64,7 +64,7 @@ describe("PeerController", () => {
     beforeAll(() => {
         container.unbindAll();
         container.bind(Container.Identifiers.LogService).toConstantValue(logger);
-        container.bind(Container.Identifiers.PeerStorage).toConstantValue(peerStorage);
+        container.bind(Container.Identifiers.PeerRepository).toConstantValue(peerRepository);
         container.bind(Container.Identifiers.DatabaseService).toConstantValue(database);
         container.bind(Container.Identifiers.DatabaseInteraction).toConstantValue(databaseInteractions);
         container.bind(Container.Identifiers.Application).toConstantValue(app);
@@ -88,7 +88,7 @@ describe("PeerController", () => {
             peers[2].latency = 117634;
             peers[3].latency = 297600;
             peers[4].latency = 1197634;
-            peerStorage.getPeers = jest.fn().mockReturnValueOnce(peers);
+            peerRepository.getPeers = jest.fn().mockReturnValueOnce(peers);
 
             const request = {
                 socket: {
@@ -113,7 +113,7 @@ describe("PeerController", () => {
             peers[2].latency = 117634;
             peers[3].latency = 297600;
             peers[4].latency = 1197634;
-            peerStorage.getPeers = jest.fn().mockReturnValueOnce(peers);
+            peerRepository.getPeers = jest.fn().mockReturnValueOnce(peers);
 
             const request = {
                 socket: {

--- a/__tests__/unit/core-p2p/socket-server/controllers/transactions.test.ts
+++ b/__tests__/unit/core-p2p/socket-server/controllers/transactions.test.ts
@@ -10,7 +10,7 @@ describe("TransactionsController", () => {
     const container = new Container.Container();
 
     const logger = { warning: jest.fn(), debug: jest.fn(), info: jest.fn() };
-    const peerStorage = { getPeers: jest.fn() };
+    const peerRepository = { getPeers: jest.fn() };
     const database = { getCommonBlocks: jest.fn(), getBlocksForDownload: jest.fn() };
     const blockchain = {
         getLastBlock: jest.fn(),
@@ -19,7 +19,7 @@ describe("TransactionsController", () => {
         getLastDownloadedBlock: jest.fn(),
     };
     const processor = {
-        process: jest.fn().mockReturnValue({ accept: []}),
+        process: jest.fn().mockReturnValue({ accept: [] }),
     };
     const createProcessor = jest.fn();
     const appPlugins = [{ package: "@arkecosystem/core-api", options: {} }];
@@ -60,7 +60,7 @@ describe("TransactionsController", () => {
     beforeAll(() => {
         container.unbindAll();
         container.bind(Container.Identifiers.LogService).toConstantValue(logger);
-        container.bind(Container.Identifiers.PeerStorage).toConstantValue(peerStorage);
+        container.bind(Container.Identifiers.PeerRepository).toConstantValue(peerRepository);
         container.bind(Container.Identifiers.DatabaseService).toConstantValue(database);
         container.bind(Container.Identifiers.Application).toConstantValue(app);
         container.bind(Container.Identifiers.TransactionPoolProcessor).toConstantValue(processor);

--- a/__tests__/unit/core-p2p/transaction-broadcaster.test.ts
+++ b/__tests__/unit/core-p2p/transaction-broadcaster.test.ts
@@ -9,14 +9,14 @@ describe("TransactionBroadcaster", () => {
     describe("broadcastTransactions", () => {
         const logger = { warning: jest.fn(), debug: jest.fn() };
         const configuration = { getRequired: jest.fn() };
-        const storage = { getPeers: jest.fn() };
+        const repository = { getPeers: jest.fn() };
         const communicator = { postTransactions: jest.fn() };
 
         beforeAll(() => {
             container.unbindAll();
             container.bind(Container.Identifiers.LogService).toConstantValue(logger);
             container.bind(Container.Identifiers.PluginConfiguration).toConstantValue(configuration);
-            container.bind(Container.Identifiers.PeerStorage).toConstantValue(storage);
+            container.bind(Container.Identifiers.PeerRepository).toConstantValue(repository);
             container.bind(Container.Identifiers.PeerCommunicator).toConstantValue(communicator);
         });
 
@@ -24,7 +24,7 @@ describe("TransactionBroadcaster", () => {
             logger.warning.mockClear();
             logger.debug.mockClear();
             configuration.getRequired.mockClear();
-            storage.getPeers.mockClear();
+            repository.getPeers.mockClear();
             communicator.postTransactions.mockClear();
         });
 
@@ -35,14 +35,14 @@ describe("TransactionBroadcaster", () => {
 
             expect(logger.warning).toBeCalledWith("Broadcasting 0 transactions");
             expect(configuration.getRequired).not.toBeCalled();
-            expect(storage.getPeers).not.toBeCalled();
+            expect(repository.getPeers).not.toBeCalled();
             expect(communicator.postTransactions).not.toBeCalled();
         });
 
         it("should broadcast transaction to peers", async () => {
             const peers = [{}, {}, {}];
             configuration.getRequired.mockReturnValue(3);
-            storage.getPeers.mockReturnValue(peers);
+            repository.getPeers.mockReturnValue(peers);
             const transactions = [{}];
 
             const serializedTx = Buffer.alloc(0);
@@ -52,7 +52,7 @@ describe("TransactionBroadcaster", () => {
             await broadcaster.broadcastTransactions(transactions as Interfaces.ITransaction[]);
 
             expect(configuration.getRequired).toBeCalledWith("maxPeersBroadcast");
-            expect(storage.getPeers).toBeCalled();
+            expect(repository.getPeers).toBeCalled();
             expect(logger.debug).toBeCalledWith("Broadcasting 1 transaction to 3 peers");
             expect(spySerialize).toBeCalled();
             expect(communicator.postTransactions).toBeCalledWith(peers[0], [serializedTx]);

--- a/__tests__/unit/core-test-framework/mocks/peer-repository.test.ts
+++ b/__tests__/unit/core-test-framework/mocks/peer-repository.test.ts
@@ -1,6 +1,6 @@
 import "jest-extended";
 
-import { PeerStorage } from "@packages/core-test-framework/src/mocks";
+import { PeerRepository } from "@packages/core-test-framework/src/mocks";
 import { Contracts } from "@packages/core-kernel";
 
 let peer: Partial<Contracts.P2P.Peer> = {
@@ -20,21 +20,21 @@ let peer: Partial<Contracts.P2P.Peer> = {
 };
 
 const clear = () => {
-    PeerStorage.setPeers([]);
+    PeerRepository.setPeers([]);
 };
 
-describe("PeerStorage", () => {
+describe("PeerRepository", () => {
     describe("default values", () => {
         it("getPeers should return empty array", async () => {
-            expect(PeerStorage.instance.getPeers()).toEqual([]);
+            expect(PeerRepository.instance.getPeers()).toEqual([]);
         });
 
         it("hasPeer should return false", async () => {
-            expect(PeerStorage.instance.hasPeer("127.0.0.1")).toBeFalse();
+            expect(PeerRepository.instance.hasPeer("127.0.0.1")).toBeFalse();
         });
 
         it("getPeer should return undefined", async () => {
-            expect(PeerStorage.instance.getPeer("127.0.0.1")).toBeUndefined();
+            expect(PeerRepository.instance.getPeer("127.0.0.1")).toBeUndefined();
         });
     });
 
@@ -42,19 +42,19 @@ describe("PeerStorage", () => {
         beforeEach(() => {
             clear();
 
-            PeerStorage.setPeers([peer]);
+            PeerRepository.setPeers([peer]);
         });
 
         it("getPeers should return mocked peer", async () => {
-            expect(PeerStorage.instance.getPeers()).toEqual([peer]);
+            expect(PeerRepository.instance.getPeers()).toEqual([peer]);
         });
 
         it("getPeers should return true", async () => {
-            expect(PeerStorage.instance.hasPeer("127.0.0.1")).toBeTrue();
+            expect(PeerRepository.instance.hasPeer("127.0.0.1")).toBeTrue();
         });
 
         it("getPeers should return first peer", async () => {
-            expect(PeerStorage.instance.getPeer("127.0.0.1")).toEqual(peer);
+            expect(PeerRepository.instance.getPeer("127.0.0.1")).toEqual(peer);
         });
     });
 });

--- a/__tests__/unit/core-test-framework/mocks/query.test.ts
+++ b/__tests__/unit/core-test-framework/mocks/query.test.ts
@@ -13,7 +13,7 @@ const clear = () => {
     TransactionPoolQuery.setTransactions([]);
 };
 
-describe("PeerStorage", () => {
+describe("TransactionPoolQuery", () => {
     describe("default values", () => {
         it("getFromHighestPriority should return", async () => {
             expect(TransactionPoolQuery.instance.getFromHighestPriority()).toEqual({ transactions: [] });

--- a/__tests__/unit/core-webhooks/service-provider.test.ts
+++ b/__tests__/unit/core-webhooks/service-provider.test.ts
@@ -34,7 +34,7 @@ beforeEach(() => {
 
     app.bind(Container.Identifiers.PeerNetworkMonitor).toConstantValue({});
 
-    app.bind(Container.Identifiers.PeerStorage).toConstantValue({});
+    app.bind(Container.Identifiers.PeerRepository).toConstantValue({});
 
     app.bind(Container.Identifiers.DatabaseRoundRepository).toConstantValue({});
 

--- a/packages/core-api/src/controllers/peers.ts
+++ b/packages/core-api/src/controllers/peers.ts
@@ -8,11 +8,11 @@ import { Controller } from "./controller";
 
 @Container.injectable()
 export class PeersController extends Controller {
-    @Container.inject(Container.Identifiers.PeerStorage)
-    private readonly peerStorage!: Contracts.P2P.PeerStorage;
+    @Container.inject(Container.Identifiers.PeerRepository)
+    private readonly peerRepository!: Contracts.P2P.PeerRepository;
 
     public async index(request: Hapi.Request, h: Hapi.ResponseToolkit) {
-        const allPeers: Contracts.P2P.Peer[] = [...this.peerStorage.getPeers()];
+        const allPeers: Contracts.P2P.Peer[] = [...this.peerRepository.getPeers()];
 
         let results = allPeers;
 
@@ -85,10 +85,10 @@ export class PeersController extends Controller {
     }
 
     public async show(request: Hapi.Request, h: Hapi.ResponseToolkit) {
-        if (!this.peerStorage.hasPeer(request.params.ip)) {
+        if (!this.peerRepository.hasPeer(request.params.ip)) {
             return Boom.notFound("Peer not found");
         }
 
-        return super.respondWithResource(this.peerStorage.getPeer(request.params.ip), PeerResource);
+        return super.respondWithResource(this.peerRepository.getPeer(request.params.ip), PeerResource);
     }
 }

--- a/packages/core-blockchain/src/blockchain.ts
+++ b/packages/core-blockchain/src/blockchain.ts
@@ -38,8 +38,8 @@ export class Blockchain implements Contracts.Blockchain.Blockchain {
     @Container.inject(Container.Identifiers.PeerNetworkMonitor)
     private readonly networkMonitor!: Contracts.P2P.NetworkMonitor;
 
-    @Container.inject(Container.Identifiers.PeerStorage)
-    private readonly peerStorage!: Contracts.P2P.PeerStorage;
+    @Container.inject(Container.Identifiers.PeerRepository)
+    private readonly peerRepository!: Contracts.P2P.PeerRepository;
 
     @Container.inject(Container.Identifiers.EventDispatcherService)
     private readonly events!: Contracts.Kernel.EventDispatcher;
@@ -419,7 +419,7 @@ export class Blockchain implements Contracts.Blockchain.Blockchain {
      * Determine if the blockchain is synced.
      */
     public isSynced(block?: Interfaces.IBlockData): boolean {
-        if (!this.peerStorage.hasPeers()) {
+        if (!this.peerRepository.hasPeers()) {
             return true;
         }
 

--- a/packages/core-kernel/src/contracts/p2p/index.ts
+++ b/packages/core-kernel/src/contracts/p2p/index.ts
@@ -3,7 +3,7 @@ export * from "./network-state";
 export * from "./peer-connector";
 export * from "./peer-communicator";
 export * from "./peer-processor";
-export * from "./peer-storage";
+export * from "./peer-repository";
 export * from "./peer-verifier";
 export * from "./peer";
 export * from "./server";

--- a/packages/core-kernel/src/contracts/p2p/network-state.ts
+++ b/packages/core-kernel/src/contracts/p2p/network-state.ts
@@ -4,7 +4,7 @@ export interface NetworkState {
     nodeHeight: number | undefined;
     lastBlockId: string | undefined;
 
-    // static analyze(monitor: NetworkMonitor, storage: PeerStorage): NetworkState;
+    // static analyze(monitor: NetworkMonitor, repository: PeerRepository): NetworkState;
     // static parse(data: any): NetworkState;
 
     setLastBlock(lastBlock);

--- a/packages/core-kernel/src/contracts/p2p/peer-repository.ts
+++ b/packages/core-kernel/src/contracts/p2p/peer-repository.ts
@@ -1,6 +1,6 @@
 import { Peer } from "./peer";
 
-export interface PeerStorage {
+export interface PeerRepository {
     getPeers(): Peer[];
 
     hasPeers(): boolean;

--- a/packages/core-kernel/src/ioc/identifiers.ts
+++ b/packages/core-kernel/src/ioc/identifiers.ts
@@ -92,7 +92,7 @@ export const Identifiers = {
     PeerConnector: Symbol.for("Peer<Connector>"),
     PeerNetworkMonitor: Symbol.for("Peer<NetworkMonitor>"),
     PeerProcessor: Symbol.for("Peer<Processor>"),
-    PeerStorage: Symbol.for("Peer<Storage>"),
+    PeerRepository: Symbol.for("Peer<Repository>"),
     PeerTransactionBroadcaster: Symbol.for("Peer<TransactionBroadcaster>"),
     PeerEventListener: Symbol.for("Peer<EventListener>"),
     // Transaction Pool

--- a/packages/core-p2p/src/contracts.ts
+++ b/packages/core-p2p/src/contracts.ts
@@ -4,7 +4,7 @@ export type PeerFactory = (ip: string) => Contracts.P2P.Peer;
 
 export interface PeerService {
     connector: Contracts.P2P.PeerConnector;
-    storage: Contracts.P2P.PeerStorage;
+    repository: Contracts.P2P.PeerRepository;
     communicator: Contracts.P2P.PeerCommunicator;
     processor: Contracts.P2P.PeerProcessor;
     networkMonitor: Contracts.P2P.NetworkMonitor;

--- a/packages/core-p2p/src/index.ts
+++ b/packages/core-p2p/src/index.ts
@@ -4,7 +4,7 @@ export * from "./enums";
 export * from "./network-state";
 export * from "./network-monitor";
 export * from "./peer";
-export * from "./peer-storage";
+export * from "./peer-repository";
 export * from "./service-provider";
 export * from "./socket-server/codecs";
 export * from "./utils";

--- a/packages/core-p2p/src/listeners.ts
+++ b/packages/core-p2p/src/listeners.ts
@@ -19,11 +19,11 @@ export class DisconnectInvalidPeers implements Contracts.Kernel.EventListener {
 
     /**
      * @private
-     * @type {Contracts.P2P.PeerStorage}
+     * @type {Contracts.P2P.PeerRepository}
      * @memberof DisconnectInvalidPeers
      */
-    @Container.inject(Container.Identifiers.PeerStorage)
-    private readonly storage!: Contracts.P2P.PeerStorage;
+    @Container.inject(Container.Identifiers.PeerRepository)
+    private readonly repository!: Contracts.P2P.PeerRepository;
 
     /**
      * @private
@@ -38,7 +38,7 @@ export class DisconnectInvalidPeers implements Contracts.Kernel.EventListener {
      * @memberof DisconnectInvalidPeers
      */
     public async handle(): Promise<void> {
-        const peers: Contracts.P2P.Peer[] = this.storage.getPeers();
+        const peers: Contracts.P2P.Peer[] = this.repository.getPeers();
 
         for (const peer of peers) {
             if (!isValidVersion(this.app, peer)) {
@@ -64,11 +64,11 @@ export class DisconnectPeer implements Contracts.Kernel.EventListener {
 
     /**
      * @private
-     * @type {Contracts.P2P.PeerStorage}
+     * @type {Contracts.P2P.PeerRepository}
      * @memberof DisconnectPeer
      */
-    @Container.inject(Container.Identifiers.PeerStorage)
-    private readonly storage!: Contracts.P2P.PeerStorage;
+    @Container.inject(Container.Identifiers.PeerRepository)
+    private readonly repository!: Contracts.P2P.PeerRepository;
 
     /**
      * @param {*} {peer}
@@ -78,6 +78,6 @@ export class DisconnectPeer implements Contracts.Kernel.EventListener {
     public async handle({ data }): Promise<void> {
         this.connector.disconnect(data.peer);
 
-        this.storage.forgetPeer(data.peer);
+        this.repository.forgetPeer(data.peer);
     }
 }

--- a/packages/core-p2p/src/network-state.ts
+++ b/packages/core-p2p/src/network-state.ts
@@ -70,7 +70,7 @@ export class NetworkState implements Contracts.P2P.NetworkState {
 
     public static async analyze(
         monitor: Contracts.P2P.NetworkMonitor,
-        storage: Contracts.P2P.PeerStorage,
+        repository: Contracts.P2P.PeerRepository,
     ): Promise<Contracts.P2P.NetworkState> {
         // @ts-ignore - app exists but isn't on the interface for now
         const lastBlock: Interfaces.IBlock = monitor.app
@@ -83,7 +83,7 @@ export class NetworkState implements Contracts.P2P.NetworkState {
             lastBlock.data.height,
         );
 
-        const peers: Contracts.P2P.Peer[] = storage.getPeers();
+        const peers: Contracts.P2P.Peer[] = repository.getPeers();
         // @ts-ignore - app exists but isn't on the interface for now
         const configuration = monitor.app.getTagged<Providers.PluginConfiguration>(
             Container.Identifiers.PluginConfiguration,

--- a/packages/core-p2p/src/peer-repository.ts
+++ b/packages/core-p2p/src/peer-repository.ts
@@ -3,7 +3,7 @@ import { cidr } from "ip";
 
 // todo: review the implementation
 @Container.injectable()
-export class PeerStorage implements Contracts.P2P.PeerStorage {
+export class PeerRepository implements Contracts.P2P.PeerRepository {
     private readonly peers: Map<string, Contracts.P2P.Peer> = new Map<string, Contracts.P2P.Peer>();
     private readonly peersPending: Map<string, Contracts.P2P.Peer> = new Map<string, Contracts.P2P.Peer>();
 

--- a/packages/core-p2p/src/service-provider.ts
+++ b/packages/core-p2p/src/service-provider.ts
@@ -8,7 +8,7 @@ import { Peer } from "./peer";
 import { PeerCommunicator } from "./peer-communicator";
 import { PeerConnector } from "./peer-connector";
 import { PeerProcessor } from "./peer-processor";
-import { PeerStorage } from "./peer-storage";
+import { PeerRepository } from "./peer-repository";
 import { Server } from "./socket-server/server";
 import { TransactionBroadcaster } from "./transaction-broadcaster";
 
@@ -99,7 +99,7 @@ export class ServiceProvider extends Providers.ServiceProvider {
     }
 
     private registerServices(): void {
-        this.app.bind(Container.Identifiers.PeerStorage).to(PeerStorage).inSingletonScope();
+        this.app.bind(Container.Identifiers.PeerRepository).to(PeerRepository).inSingletonScope();
 
         this.app.bind(Container.Identifiers.PeerConnector).to(PeerConnector).inSingletonScope();
 

--- a/packages/core-p2p/src/socket-server/controllers/peer.ts
+++ b/packages/core-p2p/src/socket-server/controllers/peer.ts
@@ -10,8 +10,8 @@ import { getPeerIp } from "../../utils/get-peer-ip";
 import { constants } from "../../constants";
 
 export class PeerController extends Controller {
-    @Container.inject(Container.Identifiers.PeerStorage)
-    private readonly peerStorage!: Contracts.P2P.PeerStorage;
+    @Container.inject(Container.Identifiers.PeerRepository)
+    private readonly peerRepository!: Contracts.P2P.PeerRepository;
 
     @Container.inject(Container.Identifiers.DatabaseInteraction)
     private readonly databaseInteraction!: DatabaseInteraction;
@@ -19,7 +19,7 @@ export class PeerController extends Controller {
     public getPeers(request: Hapi.Request, h: Hapi.ResponseToolkit): Contracts.P2P.PeerBroadcast[] {
         const peerIp = getPeerIp(request.socket);
 
-        return this.peerStorage
+        return this.peerRepository
             .getPeers()
             .filter((peer) => peer.ip !== peerIp)
             .filter((peer) => peer.port !== -1)

--- a/packages/core-test-framework/src/mocks/index.ts
+++ b/packages/core-test-framework/src/mocks/index.ts
@@ -1,7 +1,7 @@
 export * as BlockRepository from "./block-repository";
 export * as Blockchain from "./blockchain";
 export * as NetworkMonitor from "./network-monitor";
-export * as PeerStorage from "./peer-storage";
+export * as PeerRepository from "./peer-repository";
 export * as TransactionPoolQuery from "./query";
 export * as RoundRepository from "./round-repository";
 export * as ServiceProviderRepository from "./service-provider-repository";

--- a/packages/core-test-framework/src/mocks/peer-repository.ts
+++ b/packages/core-test-framework/src/mocks/peer-repository.ts
@@ -1,5 +1,5 @@
 import { Contracts } from "@arkecosystem/core-kernel";
-import { PeerStorage } from "@arkecosystem/core-p2p";
+import { PeerRepository } from "@arkecosystem/core-p2p";
 
 let mockPeers: Partial<Contracts.P2P.Peer>[] = [];
 
@@ -7,7 +7,7 @@ export const setPeers = (peers: Partial<Contracts.P2P.Peer>[]) => {
     mockPeers = peers;
 };
 
-class PeerStorageMock implements Partial<PeerStorage> {
+class PeerRepositoryMock implements Partial<PeerRepository> {
     public getPeers(): Contracts.P2P.Peer[] {
         return mockPeers as Contracts.P2P.Peer[];
     }
@@ -21,4 +21,4 @@ class PeerStorageMock implements Partial<PeerStorage> {
     }
 }
 
-export const instance = new PeerStorageMock();
+export const instance = new PeerRepositoryMock();


### PR DESCRIPTION
## Summary

Renamed `PeerStorage` into `PeerRepository`. Similarly to `core-transaction-pool` _storage_ is reserved for service that handles storing data to disk.

## Checklist

- [x] Tests
- [x] Ready to be merged
