### PR TITLE
refactor: use core-database connection in core-snapshots

### DIFF
--- a/__tests__/unit/core-manager/actions/info-database-size.test.ts
+++ b/__tests__/unit/core-manager/actions/info-database-size.test.ts
@@ -1,7 +1,7 @@
 import "jest-extended";
 
+import { Container } from "@packages/core-kernel";
 import { Action } from "@packages/core-manager/src/actions/info-database-size";
-import { Identifiers } from "@packages/core-snapshots";
 import { Sandbox } from "@packages/core-test-framework";
 
 let sandbox: Sandbox;
@@ -20,7 +20,7 @@ const databaseConnection = {
 beforeEach(() => {
     sandbox = new Sandbox();
 
-    sandbox.app.bind(Identifiers.SnapshotDatabaseConnection).toConstantValue(databaseConnection);
+    sandbox.app.bind(Container.Identifiers.DatabaseConnection).toConstantValue(databaseConnection);
 
     action = sandbox.app.resolve(Action);
 });

--- a/__tests__/unit/core-snapshots/database-service.test.ts
+++ b/__tests__/unit/core-snapshots/database-service.test.ts
@@ -21,7 +21,7 @@ let database: SnapshotDatabaseService;
 let filesystem: Filesystem;
 
 class MockWorkerWrapper extends EventEmitter {
-    constructor() {
+    public constructor() {
         super();
     }
 
@@ -114,11 +114,6 @@ beforeEach(() => {
 
     sandbox.app.bind(Container.Identifiers.ApplicationNetwork).toConstantValue("testnet");
 
-    sandbox.app
-        .bind(Container.Identifiers.PluginConfiguration)
-        .to(Providers.PluginConfiguration)
-        .when(Container.Selectors.anyAncestorOrTargetTaggedFirst("plugin", "@arkecosystem/core-snapshots"));
-
     sandbox.app.bind(Container.Identifiers.FilesystemService).to(LocalFilesystem).inSingletonScope();
     sandbox.app.bind(Identifiers.SnapshotFilesystem).to(Filesystem).inSingletonScope();
 
@@ -132,15 +127,10 @@ beforeEach(() => {
 
     sandbox.app.bind(Identifiers.SnapshotDatabaseService).to(SnapshotDatabaseService).inSingletonScope();
 
-    const pluginConfiguration = sandbox.app.getTagged<Providers.PluginConfiguration>(
-        Container.Identifiers.PluginConfiguration,
-        "plugin",
-        "@arkecosystem/core-snapshots",
-    );
-
-    pluginConfiguration.set("chunkSize", configuration.chunkSize);
-    pluginConfiguration.set("dispatchUpdateStep", configuration.dispatchUpdateStep);
-    pluginConfiguration.set("connection", configuration.connection);
+    sandbox.app.bind(Container.Identifiers.PluginConfiguration).to(Providers.PluginConfiguration).inSingletonScope();
+    sandbox.app
+        .get<Providers.PluginConfiguration>(Container.Identifiers.PluginConfiguration)
+        .from("@arkecosystem/core-snapshots", configuration);
 
     database = sandbox.app.get<SnapshotDatabaseService>(Identifiers.SnapshotDatabaseService);
     filesystem = sandbox.app.get<Filesystem>(Identifiers.SnapshotFilesystem);

--- a/__tests__/unit/core-snapshots/service-provider.test.ts
+++ b/__tests__/unit/core-snapshots/service-provider.test.ts
@@ -52,8 +52,17 @@ describe("ServiceProvider", () => {
         await expect(serviceProvider.dispose()).toResolve();
     });
 
-    it("should not be required", async () => {
+    it("should be required", async () => {
         await expect(serviceProvider.required()).resolves.toBeTrue();
+    });
+
+    it("should depend on core-database", async () => {
+        expect(serviceProvider.dependencies()).toEqual([
+            {
+                name: "@arkecosystem/core-database",
+                required: true,
+            },
+        ]);
     });
 
     describe("ServiceProvider.configSchema", () => {

--- a/__tests__/unit/core-snapshots/service-provider.test.ts
+++ b/__tests__/unit/core-snapshots/service-provider.test.ts
@@ -9,9 +9,6 @@ import * as typeorm from "typeorm";
 let sandbox: Sandbox;
 
 const spyOnGetCustomRepository = jest.spyOn(typeorm, "getCustomRepository").mockReturnValue(undefined);
-const spyOnCreateConnection = jest.spyOn(typeorm, "createConnection").mockResolvedValue({
-    close: jest.fn(),
-} as any);
 
 ServiceProvider.prototype.config = jest.fn().mockReturnValue({
     all: jest.fn().mockReturnValue({
@@ -39,7 +36,6 @@ describe("ServiceProvider", () => {
     it("should register", async () => {
         await expect(serviceProvider.register()).toResolve();
         expect(spyOnGetCustomRepository).toHaveBeenCalledTimes(3);
-        expect(spyOnCreateConnection).toHaveBeenCalled();
     });
 
     it("should register is default connection is already active", async () => {
@@ -47,13 +43,11 @@ describe("ServiceProvider", () => {
 
         await expect(serviceProvider.register()).toResolve();
         expect(spyOnGetCustomRepository).toHaveBeenCalledTimes(3);
-        expect(spyOnCreateConnection).toHaveBeenCalled();
     });
 
     it("should dispose", async () => {
         await expect(serviceProvider.register()).toResolve();
         expect(spyOnGetCustomRepository).toHaveBeenCalled();
-        expect(spyOnCreateConnection).toHaveBeenCalled();
 
         await expect(serviceProvider.dispose()).toResolve();
     });
@@ -65,15 +59,6 @@ describe("ServiceProvider", () => {
     describe("ServiceProvider.configSchema", () => {
         beforeEach(() => {
             serviceProvider = sandbox.app.resolve<ServiceProvider>(ServiceProvider);
-
-            for (const key of Object.keys(process.env)) {
-                if (key.includes("CORE_DB_")) {
-                    delete process.env[key];
-                }
-            }
-
-            process.env.CORE_TOKEN = "ark";
-            process.env.CORE_NETWORK_NAME = "testnet";
         });
 
         it("should validate schema using defaults", async () => {
@@ -85,16 +70,6 @@ describe("ServiceProvider", () => {
             expect(result.error).toBeUndefined();
 
             expect(result.value.updateStep).toBeNumber();
-
-            expect(result.value.connection.type).toEqual("postgres");
-            expect(result.value.connection.host).toEqual("localhost");
-            expect(result.value.connection.port).toEqual(5432);
-            expect(result.value.connection.database).toEqual("ark_testnet");
-            expect(result.value.connection.username).toEqual("ark");
-            expect(result.value.connection.password).toBeString();
-            expect(result.value.connection.entityPrefix).toBeString();
-            expect(result.value.connection.synchronize).toBeFalse();
-            expect(result.value.connection.logging).toBeFalse();
         });
 
         it("should allow configuration extension", async () => {
@@ -108,76 +83,6 @@ describe("ServiceProvider", () => {
 
             expect(result.error).toBeUndefined();
             expect(result.value.customField).toEqual("dummy");
-        });
-
-        describe("process.env.CORE_DB_HOST", () => {
-            it("should return value of process.env.CORE_DB_HOST if defined", async () => {
-                process.env.CORE_DB_HOST = "custom_hostname";
-
-                jest.resetModules();
-                const result = (serviceProvider.configSchema() as AnySchema).validate(
-                    (await import("@packages/core-snapshots/src/defaults")).defaults,
-                );
-
-                expect(result.error).toBeUndefined();
-                expect(result.value.connection.host).toEqual("custom_hostname");
-            });
-        });
-
-        describe("process.env.CORE_DB_PORT", () => {
-            it("should return value of process.env.CORE_DB_PORT if defined", async () => {
-                process.env.CORE_DB_PORT = "123";
-
-                jest.resetModules();
-                const result = (serviceProvider.configSchema() as AnySchema).validate(
-                    (await import("@packages/core-snapshots/src/defaults")).defaults,
-                );
-
-                expect(result.error).toBeUndefined();
-                expect(result.value.connection.port).toEqual(123);
-            });
-        });
-
-        describe("process.env.CORE_DB_DATABASE", () => {
-            it("should return value of process.env.CORE_DB_PORT if defined", async () => {
-                process.env.CORE_DB_DATABASE = "custom_database";
-
-                jest.resetModules();
-                const result = (serviceProvider.configSchema() as AnySchema).validate(
-                    (await import("@packages/core-snapshots/src/defaults")).defaults,
-                );
-
-                expect(result.error).toBeUndefined();
-                expect(result.value.connection.database).toEqual("custom_database");
-            });
-        });
-
-        describe("process.env.CORE_DB_USERNAME", () => {
-            it("should return value of process.env.CORE_DB_USERNAME if defined", async () => {
-                process.env.CORE_DB_USERNAME = "custom_username";
-
-                jest.resetModules();
-                const result = (serviceProvider.configSchema() as AnySchema).validate(
-                    (await import("@packages/core-snapshots/src/defaults")).defaults,
-                );
-
-                expect(result.error).toBeUndefined();
-                expect(result.value.connection.username).toEqual("custom_username");
-            });
-        });
-
-        describe("process.env.CORE_DB_PASSWORD", () => {
-            it("should return value of process.env.CORE_DB_PASSWORD if defined", async () => {
-                process.env.CORE_DB_PASSWORD = "custom_password";
-
-                jest.resetModules();
-                const result = (serviceProvider.configSchema() as AnySchema).validate(
-                    (await import("@packages/core-snapshots/src/defaults")).defaults,
-                );
-
-                expect(result.error).toBeUndefined();
-                expect(result.value.connection.password).toEqual("custom_password");
-            });
         });
 
         describe("schema restrictions", () => {
@@ -213,141 +118,6 @@ describe("ServiceProvider", () => {
                 result = (serviceProvider.configSchema() as AnySchema).validate(defaults);
 
                 expect(result.error!.message).toEqual('"updateStep" is required');
-            });
-
-            it("connection is required && is object", async () => {
-                defaults.connection = true;
-                let result = (serviceProvider.configSchema() as AnySchema).validate(defaults);
-
-                expect(result.error!.message).toEqual('"connection" must be of type object');
-
-                delete defaults.connection;
-                result = (serviceProvider.configSchema() as AnySchema).validate(defaults);
-
-                expect(result.error!.message).toEqual('"connection" is required');
-            });
-
-            it("connection.type is required && is string", async () => {
-                defaults.connection.type = false;
-                let result = (serviceProvider.configSchema() as AnySchema).validate(defaults);
-
-                expect(result.error!.message).toEqual('"connection.type" must be a string');
-
-                delete defaults.connection.type;
-                result = (serviceProvider.configSchema() as AnySchema).validate(defaults);
-
-                expect(result.error!.message).toEqual('"connection.type" is required');
-            });
-
-            it("connection.host is required && is string", async () => {
-                defaults.connection.host = false;
-                let result = (serviceProvider.configSchema() as AnySchema).validate(defaults);
-
-                expect(result.error!.message).toEqual('"connection.host" must be a string');
-
-                delete defaults.connection.host;
-                result = (serviceProvider.configSchema() as AnySchema).validate(defaults);
-
-                expect(result.error!.message).toEqual('"connection.host" is required');
-            });
-
-            it("connection.port is required && is integer && >= 1 && <= 65535", async () => {
-                defaults.connection.port = false;
-                let result = (serviceProvider.configSchema() as AnySchema).validate(defaults);
-
-                expect(result.error!.message).toEqual('"connection.port" must be a number');
-
-                defaults.connection.port = 1.12;
-                result = (serviceProvider.configSchema() as AnySchema).validate(defaults);
-
-                expect(result.error!.message).toEqual('"connection.port" must be an integer');
-
-                defaults.connection.port = 0;
-                result = (serviceProvider.configSchema() as AnySchema).validate(defaults);
-
-                expect(result.error!.message).toEqual('"connection.port" must be greater than or equal to 1');
-
-                defaults.connection.port = 65536;
-                result = (serviceProvider.configSchema() as AnySchema).validate(defaults);
-
-                expect(result.error!.message).toEqual('"connection.port" must be less than or equal to 65535');
-
-                delete defaults.connection.port;
-                result = (serviceProvider.configSchema() as AnySchema).validate(defaults);
-
-                expect(result.error!.message).toEqual('"connection.port" is required');
-            });
-
-            it("connection.database is required && is string", async () => {
-                defaults.connection.database = false;
-                let result = (serviceProvider.configSchema() as AnySchema).validate(defaults);
-
-                expect(result.error!.message).toEqual('"connection.database" must be a string');
-
-                delete defaults.connection.database;
-                result = (serviceProvider.configSchema() as AnySchema).validate(defaults);
-
-                expect(result.error!.message).toEqual('"connection.database" is required');
-            });
-
-            it("connection.username is required && is string", async () => {
-                defaults.connection.username = false;
-                let result = (serviceProvider.configSchema() as AnySchema).validate(defaults);
-
-                expect(result.error!.message).toEqual('"connection.username" must be a string');
-
-                delete defaults.connection.username;
-                result = (serviceProvider.configSchema() as AnySchema).validate(defaults);
-
-                expect(result.error!.message).toEqual('"connection.username" is required');
-            });
-
-            it("connection.password is required && is string", async () => {
-                defaults.connection.password = false;
-                let result = (serviceProvider.configSchema() as AnySchema).validate(defaults);
-
-                expect(result.error!.message).toEqual('"connection.password" must be a string');
-
-                delete defaults.connection.password;
-                result = (serviceProvider.configSchema() as AnySchema).validate(defaults);
-
-                expect(result.error!.message).toEqual('"connection.password" is required');
-            });
-
-            it("connection.entityPrefix is required && is string", async () => {
-                defaults.connection.entityPrefix = false;
-                let result = (serviceProvider.configSchema() as AnySchema).validate(defaults);
-
-                expect(result.error!.message).toEqual('"connection.entityPrefix" must be a string');
-
-                delete defaults.connection.entityPrefix;
-                result = (serviceProvider.configSchema() as AnySchema).validate(defaults);
-
-                expect(result.error!.message).toEqual('"connection.entityPrefix" is required');
-            });
-
-            it("connection.synchronize is required && is boolean", async () => {
-                defaults.connection.synchronize = 123;
-                let result = (serviceProvider.configSchema() as AnySchema).validate(defaults);
-
-                expect(result.error!.message).toEqual('"connection.synchronize" must be a boolean');
-
-                delete defaults.connection.synchronize;
-                result = (serviceProvider.configSchema() as AnySchema).validate(defaults);
-
-                expect(result.error!.message).toEqual('"connection.synchronize" is required');
-            });
-
-            it("connection.logging is required && is boolean", async () => {
-                defaults.connection.logging = 123;
-                let result = (serviceProvider.configSchema() as AnySchema).validate(defaults);
-
-                expect(result.error!.message).toEqual('"connection.logging" must be a boolean');
-
-                delete defaults.connection.logging;
-                result = (serviceProvider.configSchema() as AnySchema).validate(defaults);
-
-                expect(result.error!.message).toEqual('"connection.logging" is required');
             });
         });
     });

--- a/__tests__/unit/core/commands/config-manager.test.ts
+++ b/__tests__/unit/core/commands/config-manager.test.ts
@@ -59,6 +59,9 @@ describe("ConfigManagerCommand", () => {
                                 package: "@arkecosystem/core-logger-pino",
                             },
                             {
+                                package: "@arkecosystem/core-database",
+                            },
+                            {
                                 package: "@arkecosystem/core-snapshots",
                             },
                             {
@@ -118,6 +121,9 @@ describe("ConfigManagerCommand", () => {
                                 package: "@arkecosystem/core-logger-pino",
                             },
                             {
+                                package: "@arkecosystem/core-database",
+                            },
+                            {
                                 package: "@arkecosystem/core-snapshots",
                             },
                             {
@@ -167,6 +173,9 @@ describe("ConfigManagerCommand", () => {
                         plugins: [
                             {
                                 package: "@arkecosystem/core-logger-pino",
+                            },
+                            {
+                                package: "@arkecosystem/core-database",
                             },
                             {
                                 package: "@arkecosystem/core-snapshots",
@@ -223,6 +232,9 @@ describe("ConfigManagerCommand", () => {
                         plugins: [
                             {
                                 package: "@arkecosystem/core-logger-pino",
+                            },
+                            {
+                                package: "@arkecosystem/core-database",
                             },
                             {
                                 package: "@arkecosystem/core-snapshots",
@@ -282,6 +294,9 @@ describe("ConfigManagerCommand", () => {
                         plugins: [
                             {
                                 package: "@arkecosystem/core-logger-pino",
+                            },
+                            {
+                                package: "@arkecosystem/core-database",
                             },
                             {
                                 package: "@arkecosystem/core-snapshots",

--- a/__tests__/unit/core/commands/snapshot-dump.test.ts
+++ b/__tests__/unit/core/commands/snapshot-dump.test.ts
@@ -1,35 +1,41 @@
-import { Console } from "@arkecosystem/core-test-framework";
+import { Utils } from "@packages/core-cli";
+import { Container } from "@packages/core-kernel";
+import { Console, Sandbox } from "@packages/core-test-framework";
 import { Command } from "@packages/core/src/commands/snapshot-dump";
-import { Application, Container } from "@packages/core-kernel";
-import { ServiceProvider } from "@packages/core-snapshots";
-import { join, resolve } from "path";
 
 let cli;
 let mockSnapshotService;
+let mockEventListener;
+let spyOnTerminate;
+
 beforeEach(() => {
     cli = new Console();
 
-    ServiceProvider.prototype.register = jest.fn();
-    Application.prototype.configPath = jest
-        .fn()
-        .mockImplementation((path: string = "") => join(resolve("packages/core/bin/config/testnet/"), path));
+    const sandbox = new Sandbox();
 
     mockSnapshotService = {
         dump: jest.fn(),
     };
-    // @ts-ignore
-    Application.prototype.get = function (serviceIdentifier) {
-        if (serviceIdentifier === Container.Identifiers.SnapshotService) {
-            return mockSnapshotService;
-        }
 
-        return this.container.get(serviceIdentifier);
+    mockEventListener = {
+        listen: jest.fn(),
     };
+
+    sandbox.app.bind(Container.Identifiers.SnapshotService).toConstantValue(mockSnapshotService);
+    sandbox.app.bind(Container.Identifiers.EventDispatcherService).toConstantValue(mockEventListener);
+
+    jest.spyOn(Utils, "buildApplication").mockResolvedValue(sandbox.app);
+    spyOnTerminate = jest.spyOn(sandbox.app, "terminate").mockImplementation(async () => {});
+});
+
+afterEach(() => {
+    jest.clearAllMocks();
 });
 
 describe("DumpCommand", () => {
     it("should run dump", async () => {
         await expect(cli.execute(Command)).toResolve();
         expect(mockSnapshotService.dump).toHaveBeenCalled();
+        expect(spyOnTerminate).toHaveBeenCalled();
     });
 });

--- a/__tests__/unit/core/commands/snapshot-truncate.test.ts
+++ b/__tests__/unit/core/commands/snapshot-truncate.test.ts
@@ -1,36 +1,35 @@
-import { Console } from "@arkecosystem/core-test-framework";
+import { Utils } from "@arkecosystem/core-cli";
+import { Container } from "@arkecosystem/core-kernel";
+import { Console, Sandbox } from "@packages/core-test-framework";
 import { Command } from "@packages/core/src/commands/snapshot-truncate";
-import { Application, Container } from "@arkecosystem/core-kernel";
-import { ServiceProvider } from "@packages/core-snapshots";
-import { join, resolve } from "path";
 
 let cli;
 let mockSnapshotService;
+let spyOnTerminate;
 
 beforeEach(() => {
     cli = new Console();
 
-    ServiceProvider.prototype.register = jest.fn();
-    Application.prototype.configPath = jest
-        .fn()
-        .mockImplementation((path: string = "") => join(resolve("packages/core/bin/config/testnet/"), path));
+    const sandbox = new Sandbox();
 
     mockSnapshotService = {
         truncate: jest.fn(),
     };
-    // @ts-ignore
-    Application.prototype.get = function (serviceIdentifier) {
-        if (serviceIdentifier === Container.Identifiers.SnapshotService) {
-            return mockSnapshotService;
-        }
 
-        return this.container.get(serviceIdentifier);
-    };
+    sandbox.app.bind(Container.Identifiers.SnapshotService).toConstantValue(mockSnapshotService);
+
+    jest.spyOn(Utils, "buildApplication").mockResolvedValue(sandbox.app);
+    spyOnTerminate = jest.spyOn(sandbox.app, "terminate").mockImplementation(async () => {});
+});
+
+afterEach(() => {
+    jest.clearAllMocks();
 });
 
 describe("SnapshotTruncateCommand", () => {
     it("should run truncate", async () => {
         await expect(cli.execute(Command)).toResolve();
         expect(mockSnapshotService.truncate).toHaveBeenCalled();
+        expect(spyOnTerminate).toHaveBeenCalled();
     });
 });

--- a/packages/core-manager/src/actions/info-database-size.ts
+++ b/packages/core-manager/src/actions/info-database-size.ts
@@ -1,5 +1,4 @@
 import { Application, Container } from "@arkecosystem/core-kernel";
-import { Identifiers } from "@arkecosystem/core-snapshots";
 import { Connection } from "typeorm";
 
 import { Actions } from "../contracts";
@@ -18,7 +17,7 @@ export class Action implements Actions.Action {
     }
 
     private async getDatabaseSize(): Promise<number> {
-        const connection = this.app.get<Connection>(Identifiers.SnapshotDatabaseConnection);
+        const connection = this.app.get<Connection>(Container.Identifiers.DatabaseConnection);
 
         const result = await connection.query(`SELECT pg_database_size('${connection.options.database}');`);
 

--- a/packages/core-snapshots/src/database-service.ts
+++ b/packages/core-snapshots/src/database-service.ts
@@ -18,6 +18,10 @@ export class SnapshotDatabaseService implements Database.DatabaseService {
     @Container.tagged("plugin", "@arkecosystem/core-snapshots")
     private readonly configuration!: Providers.PluginConfiguration;
 
+    @Container.inject(Container.Identifiers.PluginConfiguration)
+    @Container.tagged("plugin", "@arkecosystem/core-database")
+    private readonly coreDatabaseConfiguration!: Providers.PluginConfiguration;
+
     @Container.inject(Container.Identifiers.LogService)
     private readonly logger!: Contracts.Kernel.Logger;
 
@@ -278,7 +282,7 @@ export class SnapshotDatabaseService implements Database.DatabaseService {
                 updateStep: this.configuration.getOptional("updateStep", 1000),
             },
             networkConfig: Managers.configManager.all()!,
-            connection: this.configuration.get("connection"),
+            connection: this.coreDatabaseConfiguration.getRequired("connection"),
         };
     }
 

--- a/packages/core-snapshots/src/defaults.ts
+++ b/packages/core-snapshots/src/defaults.ts
@@ -1,14 +1,3 @@
 export const defaults = {
     updateStep: 1000,
-    connection: {
-        type: "postgres",
-        host: process.env.CORE_DB_HOST || "localhost",
-        port: process.env.CORE_DB_PORT || 5432,
-        database: process.env.CORE_DB_DATABASE || `${process.env.CORE_TOKEN}_${process.env.CORE_NETWORK_NAME}`,
-        username: process.env.CORE_DB_USERNAME || process.env.CORE_TOKEN,
-        password: process.env.CORE_DB_PASSWORD || "password",
-        entityPrefix: "public.",
-        synchronize: false,
-        logging: false,
-    },
 };

--- a/packages/core-snapshots/src/service-provider.ts
+++ b/packages/core-snapshots/src/service-provider.ts
@@ -23,17 +23,6 @@ export class ServiceProvider extends Providers.ServiceProvider {
     public configSchema(): object {
         return Joi.object({
             updateStep: Joi.number().integer().min(1).max(2000).required(),
-            connection: Joi.object({
-                type: Joi.string().required(),
-                host: Joi.string().required(),
-                port: Joi.number().integer().min(1).max(65535).required(),
-                database: Joi.string().required(),
-                username: Joi.string().required(),
-                password: Joi.string().required(),
-                entityPrefix: Joi.string().required(),
-                synchronize: Joi.bool().required(),
-                logging: Joi.bool().required(),
-            }).required(),
         }).unknown(true);
     }
 

--- a/packages/core-snapshots/src/service-provider.ts
+++ b/packages/core-snapshots/src/service-provider.ts
@@ -1,4 +1,4 @@
-import { Container, Providers } from "@arkecosystem/core-kernel";
+import { Container, Contracts, Providers } from "@arkecosystem/core-kernel";
 import Joi from "joi";
 import { getCustomRepository } from "typeorm";
 
@@ -18,6 +18,15 @@ export class ServiceProvider extends Providers.ServiceProvider {
 
     public async required(): Promise<boolean> {
         return true;
+    }
+
+    public dependencies(): Contracts.Kernel.PluginDependency[] {
+        return [
+            {
+                name: "@arkecosystem/core-database",
+                required: true,
+            },
+        ];
     }
 
     public configSchema(): object {

--- a/packages/core/bin/config/devnet/app.json
+++ b/packages/core/bin/config/devnet/app.json
@@ -92,6 +92,9 @@
                 "package": "@arkecosystem/core-logger-pino"
             },
             {
+                "package": "@arkecosystem/core-database"
+            },
+            {
                 "package": "@arkecosystem/core-snapshots"
             }
         ]
@@ -100,6 +103,9 @@
         "plugins": [
             {
                 "package": "@arkecosystem/core-logger-pino"
+            },
+            {
+                "package": "@arkecosystem/core-database"
             },
             {
                 "package": "@arkecosystem/core-snapshots"

--- a/packages/core/bin/config/mainnet/app.json
+++ b/packages/core/bin/config/mainnet/app.json
@@ -92,6 +92,9 @@
                 "package": "@arkecosystem/core-logger-pino"
             },
             {
+                "package": "@arkecosystem/core-database"
+            },
+            {
                 "package": "@arkecosystem/core-snapshots"
             }
         ]
@@ -100,6 +103,9 @@
         "plugins": [
             {
                 "package": "@arkecosystem/core-logger-pino"
+            },
+            {
+                "package": "@arkecosystem/core-database"
             },
             {
                 "package": "@arkecosystem/core-snapshots"

--- a/packages/core/bin/config/testnet/app.json
+++ b/packages/core/bin/config/testnet/app.json
@@ -92,6 +92,9 @@
                 "package": "@arkecosystem/core-logger-pino"
             },
             {
+                "package": "@arkecosystem/core-database"
+            },
+            {
                 "package": "@arkecosystem/core-snapshots"
             }
         ]
@@ -100,6 +103,9 @@
         "plugins": [
             {
                 "package": "@arkecosystem/core-logger-pino"
+            },
+            {
+                "package": "@arkecosystem/core-database"
             },
             {
                 "package": "@arkecosystem/core-snapshots"

--- a/packages/core/src/commands/config-manager.ts
+++ b/packages/core/src/commands/config-manager.ts
@@ -173,6 +173,9 @@ export class Command extends Commands.Command {
                     package: "@arkecosystem/core-logger-pino",
                 },
                 {
+                    package: "@arkecosystem/core-database",
+                },
+                {
                     package: "@arkecosystem/core-snapshots",
                 },
                 {
@@ -213,7 +216,7 @@ export class Command extends Commands.Command {
         }
 
         if (Object.keys(packageOptions.plugins).length) {
-            result.plugins[2].options = packageOptions;
+            result.plugins.find((plugin) => plugin.package === "@arkecosystem/core-manager").options = packageOptions;
         }
 
         return result;


### PR DESCRIPTION
## Summary

Use core-database connection in core-snapshots.

Changes:
 - core-snapshots depends on core-database package
 - pass core-database connection data to snapshot workers
 - updated `app.json` files
 - use core-database connection in core-manager for  `info.databaseSize` action
 - update `config:manager` CLI command

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged