### PR TITLE
fix(core-api): cache status code and headers

### DIFF
--- a/__tests__/unit/core-api/service-provider.test.ts
+++ b/__tests__/unit/core-api/service-provider.test.ts
@@ -213,9 +213,7 @@ describe("ServiceProvider", () => {
             // @ts-ignore
             defaults.customField = "dummy";
 
-            const result = (coreApiServiceProvider.configSchema() as AnySchema).validate(
-               defaults
-            );
+            const result = (coreApiServiceProvider.configSchema() as AnySchema).validate(defaults);
 
             expect(result.error).toBeUndefined();
             expect(result.value.customField).toEqual("dummy");
@@ -346,7 +344,7 @@ describe("ServiceProvider", () => {
                 expect(result.value.plugins.cache.enabled).toEqual(false);
             });
 
-            it("should return true if process.env.CORE_API_CACHE_DISABLED is defined", async () => {
+            it("should return true if process.env.CORE_API_CACHE is defined", async () => {
                 process.env.CORE_API_CACHE = "true";
 
                 jest.resetModules();

--- a/packages/core-api/src/plugins/cache.ts
+++ b/packages/core-api/src/plugins/cache.ts
@@ -34,22 +34,17 @@ export = {
             type: "onPreHandler",
             async method(request: Hapi.Request, h: Hapi.ResponseToolkit) {
                 const cacheKey: string = generateCacheKey(request);
+                const value: { isBoom: boolean; data: Record<string, any> } | undefined = cache.get(cacheKey);
 
-                if (cache.has(cacheKey)) {
-                    const value: { isBoom: boolean; data: Record<string, any> } | undefined = cache.get(cacheKey);
-
-                    if (value === undefined || value === null) {
-                        return h.continue;
-                    }
-
+                if (value) {
                     if (value.isBoom) {
                         return h.response(value.data.payload).code(value.data.statusCode).takeover();
                     }
 
                     return h.response(value.data).code(200).takeover();
+                } else {
+                    return h.continue;
                 }
-
-                return h.continue;
             },
         });
 

--- a/packages/core-api/src/plugins/cache.ts
+++ b/packages/core-api/src/plugins/cache.ts
@@ -53,12 +53,10 @@ export = {
             async method(request: Hapi.Request, h: Hapi.ResponseToolkit) {
                 const cacheKey: string = generateCacheKey(request);
 
-                if (!cache.has(cacheKey)) {
-                    cache.set(cacheKey, {
-                        isBoom: request.response.isBoom === true,
-                        data: request.response.isBoom ? request.response.output : request.response.source,
-                    });
-                }
+                cache.set(cacheKey, {
+                    isBoom: request.response.isBoom === true,
+                    data: request.response.isBoom ? request.response.output : request.response.source,
+                });
 
                 return h.continue;
             },

--- a/packages/core-api/src/plugins/cache.ts
+++ b/packages/core-api/src/plugins/cache.ts
@@ -85,6 +85,10 @@ export = {
                     cachedResponse.headers["location"] = headers["location"];
                 }
 
+                if ("content-type" in headers) {
+                    cachedResponse["content-type"] = headers["content-type"];
+                }
+
                 cache.set(cacheKey, cachedResponse);
 
                 return h.continue;

--- a/packages/core-api/src/plugins/cache.ts
+++ b/packages/core-api/src/plugins/cache.ts
@@ -2,6 +2,12 @@ import { Crypto } from "@arkecosystem/crypto";
 import Hapi from "@hapi/hapi";
 import NodeCache from "node-cache";
 
+type CachedResponse = {
+    code: number;
+    headers: Record<string, string>;
+    payload: unknown;
+};
+
 const generateCacheKey = (request: Hapi.Request): string =>
     Crypto.HashAlgorithms.sha256(
         JSON.stringify({
@@ -34,14 +40,20 @@ export = {
             type: "onPreHandler",
             async method(request: Hapi.Request, h: Hapi.ResponseToolkit) {
                 const cacheKey: string = generateCacheKey(request);
-                const value: { isBoom: boolean; data: Record<string, any> } | undefined = cache.get(cacheKey);
+                const cachedResponse: CachedResponse | undefined = cache.get(cacheKey);
 
-                if (value) {
-                    if (value.isBoom) {
-                        return h.response(value.data.payload).code(value.data.statusCode).takeover();
+                if (cachedResponse) {
+                    const newResponse = h.response(cachedResponse.payload).code(cachedResponse.code);
+
+                    for (const [headerName, headerValue] of Object.entries(cachedResponse.headers)) {
+                        newResponse.header(headerName, headerValue, {
+                            append: false,
+                            override: false,
+                            duplicate: false,
+                        });
                     }
 
-                    return h.response(value.data).code(200).takeover();
+                    return newResponse.takeover();
                 } else {
                     return h.continue;
                 }
@@ -53,10 +65,19 @@ export = {
             async method(request: Hapi.Request, h: Hapi.ResponseToolkit) {
                 const cacheKey: string = generateCacheKey(request);
 
-                cache.set(cacheKey, {
-                    isBoom: request.response.isBoom === true,
-                    data: request.response.isBoom ? request.response.output : request.response.source,
-                });
+                if (request.response.isBoom) {
+                    cache.set(cacheKey, {
+                        code: request.response.output.statusCode,
+                        headers: request.response.output.headers,
+                        payload: request.response.output.payload,
+                    });
+                } else {
+                    cache.set(cacheKey, {
+                        code: request.response.statusCode,
+                        headers: request.response.headers,
+                        payload: request.response.source,
+                    });
+                }
 
                 return h.continue;
             },


### PR DESCRIPTION
## Summary

Cache plugin now caches:
 - Status code of successful responses. Subsequent responses will return status code of original response instead of hard-coded 200.
 - Headers. Subsequent responses will return headers of original response.

## Checklist

- [x] Ready to be merged
