### PR TITLE
fix(core-p2p): dispose server

### DIFF
--- a/__tests__/unit/core-p2p/service-provider.test.ts
+++ b/__tests__/unit/core-p2p/service-provider.test.ts
@@ -111,23 +111,20 @@ describe("ServiceProvider", () => {
         });
     });
 
-    describe("disposeWhen", () => {
-        it("should return false when process.env.DISABLE_P2P_SERVER", async () => {
-            process.env.DISABLE_P2P_SERVER = "true";
-            expect(await serviceProvider.disposeWhen()).toBeFalse();
-            delete process.env.DISABLE_P2P_SERVER; // reset to initial undefined value
-        });
-
-        it("should return true when !process.env.DISABLE_P2P_SERVER", async () => {
-            expect(await serviceProvider.disposeWhen()).toBeTrue();
-        });
-    });
-
     describe("dispose", () => {
-        it("should call the server dispose method", async () => {
+        it("should call the server dispose method when process.env.DISABLE_P2P_SERVER is undefined", async () => {
             await serviceProvider.dispose();
 
             expect(mockServer.dispose).toBeCalledTimes(1);
+        });
+
+        it("should not call the server dispose method when process.env.DISABLE_P2P_SERVER = true", async () => {
+            process.env.DISABLE_P2P_SERVER = "true";
+
+            await serviceProvider.dispose();
+            expect(mockServer.dispose).not.toHaveBeenCalled();
+
+            delete process.env.DISABLE_P2P_SERVER; // reset to initial undefined value
         });
     });
     describe("required", () => {

--- a/packages/core-p2p/src/service-provider.ts
+++ b/packages/core-p2p/src/service-provider.ts
@@ -41,16 +41,10 @@ export class ServiceProvider extends Providers.ServiceProvider {
         return this.app.get<Server>(Container.Identifiers.P2PServer).boot();
     }
 
-    /**
-     * @returns {Promise<boolean>}
-     * @memberof ServiceProvider
-     */
-    public async disposeWhen(): Promise<boolean> {
-        return !process.env.DISABLE_P2P_SERVER;
-    }
-
     public async dispose(): Promise<void> {
-        this.app.get<Server>(Container.Identifiers.P2PServer).dispose();
+        if (!process.env.DISABLE_P2P_SERVER) {
+            this.app.get<Server>(Container.Identifiers.P2PServer).dispose();
+        }
     }
 
     public async required(): Promise<boolean> {


### PR DESCRIPTION
## Summary

Remove disposeWhen to prevent continuous server rebooting. Use check inside dispose to determine if server was booted. 

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged