### PR TITLE
chore(core-p2p): queue postTransactions requests

### DIFF
--- a/__tests__/unit/core-p2p/peer-communicator.test.ts
+++ b/__tests__/unit/core-p2p/peer-communicator.test.ts
@@ -45,7 +45,7 @@ describe("PeerCommunicator", () => {
         version: () => version,
         get: () => { return () => queue },
     };
-    const emitter = { dispatch: jest.fn() };
+    const emitter = { dispatch: jest.fn(), listen: jest.fn() };
     const connector = { forgetError: jest.fn(), connect: jest.fn(), emit: jest.fn(), setError: jest.fn() };
 
     beforeAll(() => {

--- a/__tests__/unit/core-p2p/peer-communicator.test.ts
+++ b/__tests__/unit/core-p2p/peer-communicator.test.ts
@@ -39,11 +39,11 @@ describe("PeerCommunicator", () => {
     const headers = { version };
     const jobsQueued = [];
     const queue = { resolve: jest.fn(), resume: jest.fn(), push: (job) => jobsQueued.push(job) };
+    const createQueue = () => queue;
     const app = {
         resolve: (_) => peerVerifier,
         getTagged: () => configuration,
         version: () => version,
-        get: () => { return () => queue },
     };
     const emitter = { dispatch: jest.fn(), listen: jest.fn() };
     const connector = { forgetError: jest.fn(), connect: jest.fn(), emit: jest.fn(), setError: jest.fn() };
@@ -55,6 +55,7 @@ describe("PeerCommunicator", () => {
         container.bind(Container.Identifiers.PluginConfiguration).toConstantValue(configuration);
         container.bind(Container.Identifiers.EventDispatcherService).toConstantValue(emitter);
         container.bind(Container.Identifiers.PeerConnector).toConstantValue(connector);
+        container.bind(Container.Identifiers.QueueFactory).toConstantValue(createQueue);
         container.bind(Container.Identifiers.PeerCommunicator).to(PeerCommunicator);
 
         process.env.CORE_P2P_PEER_VERIFIER_DEBUG_EXTRA = "true";

--- a/packages/core-p2p/src/peer-communicator.ts
+++ b/packages/core-p2p/src/peer-communicator.ts
@@ -31,6 +31,9 @@ export class PeerCommunicator implements Contracts.P2P.PeerCommunicator {
     @Container.inject(Container.Identifiers.LogService)
     private readonly logger!: Contracts.Kernel.Logger;
 
+    @Container.inject(Container.Identifiers.QueueFactory)
+    private readonly createQueue!: Types.QueueFactory;
+
     private outgoingRateLimiter!: RateLimiter;
 
     private postTransactionsQueueByIp: Map<string, Contracts.Kernel.Queue> = new Map();
@@ -72,7 +75,7 @@ export class PeerCommunicator implements Contracts.P2P.PeerCommunicator {
         if (!this.postTransactionsQueueByIp.get(peer.ip)) {
             this.postTransactionsQueueByIp.set(
                 peer.ip,
-                await this.app.get<Types.QueueFactory>(Container.Identifiers.QueueFactory)()
+                await this.createQueue(),
             );
         }
 

--- a/packages/core-p2p/src/peer-communicator.ts
+++ b/packages/core-p2p/src/peer-communicator.ts
@@ -44,6 +44,10 @@ export class PeerCommunicator implements Contracts.P2P.PeerCommunicator {
             rateLimit: this.configuration.getOptional<number>("rateLimit", 100),
             rateLimitPostTransactions: this.configuration.getOptional<number>("rateLimitPostTransactions", 25),
         });
+
+        this.events.listen(Enums.PeerEvent.Disconnect, {
+            handle: ({ data }) => this.postTransactionsQueueByIp.delete(data.peer.ip),
+        });
     }
 
     public async postBlock(peer: Contracts.P2P.Peer, block: Interfaces.IBlock) {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
Use a queue for sending postTransactions requests, so that we send them sequentially and allowing us to better control throttling according to rate limit (adding a slight delay between each request).

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
