### PR TITLE
fix(install-next): remove bad line

### DIFF
--- a/install-next.sh
+++ b/install-next.sh
@@ -224,7 +224,6 @@ done
 echo 'export PATH=$(yarn global bin):$PATH' >> ~/.bashrc
 export PATH=$(yarn global bin):$PATH
 ark config:publish --network=devnet
-ark config:cli --channel=next
 
 success "Installed ARK Core!"
 


### PR DESCRIPTION

## Summary

`ark config:cli --channel=next` causes an early exit bc we're already on `@arkecosystem/core@next`.

Removing the following line resolves this issue and allows successful completion of setup:
https://github.com/ArkEcosystem/core/blob/60bf124f393c908db23cec5b3bd7cd1d497653f7/install-next.sh#L227

## Checklist

- [x] Ready to be merged
