### PR TITLE
fix(core-kernel): improve sorting performance

### DIFF
--- a/packages/core-kernel/package.json
+++ b/packages/core-kernel/package.json
@@ -30,6 +30,7 @@
         "deepmerge": "^4.2.2",
         "env-paths": "^2.2.0",
         "fs-extra": "^8.1.0",
+        "functional-red-black-tree": "^1.0.1",
         "import-fresh": "^3.2.1",
         "inversify": "^5.0.1",
         "ipaddr.js": "^2.0.0",
@@ -44,6 +45,7 @@
     "devDependencies": {
         "@types/cron": "^1.7.1",
         "@types/fs-extra": "^8.0.1",
+        "@types/functional-red-black-tree": "^1.0.0",
         "@types/got": "^9.6.9",
         "@types/log-process-errors": "^4.1.0",
         "@types/semver": "^6.2.0"

--- a/packages/core-kernel/src/services/search/pagination-service.ts
+++ b/packages/core-kernel/src/services/search/pagination-service.ts
@@ -4,6 +4,8 @@ import { Pagination, ResultsPage, Sorting } from "../../contracts/search";
 import { injectable } from "../../ioc";
 import { get } from "../../utils";
 
+import createTree from "functional-red-black-tree";
+
 @injectable()
 export class PaginationService {
     public getEmptyPage(): ResultsPage<any> {
@@ -11,20 +13,47 @@ export class PaginationService {
     }
 
     public getPage<T>(pagination: Pagination, sorting: Sorting, items: Iterable<T>): ResultsPage<T> {
-        // todo: Array.from(items) can be avoided.
-        // todo: There is no reason to sort items that will not be included into result.
-        // todo: Only pagination.offset + pagination.limit items have to be kept in memory.
+        const all = Array.from(items);
 
-        const total = Array.from(items).sort((a, b) => this.compare(a, b, sorting));
+        const results =
+            sorting.length === 0
+                ? all.slice(pagination.offset, pagination.offset + pagination.limit)
+                : this.getTop(sorting, pagination.offset + pagination.limit, all).slice(pagination.offset);
 
         return {
-            results: total.slice(pagination.offset, pagination.offset + pagination.limit),
-            totalCount: total.length,
+            results,
+            totalCount: all.length,
             meta: { totalCountIsEstimate: false },
         };
     }
 
-    private compare<T>(a: T, b: T, sorting: Sorting): number {
+    public getTop<T>(sorting: Sorting, count: number, items: Iterable<T>): T[] {
+        if (count < 0) {
+            throw new RangeError(`Count should be greater or equal than zero.`);
+        }
+
+        if (count === 0) {
+            return [];
+        }
+
+        let tree = createTree<T, undefined>((a, b) => {
+            return this.compare(a, b, sorting);
+        });
+
+        for (const item of items) {
+            if (tree.length < count || this.compare(item, tree.end.key, sorting) === -1) {
+                tree = tree.insert(item, undefined);
+            }
+
+            if (tree.length > count) {
+                tree = tree.remove(tree.end.key!);
+            }
+        }
+
+        return tree.keys;
+    }
+
+    public compare<T>(a: T, b: T, sorting: Sorting): number {
         for (const { property, direction } of sorting) {
             let valueA = get(a, property);
             let valueB = get(b, property);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4286,6 +4286,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/functional-red-black-tree@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/functional-red-black-tree/-/functional-red-black-tree-1.0.0.tgz#3d4b3eae7323f1fe4e7fa7bbd97a359c3187172d"
+  integrity sha512-Zne5g06/Ywy55xUqcJLls7zVkme+tkRK4UPaW28eMWE6rYzeqirlKbCZqc0CF2Yb1bMl8Od2FVZOB2tDe/gTpg==
+
 "@types/glob@*", "@types/glob@^7.1.1":
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.1.tgz#aa59a1c6e3fbc421e07ccd31a944c30eba521575"


### PR DESCRIPTION
## Summary

Improve pagination service sorting performance. Results (offset + limit) are kept sorted in binary tree rest remains unsorted. It's 10x faster at getting first page.

## Checklist

- [x] Ready to be merged
