### PR TITLE
fix(core-transaction-pool): prioritized removeForgedTransaction

### DIFF
--- a/__tests__/unit/core-transaction-pool/sender-mempool.test.ts
+++ b/__tests__/unit/core-transaction-pool/sender-mempool.test.ts
@@ -207,7 +207,7 @@ describe("SenderMempool.removeForgedTransaction", () => {
         expect(remainingTransactions).toStrictEqual([transaction3]);
     });
 
-    it("should return all added transactions when accepting unknown transaction", async () => {
+    it("should return no transactions when accepting unknown transaction", async () => {
         configuration.getRequired.mockReturnValueOnce(10); // maxTransactionsPerSender
 
         const senderMempool = container.resolve(SenderMempool);
@@ -217,7 +217,7 @@ describe("SenderMempool.removeForgedTransaction", () => {
         const removedTransactions = await senderMempool.removeForgedTransaction(transaction3.id);
         const remainingTransactions = senderMempool.getFromEarliest();
 
-        expect(removedTransactions).toStrictEqual([transaction1, transaction2]);
-        expect(remainingTransactions).toStrictEqual([]);
+        expect(removedTransactions).toStrictEqual([]);
+        expect(remainingTransactions).toStrictEqual([transaction1, transaction2]);
     });
 });

--- a/packages/core-transaction-pool/src/sender-mempool.ts
+++ b/packages/core-transaction-pool/src/sender-mempool.ts
@@ -92,14 +92,13 @@ export class SenderMempool implements Contracts.TransactionPool.SenderMempool {
         try {
             this.concurrency++;
 
-            return await this.lock.runExclusive(async () => {
-                const index: number = this.transactions.findIndex((t) => t.id === id);
-                if (index === -1) {
-                    return this.transactions.splice(0, this.transactions.length);
-                } else {
-                    return this.transactions.splice(0, index + 1);
-                }
-            });
+            const index: number = this.transactions.findIndex((t) => t.id === id);
+
+            if (index !== -1) {
+                return this.transactions.splice(0, index + 1);
+            } else {
+                return []; // TODO: implement this.reboot();
+            }
         } finally {
             this.concurrency--;
         }


### PR DESCRIPTION
## Summary

`removeForgedTransaction` no longer awaits potentially long `addTransaction` queue.

## Checklist

- [x] Tests
- [ ] Ready to be merged
