### PR TITLE
refactor(core-p2p): downloaded chunks cache

### DIFF
--- a/__tests__/unit/core-p2p/chunk-cache.test.ts
+++ b/__tests__/unit/core-p2p/chunk-cache.test.ts
@@ -1,0 +1,82 @@
+import "jest-extended";
+
+import { ChunkCache } from "@packages/core-p2p/src/chunk-cache";
+import { Sandbox } from "@packages/core-test-framework";
+
+describe("EventListener", () => {
+    let sandbox: Sandbox;
+    let chunkCache: ChunkCache;
+
+    beforeEach(() => {
+        sandbox = new Sandbox();
+
+        chunkCache = sandbox.app.resolve(ChunkCache);
+    });
+
+    describe("set", () => {
+        it("should set data", () => {
+            chunkCache.set("1-2", []);
+        });
+
+        it("should remove first inserted data when cache is full", () => {
+            for (let i = 0; i < 100; i++) {
+                chunkCache.set(`${i}`, []);
+            }
+
+            expect(() => {
+                chunkCache.get("0");
+            }).not.toThrowError();
+
+            chunkCache.set(`101`, []);
+
+            expect(() => {
+                chunkCache.get("0");
+            }).toThrowError();
+        });
+    });
+
+    describe("get", () => {
+        it("should get data", () => {
+            const chunk = [{ id: "1" }, { id: "2" }];
+
+            // @ts-ignore
+            chunkCache.set("1-2", chunk);
+
+            expect(chunkCache.get("1-2")).toBe(chunk);
+        });
+
+        it("should throw error if key does not exists", () => {
+            expect(() => {
+                chunkCache.get("1-2");
+            }).toThrowError(`Downloaded chunk for key 1-2 is not defined.`);
+        });
+    });
+
+    describe("has", () => {
+        it("should return true if key exists", () => {
+            chunkCache.set("1-2", []);
+
+            expect(chunkCache.has("1-2")).toBe(true);
+        });
+
+        it("should return false if key does not exists", () => {
+            expect(chunkCache.has("1-2")).toBe(false);
+        });
+    });
+
+    describe("remove", () => {
+        it("should remove by key", () => {
+            chunkCache.set("1-2", []);
+            expect(chunkCache.has("1-2")).toBe(true);
+
+            chunkCache.remove("1-2");
+            expect(chunkCache.has("1-2")).toBe(false);
+        });
+
+        it("should pass if key doesnt exists", () => {
+            expect(chunkCache.has("1-2")).toBe(false);
+
+            chunkCache.remove("1-2");
+        });
+    });
+});

--- a/__tests__/unit/core-p2p/network-monitor.test.ts
+++ b/__tests__/unit/core-p2p/network-monitor.test.ts
@@ -17,7 +17,6 @@ describe("NetworkMonitor", () => {
     const container = new Container.Container();
 
     const logger = { warning: jest.fn(), debug: jest.fn(), error: jest.fn(), info: jest.fn() };
-    // const chunkCache = { has: jest.fn(), get: jest.fn(), set: jest.fn(), remove: jest.fn() };
     const config = {
         dns: ["1.1.1.1"],
         ntp: ["time.google.com"],

--- a/packages/core-kernel/src/contracts/p2p/chunk-cache.ts
+++ b/packages/core-kernel/src/contracts/p2p/chunk-cache.ts
@@ -1,0 +1,8 @@
+import { Interfaces } from "@packages/crypto";
+
+export interface ChunkCache {
+    has(key: string): boolean;
+    get(key: string): Interfaces.IBlockData[];
+    set(key: string, data: Interfaces.IBlockData[]): void;
+    remove(key: string): void;
+}

--- a/packages/core-kernel/src/contracts/p2p/index.ts
+++ b/packages/core-kernel/src/contracts/p2p/index.ts
@@ -1,3 +1,5 @@
+export * from "./chunk-cache";
+export * from "./nes-client";
 export * from "./network-monitor";
 export * from "./network-state";
 export * from "./peer-connector";

--- a/packages/core-kernel/src/ioc/identifiers.ts
+++ b/packages/core-kernel/src/ioc/identifiers.ts
@@ -92,6 +92,7 @@ export const Identifiers = {
     // P2P - @todo: better names that won't clash
     PeerCommunicator: Symbol.for("Peer<Communicator>"),
     PeerConnector: Symbol.for("Peer<Connector>"),
+    PeerChunkCache: Symbol.for("Peer<ChunkCache>"),
     PeerNetworkMonitor: Symbol.for("Peer<NetworkMonitor>"),
     PeerProcessor: Symbol.for("Peer<Processor>"),
     PeerRepository: Symbol.for("Peer<Repository>"),

--- a/packages/core-p2p/src/chunk-cache.ts
+++ b/packages/core-p2p/src/chunk-cache.ts
@@ -1,0 +1,52 @@
+import { Container, Contracts } from "@packages/core-kernel";
+import { Interfaces } from "@packages/crypto";
+
+interface ChunkData {
+    key: string;
+    data: Interfaces.IBlockData[];
+}
+
+@Container.injectable()
+export class ChunkCache implements Contracts.P2P.ChunkCache {
+    /**
+     * If downloading some chunk fails but nevertheless we manage to download higher chunks,
+     * then they are stored here for later retrieval.
+     */
+    private downloadedChunksCache: ChunkData[] = [];
+
+    /**
+     * Maximum number of entries to keep in `downloadedChunksCache`.
+     * At 400 blocks per chunk, 100 chunks would amount to 40k blocks.
+     * Chunks are removed by First in first out method.
+     */
+    private downloadedChunksCacheMax: number = 100;
+
+    public has(key: string): boolean {
+        return this.downloadedChunksCache.some((chunkData) => chunkData.key === key);
+    }
+
+    public get(key: string): Interfaces.IBlockData[] {
+        const chunkData = this.downloadedChunksCache.find((chunkData) => chunkData.key === key);
+
+        if (!chunkData) {
+            throw new Error(`Downloaded chunk for key ${key} is not defined.`);
+        }
+
+        return chunkData.data;
+    }
+
+    public set(key: string, data: Interfaces.IBlockData[]): void {
+        this.downloadedChunksCache.push({
+            key: key,
+            data: data,
+        });
+
+        if (this.downloadedChunksCache.length > this.downloadedChunksCacheMax) {
+            this.downloadedChunksCache.shift();
+        }
+    }
+
+    public remove(key: string): void {
+        this.downloadedChunksCache = this.downloadedChunksCache.filter((chunkData) => chunkData.key !== key);
+    }
+}

--- a/packages/core-p2p/src/chunk-cache.ts
+++ b/packages/core-p2p/src/chunk-cache.ts
@@ -1,5 +1,5 @@
-import { Container, Contracts } from "@packages/core-kernel";
-import { Interfaces } from "@packages/crypto";
+import { Container, Contracts } from "@arkecosystem/core-kernel";
+import { Interfaces } from "@arkecosystem/crypto";
 
 interface ChunkData {
     key: string;

--- a/packages/core-p2p/src/network-monitor.ts
+++ b/packages/core-p2p/src/network-monitor.ts
@@ -455,12 +455,14 @@ export class NetworkMonitor implements Contracts.P2P.NetworkMonitor {
         }
         // Save any downloaded chunks that are higher than a failed chunk for later reuse.
         for (i++; i < chunksToDownload; i++) {
-            const height: number = fromBlockHeight + this.downloadChunkSize * i;
-            const blocksRange: string = `[${(height + 1).toLocaleString()}, ${(
-                height + this.downloadChunkSize
-            ).toLocaleString()}]`;
+            if (downloadResults[i]) {
+                const height: number = fromBlockHeight + this.downloadChunkSize * i;
+                const blocksRange: string = `[${(height + 1).toLocaleString()}, ${(
+                    height + this.downloadChunkSize
+                ).toLocaleString()}]`;
 
-            this.chunkCache.set(blocksRange, downloadResults[i]);
+                this.chunkCache.set(blocksRange, downloadResults[i]);
+            }
         }
 
         // if we did not manage to download any block, reduce chunk size for next time

--- a/packages/core-p2p/src/service-provider.ts
+++ b/packages/core-p2p/src/service-provider.ts
@@ -2,6 +2,7 @@ import { Container, Providers, Services, Types, Utils } from "@arkecosystem/core
 import Joi from "joi";
 
 import { ValidateAndAcceptPeerAction } from "./actions";
+import { ChunkCache } from "./chunk-cache";
 import { EventListener } from "./event-listener";
 import { NetworkMonitor } from "./network-monitor";
 import { Peer } from "./peer";
@@ -99,6 +100,8 @@ export class ServiceProvider extends Providers.ServiceProvider {
         this.app.bind(Container.Identifiers.PeerCommunicator).to(PeerCommunicator).inSingletonScope();
 
         this.app.bind(Container.Identifiers.PeerProcessor).to(PeerProcessor).inSingletonScope();
+
+        this.app.bind(Container.Identifiers.PeerChunkCache).to(ChunkCache).inSingletonScope();
 
         this.app.bind(Container.Identifiers.PeerNetworkMonitor).to(NetworkMonitor).inSingletonScope();
 


### PR DESCRIPTION
## Summary

Reimplement downloaded chunkc cache, that uses FIFO (First In - First Out) to limit cache size. 

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged