### PR TITLE
fix(core-p2p): do not consume when just checking rate limit

### DIFF
--- a/packages/core-p2p/src/peer-communicator.ts
+++ b/packages/core-p2p/src/peer-communicator.ts
@@ -289,12 +289,16 @@ export class PeerCommunicator implements Contracts.P2P.PeerCommunicator {
 
     private async throttle(peer: Contracts.P2P.Peer, event: string): Promise<void> {
         const msBeforeReCheck = 1000;
-        while (await this.outgoingRateLimiter.hasExceededRateLimit(peer.ip, event)) {
+        while (await this.outgoingRateLimiter.hasExceededRateLimitNoConsume(peer.ip, event)) {
             this.logger.debug(
                 `Throttling outgoing requests to ${peer.ip}/${event} to avoid triggering their rate limit`,
             );
             await delay(msBeforeReCheck);
         }
+        try {
+            await this.outgoingRateLimiter.hasExceededRateLimit(peer.ip, event);
+        } //@ts-ignore
+        catch {}
     }
 
     private handleSocketError(peer: Contracts.P2P.Peer, event: string, error: Error, disconnect: boolean = true): void {

--- a/packages/core-p2p/src/peer-communicator.ts
+++ b/packages/core-p2p/src/peer-communicator.ts
@@ -296,7 +296,7 @@ export class PeerCommunicator implements Contracts.P2P.PeerCommunicator {
             await delay(msBeforeReCheck);
         }
         try {
-            await this.outgoingRateLimiter.hasExceededRateLimit(peer.ip, event);
+            await this.outgoingRateLimiter.consume(peer.ip, event);
         } //@ts-ignore
         catch {}
     }

--- a/packages/core-p2p/src/rate-limiter.ts
+++ b/packages/core-p2p/src/rate-limiter.ts
@@ -56,6 +56,26 @@ export class RateLimiter {
         return false;
     }
 
+    public async hasExceededRateLimitNoConsume(ip: string, endpoint?: string): Promise<boolean> {
+        const global = await this.global.get(ip);
+        if(global !== null && global.remainingPoints <= 0) {
+            return true;
+        }
+
+        if (endpoint && this.endpoints.has(endpoint)) {
+            const endpointLimiters: RateLimiterMemory | undefined = this.endpoints.get(endpoint);
+
+            Utils.assert.defined<RateLimiterMemory>(endpointLimiters);
+
+            const endpointLimiter = await endpointLimiters.get(ip);
+            if(endpointLimiter !== null && endpointLimiter.remainingPoints <= 0) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     public getRateLimitedEndpoints(): string[] {
         return Array.from(this.endpoints.keys());
     }

--- a/packages/core-p2p/src/rate-limiter.ts
+++ b/packages/core-p2p/src/rate-limiter.ts
@@ -38,17 +38,21 @@ export class RateLimiter {
         }
     }
 
+    public async consume(ip: string, endpoint?: string): Promise<void> {
+        await this.global.consume(ip);
+
+        if (endpoint && this.endpoints.has(endpoint)) {
+            const rateLimiter: RateLimiterMemory | undefined = this.endpoints.get(endpoint);
+
+            Utils.assert.defined<RateLimiterMemory>(rateLimiter);
+
+            await rateLimiter.consume(ip);
+        }
+    }
+
     public async hasExceededRateLimit(ip: string, endpoint?: string): Promise<boolean> {
         try {
-            await this.global.consume(ip);
-
-            if (endpoint && this.endpoints.has(endpoint)) {
-                const rateLimiter: RateLimiterMemory | undefined = this.endpoints.get(endpoint);
-
-                Utils.assert.defined<RateLimiterMemory>(rateLimiter);
-
-                await rateLimiter.consume(ip);
-            }
+            await this.consume(ip, endpoint);
         } catch {
             return true;
         }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
In outgoing rate limiter (for throttling) it is wrong to consume 1 point of the rate limiter when we are just checking rate limit (not actually sending message).
Instead consume only when we know we do not hit rate limit.
<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
