### PR TITLE
fix(core-forger): set max payload for whole forger connection

### DIFF
--- a/__tests__/unit/core-forger/client.test.ts
+++ b/__tests__/unit/core-forger/client.test.ts
@@ -39,13 +39,21 @@ describe("Client", () => {
     describe("register", () => {
         it("should register hosts", async () => {
             client.register(hosts);
-            expect(Nes.Client).toHaveBeenCalledWith(`ws://${host.hostname}:${host.port}`);
+
+            const expectedUrl = `ws://${host.hostname}:${host.port}`;
+            const expectedOptions = { ws: { maxPayload: 20971520 } };
+
+            expect(Nes.Client).toHaveBeenCalledWith(expectedUrl, expectedOptions);
             expect(client.hosts).toEqual([{ ...host, socket: expect.anything() }]);
         });
 
         it("should register IPv6 hosts", async () => {
             client.register(hostsIPv6);
-            expect(Nes.Client).toHaveBeenCalledWith(`ws://[${hostIPv6.hostname}]:${hostIPv6.port}`);
+
+            const expectedUrl = `ws://[${hostIPv6.hostname}]:${hostIPv6.port}`;
+            const expectedOptions = { ws: { maxPayload: 20971520 } };
+
+            expect(Nes.Client).toHaveBeenCalledWith(expectedUrl, expectedOptions);
             expect(client.hosts).toEqual([{ ...hostIPv6, socket: expect.anything() }]);
         });
 
@@ -88,7 +96,7 @@ describe("Client", () => {
             await expect(client.broadcastBlock(forgedBlockWithTransactions)).toResolve();
 
             expect(logger.error).toHaveBeenCalledWith(
-                `Broadcast block failed: Request to ${host.hostname}:${host.port}<p2p.blocks.postBlock> failed, because of 'this.host.socket.setMaxPayload is not a function'.`,
+                `Broadcast block failed: Request to ${host.hostname}:${host.port}<p2p.blocks.postBlock> failed, because of 'this.host.socket.request is not a function'.`,
             );
         });
 

--- a/packages/core-forger/src/client.ts
+++ b/packages/core-forger/src/client.ts
@@ -41,7 +41,9 @@ export class Client {
      */
     public register(hosts: RelayHost[]) {
         this.hosts = hosts.map((host: RelayHost) => {
-            const connection = new Nes.Client(`ws://${Utils.IpAddress.normalizeAddress(host.hostname)}:${host.port}`);
+            const url = `ws://${Utils.IpAddress.normalizeAddress(host.hostname)}:${host.port}`;
+            const options = { ws: { maxPayload: MAX_PAYLOAD_CLIENT } };
+            const connection = new Nes.Client(url, options);
             connection.connect().catch((e) => {}); // connect promise can fail when p2p is not ready, it's fine it will retry
 
             connection.onError = (e) => {
@@ -213,8 +215,6 @@ export class Client {
                 path: event,
                 payload: codec.request.serialize(payload),
             };
-
-            this.host.socket.setMaxPayload(MAX_PAYLOAD_CLIENT);
 
             const response: any = await this.host.socket.request(options);
 

--- a/packages/core-p2p/src/hapi-nes/client.ts
+++ b/packages/core-p2p/src/hapi-nes/client.ts
@@ -463,7 +463,7 @@ export class Client {
     }
 
     private _resetMaxPayload() {
-        this.setMaxPayload(DEFAULT_MAX_PAYLOAD_CLIENT);
+        this.setMaxPayload(this._settings.ws.maxPayload);
     }
 
     private _onMessage(message) {

--- a/packages/core-p2p/src/hapi-nes/client.ts
+++ b/packages/core-p2p/src/hapi-nes/client.ts
@@ -485,9 +485,10 @@ export class Client {
         let error: any = null;
         if (update.statusCode && update.statusCode >= 400) {
             /* istanbul ignore next */
-            update.payload = update.payload instanceof Buffer ?
-                (update.payload as Buffer).slice(0, 512).toString() // slicing to reduce possible intensive toString() call
-                : "Error";
+            update.payload =
+                update.payload instanceof Buffer
+                    ? (update.payload as Buffer).slice(0, 512).toString() // slicing to reduce possible intensive toString() call
+                    : "Error";
             error = NesError(update.payload, errorTypes.SERVER);
             error.statusCode = update.statusCode;
             error.data = update.payload;
@@ -498,7 +499,7 @@ export class Client {
         // Ping
 
         if (update.type === "ping") {
-            if (this._lastPinged && (Date.now() < this._lastPinged + 1000)) {
+            if (this._lastPinged && Date.now() < this._lastPinged + 1000) {
                 this._lastPinged = Date.now();
                 return this.onError(NesError("Ping exceeded limit", errorTypes.PROTOCOL));
             }


### PR DESCRIPTION
## Summary

- Set max payload to `this._settings.ws.maxPayload` value provided during instantiation.
- Set high max payload for whole forger connection.

## Checklist

- [x] Tests
- [x] Ready to be merged
