### PR TITLE
chore(core-p2p): set default max payload on ws client

### DIFF
--- a/__tests__/unit/core-p2p/hapi-nes/client.test.ts
+++ b/__tests__/unit/core-p2p/hapi-nes/client.test.ts
@@ -48,10 +48,10 @@ const createServerWithPlugin = async (pluginOptions = {}, serverOptions = {}, wi
 };
 
 describe("Client", () => {
-    it("defaults options.ws.maxPayload to zero (node)", () => {
+    it("defaults options.ws.maxPayload to 102400 (node)", () => {
         const client = new Client("http://localhost");
         // @ts-ignore
-        expect(client._settings.ws).toEqual({ maxPayload: 0 });
+        expect(client._settings.ws).toEqual({ maxPayload: 102400 });
     });
 
     it("allows setting options.ws.maxPayload (node)", () => {

--- a/packages/core-p2p/src/hapi-nes/client.ts
+++ b/packages/core-p2p/src/hapi-nes/client.ts
@@ -75,7 +75,6 @@ export class Client {
 
     public id;
 
-    private _isBrowser;
     private _url;
     private _settings;
     private _heartbeatTimeout;
@@ -92,15 +91,10 @@ export class Client {
     public constructor(url, options?) {
         options = options || {};
 
-        this._isBrowser = false;
+        options.ws = options.ws || {};
 
-        /* istanbul ignore else */
-        if (!this._isBrowser) {
-            options.ws = options.ws || {};
-
-            if (options.ws.maxPayload === undefined) {
-                options.ws.maxPayload = 0; // Override default 100Mb limit in ws module to avoid breaking change
-            }
+        if (options.ws.maxPayload === undefined) {
+            options.ws.maxPayload = DEFAULT_MAX_PAYLOAD_CLIENT;
         }
 
         // Configuration


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
And remove useless `_isBrowser`

Needs #4309 before merge to fix failing test.
<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
