### PR TITLE
feat(core-test-framework): added vendor field support to transaction factory

### DIFF
--- a/__tests__/unit/core-test-framework/utils/transaction-factory.test.ts
+++ b/__tests__/unit/core-test-framework/utils/transaction-factory.test.ts
@@ -349,6 +349,14 @@ describe("TransactionFactory", () => {
         });
     });
 
+    describe("withVendorField", () => {
+        it("should return transaction factory", async () => {
+            const entity = transactionFactory.htlcLock(htlcLockAsset).withVendorField("Test VendorField");
+
+            expect(entity).toBeInstanceOf(TransactionFactory);
+        });
+    });
+
     describe("create", () => {
         it("should return transactions - with default parameters", async () => {
             const entity = transactionFactory.transfer().withVersion(2).create();

--- a/packages/core-test-framework/src/utils/transaction-factory.ts
+++ b/packages/core-test-framework/src/utils/transaction-factory.ts
@@ -32,6 +32,7 @@ export class TransactionFactory {
     private version: number | undefined;
     private senderPublicKey: string | undefined;
     private expiration: number | undefined;
+    private vendorField: string | undefined;
 
     protected constructor(app?: Contracts.Kernel.Application) {
         // @ts-ignore - this is only needed because of the "getNonce"
@@ -288,6 +289,12 @@ export class TransactionFactory {
         return this;
     }
 
+    public withVendorField(vendorField: string): TransactionFactory {
+        this.vendorField = vendorField;
+
+        return this;
+    }
+
     public withPassphrase(passphrase: string): TransactionFactory {
         this.passphrase = passphrase;
 
@@ -413,6 +420,10 @@ export class TransactionFactory {
 
             if (this.expiration) {
                 this.builder.expiration(this.expiration);
+            }
+
+            if (this.vendorField) {
+                this.builder.vendorField(this.vendorField);
             }
 
             this.builder.senderPublicKey(this.senderPublicKey);


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

I added `withVendorField` support to transaction factory.

The reason for this is that `TransactionFactory` from `core-test-framework` is extended and there is no support for testing vendorField via that `TransactionFactory`.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
