### PR TITLE
fix(core-logger-pino): split log files per process

### DIFF
--- a/__tests__/unit/core-logger-pino/driver.test.ts
+++ b/__tests__/unit/core-logger-pino/driver.test.ts
@@ -152,11 +152,11 @@ describe("Logger", () => {
             },
         });
 
-        writableMock.emit("close");
+        writableMock.destroy(new Error("Test error"));
 
         await sleep(100);
 
-        expect(message).toMatch("File stream closed due to an error: Error: premature close");
+        expect(message).toMatch("File stream closed due to an error: Error: Test error");
     });
 
     it("should rotate the log 3 times", async () => {

--- a/__tests__/unit/core-logger-pino/driver.test.ts
+++ b/__tests__/unit/core-logger-pino/driver.test.ts
@@ -16,6 +16,7 @@ let app: Application;
 
 beforeEach(async () => {
     app = new Application(new Container());
+    app.bind(Identifiers.ConfigFlags).toConstantValue("core");
     app.bind(Identifiers.ApplicationNamespace).toConstantValue("ark-unitnet");
     app.bind("path.log").toConstantValue(dirSync().name);
 

--- a/__tests__/unit/core-logger-pino/driver.test.ts
+++ b/__tests__/unit/core-logger-pino/driver.test.ts
@@ -128,10 +128,9 @@ describe("Logger", () => {
         expect(message).toMatch(/non_silent_message/);
     });
 
-    // TODO: Re-enable tests
-    // this passes locally but fails on pipelines
-    it.skip("should rotate the log 3 times", async () => {
+    it("should rotate the log 3 times", async () => {
         const app = new Application(new Container());
+        app.bind(Identifiers.ConfigFlags).toConstantValue("core");
         app.bind(Identifiers.ApplicationNamespace).toConstantValue("ark-unitnet");
         app.useLogPath(dirSync().name);
 
@@ -148,7 +147,7 @@ describe("Logger", () => {
         for (let i = 0; i < 3; i++) {
             logger.info(`Test ${i + 1}`);
 
-            await sleep(1000);
+            await sleep(800);
         }
 
         const files = readdirSync(app.logPath());

--- a/__tests__/unit/core-logger-pino/service-provider.test.ts
+++ b/__tests__/unit/core-logger-pino/service-provider.test.ts
@@ -1,7 +1,6 @@
 import "jest-extended";
 
-import { Providers } from "@arkecosystem/core-kernel";
-import { Application, Container, Services } from "@packages/core-kernel/src";
+import { Application, Container, Providers, Services } from "@packages/core-kernel";
 import { ServiceProvider } from "@packages/core-logger-pino/src";
 import { defaults } from "@packages/core-logger-pino/src/defaults";
 import { AnySchema } from "joi";
@@ -11,6 +10,8 @@ let app: Application;
 
 beforeEach(() => {
     app = new Application(new Container.Container());
+
+    app.bind(Container.Identifiers.ConfigFlags).toConstantValue("core");
 });
 
 describe("ServiceProvider", () => {

--- a/packages/core-logger-pino/src/driver.ts
+++ b/packages/core-logger-pino/src/driver.ts
@@ -1,5 +1,6 @@
 import { Container, Contracts, Utils } from "@arkecosystem/core-kernel";
 import chalk, { Chalk } from "chalk";
+import * as console from "console";
 import pino, { PrettyOptions } from "pino";
 import PinoPretty from "pino-pretty";
 import pump from "pump";
@@ -106,6 +107,9 @@ export class PinoLogger implements Contracts.Kernel.Logger {
                 // @ts-ignore - Object literal may only specify known properties, and 'colorize' does not exist in type 'PrettyOptions'.
                 this.createPrettyTransport(options.levels.console, { colorize: true }),
                 process.stdout,
+                (err) => {
+                    console.log("Stdout stream closed due to an error:", err);
+                },
             );
         }
 
@@ -116,6 +120,9 @@ export class PinoLogger implements Contracts.Kernel.Logger {
                 // @ts-ignore - Object literal may only specify known properties, and 'colorize' does not exist in type 'PrettyOptions'.
                 this.createPrettyTransport(options.levels.file, { colorize: false }),
                 this.fileStream,
+                (err) => {
+                    console.log("File stream closed due to an error:", err);
+                },
             );
         }
 

--- a/packages/core-logger-pino/src/driver.ts
+++ b/packages/core-logger-pino/src/driver.ts
@@ -24,6 +24,9 @@ export class PinoLogger implements Contracts.Kernel.Logger {
     @Container.inject(Container.Identifiers.Application)
     private readonly app!: Contracts.Kernel.Application;
 
+    @Container.inject(Container.Identifiers.ConfigFlags)
+    private readonly configFlags!: { processType: string };
+
     /**
      * @private
      * @type {Record<string, Chalk>}
@@ -262,7 +265,7 @@ export class PinoLogger implements Contracts.Kernel.Logger {
         return createStream(
             (time: number | Date, index?: number): string => {
                 if (!time) {
-                    return `${this.app.namespace()}-current.log`;
+                    return `${this.app.namespace()}-${this.configFlags.processType}-current.log`;
                 }
 
                 if (typeof time === "number") {
@@ -276,7 +279,7 @@ export class PinoLogger implements Contracts.Kernel.Logger {
                     filename += `.${index}`;
                 }
 
-                return `${this.app.namespace()}-${filename}.log.gz`;
+                return `${this.app.namespace()}-${this.configFlags.processType}-${filename}.log.gz`;
             },
             {
                 path: this.app.logPath(),

--- a/packages/core-logger-pino/src/driver.ts
+++ b/packages/core-logger-pino/src/driver.ts
@@ -107,8 +107,9 @@ export class PinoLogger implements Contracts.Kernel.Logger {
                 // @ts-ignore - Object literal may only specify known properties, and 'colorize' does not exist in type 'PrettyOptions'.
                 this.createPrettyTransport(options.levels.console, { colorize: true }),
                 process.stdout,
+                /* istanbul ignore next */
                 (err) => {
-                    console.log("Stdout stream closed due to an error:", err);
+                    console.error("Stdout stream closed due to an error:", err);
                 },
             );
         }
@@ -121,7 +122,7 @@ export class PinoLogger implements Contracts.Kernel.Logger {
                 this.createPrettyTransport(options.levels.file, { colorize: false }),
                 this.fileStream,
                 (err) => {
-                    console.log("File stream closed due to an error:", err);
+                    console.error("File stream closed due to an error:", err);
                 },
             );
         }


### PR DESCRIPTION
## Summary

Split log files for each process. This will probably fix issue with missing logs. 

Log error when fileStream or stdout is closed or destoryed. 

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged