### PR TITLE
fix(core-p2p): lastBlockHeightInRound computation

### DIFF
--- a/packages/core-p2p/src/peer-verifier.ts
+++ b/packages/core-p2p/src/peer-verifier.ts
@@ -359,7 +359,7 @@ export class PeerVerifier implements Contracts.P2P.PeerVerifier {
     private async verifyPeerBlocks(startHeight: number, claimedHeight: number, deadline: number): Promise<boolean> {
         const roundInfo = Utils.roundCalculator.calculateRound(startHeight);
         const { maxDelegates, roundHeight } = roundInfo;
-        const lastBlockHeightInRound = roundHeight + maxDelegates;
+        const lastBlockHeightInRound = roundHeight + maxDelegates - 1;
 
         // Verify a few blocks that are not too far up from the last common block. Within the
         // same round as the last common block or in the next round if the last common block is


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
If the starting height for the round is `X`, then last block height for the round is `X + <activeDelegates> - 1`.
Example : starting height for round 1 is 1, last block height in round is `1 + 51 - 1 = 51`
<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
