### PR TITLE
refactor: move snapshot progress renderer to core-snapshots package

### DIFF
--- a/__tests__/unit/core-snapshots/progress-renderer.test.ts
+++ b/__tests__/unit/core-snapshots/progress-renderer.test.ts
@@ -1,9 +1,10 @@
 import "jest-extended";
-import { Sandbox } from "@packages/core-test-framework/src";
+
 import { Container } from "@packages/core-kernel";
 import { MemoryEventDispatcher } from "@packages/core-kernel/src/services/events/drivers/memory";
-import { ProgressRenderer } from "@packages/core/src/utils/snapshot-progress-renderer";
 import { SnapshotApplicationEvents } from "@packages/core-snapshots";
+import { ProgressRenderer } from "@packages/core-snapshots/src/progress-renderer";
+import { Sandbox } from "@packages/core-test-framework/src";
 
 let sandbox: Sandbox;
 let eventDispatcher: MemoryEventDispatcher;
@@ -28,7 +29,7 @@ afterEach(() => {
 
 describe("SnapshotProgressRenderer", () => {
     it("should render on start", async () => {
-        new ProgressRenderer(mockOra as any, sandbox.app);
+        new ProgressRenderer(mockOra, sandbox.app);
 
         await eventDispatcher.dispatch(SnapshotApplicationEvents.SnapshotStart, {
             table: "blocks",
@@ -39,7 +40,7 @@ describe("SnapshotProgressRenderer", () => {
     });
 
     it("should render on update", async () => {
-        new ProgressRenderer(mockOra as any, sandbox.app);
+        new ProgressRenderer(mockOra, sandbox.app);
 
         await eventDispatcher.dispatch(SnapshotApplicationEvents.SnapshotStart, {
             table: "blocks",
@@ -55,7 +56,7 @@ describe("SnapshotProgressRenderer", () => {
     });
 
     it("should render on end", async () => {
-        new ProgressRenderer(mockOra as any, sandbox.app);
+        new ProgressRenderer(mockOra, sandbox.app);
 
         await eventDispatcher.dispatch(SnapshotApplicationEvents.SnapshotStart, {
             table: "blocks",

--- a/packages/core-snapshots/package.json
+++ b/packages/core-snapshots/package.json
@@ -27,6 +27,7 @@
         "bytebuffer": "^5.0.1",
         "fs-extra": "^8.1.0",
         "msgpack-lite": "^0.1.26",
+        "ora": "^4.0.3",
         "pg-query-stream": "^3.0.4",
         "pluralize": "^8.0.0",
         "typeorm": "0.2.25",

--- a/packages/core-snapshots/src/index.ts
+++ b/packages/core-snapshots/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./ioc";
 export * from "./events";
+export * from "./progress-renderer";
 export * from "./service-provider";
 export * from "./snapshot-service";

--- a/packages/core-snapshots/src/progress-renderer.ts
+++ b/packages/core-snapshots/src/progress-renderer.ts
@@ -1,6 +1,7 @@
 import { Container, Contracts } from "@arkecosystem/core-kernel";
-import { SnapshotApplicationEvents } from "@arkecosystem/core-snapshots";
 import { Ora } from "ora";
+
+import { SnapshotApplicationEvents } from "./events";
 
 export class ProgressRenderer {
     private isAnyStarted: boolean = false;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -73,7 +73,6 @@
         "kleur": "^4.1.1",
         "ngrok": "^3.2.5",
         "nodejs-tail": "^1.1.0",
-        "ora": "^4.0.3",
         "pretty-bytes": "^5.2.0",
         "pretty-ms": "^7.0.0",
         "prompts": "^2.4.0",

--- a/packages/core/src/commands/snapshot-dump.ts
+++ b/packages/core/src/commands/snapshot-dump.ts
@@ -1,9 +1,8 @@
 import { Commands, Components, Container, Contracts, Utils } from "@arkecosystem/core-cli";
 import { Container as KernelContainer, Contracts as KernelContracts } from "@arkecosystem/core-kernel";
+import { ProgressRenderer } from "@arkecosystem/core-snapshots";
 import { Networks } from "@arkecosystem/crypto";
 import Joi from "joi";
-
-import { ProgressRenderer } from "../utils/snapshot-progress-renderer";
 
 /**
  * @export

--- a/packages/core/src/commands/snapshot-restore.ts
+++ b/packages/core/src/commands/snapshot-restore.ts
@@ -1,9 +1,8 @@
 import { Commands, Components, Container, Contracts, Utils } from "@arkecosystem/core-cli";
 import { Container as KernelContainer, Contracts as KernelContracts } from "@arkecosystem/core-kernel";
+import { ProgressRenderer } from "@arkecosystem/core-snapshots";
 import { Networks } from "@arkecosystem/crypto";
 import Joi from "joi";
-
-import { ProgressRenderer } from "../utils/snapshot-progress-renderer";
 
 /**
  * @export

--- a/packages/core/src/commands/snapshot-verify.ts
+++ b/packages/core/src/commands/snapshot-verify.ts
@@ -1,9 +1,8 @@
 import { Commands, Components, Container, Contracts, Utils } from "@arkecosystem/core-cli";
 import { Container as KernelContainer, Contracts as KernelContracts } from "@arkecosystem/core-kernel";
+import { ProgressRenderer } from "@arkecosystem/core-snapshots";
 import { Networks } from "@arkecosystem/crypto";
 import Joi from "joi";
-
-import { ProgressRenderer } from "../utils/snapshot-progress-renderer";
 
 /**
  * @export


### PR DESCRIPTION
## Summary

Move snapshots `ProgressRenderer` from core to core-snapshots.

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged