### PR TITLE
chore(core-transactions): implement throwIfCannotEnterPool on MultiSignatureRegistration

### DIFF
--- a/__tests__/unit/core-transactions/handlers/__support__/app.ts
+++ b/__tests__/unit/core-transactions/handlers/__support__/app.ts
@@ -170,7 +170,10 @@ export const initApp = (): Application => {
     return app;
 };
 
-export const buildSenderWallet = (factoryBuilder: FactoryBuilder): Wallets.Wallet => {
+export const buildSenderWallet = (
+    factoryBuilder: FactoryBuilder,
+    passphrase: string = passphrases[0],
+): Wallets.Wallet => {
     const wallet: Wallets.Wallet = factoryBuilder
         .get("Wallet")
         .withOptions({

--- a/__tests__/unit/core-transactions/handlers/two/multi-signature-registration.test.ts
+++ b/__tests__/unit/core-transactions/handlers/two/multi-signature-registration.test.ts
@@ -355,6 +355,14 @@ describe("MultiSignatureRegistrationTransaction", () => {
             await expect(handler.throwIfCannotEnterPool(multiSignatureTransaction)).toResolve();
         });
 
+        it("should throw if transaction asset is undefined", async () => {
+            delete multiSignatureTransaction.data.asset;
+
+            await expect(handler.throwIfCannotEnterPool(multiSignatureTransaction)).rejects.toThrow(
+                Exceptions.Runtime.AssertionException,
+            );
+        });
+
         it("should throw if transaction by sender already in pool", async () => {
             await app.get<Mempool>(Identifiers.TransactionPoolMempool).addTransaction(multiSignatureTransaction);
 

--- a/packages/core-transactions/src/handlers/two/multi-signature-registration.ts
+++ b/packages/core-transactions/src/handlers/two/multi-signature-registration.ts
@@ -94,6 +94,7 @@ export class MultiSignatureRegistrationTransactionHandler extends TransactionHan
 
     public async throwIfCannotEnterPool(transaction: Interfaces.ITransaction): Promise<void> {
         AppUtils.assert.defined<string>(transaction.data.senderPublicKey);
+        AppUtils.assert.defined<Interfaces.IMultiSignatureAsset>(transaction.data.asset?.multiSignature);
 
         const hasSender: boolean = this.poolQuery
             .getAllBySender(transaction.data.senderPublicKey)
@@ -103,6 +104,25 @@ export class MultiSignatureRegistrationTransactionHandler extends TransactionHan
         if (hasSender) {
             throw new Contracts.TransactionPool.PoolError(
                 `Sender ${transaction.data.senderPublicKey} already has a transaction of type '${Enums.TransactionType.MultiSignature}' in the pool`,
+                "ERR_PENDING",
+            );
+        }
+
+        const address = Identities.Address.fromMultiSignatureAsset(transaction.data.asset.multiSignature);
+        const hasAddress: boolean = this.poolQuery
+            .getAll()
+            .whereKind(transaction)
+            .wherePredicate(
+                (t) =>
+                    Identities.Address.fromMultiSignatureAsset(
+                        t.data.asset!.multiSignature as Interfaces.IMultiSignatureAsset,
+                    ) === address,
+            )
+            .has();
+
+        if (hasAddress) {
+            throw new Contracts.TransactionPool.PoolError(
+                `MultiSignatureRegistration for address ${address} already in the pool`,
                 "ERR_PENDING",
             );
         }


### PR DESCRIPTION
## Summary

Implement throwIfCannotEnterPool to prevent accepting transactions with the same MultiSignature address into pool. 

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged