### PR TITLE
test(core-pino-logger): fix log rotate check

### DIFF
--- a/__tests__/unit/core-logger-pino/driver.test.ts
+++ b/__tests__/unit/core-logger-pino/driver.test.ts
@@ -165,6 +165,9 @@ describe("Logger", () => {
         app.bind(Identifiers.ApplicationNamespace).toConstantValue("ark-unitnet");
         app.useLogPath(dirSync().name);
 
+        const ms = new Date().getMilliseconds();
+        await sleep(1000 - ms + 400);
+
         const logger = await app.resolve(PinoLogger).make({
             levels: {
                 console: process.env.CORE_LOG_LEVEL || "emergency",


### PR DESCRIPTION
## Summary

Fix log rotate check. 

Rotating file stream is comparing interval to local time. To produce deterministic results tests are delayed and starts every time with 400ms delay after the last second. 

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged