### PR TITLE
fix(core-p2p): parse peers from URL response

### DIFF
--- a/__tests__/unit/core-p2p/network-monitor.test.ts
+++ b/__tests__/unit/core-p2p/network-monitor.test.ts
@@ -147,6 +147,31 @@ describe("NetworkMonitor", () => {
                 }
             });
 
+            it("should populate peers from URL config by calling validateAndAcceptPeer, when body is string", async () => {
+                appConfigPeers.sources = ["http://peers.someurl.com"];
+
+                const peers = [
+                    { ip: "187.177.54.44", port: 4000 },
+                    { ip: "188.177.54.44", port: 4000 },
+                    { ip: "189.177.54.44", port: 4000 },
+                    { ip: "190.177.54.44", port: 4000 },
+                    { ip: "191.177.54.44", port: 4000 },
+                ];
+                jest.spyOn(Utils.http, "get").mockResolvedValueOnce({
+                    data: JSON.stringify(peers),
+                } as Utils.HttpResponse);
+
+                await networkMonitor.boot();
+
+                expect(triggerService.call).toBeCalledTimes(peers.length); // for each peer validateAndAcceptPeer is called
+                for (const peer of peers) {
+                    expect(triggerService.call).toBeCalledWith("validateAndAcceptPeer", {
+                        peer: expect.objectContaining(peer),
+                        options: { seed: true, lessVerbose: true },
+                    });
+                }
+            });
+
             it("should handle as empty array if appConfigPeers.sources is undefined", async () => {
                 // @ts-ignore
                 appConfigPeers.sources = undefined;

--- a/packages/core-p2p/src/network-monitor.ts
+++ b/packages/core-p2p/src/network-monitor.ts
@@ -618,7 +618,7 @@ export class NetworkMonitor implements Contracts.P2P.NetworkMonitor {
             // URL...
             this.logger.debug(`GET ${url}`);
             const { data } = await Utils.http.get(url);
-            return data;
+            return typeof data === "object" ? data : JSON.parse(data);
         }
 
         return [];


### PR DESCRIPTION
## Summary

Fix #4425.
Parse peers from URL response if response is type of string

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged