### PR TITLE
chore(core-transaction-pool): use Core transaction group as default

### DIFF
--- a/__tests__/unit/core-transaction-pool/processor.test.ts
+++ b/__tests__/unit/core-transaction-pool/processor.test.ts
@@ -19,6 +19,8 @@ const transaction2 = Transactions.BuilderFactory.transfer()
     .sign("sender's secret")
     .build();
 
+transaction2.data.typeGroup = undefined;
+
 const pool = { addTransaction: jest.fn() };
 const dynamicFeeMatcher = { throwIfCannotBroadcast: jest.fn() };
 const spyBroadcastTransactions = jest.fn();

--- a/__tests__/unit/core-transaction-pool/processor.test.ts
+++ b/__tests__/unit/core-transaction-pool/processor.test.ts
@@ -1,8 +1,7 @@
-import { Container, Contracts } from "@arkecosystem/core-kernel";
-import { Identities, Managers, Transactions } from "@arkecosystem/crypto";
-
-import { TransactionFeeToLowError } from "../../../packages/core-transaction-pool/src/errors";
-import { Processor } from "../../../packages/core-transaction-pool/src/processor";
+import { Container, Contracts } from "@packages/core-kernel";
+import { TransactionFeeToLowError } from "@packages/core-transaction-pool/src/errors";
+import { Processor } from "@packages/core-transaction-pool/src/processor";
+import { Identities, Managers, Transactions } from "@packages/crypto";
 
 Managers.configManager.getMilestone().aip11 = true;
 const transaction1 = Transactions.BuilderFactory.transfer()
@@ -26,8 +25,8 @@ const spyBroadcastTransactions = jest.fn();
 const transactionBroadcaster = {
     broadcastTransactions: () => {
         spyBroadcastTransactions(); // some weird issue with jest, can't use directly jest.fn() mocking promise so using this trick
-        return Promise.resolve()
-    }
+        return Promise.resolve();
+    },
 };
 const workerPool = { isTypeGroupSupported: jest.fn(), getTransactionFromData: jest.fn() };
 const logger = { error: jest.fn() };

--- a/packages/core-transaction-pool/src/processor.ts
+++ b/packages/core-transaction-pool/src/processor.ts
@@ -1,6 +1,6 @@
-import ByteBuffer from "bytebuffer";
 import { Container, Contracts, Utils as AppUtils } from "@arkecosystem/core-kernel";
-import { Interfaces, Transactions, Enums } from "@arkecosystem/crypto";
+import { Enums, Interfaces, Transactions } from "@arkecosystem/crypto";
+import ByteBuffer from "bytebuffer";
 
 import { InvalidTransactionDataError } from "./errors";
 
@@ -22,12 +22,14 @@ export class Processor implements Contracts.TransactionPool.Processor {
     @Container.inject(Container.Identifiers.LogService)
     private readonly logger!: Contracts.Kernel.Logger;
 
-    public async process(data: Interfaces.ITransactionData[] | Buffer[]): Promise<{
-        accept: string[],
-        broadcast: string[],
-        invalid: string[],
-        excess: string[],
-        errors?: { [id: string]: Contracts.TransactionPool.ProcessorError },
+    public async process(
+        data: Interfaces.ITransactionData[] | Buffer[],
+    ): Promise<{
+        accept: string[];
+        broadcast: string[];
+        invalid: string[];
+        excess: string[];
+        errors?: { [id: string]: Contracts.TransactionPool.ProcessorError };
     }> {
         const accept: string[] = [];
         const broadcast: string[] = [];
@@ -42,9 +44,10 @@ export class Processor implements Contracts.TransactionPool.Processor {
                 const transactionData = data[i];
 
                 try {
-                    const transaction = transactionData instanceof Buffer
-                        ? await this.getTransactionFromBuffer(transactionData)
-                        : await this.getTransactionFromData(transactionData as Interfaces.ITransactionData);
+                    const transaction =
+                        transactionData instanceof Buffer
+                            ? await this.getTransactionFromBuffer(transactionData)
+                            : await this.getTransactionFromData(transactionData);
                     await this.pool.addTransaction(transaction);
                     accept.push(transactionData instanceof Buffer ? `${i}` : transactionData.id ?? `${i}`);
 
@@ -72,9 +75,9 @@ export class Processor implements Contracts.TransactionPool.Processor {
             }
         } finally {
             if (this.transactionBroadcaster && broadcastableTransactions.length !== 0) {
-                this.transactionBroadcaster.broadcastTransactions(broadcastableTransactions).catch(
-                    (error) => this.logger.error(error.stack)
-                );
+                this.transactionBroadcaster
+                    .broadcastTransactions(broadcastableTransactions)
+                    .catch((error) => this.logger.error(error.stack));
                 for (const transaction of broadcastableTransactions) {
                     AppUtils.assert.defined<string>(transaction.id);
                     broadcast.push(transaction.id);
@@ -91,9 +94,7 @@ export class Processor implements Contracts.TransactionPool.Processor {
         };
     }
 
-    private async getTransactionFromBuffer(
-        transactionData: Buffer,
-    ): Promise<Interfaces.ITransaction> {
+    private async getTransactionFromBuffer(transactionData: Buffer): Promise<Interfaces.ITransaction> {
         try {
             const transactionCommon = {} as Interfaces.ITransactionData;
             const txByteBuffer = ByteBuffer.wrap(transactionData);

--- a/packages/core-transaction-pool/src/processor.ts
+++ b/packages/core-transaction-pool/src/processor.ts
@@ -1,6 +1,6 @@
 import ByteBuffer from "bytebuffer";
 import { Container, Contracts, Utils as AppUtils } from "@arkecosystem/core-kernel";
-import { Interfaces, Transactions } from "@arkecosystem/crypto";
+import { Interfaces, Transactions, Enums } from "@arkecosystem/crypto";
 
 import { InvalidTransactionDataError } from "./errors";
 
@@ -99,7 +99,7 @@ export class Processor implements Contracts.TransactionPool.Processor {
             const txByteBuffer = ByteBuffer.wrap(transactionData);
             Transactions.Deserializer.deserializeCommon(transactionCommon, txByteBuffer);
 
-            if (this.workerPool.isTypeGroupSupported(transactionCommon.typeGroup!)) {
+            if (this.workerPool.isTypeGroupSupported(transactionCommon.typeGroup || Enums.TransactionTypeGroup.Core)) {
                 return await this.workerPool.getTransactionFromData(transactionData);
             } else {
                 return Transactions.TransactionFactory.fromBytes(transactionData);
@@ -113,7 +113,7 @@ export class Processor implements Contracts.TransactionPool.Processor {
         transactionData: Interfaces.ITransactionData,
     ): Promise<Interfaces.ITransaction> {
         try {
-            if (this.workerPool.isTypeGroupSupported(transactionData.typeGroup!)) {
+            if (this.workerPool.isTypeGroupSupported(transactionData.typeGroup || Enums.TransactionTypeGroup.Core)) {
                 return await this.workerPool.getTransactionFromData(transactionData);
             } else {
                 return Transactions.TransactionFactory.fromData(transactionData);


### PR DESCRIPTION
## Summary

Use `Core` transaction type group by default for cases when transaction group is not provided. Now even transactions without defined `typeGroup` are processed by workers.  

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged