### PR TITLE
chore(core-state): remove valuesByIndex

### DIFF
--- a/__tests__/unit/core-state/wallets/wallet-repository.test.ts
+++ b/__tests__/unit/core-state/wallets/wallet-repository.test.ts
@@ -281,11 +281,11 @@ describe("Wallet Repository", () => {
         );
     });
 
-    describe("valuesByIndex", () => {
+    describe("allByIndex", () => {
         it("should return values on index", () => {
             const wallet = walletRepo.findByAddress("address");
 
-            expect(walletRepo.valuesByIndex("addresses")).toEqual([wallet]);
+            expect(walletRepo.allByIndex("addresses")).toEqual([wallet]);
         });
     });
 
@@ -294,18 +294,18 @@ describe("Wallet Repository", () => {
             const wallet = walletRepo.findByAddress("address");
             walletRepo.setOnIndex("addresses", "address2", wallet);
 
-            expect(walletRepo.valuesByIndex("addresses")).toEqual([wallet, wallet]);
+            expect(walletRepo.allByIndex("addresses")).toEqual([wallet, wallet]);
         });
     });
 
     describe("forgetOnIndex", () => {
         it("should forget wallet on index", () => {
             const wallet = walletRepo.findByAddress("address");
-            expect(walletRepo.valuesByIndex("addresses")).toEqual([wallet]);
+            expect(walletRepo.allByIndex("addresses")).toEqual([wallet]);
 
             walletRepo.forgetOnIndex("addresses", "address");
 
-            expect(walletRepo.valuesByIndex("addresses")).toEqual([]);
+            expect(walletRepo.allByIndex("addresses")).toEqual([]);
         });
     });
 });

--- a/packages/core-kernel/src/contracts/state/wallets.ts
+++ b/packages/core-kernel/src/contracts/state/wallets.ts
@@ -191,8 +191,6 @@ export interface WalletRepository {
 
     index(wallet: Wallet): void;
 
-    valuesByIndex(index: string): ReadonlyArray<Wallet>;
-
     setOnIndex(index: string, key: string, wallet: Wallet): void;
 
     forgetOnIndex(index: string, key: string): void;

--- a/packages/core-state/src/wallets/wallet-repository.ts
+++ b/packages/core-state/src/wallets/wallet-repository.ts
@@ -136,10 +136,6 @@ export class WalletRepository implements Contracts.State.WalletRepository {
         }
     }
 
-    public valuesByIndex(index: string): ReadonlyArray<Contracts.State.Wallet> {
-        return this.getIndex(index).values();
-    }
-
     public setOnIndex(index: string, key: string, wallet: Contracts.State.Wallet): void {
         this.getIndex(index).set(key, wallet);
     }


### PR DESCRIPTION
## Summary

Remove duplicated method `valuesByIndex`. Keep `allByIndex` with same functionality. 

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged