### PR TITLE
fix(core-p2p): hard limit number of txs in codec

### DIFF
--- a/packages/core-p2p/src/socket-server/codecs/blocks.ts
+++ b/packages/core-p2p/src/socket-server/codecs/blocks.ts
@@ -2,7 +2,7 @@ import { Utils } from "@arkecosystem/crypto";
 import { blocks } from "./proto/protos";
 
 const hardLimitNumberOfBlocks = 400;
-const hardLimitNumberOfTransactions = 400;
+const hardLimitNumberOfTransactions = 500;
 
 export const getBlocks = {
     request: {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
Set hard limit number of txs to 500. (fixes devnet sync issue - we have at some point 500 txs per block)
<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
