### PR TITLE
deps: bump rotating-file-stream min version to 2.1.5

### DIFF
--- a/packages/core-logger-pino/package.json
+++ b/packages/core-logger-pino/package.json
@@ -27,7 +27,7 @@
         "pino-pretty": "^4.0.0",
         "pump": "^3.0.0",
         "readable-stream": "^3.4.0",
-        "rotating-file-stream": "^2.0.0",
+        "rotating-file-stream": "^2.1.5",
         "split2": "^3.1.1",
         "stream": "^0.0.2"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -14140,10 +14140,10 @@ rollup@^2.18.0:
   optionalDependencies:
     fsevents "~2.1.2"
 
-rotating-file-stream@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/rotating-file-stream/-/rotating-file-stream-2.0.0.tgz#68ffb5abcf5b46009dc26d70b7675b9913310f77"
-  integrity sha512-CICpV69VCUujsdLdD6bqig7A9NjQU+HXRlt4YOqArg7wZynmvVOFYuL7tFF7UQEE7rUxy8G4RrRgo0tX1RU5uw==
+rotating-file-stream@^2.1.5:
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/rotating-file-stream/-/rotating-file-stream-2.1.5.tgz#6490d0a09e11dd4d441aa5d4d3676debed4a44e4"
+  integrity sha512-wnYazkT8oD5HXTj44WhB030aKo74OyICrPz/QKCUah59QD7Np4OhdoTC0WNZfhMx1ClsZp4lYMlAdof+DIkZ1Q==
 
 rsvp@^4.8.4:
   version "4.8.5"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
There were some issue in devnet sync over night that might be solved by using latest version 2.1.5 from rotating-file-stream.

Log of the devnet sync error : 
```
out: TypeError: Cannot read property 'write' of null
out:     at rewrite (/core/node_modules/rotating-file-stream/index.js:86:25)
out:     at /core/node_modules/rotating-file-stream/index.js:97:28
out:     at FSReqCallback.oncomplete (fs.js:169:5)
out:  ✖  uncaughtException (an exception was thrown but not caught)  TypeError: Cannot read property 'write' of null
out:     at rewrite (/core/node_modules/rotating-file-stream/index.js:86:25)
out:     at /core/node_modules/rotating-file-stream/index.js:97:28
out:     at FSReqCallback.oncomplete (fs.js:169:5)
out: terminate called after throwing an instance of 'std::bad_alloc'
out:   what():  std::bad_alloc
```
<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
