### PR TITLE
fix(core-p2p): reset max payload size later

### DIFF
--- a/packages/core-p2p/src/hapi-nes/client.ts
+++ b/packages/core-p2p/src/hapi-nes/client.ts
@@ -467,7 +467,6 @@ export class Client {
     }
 
     private _onMessage(message) {
-        this._resetMaxPayload();
         this._beat();
 
         let update;
@@ -505,6 +504,8 @@ export class Client {
             this._lastPinged = Date.now();
             return this._send({ type: "ping" }, false).catch(ignore); // Ignore errors
         }
+
+        this._resetMaxPayload();
 
         // Lookup request (message must include an id from this point)
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

I don't know if community PR contributions are welcome for Core 3.0 but this fixes #4428. The issue is caused by a race condition where a request is sent from the forger with a max payload value of 20MB but then an internal ping message is processed before a reply to the original request is received which resets the max payload value back to the 100KB default. Since the response to `p2p.internal.getCurrentRound` is greater than 100KB, the subsequent reply triggers a disconnection since the max payload size of 100KB has been exceeded. Although less common, it can also occur in the middle of other requests e.g. if a ping is processed after the request is sent but before the response is received when fetching more than 100KB of unconfirmed transactions from the pool to include in a block. If any disconnection occurs during the delegate's slot, they will fail to forge.

This can also manifest itself in the relay too when requesting blocks via `p2p.peer.getBlocks` whenever an intermediate ping message is handled after making the request but prior to receiving the reply in cases where the size of the requested blocks exceeds 100KB. Because of this factor, I feel that this proposed mitigation solution is better than, for example, hacking a way to disable ping messages in the forger connection. We can't disable ping messages in normal peer connections since they are necessary to ensure peer connections are still alive.

The issue arises since ec3539b due to the way the forked Nes client blindly resets the max payload size as soon as any message is received including when it is a ping message. If we move this so it only resets the payload size after determining that it is not a ping message, the problem is resolved. This is safe because ordinary peer connections always have a max payload size of 100KB unless the node has requested blocks via `p2p.peer.getBlocks` so there is rarely an opportunity to exceed 100KB anyway, and even in such limited circumstances where a peer's max payload size is (temporarily) greater than 100KB, only one ping message is permitted per second, so any flood of oversized ping messages would cause an immediate disconnection. Similarly, situations triggering `onError` prior to the max payload size being reset are harmless since `onError` also causes an immediate disconnection so nobody can flood the socket with large invalid messages. Assuming iptables is configured properly, the IP would quickly become blocked in all such cases so there is no attack vector here by making this change.

Regardless of whether this ultimately gets merged or not, I would like to recognise and give thanks to fellow delegates cactus1549, bigfriendlymaniac (dark_bfx and dark_jamie on devnet) and ghostfaceuk (darkcrow on devnet) for their assistance by modifying their nodes to help me track down the root cause of this bug since it was annoying and time consuming to reproduce.

## Checklist

<!-- Have you done all of these things?  -->

- [x] Tests (if necessary)
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
