### PR TITLE
fix(core-p2p): use internal Hapi routes

### DIFF
--- a/__tests__/unit/core-p2p/socket-server/routes/blocks.test.ts
+++ b/__tests__/unit/core-p2p/socket-server/routes/blocks.test.ts
@@ -33,6 +33,7 @@ describe("BlocksRoute", () => {
                 payload: {
                     maxBytes: config.maxBytes,
                 },
+                isInternal: true,
             },
         }));
 

--- a/__tests__/unit/core-p2p/socket-server/routes/internal.test.ts
+++ b/__tests__/unit/core-p2p/socket-server/routes/internal.test.ts
@@ -33,6 +33,7 @@ describe("InternalRoute", () => {
                 payload: {
                     maxBytes: config.maxBytes,
                 },
+                isInternal: true,
             },
         }));
 

--- a/__tests__/unit/core-p2p/socket-server/routes/peer.test.ts
+++ b/__tests__/unit/core-p2p/socket-server/routes/peer.test.ts
@@ -33,6 +33,7 @@ describe("PeerRoute", () => {
                 payload: {
                     maxBytes: config.maxBytes,
                 },
+                isInternal: true,
             },
         }));
 

--- a/__tests__/unit/core-p2p/socket-server/routes/transactions.test.ts
+++ b/__tests__/unit/core-p2p/socket-server/routes/transactions.test.ts
@@ -38,6 +38,7 @@ describe("BlocksRoute", () => {
                 payload: {
                     maxBytes: config.maxBytes,
                 },
+                isInternal: true,
             },
         }));
 

--- a/packages/core-p2p/src/hapi-nes/socket.ts
+++ b/packages/core-p2p/src/hapi-nes/socket.ts
@@ -341,6 +341,7 @@ export class Socket {
                 },
             },
             remoteAddress: this.info.remoteAddress,
+            allowInternals: true,
         };
 
         const res = await this.server.inject(shot);

--- a/packages/core-p2p/src/socket-server/routes/route.ts
+++ b/packages/core-p2p/src/socket-server/routes/route.ts
@@ -8,11 +8,11 @@ export type Codec = {
     request: {
         serialize: any;
         deserialize: any;
-    },
+    };
     response: {
         serialize: any;
         deserialize: any;
-    },
+    };
 };
 
 export type RouteConfig = {
@@ -42,6 +42,7 @@ export abstract class Route {
                     payload: {
                         maxBytes: config.maxBytes,
                     },
+                    isInternal: true,
                 },
             });
         }


### PR DESCRIPTION
## Summary

Prevent exposing core-p2p routes on HTTP server. Are routes are now internal. Call are forwarded via websocket server. 

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged