### PR TITLE
fix(core-transaction-pool): accept only verified transactions

### DIFF
--- a/__tests__/unit/core-transaction-pool/worker-script-handler.test.ts
+++ b/__tests__/unit/core-transaction-pool/worker-script-handler.test.ts
@@ -1,8 +1,7 @@
-import { Transactions as MagistrateTransactions } from "@arkecosystem/core-magistrate-crypto";
-import { Generators } from "@arkecosystem/core-test-framework";
-import { Identities, Managers, Transactions } from "@arkecosystem/crypto";
-
-import { WorkerScriptHandler } from "../../../packages/core-transaction-pool/src/worker-script-handler";
+import { Transactions as MagistrateTransactions } from "@packages/core-magistrate-crypto";
+import { Generators } from "@packages/core-test-framework";
+import { WorkerScriptHandler } from "@packages/core-transaction-pool/src/worker-script-handler";
+import { Identities, Managers, Transactions } from "@packages/crypto";
 
 describe("WorkerScriptHandler.loadCryptoPackage", () => {
     it("should register crypto package transactions", () => {
@@ -47,6 +46,10 @@ describe("WorkerScriptHandler.getTransactionFromData", () => {
             .build();
         const result = await workerScriptHandler.getTransactionFromData(transaction.data);
 
-        expect(result).toEqual({ id: transaction.id, serialized: transaction.serialized.toString("hex") });
+        expect(result).toEqual({
+            id: transaction.id,
+            serialized: transaction.serialized.toString("hex"),
+            isVerified: true,
+        });
     });
 });

--- a/__tests__/unit/core-transaction-pool/worker.test.ts
+++ b/__tests__/unit/core-transaction-pool/worker.test.ts
@@ -1,7 +1,6 @@
-import { Container } from "@arkecosystem/core-kernel";
-import { Identities, Managers, Transactions } from "@arkecosystem/crypto";
-
-import { Worker } from "../../../packages/core-transaction-pool/src/worker";
+import { Container } from "@packages/core-kernel";
+import { Worker } from "@packages/core-transaction-pool/src/worker";
+import { Identities, Managers, Transactions } from "@packages/crypto";
 
 const createWorkerSubprocess = jest.fn();
 
@@ -64,6 +63,7 @@ describe("Worker.getTransactionFromData", () => {
         ipcSubprocess.sendRequest.mockResolvedValueOnce({
             id: transaction.id,
             serialized: transaction.serialized.toString("hex"),
+            isVerified: true,
         });
 
         const result = await worker.getTransactionFromData(transaction.data);

--- a/packages/core-kernel/src/contracts/transaction-pool/worker.ts
+++ b/packages/core-kernel/src/contracts/transaction-pool/worker.ts
@@ -5,6 +5,7 @@ import { IpcSubprocess } from "../../utils/ipc-subprocess";
 export type SerializedTransaction = {
     id: string;
     serialized: string;
+    isVerified: boolean;
 };
 
 export interface WorkerScriptHandler {

--- a/packages/core-transaction-pool/src/worker-script-handler.ts
+++ b/packages/core-transaction-pool/src/worker-script-handler.ts
@@ -20,9 +20,10 @@ export class WorkerScriptHandler implements Contracts.TransactionPool.WorkerScri
     public async getTransactionFromData(
         transactionData: Interfaces.ITransactionData | Buffer,
     ): Promise<Contracts.TransactionPool.SerializedTransaction> {
-        const tx = transactionData instanceof Buffer
-            ? Transactions.TransactionFactory.fromBytes(transactionData)
-            : Transactions.TransactionFactory.fromData(transactionData);
-        return { id: tx.id!, serialized: tx.serialized.toString("hex") };
+        const tx =
+            transactionData instanceof Buffer
+                ? Transactions.TransactionFactory.fromBytes(transactionData)
+                : Transactions.TransactionFactory.fromData(transactionData);
+        return { id: tx.id!, serialized: tx.serialized.toString("hex"), isVerified: tx.isVerified };
     }
 }

--- a/packages/core-transaction-pool/src/worker.ts
+++ b/packages/core-transaction-pool/src/worker.ts
@@ -32,7 +32,10 @@ export class Worker implements Contracts.TransactionPool.Worker {
             this.ipcSubprocess.sendAction("setHeight", currentHeight);
         }
 
-        const { id, serialized } = await this.ipcSubprocess.sendRequest("getTransactionFromData", transactionData);
-        return Transactions.TransactionFactory.fromBytesUnsafe(Buffer.from(serialized, "hex"), id);
+        const { id, serialized, isVerified } = await this.ipcSubprocess.sendRequest("getTransactionFromData", transactionData);
+        const transaction = Transactions.TransactionFactory.fromBytesUnsafe(Buffer.from(serialized, "hex"), id);
+        transaction.isVerified = isVerified;
+
+        return transaction;
     }
 }


### PR DESCRIPTION
## Summary

Pass additional parameter `isVerified` form workers getTransactionFromData method. 

This PR ensures that transaction verify status is valid when transaction is made on worker pool and prevents invalid transactions to enter transaction pool and potentially being forged.  

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged