### PR TITLE
fix(core-p2p): disable perMessageDeflate on WS

### DIFF
--- a/__tests__/unit/core-p2p/hapi-nes/client.test.ts
+++ b/__tests__/unit/core-p2p/hapi-nes/client.test.ts
@@ -48,16 +48,22 @@ const createServerWithPlugin = async (pluginOptions = {}, serverOptions = {}, wi
 };
 
 describe("Client", () => {
-    it("defaults options.ws.maxPayload to 102400 (node)", () => {
+    it("defaults options.ws.maxPayload to 102400 (node) && perMessageDeflate to false", () => {
         const client = new Client("http://localhost");
         // @ts-ignore
-        expect(client._settings.ws).toEqual({ maxPayload: 102400 });
+        expect(client._settings.ws).toEqual({ maxPayload: 102400, perMessageDeflate: false });
     });
 
     it("allows setting options.ws.maxPayload (node)", () => {
         const client = new Client("http://localhost", { ws: { maxPayload: 100 } });
         // @ts-ignore
-        expect(client._settings.ws).toEqual({ maxPayload: 100 });
+        expect(client._settings.ws).toEqual({ maxPayload: 100, perMessageDeflate: false });
+    });
+
+    it("prevents setting options.ws.perMessageDeflate (node)", () => {
+        const client = new Client("http://localhost", { ws: { perMessageDeflate: true } });
+        // @ts-ignore
+        expect(client._settings.ws).toEqual({ maxPayload: 102400, perMessageDeflate: false });
     });
 
     describe("onError", () => {
@@ -632,7 +638,7 @@ describe("Client", () => {
     describe("request()", () => {
         it("defaults to POST", async () => {
             const server = await createServerWithPlugin({ headers: "*" });
-            
+
             server.route({
                 method: "POST",
                 path: "/",
@@ -778,7 +784,7 @@ describe("Client", () => {
         describe("_onMessage", () => {
             it("ignores invalid incoming message", async () => {
                 const server = await createServerWithPlugin({}, {}, true);
-                
+
                 server.route({
                     method: "POST",
                     path: "/",
@@ -1010,7 +1016,7 @@ describe("Client", () => {
         describe("ping / pong", () => {
             it.each([["ping"], ["pong"]])("terminates when receiving a ws.%s", async (method) => {
                 const server = await createServerWithPlugin({}, {}, true);
-                
+
                 server.route({
                     method: "POST",
                     path: "/",

--- a/packages/core-p2p/src/hapi-nes/client.ts
+++ b/packages/core-p2p/src/hapi-nes/client.ts
@@ -93,12 +93,13 @@ export class Client {
 
         options.ws = options.ws || {};
 
-        if (options.ws.maxPayload === undefined) {
-            options.ws.maxPayload = DEFAULT_MAX_PAYLOAD_CLIENT;
+        options.ws = {
+            maxPayload: DEFAULT_MAX_PAYLOAD_CLIENT,
+            ...options.ws,
+            perMessageDeflate: false
         }
 
         // Configuration
-
         this._url = url;
         this._settings = options;
         this._heartbeatTimeout = false; // Server heartbeat configuration

--- a/packages/core-p2p/src/hapi-nes/listener.ts
+++ b/packages/core-p2p/src/hapi-nes/listener.ts
@@ -34,7 +34,7 @@ export class Listener {
 
         // WebSocket listener
 
-        const options: any = { server: this._server.listener, maxPayload: settings.maxPayload };
+        const options: any = { server: this._server.listener, maxPayload: settings.maxPayload, perMessageDeflate: false };
         if (settings.origin) {
             options.verifyClient = (info) => settings.origin.indexOf(info.origin) >= 0;
         }


### PR DESCRIPTION
## Summary

Disable perMessageDefalate option on client and listener. Setting perMessageDefalate to false disables [websocket compression](https://github.com/websockets/ws#websocket-compression). 

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged