### PR TITLE
fix(core): help output message and --help flag

### DIFF
--- a/__tests__/unit/core-cli/commands/command.test.ts
+++ b/__tests__/unit/core-cli/commands/command.test.ts
@@ -134,7 +134,7 @@ describe("Command", () => {
         });
 
         it("should run the command in non-interactive mode", async () => {
-            cmd.register(["env:paths", "--no-interaction"]);
+            cmd.register(["env:paths"]);
 
             const interact = jest.spyOn(cmd, "interact");
 

--- a/__tests__/unit/core-cli/commands/command.test.ts
+++ b/__tests__/unit/core-cli/commands/command.test.ts
@@ -1,7 +1,7 @@
 import { Container } from "@arkecosystem/core-cli";
 import { Console } from "@arkecosystem/core-test-framework";
-import Joi from "joi";
 import { Command, DiscoverConfig } from "@packages/core-cli/src/commands";
+import Joi from "joi";
 import { setGracefulCleanup } from "tmp";
 
 @Container.injectable()
@@ -22,6 +22,7 @@ class StubCommand extends Command {
 
 let cli;
 let cmd;
+let spyOnSetVerbosity;
 
 beforeAll(() => setGracefulCleanup());
 
@@ -30,6 +31,8 @@ beforeEach(() => {
 
     cmd = cli.app.resolve(StubCommand);
     cmd.register(["env:paths", "john", "doe", "--hello=world"]);
+
+    spyOnSetVerbosity = jest.spyOn(cmd.output, "setVerbosity");
 });
 
 afterEach(() => jest.resetAllMocks());
@@ -38,22 +41,32 @@ describe("Command", () => {
     describe("#register", () => {
         it("should register the command", () => {
             cmd.register(["env:paths", "john", "doe", "--hello=world"]);
+
+            expect(spyOnSetVerbosity).toHaveBeenCalledWith(1);
         });
 
         it("should register the command with an output verbosity of quiet", () => {
             cmd.register(["env:paths", "--quiet"]);
+
+            expect(spyOnSetVerbosity).toHaveBeenCalledWith(0);
         });
 
         it("should register the command with an output verbosity of normal", () => {
             cmd.register(["env:paths", "-v"]);
+
+            expect(spyOnSetVerbosity).toHaveBeenCalledWith(1);
         });
 
         it("should register the command with an output verbosity of verbose", () => {
             cmd.register(["env:paths", "-vv"]);
+
+            expect(spyOnSetVerbosity).toHaveBeenCalledWith(2);
         });
 
         it("should register the command with an output verbosity of debug", () => {
             cmd.register(["env:paths", "-vvv"]);
+
+            expect(spyOnSetVerbosity).toHaveBeenCalledWith(3);
         });
 
         it("should register the command and encounter an error", () => {

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -82,7 +82,7 @@ export class CommandLineInterface {
         if (commandInstance && flags.help) {
             commandInstance.showHelp();
 
-            process.exit(2);
+            process.exit(0);
         }
 
         commandInstance.register(this.argv);

--- a/packages/core/src/commands/help.ts
+++ b/packages/core/src/commands/help.ts
@@ -81,7 +81,6 @@ ${blue().bold("Usage")}
 ${blue().bold("Flags")}
   --help              Display the corresponding help message.
   --quiet             Do not output any message
-  --version           Display the application version.
   --no-interaction    Do not ask interactive questions.
   --v|vv|vvv          Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
 

--- a/packages/core/src/commands/help.ts
+++ b/packages/core/src/commands/help.ts
@@ -81,7 +81,9 @@ ${blue().bold("Usage")}
 ${blue().bold("Flags")}
   --help              Display the corresponding help message.
   --quiet             Do not output any message
-  --v|vv|vvv          Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
+
+${blue().bold("Arguments")}
+  -v|vv|vvv          Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
 
 ${blue().bold("Available Commands")}
 ${commandsAsString.join("\n")}`,

--- a/packages/core/src/commands/help.ts
+++ b/packages/core/src/commands/help.ts
@@ -81,7 +81,6 @@ ${blue().bold("Usage")}
 ${blue().bold("Flags")}
   --help              Display the corresponding help message.
   --quiet             Do not output any message
-  --no-interaction    Do not ask interactive questions.
   --v|vv|vvv          Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
 
 ${blue().bold("Available Commands")}


### PR DESCRIPTION
## Summary

- Remove unused flags from core help command.
- Test verbosity
- Exit process with 0 when using --help flag

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged