### PR TITLE
chore(core-blockchain): remove duplicated revertRound call

### DIFF
--- a/__tests__/unit/core-blockchain/process-blocks-job.test.ts
+++ b/__tests__/unit/core-blockchain/process-blocks-job.test.ts
@@ -201,7 +201,6 @@ describe("Blockchain", () => {
             blockchainService.clearQueue = jest.fn();
             blockchainService.resetLastDownloadedBlock = jest.fn();
             databaseInteraction.restoreCurrentRound = jest.fn();
-            databaseService.deleteRound = jest.fn();
 
             stateStore.setLastBlock = jest.fn();
 
@@ -211,7 +210,6 @@ describe("Blockchain", () => {
             expect(blockchainService.clearQueue).toBeCalledTimes(1);
             expect(blockchainService.resetLastDownloadedBlock).toBeCalledTimes(1);
             expect(databaseInteraction.restoreCurrentRound).toBeCalledTimes(1);
-            expect(databaseService.deleteRound).toBeCalledTimes(1);
         });
 
         it("should stop app when revertBlockHandler return Corrupted", async () => {
@@ -230,7 +228,6 @@ describe("Blockchain", () => {
             blockchainService.clearQueue = jest.fn();
             blockchainService.resetLastDownloadedBlock = jest.fn();
             databaseInteraction.restoreCurrentRound = jest.fn();
-            databaseService.deleteRound = jest.fn();
 
             stateStore.setLastBlock = jest.fn();
 
@@ -240,7 +237,6 @@ describe("Blockchain", () => {
             expect(blockchainService.clearQueue).toBeCalledTimes(1);
             expect(blockchainService.resetLastDownloadedBlock).toBeCalledTimes(1);
             expect(databaseInteraction.restoreCurrentRound).toBeCalledTimes(1);
-            expect(databaseService.deleteRound).toBeCalledTimes(1);
 
             expect(process.exit).toHaveBeenCalled();
         });

--- a/packages/core-blockchain/src/process-blocks-job.ts
+++ b/packages/core-blockchain/src/process-blocks-job.ts
@@ -1,4 +1,4 @@
-import { DatabaseService, Repositories } from "@arkecosystem/core-database";
+import { Repositories } from "@arkecosystem/core-database";
 import { Container, Contracts, Services, Utils } from "@arkecosystem/core-kernel";
 import { DatabaseInteraction } from "@arkecosystem/core-state";
 import { Blocks, Crypto, Interfaces, Utils as CryptoUtils } from "@arkecosystem/crypto";
@@ -20,9 +20,6 @@ export class ProcessBlocksJob implements Contracts.Kernel.QueueJob {
 
     @Container.inject(Container.Identifiers.StateStore)
     private readonly stateStore!: Contracts.State.StateStore;
-
-    @Container.inject(Container.Identifiers.DatabaseService)
-    private readonly database!: DatabaseService;
 
     @Container.inject(Container.Identifiers.DatabaseBlockRepository)
     private readonly blockRepository!: Repositories.BlockRepository;
@@ -179,9 +176,7 @@ export class ProcessBlocksJob implements Contracts.Kernel.QueueJob {
     private async revertBlocks(blocksToRevert: Interfaces.IBlock[]): Promise<void> {
         // Rounds are saved while blocks are being processed and may now be out of sync with the last
         // block that was written into the database.
-
         const lastHeight: number = blocksToRevert[0].data.height;
-        const deleteRoundsAfter: number = Utils.roundCalculator.calculateRound(lastHeight).round;
 
         this.logger.info(
             `Reverting ${Utils.pluralize(
@@ -200,8 +195,6 @@ export class ProcessBlocksJob implements Contracts.Kernel.QueueJob {
             }
         }
 
-        // TODO: Remove, because next rounds are deleted on restore
-        await this.database.deleteRound(deleteRoundsAfter + 1);
         await this.databaseInteraction.restoreCurrentRound();
 
         this.blockchain.clearQueue();


### PR DESCRIPTION
## Summary

Remove duplicated deleteRound call. DeleteRound is called inside RoundState.restore() method. 

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged