### PR TITLE
fix(core-blockchain): remove BlockNotReadyCounter on Unchained handler

### DIFF
--- a/__tests__/unit/core-blockchain/processor/handlers/unchained-handler.test.ts
+++ b/__tests__/unit/core-blockchain/processor/handlers/unchained-handler.test.ts
@@ -119,6 +119,27 @@ describe("UnchainedHandler", () => {
             });
         });
 
+        describe("when it is a NotReadyToAcceptNewHeight case", () => {
+            it("should return Rejected when height > lastBlock height +1", async () => {
+                const unchainedHandler = sandbox.app.resolve<UnchainedHandler>(UnchainedHandler);
+                unchainedHandler.initialize(true);
+
+                const lastBlock = { data: { id: "123", height: 443, timestamp: 111112 } };
+                const block = {
+                    data: {
+                        id: "987",
+                        height: lastBlock.data.height + 2,
+                        timestamp: 111122,
+                        generatorPublicKey: "03ea97a59522c4cb4bb3420fc94555f6223813d9817dd421bf533b390a7ea140db",
+                    },
+                };
+                blockchain.getLastBlock = jest.fn().mockReturnValue(lastBlock);
+                blockchain.getQueue = jest.fn().mockReturnValue({ size: jest.fn().mockReturnValueOnce(1) });
+
+                expect(await unchainedHandler.execute(block as Interfaces.IBlock)).toBe(BlockProcessorResult.Rejected);
+            });
+        });
+
         describe("when block is already in blockchain (height < last height)", () => {
             it("should return DiscardedButCanBeBroadcasted", async () => {
                 const unchainedHandler = sandbox.app.resolve<UnchainedHandler>(UnchainedHandler);

--- a/__tests__/unit/core-blockchain/processor/handlers/unchained-handler.test.ts
+++ b/__tests__/unit/core-blockchain/processor/handlers/unchained-handler.test.ts
@@ -119,34 +119,6 @@ describe("UnchainedHandler", () => {
             });
         });
 
-        describe("when it is a ExceededNotReadyToAcceptNewHeightMaxAttempts case", () => {
-            it("should return DiscardedButCanBeBroadcasted 5 times then Rollback when height > lastBlock height +1", async () => {
-                const unchainedHandler = sandbox.app.resolve<UnchainedHandler>(UnchainedHandler);
-                unchainedHandler.initialize(true);
-
-                const lastBlock = { data: { id: "123", height: 443, timestamp: 111112 } };
-                const block = {
-                    data: {
-                        id: "987",
-                        height: lastBlock.data.height + 2,
-                        timestamp: 111122,
-                        generatorPublicKey: "03ea97a59522c4cb4bb3420fc94555f6223813d9817dd421bf533b390a7ea140db",
-                    },
-                };
-                blockchain.getLastBlock = jest.fn().mockReturnValue(lastBlock);
-                blockchain.getQueue = jest.fn().mockReturnValue({ size: jest.fn().mockReturnValueOnce(1) });
-
-                for (let i = 0; i < 5; i++) {
-                    expect(await unchainedHandler.execute(block as Interfaces.IBlock)).toBe(
-                        BlockProcessorResult.DiscardedButCanBeBroadcasted,
-                    );
-                }
-
-                expect(await unchainedHandler.execute(block as Interfaces.IBlock)).toBe(BlockProcessorResult.Rollback);
-                expect(stateStore.setNumberOfBlocksToRollback).toHaveBeenCalledWith(5000);
-            });
-        });
-
         describe("when block is already in blockchain (height < last height)", () => {
             it("should return DiscardedButCanBeBroadcasted", async () => {
                 const unchainedHandler = sandbox.app.resolve<UnchainedHandler>(UnchainedHandler);

--- a/packages/core-blockchain/src/processor/handlers/unchained-handler.ts
+++ b/packages/core-blockchain/src/processor/handlers/unchained-handler.ts
@@ -55,6 +55,7 @@ export class UnchainedHandler implements BlockHandler {
                 return BlockProcessorResult.Rejected;
             }
 
+            case UnchainedBlockStatus.NotReadyToAcceptNewHeight:
             case UnchainedBlockStatus.GeneratorMismatch:
             case UnchainedBlockStatus.InvalidTimestamp: {
                 return BlockProcessorResult.Rejected;
@@ -74,21 +75,6 @@ export class UnchainedHandler implements BlockHandler {
             this.logger.debug(
                 `Blockchain not ready to accept new block at height ${block.data.height.toLocaleString()}. Last block: ${lastBlock.data.height.toLocaleString()}`,
             );
-
-            // TODO: We've already cleared the queue. Move to clear queue
-            // Also remove all remaining queued blocks. Since blocks are downloaded in batches,
-            // it is very likely that all blocks will be disregarded at this point anyway.
-            // NOTE: This isn't really elegant, but still better than spamming the log with
-            //       useless `not ready to accept` messages.
-            if (this.blockchain.getQueue().size() > 0) {
-                this.logger.debug(
-                    `Discarded ${Utils.pluralize(
-                        "chunk",
-                        this.blockchain.getQueue().size(),
-                        true,
-                    )} of downloaded blocks.`,
-                );
-            }
 
             return UnchainedBlockStatus.NotReadyToAcceptNewHeight;
         } else if (block.data.height < lastBlock.data.height) {


### PR DESCRIPTION
## Summary

Remove BlockNotReadyCounter on Unchained handler. All downloaded blocks that have height higher than currentBlockHeight + 2 should be rejected. 

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged