### PR TITLE
fix(core-p2p): fix rollback condition

### DIFF
--- a/__tests__/unit/core-p2p/network-monitor.test.ts
+++ b/__tests__/unit/core-p2p/network-monitor.test.ts
@@ -570,15 +570,15 @@ describe("NetworkMonitor", () => {
     describe("checkNetworkHealth", () => {
         it("should not rollback when there are no verified peers", async () => {
             const peers = [
-                new Peer("180.177.54.4", 4000), // 100
-                new Peer("180.177.54.4", 4000), // 100
-                new Peer("180.177.54.4", 4000), // 100
-                new Peer("180.177.54.4", 4000), // 103
-                new Peer("180.177.54.4", 4000), // 103
-                new Peer("180.177.54.4", 4000), // 105
-                new Peer("180.177.54.4", 4000), // 105
-                new Peer("180.177.54.4", 4000), // 105
-                new Peer("180.177.54.4", 4000), // 105
+                new Peer("180.177.54.4", 4000),
+                new Peer("180.177.54.4", 4000),
+                new Peer("180.177.54.4", 4000),
+                new Peer("180.177.54.4", 4000),
+                new Peer("180.177.54.4", 4000),
+                new Peer("180.177.54.4", 4000),
+                new Peer("180.177.54.4", 4000),
+                new Peer("180.177.54.4", 4000),
+                new Peer("180.177.54.4", 4000),
             ];
 
             try {
@@ -599,27 +599,28 @@ describe("NetworkMonitor", () => {
             const lastBlock = { data: { height: 103 } };
 
             const peers = [
-                new Peer("180.177.54.4", 4000), // 100
-                new Peer("180.177.54.4", 4000), // 100
-                new Peer("180.177.54.4", 4000), // 100
-                new Peer("180.177.54.4", 4000), // 103
-                new Peer("180.177.54.4", 4000), // 103
-                new Peer("180.177.54.4", 4000), // 105
-                new Peer("180.177.54.4", 4000), // 105
-                new Peer("180.177.54.4", 4000), // 105
-                new Peer("180.177.54.4", 4000), // 105
+                new Peer("180.177.54.4", 4000),
+                new Peer("180.177.54.4", 4000),
+                new Peer("180.177.54.4", 4000),
+                new Peer("180.177.54.4", 4000),
+                new Peer("180.177.54.4", 4000),
+                new Peer("180.177.54.4", 4000),
+                new Peer("180.177.54.4", 4000),
+                new Peer("180.177.54.4", 4000),
+                new Peer("180.177.54.4", 4000),
             ];
 
             peers[0].verificationResult = new PeerVerificationResult(103, 100, 100);
             peers[1].verificationResult = new PeerVerificationResult(103, 100, 100);
             peers[2].verificationResult = new PeerVerificationResult(103, 100, 100);
-            peers[3].verificationResult = new PeerVerificationResult(103, 103, 103);
-            peers[4].verificationResult = new PeerVerificationResult(103, 103, 103);
 
+            peers[3].verificationResult = new PeerVerificationResult(103, 105, 100);
+            peers[4].verificationResult = new PeerVerificationResult(103, 105, 100);
             peers[5].verificationResult = new PeerVerificationResult(103, 105, 100);
             peers[6].verificationResult = new PeerVerificationResult(103, 105, 100);
-            peers[7].verificationResult = new PeerVerificationResult(103, 105, 100);
-            peers[8].verificationResult = new PeerVerificationResult(103, 105, 100);
+
+            peers[7].verificationResult = new PeerVerificationResult(103, 103, 103);
+            peers[8].verificationResult = new PeerVerificationResult(103, 103, 103);
 
             try {
                 repository.getPeers.mockReturnValue(peers);
@@ -654,12 +655,15 @@ describe("NetworkMonitor", () => {
             ];
 
             peers[0].verificationResult = new PeerVerificationResult(43, 47, 12);
+
             peers[1].verificationResult = new PeerVerificationResult(43, 47, 31);
             peers[2].verificationResult = new PeerVerificationResult(43, 47, 31);
             peers[3].verificationResult = new PeerVerificationResult(43, 47, 31);
+
             peers[4].verificationResult = new PeerVerificationResult(43, 47, 35);
             peers[5].verificationResult = new PeerVerificationResult(43, 47, 35);
             peers[6].verificationResult = new PeerVerificationResult(43, 47, 35);
+
             peers[7].verificationResult = new PeerVerificationResult(43, 47, 43);
             peers[8].verificationResult = new PeerVerificationResult(43, 47, 43);
             peers[9].verificationResult = new PeerVerificationResult(43, 47, 43);

--- a/__tests__/unit/core-p2p/network-monitor.test.ts
+++ b/__tests__/unit/core-p2p/network-monitor.test.ts
@@ -568,95 +568,112 @@ describe("NetworkMonitor", () => {
     });
 
     describe("checkNetworkHealth", () => {
-        describe("when we have 0 peer", () => {
-            beforeEach(() => {
-                repository.getPeers = jest.fn().mockReturnValue([]);
-            });
-            afterEach(() => {
-                repository.getPeers = jest.fn();
-            });
+        it("should not rollback when there are no verified peers", async () => {
+            const peers = [
+                new Peer("180.177.54.4", 4000), // 100
+                new Peer("180.177.54.4", 4000), // 100
+                new Peer("180.177.54.4", 4000), // 100
+                new Peer("180.177.54.4", 4000), // 103
+                new Peer("180.177.54.4", 4000), // 103
+                new Peer("180.177.54.4", 4000), // 105
+                new Peer("180.177.54.4", 4000), // 105
+                new Peer("180.177.54.4", 4000), // 105
+                new Peer("180.177.54.4", 4000), // 105
+            ];
 
-            it("should return {forked: false}", async () => {
+            try {
+                repository.getPeers.mockReturnValue(peers);
+
                 const networkStatus = await networkMonitor.checkNetworkHealth();
-
                 expect(networkStatus).toEqual({ forked: false });
-            });
+            } finally {
+                repository.getPeers.mockReset();
+            }
         });
 
-        describe("when majority of our peers is on our chain", () => {
+        it("should rollback ignoring peers how are at common height", async () => {
+            //     105 (4 peers)
+            //    /
+            // 100 (3 peers) ... 103 (2 peers and us)
+
+            const lastBlock = { data: { height: 103 } };
+
             const peers = [
-                new Peer("180.177.54.4", 4000),
-                new Peer("181.177.54.4", 4000),
-                new Peer("182.177.54.4", 4000),
-                new Peer("183.177.54.4", 4000),
-                new Peer("184.177.54.4", 4000),
-                new Peer("185.177.54.4", 4000),
-                new Peer("186.177.54.4", 4000),
-                new Peer("187.177.54.4", 4000),
-                new Peer("188.177.54.4", 4000),
-                new Peer("189.177.54.4", 4000),
+                new Peer("180.177.54.4", 4000), // 100
+                new Peer("180.177.54.4", 4000), // 100
+                new Peer("180.177.54.4", 4000), // 100
+                new Peer("180.177.54.4", 4000), // 103
+                new Peer("180.177.54.4", 4000), // 103
+                new Peer("180.177.54.4", 4000), // 105
+                new Peer("180.177.54.4", 4000), // 105
+                new Peer("180.177.54.4", 4000), // 105
+                new Peer("180.177.54.4", 4000), // 105
             ];
-            // 4 peers are forked out of 10
-            peers[0].verificationResult = new PeerVerificationResult(3, 4, 2);
-            peers[1].verificationResult = new PeerVerificationResult(3, 4, 2);
-            peers[2].verificationResult = new PeerVerificationResult(3, 4, 2);
-            peers[3].verificationResult = new PeerVerificationResult(3, 4, 2);
 
-            peers[4].verificationResult = new PeerVerificationResult(3, 4, 3);
-            peers[5].verificationResult = new PeerVerificationResult(3, 4, 3);
-            peers[6].verificationResult = new PeerVerificationResult(3, 4, 3);
-            peers[7].verificationResult = new PeerVerificationResult(3, 4, 3);
-            peers[8].verificationResult = new PeerVerificationResult(3, 4, 3);
-            peers[9].verificationResult = new PeerVerificationResult(3, 4, 3);
+            peers[0].verificationResult = new PeerVerificationResult(103, 100, 100);
+            peers[1].verificationResult = new PeerVerificationResult(103, 100, 100);
+            peers[2].verificationResult = new PeerVerificationResult(103, 100, 100);
+            peers[3].verificationResult = new PeerVerificationResult(103, 103, 103);
+            peers[4].verificationResult = new PeerVerificationResult(103, 103, 103);
 
-            beforeEach(() => {
-                repository.getPeers = jest.fn().mockReturnValue(peers);
-            });
-            afterEach(() => {
-                repository.getPeers = jest.fn();
-            });
-            it("should return {forked: false}", async () => {
+            peers[5].verificationResult = new PeerVerificationResult(103, 105, 100);
+            peers[6].verificationResult = new PeerVerificationResult(103, 105, 100);
+            peers[7].verificationResult = new PeerVerificationResult(103, 105, 100);
+            peers[8].verificationResult = new PeerVerificationResult(103, 105, 100);
+
+            try {
+                repository.getPeers.mockReturnValue(peers);
+                stateStore.getLastBlock.mockReturnValue(lastBlock);
+
                 const networkStatus = await networkMonitor.checkNetworkHealth();
-
-                expect(networkStatus).toEqual({ forked: false });
-            });
+                expect(networkStatus).toEqual({ forked: true, blocksToRollback: 3 });
+            } finally {
+                repository.getPeers.mockReset();
+                stateStore.getLastBlock.mockReset();
+            }
         });
 
-        describe("when majority of our peers is on another chain", () => {
+        it("should not rollback although most peers are forked", async () => {
+            //    47 (1 peer)    47 (3 peers)   47 (3 peers)
+            //   /              /              /
+            // 12 ........... 31 ........... 35 ... 43 (3 peers and us)
+
+            const lastBlock = { data: { height: 103 } };
+
             const peers = [
                 new Peer("180.177.54.4", 4000),
-                new Peer("181.177.54.4", 4000),
-                new Peer("182.177.54.4", 4000),
-                new Peer("183.177.54.4", 4000),
-                new Peer("184.177.54.4", 4000),
-                new Peer("185.177.54.4", 4000),
-                new Peer("186.177.54.4", 4000),
-                new Peer("187.177.54.4", 4000),
-                new Peer("188.177.54.4", 4000),
-                new Peer("189.177.54.4", 4000),
+                new Peer("180.177.54.4", 4000),
+                new Peer("180.177.54.4", 4000),
+                new Peer("180.177.54.4", 4000),
+                new Peer("180.177.54.4", 4000),
+                new Peer("180.177.54.4", 4000),
+                new Peer("180.177.54.4", 4000),
+                new Peer("180.177.54.4", 4000),
+                new Peer("180.177.54.4", 4000),
+                new Peer("180.177.54.4", 4000),
             ];
-            // 7 peers are forked out of 10
-            peers[0].verificationResult = new PeerVerificationResult(43, 47, 31);
+
+            peers[0].verificationResult = new PeerVerificationResult(43, 47, 12);
             peers[1].verificationResult = new PeerVerificationResult(43, 47, 31);
             peers[2].verificationResult = new PeerVerificationResult(43, 47, 31);
-            peers[3].verificationResult = new PeerVerificationResult(43, 47, 35);
+            peers[3].verificationResult = new PeerVerificationResult(43, 47, 31);
             peers[4].verificationResult = new PeerVerificationResult(43, 47, 35);
             peers[5].verificationResult = new PeerVerificationResult(43, 47, 35);
-            peers[6].verificationResult = new PeerVerificationResult(43, 47, 12);
+            peers[6].verificationResult = new PeerVerificationResult(43, 47, 35);
+            peers[7].verificationResult = new PeerVerificationResult(43, 47, 43);
+            peers[8].verificationResult = new PeerVerificationResult(43, 47, 43);
+            peers[9].verificationResult = new PeerVerificationResult(43, 47, 43);
 
-            beforeEach(() => {
-                stateStore.getLastBlock = jest.fn().mockReturnValueOnce({ data: { height: 43 } });
-                repository.getPeers = jest.fn().mockReturnValue(peers);
-            });
-            afterEach(() => {
-                repository.getPeers = jest.fn();
-            });
+            try {
+                repository.getPeers.mockReturnValue(peers);
+                stateStore.getLastBlock.mockReturnValue(lastBlock);
 
-            it("should return {forked: true, blocksToRollback:<current height - highestCommonHeight>}", async () => {
                 const networkStatus = await networkMonitor.checkNetworkHealth();
-
-                expect(networkStatus).toEqual({ forked: true, blocksToRollback: 43 - 35 });
-            });
+                expect(networkStatus).toEqual({ forked: false });
+            } finally {
+                repository.getPeers.mockReset();
+                stateStore.getLastBlock.mockReset();
+            }
         });
     });
 

--- a/__tests__/unit/core-p2p/network-monitor.test.ts
+++ b/__tests__/unit/core-p2p/network-monitor.test.ts
@@ -602,6 +602,13 @@ describe("NetworkMonitor", () => {
             peers[2].verificationResult = new PeerVerificationResult(3, 4, 2);
             peers[3].verificationResult = new PeerVerificationResult(3, 4, 2);
 
+            peers[4].verificationResult = new PeerVerificationResult(3, 4, 3);
+            peers[5].verificationResult = new PeerVerificationResult(3, 4, 3);
+            peers[6].verificationResult = new PeerVerificationResult(3, 4, 3);
+            peers[7].verificationResult = new PeerVerificationResult(3, 4, 3);
+            peers[8].verificationResult = new PeerVerificationResult(3, 4, 3);
+            peers[9].verificationResult = new PeerVerificationResult(3, 4, 3);
+
             beforeEach(() => {
                 repository.getPeers = jest.fn().mockReturnValue(peers);
             });

--- a/packages/core-p2p/src/network-monitor.ts
+++ b/packages/core-p2p/src/network-monitor.ts
@@ -286,12 +286,13 @@ export class NetworkMonitor implements Contracts.P2P.NetworkMonitor {
 
         const forkHeights: number[] = forkedVerificationResults
             .map((verificationResult: Contracts.P2P.PeerVerificationResult) => verificationResult.highestCommonHeight)
+            .filter((forkHeight, i, arr) => arr.indexOf(forkHeight) === i) // unique
             .sort()
             .reverse();
 
         for (const forkHeight of forkHeights) {
-            const oursPeerCount = verificationResults.filter((vr) => vr.highestCommonHeight > forkHeight).length + 1;
             const theirsCount = forkedVerificationResults.filter((vr) => vr.highestCommonHeight === forkHeight).length;
+            const oursPeerCount = verificationResults.filter((vr) => vr.highestCommonHeight > forkHeight).length + 1;
             const blocksToRollback = lastBlock.data.height - forkHeight;
 
             if (theirsCount > oursPeerCount) {

--- a/packages/core-p2p/src/network-monitor.ts
+++ b/packages/core-p2p/src/network-monitor.ts
@@ -293,9 +293,10 @@ export class NetworkMonitor implements Contracts.P2P.NetworkMonitor {
         for (const forkHeight of forkHeights) {
             const forkPeerCount = forkVerificationResults.filter((vr) => vr.highestCommonHeight === forkHeight).length;
             const ourPeerCount = verificationResults.filter((vr) => vr.highestCommonHeight > forkHeight).length + 1;
-            const blocksToRollback = lastBlock.data.height - forkHeight;
 
             if (forkPeerCount > ourPeerCount) {
+                const blocksToRollback = lastBlock.data.height - forkHeight;
+
                 if (blocksToRollback > 5000) {
                     this.logger.info(
                         `Rolling back 5000/${blocksToRollback} blocks to fork at height ${forkHeight} (${ourPeerCount} vs ${forkPeerCount}).`,

--- a/packages/core-p2p/src/network-monitor.ts
+++ b/packages/core-p2p/src/network-monitor.ts
@@ -269,50 +269,51 @@ export class NetworkMonitor implements Contracts.P2P.NetworkMonitor {
             .get<Contracts.State.StateStore>(Container.Identifiers.StateStore)
             .getLastBlock();
 
-        const allPeers: Contracts.P2P.Peer[] = this.repository.getPeers();
+        const verificationResults: Contracts.P2P.PeerVerificationResult[] = this.repository
+            .getPeers()
+            .filter((peer) => peer.verificationResult)
+            .map((peer) => peer.verificationResult!);
 
-        if (!allPeers.length) {
-            this.logger.info("No peers available.");
+        if (verificationResults.length === 0) {
+            this.logger.info("No verified peers available.");
 
             return { forked: false };
         }
 
-        const forkedPeers: Contracts.P2P.Peer[] = allPeers.filter((peer: Contracts.P2P.Peer) => peer.isForked());
-        const majorityOnOurChain: boolean = forkedPeers.length / allPeers.length < 0.5;
+        const forkedVerificationResults: Contracts.P2P.PeerVerificationResult[] = verificationResults.filter(
+            (verificationResult: Contracts.P2P.PeerVerificationResult) => verificationResult.forked,
+        );
 
-        if (majorityOnOurChain) {
-            this.logger.info("The majority of peers is not forked. No need to rollback.");
-            return { forked: false };
+        const forkHeights: number[] = forkedVerificationResults
+            .map((verificationResult: Contracts.P2P.PeerVerificationResult) => verificationResult.highestCommonHeight)
+            .sort()
+            .reverse();
+
+        for (const forkHeight of forkHeights) {
+            const oursPeerCount = verificationResults.filter((vr) => vr.highestCommonHeight > forkHeight).length + 1;
+            const theirsCount = forkedVerificationResults.filter((vr) => vr.highestCommonHeight === forkHeight).length;
+            const blocksToRollback = lastBlock.data.height - forkHeight;
+
+            if (theirsCount > oursPeerCount) {
+                if (blocksToRollback > 5000) {
+                    this.logger.info(
+                        `Rolling back 5000/${blocksToRollback} blocks to fork at height ${forkHeight} (${oursPeerCount} vs ${theirsCount}).`,
+                    );
+
+                    return { forked: true, blocksToRollback: 5000 };
+                } else {
+                    this.logger.info(
+                        `Rolling back ${blocksToRollback} blocks to fork at height ${forkHeight} (${oursPeerCount} vs ${theirsCount}).`,
+                    );
+
+                    return { forked: true, blocksToRollback };
+                }
+            } else {
+                this.logger.debug(`Ignoring fork at height ${forkHeight} (${oursPeerCount} vs ${theirsCount}).`);
+            }
         }
 
-        const verifiedPeers = allPeers.filter(
-            (peer: Contracts.P2P.Peer) => peer.verificationResult?.highestCommonHeight !== undefined,
-        );
-        const groupedByCommonHeight = Utils.groupBy(
-            verifiedPeers,
-            (peer: Contracts.P2P.Peer) => peer.verificationResult!.highestCommonHeight,
-        );
-
-        const groupedByLength = Utils.groupBy(Object.values(groupedByCommonHeight), (peer) => peer.length);
-
-        // Sort by longest
-        // @ts-ignore
-        const longest = Object.keys(groupedByLength).sort((a, b) => b - a)[0];
-        const longestGroups = groupedByLength[longest];
-
-        // Sort by highest common height DESC
-        longestGroups.sort(
-            (a, b) => b[0].verificationResult.highestCommonHeight - a[0].verificationResult.highestCommonHeight,
-        );
-        const peersMostCommonHeight = longestGroups[0];
-
-        const { highestCommonHeight } = peersMostCommonHeight[0].verificationResult;
-        this.logger.info(
-            `Rolling back to most common height ${highestCommonHeight.toLocaleString()}. Own height: ${lastBlock.data.height.toLocaleString()}`,
-        );
-
-        // Now rollback blocks equal to the distance to the most common height.
-        return { forked: true, blocksToRollback: Math.min(lastBlock.data.height - highestCommonHeight, 5000) };
+        return { forked: false };
     }
 
     public async downloadBlocksFromHeight(

--- a/packages/core-p2p/src/network-monitor.ts
+++ b/packages/core-p2p/src/network-monitor.ts
@@ -280,37 +280,37 @@ export class NetworkMonitor implements Contracts.P2P.NetworkMonitor {
             return { forked: false };
         }
 
-        const forkedVerificationResults: Contracts.P2P.PeerVerificationResult[] = verificationResults.filter(
+        const forkVerificationResults: Contracts.P2P.PeerVerificationResult[] = verificationResults.filter(
             (verificationResult: Contracts.P2P.PeerVerificationResult) => verificationResult.forked,
         );
 
-        const forkHeights: number[] = forkedVerificationResults
+        const forkHeights: number[] = forkVerificationResults
             .map((verificationResult: Contracts.P2P.PeerVerificationResult) => verificationResult.highestCommonHeight)
             .filter((forkHeight, i, arr) => arr.indexOf(forkHeight) === i) // unique
             .sort()
             .reverse();
 
         for (const forkHeight of forkHeights) {
-            const theirsCount = forkedVerificationResults.filter((vr) => vr.highestCommonHeight === forkHeight).length;
-            const oursPeerCount = verificationResults.filter((vr) => vr.highestCommonHeight > forkHeight).length + 1;
+            const forkPeerCount = forkVerificationResults.filter((vr) => vr.highestCommonHeight === forkHeight).length;
+            const ourPeerCount = verificationResults.filter((vr) => vr.highestCommonHeight > forkHeight).length + 1;
             const blocksToRollback = lastBlock.data.height - forkHeight;
 
-            if (theirsCount > oursPeerCount) {
+            if (forkPeerCount > ourPeerCount) {
                 if (blocksToRollback > 5000) {
                     this.logger.info(
-                        `Rolling back 5000/${blocksToRollback} blocks to fork at height ${forkHeight} (${oursPeerCount} vs ${theirsCount}).`,
+                        `Rolling back 5000/${blocksToRollback} blocks to fork at height ${forkHeight} (${ourPeerCount} vs ${forkPeerCount}).`,
                     );
 
                     return { forked: true, blocksToRollback: 5000 };
                 } else {
                     this.logger.info(
-                        `Rolling back ${blocksToRollback} blocks to fork at height ${forkHeight} (${oursPeerCount} vs ${theirsCount}).`,
+                        `Rolling back ${blocksToRollback} blocks to fork at height ${forkHeight} (${ourPeerCount} vs ${forkPeerCount}).`,
                     );
 
                     return { forked: true, blocksToRollback };
                 }
             } else {
-                this.logger.debug(`Ignoring fork at height ${forkHeight} (${oursPeerCount} vs ${theirsCount}).`);
+                this.logger.debug(`Ignoring fork at height ${forkHeight} (${ourPeerCount} vs ${forkPeerCount}).`);
             }
         }
 


### PR DESCRIPTION
## Summary

Fix rollback condition. Previously it simply looked for _majority had forked_ condition which resulted in stalemate when enough peers were not synced up to fork height.

```
                                            10 peers at height 101
                                           /
10 peers still syncing at height 90 ... 100
                                           \
                                            15 peers at height 101
```

Only those who passed fork height are compared now.

## Checklist

- [x] Tests
- [x] Ready to be merged
