### PR TITLE
fix(core-state): revert block

### DIFF
--- a/__tests__/unit/core-state/round-state.test.ts
+++ b/__tests__/unit/core-state/round-state.test.ts
@@ -673,7 +673,7 @@ describe("RoundState", () => {
             expect(spyOnFromData).toHaveBeenCalledTimes(51);
             expect(databaseService.deleteRound).toHaveBeenCalledWith(2);
             // @ts-ignore
-            expect(roundState.blocksInCurrentRound.length).toEqual(50);
+            expect(roundState.blocksInCurrentRound.length).toEqual(51);
         });
 
         it("should throw error if last blocks is not equal to block", async () => {
@@ -687,7 +687,7 @@ describe("RoundState", () => {
             );
 
             // @ts-ignore
-            expect(roundState.blocksInCurrentRound).toEqual([]);
+            expect(roundState.blocksInCurrentRound).toEqual([blocks[0]]);
             expect(databaseService.deleteRound).not.toHaveBeenCalled();
             expect(stateStore.getLastBlocksByHeight).not.toHaveBeenCalled();
         });

--- a/packages/core-state/src/round-state.ts
+++ b/packages/core-state/src/round-state.ts
@@ -49,11 +49,12 @@ export class RoundState {
         }
 
         assert(
-            this.blocksInCurrentRound.pop()!.data.id === block.data.id,
+            this.blocksInCurrentRound[this.blocksInCurrentRound.length - 1]!.data.id === block.data.id,
             `Last block in blocksInCurrentRound doesn't match block with id ${block.data.id}`,
         );
 
         await this.revertRound(block.data.height);
+        this.blocksInCurrentRound.pop();
     }
 
     // TODO: Check if can restore from state


### PR DESCRIPTION
## Summary

Remove last block from blocksInCurrent round after calling revert method, to successfully calculate previous delegates. 

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged