### PR TITLE
refactor(core-p2p): expose NetworkState getters

### DIFF
--- a/__tests__/unit/core-forger/forger-service.test.ts
+++ b/__tests__/unit/core-forger/forger-service.test.ts
@@ -1,9 +1,10 @@
 import "jest-extended";
 
-import { ForgeNewBlockAction, IsForgingAllowedAction } from "@arkecosystem/core-forger/src/actions";
-import { Contracts } from "@arkecosystem/core-kernel";
-import { Sandbox } from "@arkecosystem/core-test-framework";
-import { Interfaces } from "@arkecosystem/crypto";
+import { ForgeNewBlockAction, IsForgingAllowedAction } from "@packages/core-forger/src/actions";
+import { Contracts } from "@packages/core-kernel";
+import { Sandbox } from "@packages/core-test-framework";
+import { Interfaces } from "@packages/crypto";
+import { Slots } from "@packages/crypto/dist/crypto";
 import { HostNoResponseError, RelayCommunicationError } from "@packages/core-forger/src/errors";
 import { ForgerService } from "@packages/core-forger/src/forger-service";
 import { Container, Enums, Services, Utils } from "@packages/core-kernel";
@@ -14,7 +15,6 @@ import { Address } from "@packages/crypto/src/identities";
 import { BuilderFactory } from "@packages/crypto/src/transactions";
 
 import { calculateActiveDelegates } from "./__utils__/calculate-active-delegates";
-import { Slots } from "@arkecosystem/crypto/dist/crypto";
 
 let sandbox: Sandbox;
 const logger = {
@@ -101,11 +101,11 @@ describe("ForgerService", () => {
 
         mockNetworkState = {
             status: NetworkStateStatus.Default,
+            getNodeHeight: () => 10,
+            getLastBlockId: () => "11111111",
             getOverHeightBlockHeaders: () => [],
             getQuorum: () => 0.7,
             toJson: () => "test json",
-            nodeHeight: 10,
-            lastBlockId: "11111111",
         };
 
         const recipientAddress = Address.fromPassphrase("recipient's secret");
@@ -630,7 +630,9 @@ describe("ForgerService", () => {
                 mockNetworkState,
             );
 
-            const loggerWarningMessage = `The NetworkState height (${mockNetworkState.nodeHeight}) and round height (${round.data.lastBlock.height}) are out of sync. This indicates delayed blocks on the network.`;
+            const loggerWarningMessage = `The NetworkState height (${mockNetworkState.getNodeHeight()}) and round height (${
+                round.data.lastBlock.height
+            }) are out of sync. This indicates delayed blocks on the network.`;
             expect(logger.warning).toHaveBeenCalledWith(loggerWarningMessage);
 
             jest.useRealTimers();

--- a/__tests__/unit/core-p2p/network-state.test.ts
+++ b/__tests__/unit/core-p2p/network-state.test.ts
@@ -1,11 +1,12 @@
-import { Container, Utils as KernelUtils } from "@arkecosystem/core-kernel";
-import { NetworkStateStatus } from "@arkecosystem/core-p2p/src/enums";
-import { NetworkState } from "@arkecosystem/core-p2p/src/network-state";
-import { Peer } from "@arkecosystem/core-p2p/src/peer";
-import { PeerVerificationResult } from "@arkecosystem/core-p2p/src/peer-verifier";
-import { Blocks, Crypto, Utils } from "@arkecosystem/crypto";
+import { Container, Utils as KernelUtils } from "@packages/core-kernel";
+import { NetworkStateStatus } from "@packages/core-p2p/src/enums";
+import { NetworkState } from "@packages/core-p2p/src/network-state";
+import { Peer } from "@packages/core-p2p/src/peer";
+import { PeerVerificationResult } from "@packages/core-p2p/src/peer-verifier";
+import { Blocks, Crypto, Utils } from "@packages/crypto";
 
 describe("NetworkState", () => {
+    // @ts-ignore
     const lastBlock = {
         data: {
             id: "17882607875259085966",

--- a/__tests__/unit/core-p2p/network-state.test.ts
+++ b/__tests__/unit/core-p2p/network-state.test.ts
@@ -153,6 +153,54 @@ describe("NetworkState", () => {
         });
     });
 
+    describe("getNodeHeight", () => {
+        it("should return node height", () => {
+            const data = {
+                status: NetworkStateStatus.Test,
+                nodeHeight: 31,
+                lastBlockId: "10024d739768a68b43a6e4124718129e1fe07b0461630b3f275b7640d298c3b7",
+                quorumDetails: {
+                    peersQuorum: 31,
+                    peersNoQuorum: 7,
+                    peersOverHeight: 0,
+                    peersOverHeightBlockHeaders: {},
+                    peersForked: 0,
+                    peersDifferentSlot: 0,
+                    peersForgingNotAllowed: 1,
+                },
+            };
+
+            const networkState = NetworkState.parse(data);
+
+            expect(networkState.getNodeHeight()).toBe(31);
+        });
+    });
+
+    describe("getLastBlockId", () => {
+        it("should return lats block id", () => {
+            const data = {
+                status: NetworkStateStatus.Test,
+                nodeHeight: 31,
+                lastBlockId: "10024d739768a68b43a6e4124718129e1fe07b0461630b3f275b7640d298c3b7",
+                quorumDetails: {
+                    peersQuorum: 31,
+                    peersNoQuorum: 7,
+                    peersOverHeight: 0,
+                    peersOverHeightBlockHeaders: {},
+                    peersForked: 0,
+                    peersDifferentSlot: 0,
+                    peersForgingNotAllowed: 1,
+                },
+            };
+
+            const networkState = NetworkState.parse(data);
+
+            expect(networkState.getLastBlockId()).toBe(
+                "10024d739768a68b43a6e4124718129e1fe07b0461630b3f275b7640d298c3b7",
+            );
+        });
+    });
+
     describe("getQuorum", () => {
         it("should return 1 when NetworkStateStatus.Test", () => {
             const data = {

--- a/packages/core-forger/src/forger-service.ts
+++ b/packages/core-forger/src/forger-service.ts
@@ -175,9 +175,9 @@ export class ForgerService {
 
             const networkState: Contracts.P2P.NetworkState = await this.client.getNetworkState();
 
-            if (networkState.nodeHeight !== this.round.lastBlock.height) {
+            if (networkState.getNodeHeight() !== this.round.lastBlock.height) {
                 this.logger.warning(
-                    `The NetworkState height (${networkState.nodeHeight!.toLocaleString()}) and round height (${this.round.lastBlock.height.toLocaleString()}) are out of sync. This indicates delayed blocks on the network.`,
+                    `The NetworkState height (${networkState.getNodeHeight()?.toLocaleString()}) and round height (${this.round.lastBlock.height.toLocaleString()}) are out of sync. This indicates delayed blocks on the network.`,
                 );
             }
 
@@ -234,19 +234,18 @@ export class ForgerService {
         round: Contracts.P2P.CurrentRound,
         networkState: Contracts.P2P.NetworkState,
     ): Promise<void> {
-        AppUtils.assert.defined<number>(networkState.nodeHeight);
-
-        Managers.configManager.setHeight(networkState.nodeHeight);
+        AppUtils.assert.defined<number>(networkState.getNodeHeight());
+        Managers.configManager.setHeight(networkState.getNodeHeight()!);
 
         const transactions: Interfaces.ITransactionData[] = await this.getTransactionsForForging();
 
         const block: Interfaces.IBlock | undefined = delegate.forge(transactions, {
             previousBlock: {
-                id: networkState.lastBlockId,
+                id: networkState.getLastBlockId(),
                 idHex: Managers.configManager.getMilestone().block.idFullSha256
-                    ? networkState.lastBlockId
-                    : Blocks.Block.toBytesHex(networkState.lastBlockId),
-                height: networkState.nodeHeight,
+                    ? networkState.getLastBlockId()
+                    : Blocks.Block.toBytesHex(networkState.getLastBlockId()),
+                height: networkState.getNodeHeight(),
             },
             timestamp: round.timestamp,
             reward: round.reward,

--- a/packages/core-kernel/src/contracts/p2p/network-state.ts
+++ b/packages/core-kernel/src/contracts/p2p/network-state.ts
@@ -1,13 +1,12 @@
 export interface NetworkState {
     readonly status: any;
 
-    nodeHeight: number | undefined;
-    lastBlockId: string | undefined;
-
     // static analyze(monitor: NetworkMonitor, repository: PeerRepository): NetworkState;
     // static parse(data: any): NetworkState;
 
-    setLastBlock(lastBlock);
+    getNodeHeight(): number | undefined;
+    getLastBlockId(): string | undefined;
+
     getQuorum();
     getOverHeightBlockHeaders();
     toJson();

--- a/packages/core-p2p/src/network-state.ts
+++ b/packages/core-p2p/src/network-state.ts
@@ -56,8 +56,8 @@ class QuorumDetails {
 
 // todo: review the implementation
 export class NetworkState implements Contracts.P2P.NetworkState {
-    public nodeHeight: number | undefined;
-    public lastBlockId: string | undefined;
+    private nodeHeight?: number;
+    private lastBlockId?: string;
     private quorumDetails: QuorumDetails;
 
     public constructor(public readonly status: NetworkStateStatus, lastBlock?: Interfaces.IBlock) {
@@ -101,7 +101,7 @@ export class NetworkState implements Contracts.P2P.NetworkState {
             return new NetworkState(NetworkStateStatus.BelowMinimumPeers, lastBlock);
         }
 
-        return await this.analyzeNetwork(lastBlock, peers, blockTimeLookup);
+        return this.analyzeNetwork(lastBlock, peers, blockTimeLookup);
     }
 
     public static parse(data: any): Contracts.P2P.NetworkState {
@@ -132,9 +132,12 @@ export class NetworkState implements Contracts.P2P.NetworkState {
         return networkState;
     }
 
-    public setLastBlock(lastBlock: Interfaces.IBlock): void {
-        this.nodeHeight = lastBlock.data.height;
-        this.lastBlockId = lastBlock.data.id;
+    public getNodeHeight(): number | undefined {
+        return this.nodeHeight;
+    }
+
+    public getLastBlockId(): string | undefined {
+        return this.lastBlockId;
     }
 
     public getQuorum(): number {
@@ -155,6 +158,11 @@ export class NetworkState implements Contracts.P2P.NetworkState {
         delete data.status;
 
         return JSON.stringify(data, undefined, 2);
+    }
+
+    private setLastBlock(lastBlock: Interfaces.IBlock): void {
+        this.nodeHeight = lastBlock.data.height;
+        this.lastBlockId = lastBlock.data.id;
     }
 
     private update(peer: Contracts.P2P.Peer, currentSlot: number): void {


### PR DESCRIPTION
## Summary

Expose NetworkState getters for nodeHeight and lastBlockId. 
Make setLastBlock private. 

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged