### PR TITLE
chore(core): allow invalid bip39 passphrases

### DIFF
--- a/__tests__/unit/core/commands/config-forger-bip38.test.ts
+++ b/__tests__/unit/core/commands/config-forger-bip38.test.ts
@@ -52,8 +52,25 @@ describe("BIP38Command", () => {
             secrets: [],
         });
 
-        jest.spyOn(cli.app.get(Container.Identifiers.Prompt), "render")
-            .mockReturnValueOnce({
+        jest.spyOn(cli.app.get(Container.Identifiers.Prompt), "render").mockReturnValueOnce({
+            // @ts-ignore
+            bip39: "random-string",
+            password,
+            passwordConfirmation: password,
+        });
+
+        await expect(cli.execute(Command)).rejects.toThrow("Failed to verify the given passphrase as BIP39 compliant.");
+    });
+
+    it("should configure from a prompt if it receives an invalid bip39 amd skipValidation flag is set", async () => {
+        await cli.withFlags({ bip39, password, skipValidation: true }).execute(Command);
+
+        expect(require(`${process.env.CORE_PATH_CONFIG}/delegates.json`)).toEqual({
+            bip38: "6PYTQC4c3Te5FCbnU5Z59uZCav121nypLmxanYn21ZoNTdc81eB9wTqeTe",
+            secrets: [],
+        });
+
+        jest.spyOn(cli.app.get(Container.Identifiers.Prompt), "render").mockReturnValueOnce({
             // @ts-ignore
             bip39: "random-string",
             password,

--- a/__tests__/unit/core/commands/config-forger-bip39.test.ts
+++ b/__tests__/unit/core/commands/config-forger-bip39.test.ts
@@ -54,8 +54,18 @@ describe("BIP39Command", () => {
         expect(require(`${process.env.CORE_PATH_CONFIG}/delegates.json`)).toEqual({ secrets: [bip39] });
     });
 
+    it("should configure from a prompt if it receives an invalid bip39 and skipValidation flag is set", async () => {
+        await cli.withFlags({ bip39 }).execute(Command);
+
+        prompts.inject(["random-string", true]);
+
+        await cli.withFlags({ skipValidation: true }).execute(Command);
+
+        expect(require(`${process.env.CORE_PATH_CONFIG}/delegates.json`)).toEqual({ secrets: ["random-string"] });
+    });
+
     it("should fail to configure from a prompt if it doesn't receive a bip39", async () => {
-        prompts.inject([null]);
+        prompts.inject([null, true]);
 
         await expect(cli.execute(Command)).rejects.toThrow("Failed to verify the given passphrase as BIP39 compliant.");
     });

--- a/__tests__/unit/core/commands/config-forger.test.ts
+++ b/__tests__/unit/core/commands/config-forger.test.ts
@@ -114,14 +114,6 @@ describe("ForgerCommand", () => {
 
             expect(require(`${process.env.CORE_PATH_CONFIG}/delegates.json`)).toEqual({ secrets: [bip39] });
         });
-
-        it("should fail to configure from a prompt if it doesn't receive a bip39", async () => {
-            prompts.inject(["bip39", null]);
-
-            await expect(cli.execute(Command)).rejects.toThrow(
-                "Failed to verify the given passphrase as BIP39 compliant.",
-            );
-        });
     });
 
     describe("BIP38Command", () => {

--- a/packages/core/src/commands/config-forger-bip38.ts
+++ b/packages/core/src/commands/config-forger-bip38.ts
@@ -1,9 +1,9 @@
 import { Commands, Container, Contracts } from "@arkecosystem/core-cli";
 import { Crypto, Identities, Managers } from "@arkecosystem/crypto";
 import { Networks } from "@arkecosystem/crypto";
-import Joi from "joi";
 import { validateMnemonic } from "bip39";
 import { writeJSONSync } from "fs-extra";
+import Joi from "joi";
 import wif from "wif";
 
 /**
@@ -48,7 +48,8 @@ export class Command extends Commands.Command {
             .setFlag("token", "The name of the token.", Joi.string().default("ark"))
             .setFlag("network", "The name of the network.", Joi.string().valid(...Object.keys(Networks)))
             .setFlag("bip39", "A delegate plain text passphrase. Referred to as BIP39.", Joi.string())
-            .setFlag("password", "A custom password that encrypts the BIP39. Referred to as BIP38.", Joi.string());
+            .setFlag("password", "A custom password that encrypts the BIP39. Referred to as BIP38.", Joi.string())
+            .setFlag("skipValidation", "Skip BIP39 mnemonic validation", Joi.boolean().default(false));
     }
 
     /**
@@ -68,7 +69,9 @@ export class Command extends Commands.Command {
                 name: "bip39",
                 message: "Please enter your delegate plain text passphrase. Referred to as BIP39.",
                 validate: /* istanbul ignore next */ (value) =>
-                    !validateMnemonic(value) ? "Failed to verify the given passphrase as BIP39 compliant." : true,
+                    !validateMnemonic(value) && !this.getFlag("skipValidation")
+                        ? "Failed to verify the given passphrase as BIP39 compliant."
+                        : true,
             },
             {
                 type: "password",
@@ -89,7 +92,7 @@ export class Command extends Commands.Command {
             },
         ]);
 
-        if (!response.bip39 || !validateMnemonic(response.bip39 as string)) {
+        if (!response.bip39) {
             throw new Error("Failed to verify the given passphrase as BIP39 compliant.");
         }
 
@@ -113,7 +116,7 @@ export class Command extends Commands.Command {
             {
                 title: "Validating passphrase is BIP39 compliant.",
                 task: () => {
-                    if (!validateMnemonic(flags.bip39)) {
+                    if (!validateMnemonic(flags.bip39) && !flags.skipValidation) {
                         this.components.fatal(`Failed to verify the given passphrase as BIP39 compliant.`);
                     }
                 },

--- a/packages/core/src/commands/config-forger-bip38.ts
+++ b/packages/core/src/commands/config-forger-bip38.ts
@@ -117,7 +117,7 @@ export class Command extends Commands.Command {
                 title: "Validating passphrase is BIP39 compliant.",
                 task: () => {
                     if (!validateMnemonic(flags.bip39) && !flags.skipValidation) {
-                        this.components.fatal(`Failed to verify the given passphrase as BIP39 compliant.`);
+                        throw new Error(`Failed to verify the given passphrase as BIP39 compliant.`);
                     }
                 },
             },

--- a/packages/core/src/commands/config-forger-bip39.ts
+++ b/packages/core/src/commands/config-forger-bip39.ts
@@ -1,7 +1,6 @@
 import { Commands, Container, Contracts } from "@arkecosystem/core-cli";
 import { Networks } from "@arkecosystem/crypto";
 import { validateMnemonic } from "bip39";
-import * as console from "console";
 import { writeJSONSync } from "fs-extra";
 import Joi from "joi";
 
@@ -78,10 +77,6 @@ export class Command extends Commands.Command {
             },
         ]);
 
-        if (!response.bip39) {
-            this.components.fatal("Failed to verify the given passphrase as BIP39 compliant.");
-        }
-
         if (response.confirm) {
             return this.performConfiguration({ ...this.getFlags(), ...response });
         }
@@ -98,11 +93,8 @@ export class Command extends Commands.Command {
             {
                 title: "Validating passphrase is BIP39 compliant.",
                 task: () => {
-                    console.log(this.getFlag("bip39"));
-                    console.log(this.getFlag("skipValidation"));
-
-                    if (!validateMnemonic(flags.bip39) && !flags.skipValidation) {
-                        this.components.fatal(`Failed to verify the given passphrase as BIP39 compliant.`);
+                    if (!flags.bip39 || (!validateMnemonic(flags.bip39) && !flags.skipValidation)) {
+                        throw new Error(`Failed to verify the given passphrase as BIP39 compliant.`);
                     }
                 },
             },

--- a/packages/core/src/commands/config-forger-bip39.ts
+++ b/packages/core/src/commands/config-forger-bip39.ts
@@ -1,8 +1,9 @@
 import { Commands, Container, Contracts } from "@arkecosystem/core-cli";
 import { Networks } from "@arkecosystem/crypto";
-import Joi from "joi";
 import { validateMnemonic } from "bip39";
+import * as console from "console";
 import { writeJSONSync } from "fs-extra";
+import Joi from "joi";
 
 /**
  * @export
@@ -45,7 +46,8 @@ export class Command extends Commands.Command {
         this.definition
             .setFlag("token", "The name of the token.", Joi.string().default("ark"))
             .setFlag("network", "The name of the network.", Joi.string().valid(...Object.keys(Networks)))
-            .setFlag("bip39", "A delegate plain text passphrase. Referred to as BIP39.", Joi.string());
+            .setFlag("bip39", "A delegate plain text passphrase. Referred to as BIP39.", Joi.string())
+            .setFlag("skipValidation", "Skip BIP39 mnemonic validation", Joi.boolean().default(false));
     }
 
     /**
@@ -65,7 +67,9 @@ export class Command extends Commands.Command {
                 name: "bip39",
                 message: "Please enter your delegate plain text passphrase. Referred to as BIP39.",
                 validate: /* istanbul ignore next */ (value) =>
-                    !validateMnemonic(value) ? `Failed to verify the given passphrase as BIP39 compliant.` : true,
+                    !validateMnemonic(value) && !this.getFlag("skipValidation")
+                        ? `Failed to verify the given passphrase as BIP39 compliant.`
+                        : true,
             },
             {
                 type: "confirm",
@@ -74,7 +78,7 @@ export class Command extends Commands.Command {
             },
         ]);
 
-        if (!response.bip39 || !validateMnemonic(response.bip39 as string)) {
+        if (!response.bip39) {
             this.components.fatal("Failed to verify the given passphrase as BIP39 compliant.");
         }
 
@@ -94,7 +98,10 @@ export class Command extends Commands.Command {
             {
                 title: "Validating passphrase is BIP39 compliant.",
                 task: () => {
-                    if (!validateMnemonic(flags.bip39)) {
+                    console.log(this.getFlag("bip39"));
+                    console.log(this.getFlag("skipValidation"));
+
+                    if (!validateMnemonic(flags.bip39) && !flags.skipValidation) {
                         this.components.fatal(`Failed to verify the given passphrase as BIP39 compliant.`);
                     }
                 },

--- a/packages/core/src/commands/config-forger.ts
+++ b/packages/core/src/commands/config-forger.ts
@@ -45,7 +45,8 @@ export class Command extends Commands.Command {
                 "method",
                 "The configuration method to use (BIP38 or BIP39).",
                 Joi.string().valid(...["bip38", "bip39"]),
-            );
+            )
+            .setFlag("skipValidation", "Skip BIP39 mnemonic validation", Joi.boolean().default(false));
     }
 
     /**


### PR DESCRIPTION
## Summary

Fix #4437.

Add `--skipValidation` flag to `config:forger`command, that allows setting bip39 incompatible passphrases. 

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged