### PR TITLE
fix(core-blockchain): deserializeTransactionsUnchecked

### DIFF
--- a/packages/core-database/src/database-service.ts
+++ b/packages/core-database/src/database-service.ts
@@ -77,7 +77,9 @@ export class DatabaseService {
             ({ serialized, id }) => Transactions.TransactionFactory.fromBytesUnsafe(serialized, id).data,
         );
 
-        return Blocks.BlockFactory.fromData(block);
+        return Blocks.BlockFactory.fromData(block, {
+            deserializeTransactionsUnchecked: true,
+        });
     }
 
     // ! three methods below (getBlocks, getBlocksForDownload, getBlocksByHeight) can be merged into one
@@ -134,7 +136,9 @@ export class DatabaseService {
             ({ serialized, id }) => Transactions.TransactionFactory.fromBytesUnsafe(serialized, id).data,
         );
 
-        const lastBlock: Interfaces.IBlock = Blocks.BlockFactory.fromData(block)!;
+        const lastBlock: Interfaces.IBlock = Blocks.BlockFactory.fromData(block, {
+            deserializeTransactionsUnchecked: true,
+        })!;
 
         return lastBlock;
     }


### PR DESCRIPTION
## Summary

Use deserializeTransactionsUnchecked on block factory to bypass api11 check. Transactions can not be successfully deserialzied when blockchain is already on height where api11 is set, but we are retrieving older block.  

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged