### PR TITLE
chore: allow unknow fields in package configuration

### DIFF
--- a/__tests__/unit/core-api/service-provider.test.ts
+++ b/__tests__/unit/core-api/service-provider.test.ts
@@ -206,6 +206,21 @@ describe("ServiceProvider", () => {
             expect(result.value.options.estimateTotalCount).toBeTrue();
         });
 
+        it("should allow configuration extension", async () => {
+            jest.resetModules();
+            const defaults = (await import("@packages/core-api/src/defaults")).defaults;
+
+            // @ts-ignore
+            defaults.customField = "dummy";
+
+            const result = (coreApiServiceProvider.configSchema() as AnySchema).validate(
+               defaults
+            );
+
+            expect(result.error).toBeUndefined();
+            expect(result.value.customField).toEqual("dummy");
+        });
+
         describe("process.env.CORE_API_DISABLED", () => {
             it("should return true when process.env.CORE_API_DISABLED is undefined", async () => {
                 jest.resetModules();

--- a/__tests__/unit/core-blockchain/service-provider.test.ts
+++ b/__tests__/unit/core-blockchain/service-provider.test.ts
@@ -1,9 +1,9 @@
 import "jest-extended";
 
-import { AnySchema } from "joi";
 import { ServiceProvider } from "@packages/core-blockchain/src/service-provider";
 import { Application, Container, Providers } from "@packages/core-kernel";
 import { Services } from "@packages/core-kernel/dist";
+import { AnySchema } from "joi";
 
 describe("ServiceProvider", () => {
     let app: Application;
@@ -106,6 +106,19 @@ describe("ServiceProvider", () => {
 
             expect(result.value.databaseRollback.maxBlockRewind).toBeNumber();
             expect(result.value.databaseRollback.steps).toBeNumber();
+        });
+
+        it("should allow configuration extension", async () => {
+            jest.resetModules();
+            const defaults = (await import("@packages/core-blockchain/src/defaults")).defaults;
+
+            // @ts-ignore
+            defaults.customField = "dummy";
+
+            const result = (serviceProvider.configSchema() as AnySchema).validate(defaults);
+
+            expect(result.error).toBeUndefined();
+            expect(result.value.customField).toEqual("dummy");
         });
 
         describe("schema restrictions", () => {

--- a/__tests__/unit/core-database/service-provider.test.ts
+++ b/__tests__/unit/core-database/service-provider.test.ts
@@ -1,9 +1,9 @@
 import "jest-extended";
 
-import { AnySchema } from "joi";
 import { defaults } from "@packages/core-database/src/defaults";
 import { ServiceProvider } from "@packages/core-database/src/service-provider";
 import { Application, Container, Providers } from "@packages/core-kernel";
+import { AnySchema } from "joi";
 import { createConnection, getCustomRepository } from "typeorm";
 
 jest.mock("typeorm", () => {
@@ -127,6 +127,19 @@ describe("ServiceProvider.configSchema", () => {
         expect(result.value.connection.entityPrefix).toBeString();
         expect(result.value.connection.synchronize).toBeFalse();
         expect(result.value.connection.logging).toBeFalse();
+    });
+
+    it("should allow configuration extension", async () => {
+        jest.resetModules();
+        const defaults = (await import("@packages/core-database/src/defaults")).defaults;
+
+        // @ts-ignore
+        defaults.customField = "dummy";
+
+        const result = (serviceProvider.configSchema() as AnySchema).validate(defaults);
+
+        expect(result.error).toBeUndefined();
+        expect(result.value.customField).toEqual("dummy");
     });
 
     describe("process.env.CORE_DB_HOST", () => {

--- a/__tests__/unit/core-forger/service-provider.test.ts
+++ b/__tests__/unit/core-forger/service-provider.test.ts
@@ -168,6 +168,19 @@ describe("ServiceProvider", () => {
             expect(result.value.password).toBeUndefined();
         });
 
+        it("should allow configuration extension", async () => {
+            jest.resetModules();
+            const defaults = (await import("@packages/core-forger/src/defaults")).defaults;
+
+            // @ts-ignore
+            defaults.customField = "dummy";
+
+            const result = (serviceProvider.configSchema() as AnySchema).validate(defaults);
+
+            expect(result.error).toBeUndefined();
+            expect(result.value.customField).toEqual("dummy");
+        });
+
         describe("process.env.CORE_P2P_PORT", () => {
             it("should parse process.env.CORE_API_PORT", async () => {
                 process.env.CORE_P2P_PORT = "5000";

--- a/__tests__/unit/core-logger-pino/service-provider.test.ts
+++ b/__tests__/unit/core-logger-pino/service-provider.test.ts
@@ -4,8 +4,8 @@ import { Providers } from "@arkecosystem/core-kernel";
 import { Application, Container, Services } from "@packages/core-kernel/src";
 import { ServiceProvider } from "@packages/core-logger-pino/src";
 import { defaults } from "@packages/core-logger-pino/src/defaults";
-import { dirSync } from "tmp";
 import { AnySchema } from "joi";
+import { dirSync } from "tmp";
 
 let app: Application;
 
@@ -64,6 +64,19 @@ describe("ServiceProvider", () => {
             expect(result.value.levels.file).toBeString();
 
             expect(result.value.fileRotator.interval).toBeString();
+        });
+
+        it("should allow configuration extension", async () => {
+            jest.resetModules();
+            const defaults = (await import("@packages/core-logger-pino/src/defaults")).defaults;
+
+            // @ts-ignore
+            defaults.customField = "dummy";
+
+            const result = (serviceProvider.configSchema() as AnySchema).validate(defaults);
+
+            expect(result.error).toBeUndefined();
+            expect(result.value.customField).toEqual("dummy");
         });
 
         describe("process.env.CORE_LOG_LEVEL", () => {

--- a/__tests__/unit/core-manager/service-provider.test.ts
+++ b/__tests__/unit/core-manager/service-provider.test.ts
@@ -1,10 +1,10 @@
 import "jest-extended";
 
-import { AnySchema } from "joi";
 import { Application, Container, Providers } from "@packages/core-kernel";
 import { defaults } from "@packages/core-manager/src/defaults";
 import { Identifiers } from "@packages/core-manager/src/ioc";
 import { ServiceProvider } from "@packages/core-manager/src/service-provider";
+import { AnySchema } from "joi";
 import { cloneDeep } from "lodash";
 import path from "path";
 import { dirSync, setGracefulCleanup } from "tmp";
@@ -270,6 +270,19 @@ describe("ServiceProvider", () => {
 
             expect(result.value.plugins.basicAuthentication.enabled).toBeFalse();
             expect(result.value.plugins.basicAuthentication.users).toEqual([]);
+        });
+
+        it("should allow configuration extension", async () => {
+            jest.resetModules();
+            const defaults = (await import("@packages/core-manager/src/defaults")).defaults;
+
+            // @ts-ignore
+            defaults.customField = "dummy";
+
+            const result = (serviceProvider.configSchema() as AnySchema).validate(defaults);
+
+            expect(result.error).toBeUndefined();
+            expect(result.value.customField).toEqual("dummy");
         });
 
         describe("process.env.CORE_WATCHER_ENABLED", () => {

--- a/__tests__/unit/core-p2p/service-provider.test.ts
+++ b/__tests__/unit/core-p2p/service-provider.test.ts
@@ -225,6 +225,19 @@ describe("ServiceProvider", () => {
             expect(result.value.ignoreMinimumNetworkReach).toBeUndefined();
         });
 
+        it("should allow configuration extension", async () => {
+            jest.resetModules();
+            const defaults = (await import("@packages/core-p2p/src/defaults")).defaults;
+
+            // @ts-ignore
+            defaults.customField = "dummy";
+
+            const result = (serviceProvider.configSchema() as AnySchema).validate(defaults);
+
+            expect(result.error).toBeUndefined();
+            expect(result.value.customField).toEqual("dummy");
+        });
+
         describe("process.env.CORE_P2P_HOST", () => {
             it("should parse process.env.CORE_P2P_HOST", async () => {
                 process.env.CORE_P2P_HOST = "127.0.0.1";

--- a/__tests__/unit/core-snapshots/service-provider.test.ts
+++ b/__tests__/unit/core-snapshots/service-provider.test.ts
@@ -3,8 +3,8 @@ import "jest-extended";
 import { Container } from "@packages/core-kernel";
 import { ServiceProvider } from "@packages/core-snapshots/src";
 import { Sandbox } from "@packages/core-test-framework";
-import * as typeorm from "typeorm";
 import { AnySchema } from "joi";
+import * as typeorm from "typeorm";
 
 let sandbox: Sandbox;
 
@@ -95,6 +95,19 @@ describe("ServiceProvider", () => {
             expect(result.value.connection.entityPrefix).toBeString();
             expect(result.value.connection.synchronize).toBeFalse();
             expect(result.value.connection.logging).toBeFalse();
+        });
+
+        it("should allow configuration extension", async () => {
+            jest.resetModules();
+            const defaults = (await import("@packages/core-snapshots/src/defaults")).defaults;
+
+            // @ts-ignore
+            defaults.customField = "dummy";
+
+            const result = (serviceProvider.configSchema() as AnySchema).validate(defaults);
+
+            expect(result.error).toBeUndefined();
+            expect(result.value.customField).toEqual("dummy");
         });
 
         describe("process.env.CORE_DB_HOST", () => {
@@ -309,5 +322,3 @@ describe("ServiceProvider", () => {
         });
     });
 });
-
-

--- a/__tests__/unit/core-state/service-provider.test.ts
+++ b/__tests__/unit/core-state/service-provider.test.ts
@@ -64,6 +64,19 @@ describe("ServiceProvider", () => {
             expect(result.value.walletSync.enabled).toBeFalse();
         });
 
+        it("should allow configuration extension", async () => {
+            jest.resetModules();
+            const defaults = (await import("@packages/core-state/src/defaults")).defaults;
+
+            // @ts-ignore
+            defaults.customField = "dummy";
+
+            const result = (serviceProvider.configSchema() as AnySchema).validate(defaults);
+
+            expect(result.error).toBeUndefined();
+            expect(result.value.customField).toEqual("dummy");
+        });
+
         describe("process.env.CORE_WALLET_SYNC_ENABLED", () => {
             it("should return value of process.env.CORE_WALLET_SYNC_ENABLED if defined", async () => {
                 process.env.CORE_WALLET_SYNC_ENABLED = "true";

--- a/__tests__/unit/core-transaction-pool/service-provider.test.ts
+++ b/__tests__/unit/core-transaction-pool/service-provider.test.ts
@@ -1,9 +1,9 @@
 import "jest-extended";
 
 import { Application, Container, Contracts, Services } from "@arkecosystem/core-kernel";
-import { AnySchema } from "joi";
 import { ServiceProvider } from "@packages/core-transaction-pool/src";
 import { fork } from "child_process";
+import { AnySchema } from "joi";
 
 jest.mock("child_process");
 
@@ -103,6 +103,19 @@ describe("ServiceProvider", () => {
                 expect(item.typeGroup).toBeNumber();
                 expect(item.packageName).toBeString();
             });
+        });
+
+        it("should allow configuration extension", async () => {
+            jest.resetModules();
+            const defaults = (await import("@packages/core-transaction-pool/src/defaults")).defaults;
+
+            // @ts-ignore
+            defaults.customField = "dummy";
+
+            const result = (serviceProvider.configSchema() as AnySchema).validate(defaults);
+
+            expect(result.error).toBeUndefined();
+            expect(result.value.customField).toEqual("dummy");
         });
 
         describe("process.env.CORE_TRANSACTION_POOL_DISABLED", () => {

--- a/__tests__/unit/core-webhooks/service-provider.test.ts
+++ b/__tests__/unit/core-webhooks/service-provider.test.ts
@@ -1,12 +1,12 @@
 import "jest-extended";
 
-import { AnySchema } from "joi";
 import { Identifiers, Server, ServiceProvider as CoreApiServiceProvider } from "@packages/core-api/src";
 import { defaults } from "@packages/core-api/src/defaults";
 import { Application, Container, Providers } from "@packages/core-kernel";
 import { NullEventDispatcher } from "@packages/core-kernel/src/services/events/drivers/null";
 import { ServiceProvider } from "@packages/core-webhooks/src";
 import { defaults as webhooksDefaults } from "@packages/core-webhooks/src/defaults";
+import { AnySchema } from "joi";
 import { dirSync, setGracefulCleanup } from "tmp";
 
 let app: Application;
@@ -171,6 +171,19 @@ describe("ServiceProvider", () => {
                 expect(item).toBeString();
             });
             expect(result.value.timeout).toBeNumber();
+        });
+
+        it("should allow configuration extension", async () => {
+            jest.resetModules();
+            const defaults = (await import("@packages/core-webhooks/src/defaults")).defaults;
+
+            // @ts-ignore
+            defaults.customField = "dummy";
+
+            const result = (serviceProvider.configSchema() as AnySchema).validate(defaults);
+
+            expect(result.error).toBeUndefined();
+            expect(result.value.customField).toEqual("dummy");
         });
 
         describe("process.env.CORE_WEBHOOKS_ENABLED", () => {

--- a/packages/core-api/src/service-provider.ts
+++ b/packages/core-api/src/service-provider.ts
@@ -83,7 +83,7 @@ export class ServiceProvider extends Providers.ServiceProvider {
             options: Joi.object({
                 estimateTotalCount: Joi.bool().required(),
             }),
-        });
+        }).unknown(true);
     }
 
     private async buildServer(type: string, id: symbol): Promise<void> {

--- a/packages/core-blockchain/src/service-provider.ts
+++ b/packages/core-blockchain/src/service-provider.ts
@@ -41,7 +41,7 @@ export class ServiceProvider extends Providers.ServiceProvider {
 
             // used in core:run & relay:run
             networkStart: Joi.bool(),
-        });
+        }).unknown(true);
     }
 
     private registerActions(): void {

--- a/packages/core-database/src/service-provider.ts
+++ b/packages/core-database/src/service-provider.ts
@@ -98,6 +98,6 @@ export class ServiceProvider extends Providers.ServiceProvider {
                 synchronize: Joi.bool().required(),
                 logging: Joi.bool().required(),
             }).required(),
-        });
+        }).unknown(true);
     }
 }

--- a/packages/core-forger/src/service-provider.ts
+++ b/packages/core-forger/src/service-provider.ts
@@ -83,7 +83,7 @@ export class ServiceProvider extends Providers.ServiceProvider {
             tracker: Joi.bool().required(),
             bip38: Joi.string(),
             password: Joi.string(),
-        });
+        }).unknown(true);
     }
 
     private registerActions(): void {

--- a/packages/core-logger-pino/src/service-provider.ts
+++ b/packages/core-logger-pino/src/service-provider.ts
@@ -30,6 +30,6 @@ export class ServiceProvider extends Providers.ServiceProvider {
             fileRotator: Joi.object({
                 interval: Joi.string().required(),
             }).required(),
-        });
+        }).unknown(true);
     }
 }

--- a/packages/core-manager/src/service-provider.ts
+++ b/packages/core-manager/src/service-provider.ts
@@ -1,7 +1,7 @@
 import { ApplicationFactory } from "@arkecosystem/core-cli";
 import { Container, Contracts, Providers, Types } from "@arkecosystem/core-kernel";
-import { cloneDeep } from "lodash";
 import Joi from "joi";
+import { cloneDeep } from "lodash";
 
 import { ActionReader } from "./action-reader";
 import { DatabaseLogger } from "./database-logger";
@@ -186,7 +186,7 @@ export class ServiceProvider extends Providers.ServiceProvider {
                         .when("enabled", { is: true, then: Joi.required() }),
                 }).required(),
             }).required(),
-        });
+        }).unknown(true);
     }
 
     private isProcessTypeManager() {

--- a/packages/core-p2p/src/service-provider.ts
+++ b/packages/core-p2p/src/service-provider.ts
@@ -89,7 +89,7 @@ export class ServiceProvider extends Providers.ServiceProvider {
             disableDiscovery: Joi.bool(),
             skipDiscovery: Joi.bool(),
             ignoreMinimumNetworkReach: Joi.bool(),
-        });
+        }).unknown(true);
     }
 
     private registerFactories(): void {

--- a/packages/core-snapshots/src/service-provider.ts
+++ b/packages/core-snapshots/src/service-provider.ts
@@ -41,7 +41,7 @@ export class ServiceProvider extends Providers.ServiceProvider {
                 synchronize: Joi.bool().required(),
                 logging: Joi.bool().required(),
             }).required(),
-        });
+        }).unknown(true);
     }
 
     private registerServices(): void {

--- a/packages/core-state/src/service-provider.ts
+++ b/packages/core-state/src/service-provider.ts
@@ -121,7 +121,7 @@ export class ServiceProvider extends Providers.ServiceProvider {
             walletSync: Joi.object({
                 enabled: Joi.boolean().required(),
             }).required(),
-        });
+        }).unknown(true);
     }
 
     private registerActions(): void {

--- a/packages/core-transaction-pool/src/service-provider.ts
+++ b/packages/core-transaction-pool/src/service-provider.ts
@@ -91,7 +91,7 @@ export class ServiceProvider extends Providers.ServiceProvider {
                     )
                     .required(),
             }).required(),
-        });
+        }).unknown(true);
     }
 
     private registerServices(): void {

--- a/packages/core-webhooks/src/service-provider.ts
+++ b/packages/core-webhooks/src/service-provider.ts
@@ -68,7 +68,7 @@ export class ServiceProvider extends Providers.ServiceProvider {
                 whitelist: Joi.array().items(Joi.string()).required(),
             }).required(),
             timeout: Joi.number().required(),
-        });
+        }).unknown(true);
     }
 
     /**


### PR DESCRIPTION
## Summary

Allow unknown filed in configuration schema to allow other developers to extend configuration with custom fields via app.json file. 

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged