### PR TITLE
fix(core-state): bind RoundState as singleton

### DIFF
--- a/packages/core-state/src/service-provider.ts
+++ b/packages/core-state/src/service-provider.ts
@@ -77,7 +77,7 @@ export class ServiceProvider extends Providers.ServiceProvider {
 
         this.app.bind(Container.Identifiers.DposState).to(DposState);
         this.app.bind(Container.Identifiers.BlockState).to(BlockState);
-        this.app.bind(Container.Identifiers.RoundState).to(RoundState);
+        this.app.bind(Container.Identifiers.RoundState).to(RoundState).inSingletonScope();
 
         this.app.bind(Container.Identifiers.StateBlockStore).toConstantValue(new BlockStore(1000));
         this.app.bind(Container.Identifiers.StateTransactionStore).toConstantValue(new TransactionStore(1000));


### PR DESCRIPTION
## Summary

Bind RoundState as singleton. It prevents unnecessary reads from DB because forgingDelegates are not initialized. 

## Checklist

- [x] Ready to be merged