### PR TITLE
fix(core-p2p): use blockchain DposState in PeerVerifier

### DIFF
--- a/packages/core-p2p/src/peer-verifier.ts
+++ b/packages/core-p2p/src/peer-verifier.ts
@@ -26,6 +26,7 @@ export class PeerVerifier implements Contracts.P2P.PeerVerifier {
     private readonly app!: Contracts.Kernel.Application;
 
     @Container.inject(Container.Identifiers.DposState)
+    @Container.tagged("state", "blockchain")
     private readonly dposState!: Contracts.State.DposState;
 
     @Container.inject(Container.Identifiers.LogService)


### PR DESCRIPTION
## Summary

Use blockchain DposState in PeerVerifier.

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged