### PR TITLE
chore(core-p2p): build server on boot

### DIFF
--- a/packages/core-kernel/src/ioc/identifiers.ts
+++ b/packages/core-kernel/src/ioc/identifiers.ts
@@ -95,6 +95,8 @@ export const Identifiers = {
     PeerRepository: Symbol.for("Peer<Repository>"),
     PeerTransactionBroadcaster: Symbol.for("Peer<TransactionBroadcaster>"),
     PeerEventListener: Symbol.for("Peer<EventListener>"),
+    P2PServer: Symbol.for("Server<P2P>"),
+
     // Transaction Pool
     TransactionPoolService: Symbol.for("TransactionPool<Service>"),
     TransactionPoolCleaner: Symbol.for("TransactionPool<Cleaner>"),

--- a/packages/core-p2p/src/service-provider.ts
+++ b/packages/core-p2p/src/service-provider.ts
@@ -38,18 +38,18 @@ export class ServiceProvider extends Providers.ServiceProvider {
 
         await this.buildServer();
 
-        if (process.env.DISABLE_P2P_SERVER) {
-            return;
-        }
-
         return this.app.get<Server>(Container.Identifiers.P2PServer).boot();
     }
 
-    public async dispose(): Promise<void> {
-        if (process.env.DISABLE_P2P_SERVER) {
-            return;
-        }
+    /**
+     * @returns {Promise<boolean>}
+     * @memberof ServiceProvider
+     */
+    public async disposeWhen(): Promise<boolean> {
+        return !process.env.DISABLE_P2P_SERVER;
+    }
 
+    public async dispose(): Promise<void> {
         this.app.get<Server>(Container.Identifiers.P2PServer).dispose();
     }
 

--- a/packages/core-p2p/src/service-provider.ts
+++ b/packages/core-p2p/src/service-provider.ts
@@ -13,8 +13,6 @@ import { Server } from "./socket-server/server";
 import { TransactionBroadcaster } from "./transaction-broadcaster";
 
 export class ServiceProvider extends Providers.ServiceProvider {
-    private serverSymbol = Symbol.for("P2P<Server>");
-
     public async register(): Promise<void> {
         this.registerFactories();
 
@@ -26,7 +24,7 @@ export class ServiceProvider extends Providers.ServiceProvider {
             return;
         }
 
-        await this.buildServer(this.serverSymbol);
+        await this.buildServer();
     }
 
     /**
@@ -44,7 +42,7 @@ export class ServiceProvider extends Providers.ServiceProvider {
     public async boot(): Promise<void> {
         this.app.get<EventListener>(Container.Identifiers.PeerEventListener).initialize();
 
-        return this.app.get<Server>(this.serverSymbol).boot();
+        return this.app.get<Server>(Container.Identifiers.P2PServer).boot();
     }
 
     public async dispose(): Promise<void> {
@@ -52,7 +50,7 @@ export class ServiceProvider extends Providers.ServiceProvider {
             return;
         }
 
-        this.app.get<Server>(this.serverSymbol).dispose();
+        this.app.get<Server>(Container.Identifiers.P2PServer).dispose();
     }
 
     public async required(): Promise<boolean> {
@@ -121,10 +119,10 @@ export class ServiceProvider extends Providers.ServiceProvider {
         this.app.bind(Container.Identifiers.PeerTransactionBroadcaster).to(TransactionBroadcaster);
     }
 
-    private async buildServer(id: symbol): Promise<void> {
-        this.app.bind<Server>(id).to(Server).inSingletonScope();
+    private async buildServer(): Promise<void> {
+        this.app.bind<Server>(Container.Identifiers.P2PServer).to(Server).inSingletonScope();
 
-        const server: Server = this.app.get<Server>(id);
+        const server: Server = this.app.get<Server>(Container.Identifiers.P2PServer);
         const serverConfig = this.config().get<Types.JsonObject>("server");
         Utils.assert.defined<Types.JsonObject>(serverConfig);
 


### PR DESCRIPTION
## Summary

Build server on boot to allow usage of ioc in server routes. 
Use bootWhen and disposeWhen methods to control p2p server boot. 

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged