### PR TITLE
chore(core-p2p): add CORE_P2P_MIN_NETWORK_REACH env variable

### DIFF
--- a/__tests__/unit/core-p2p/service-provider.test.ts
+++ b/__tests__/unit/core-p2p/service-provider.test.ts
@@ -305,6 +305,32 @@ describe("ServiceProvider", () => {
             });
         });
 
+        describe("process.env.CORE_P2P_MIN_NETWORK_REACH", () => {
+            it("should parse process.env.CORE_P2P_MIN_NETWORK_REACH", async () => {
+                process.env.CORE_P2P_MIN_NETWORK_REACH = "10";
+
+                jest.resetModules();
+                const result = (serviceProvider.configSchema() as AnySchema).validate(
+                    (await import("@packages/core-p2p/src/defaults")).defaults,
+                );
+
+                expect(result.error).toBeUndefined();
+                expect(result.value.minimumNetworkReach).toEqual(10);
+            });
+
+            it("should throw if process.env.CORE_P2P_MIN_NETWORK_REACH is not number", async () => {
+                process.env.CORE_P2P_MIN_NETWORK_REACH = "false";
+
+                jest.resetModules();
+                const result = (serviceProvider.configSchema() as AnySchema).validate(
+                    (await import("@packages/core-p2p/src/defaults")).defaults,
+                );
+
+                expect(result.error).toBeDefined();
+                expect(result.error!.message).toEqual('"minimumNetworkReach" must be a number');
+            });
+        });
+
         describe("process.env.CORE_P2P_MAX_PEERS_SAME_SUBNET", () => {
             it("should parse process.env.CORE_P2P_MAX_PEERS_SAME_SUBNET", async () => {
                 process.env.CORE_P2P_MAX_PEERS_SAME_SUBNET = "5000";

--- a/packages/core-p2p/src/defaults.ts
+++ b/packages/core-p2p/src/defaults.ts
@@ -11,7 +11,7 @@ export const defaults = {
     /**
      * The number of peers we expect to be available to start a relay
      */
-    minimumNetworkReach: 20,
+    minimumNetworkReach: process.env.CORE_P2P_MIN_NETWORK_REACH || 20,
     /**
      * The timeout to verify a peer. [milliseconds]
      */


### PR DESCRIPTION
## Summary

Add **CORE_P2P_MIN_NETWORK_REACH** ENV variable. Used to set minimum network reach when using custom number of delegates. 

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged