### PR TITLE
fix(core-manager): use force flag on update

### DIFF
--- a/__tests__/unit/core-manager/actions/info-core-update.test.ts
+++ b/__tests__/unit/core-manager/actions/info-core-update.test.ts
@@ -33,6 +33,6 @@ describe("Info:CoreUpdate", () => {
         const result = await action.execute({});
 
         expect(result).toEqual({});
-        expect(mockCliManager.runCommand).toHaveBeenCalledWith("update");
+        expect(mockCliManager.runCommand).toHaveBeenCalledWith("update", "--force");
     });
 });

--- a/packages/core-manager/src/actions/info-core-update.ts
+++ b/packages/core-manager/src/actions/info-core-update.ts
@@ -12,7 +12,7 @@ export class Action implements Actions.Action {
     public name = "info.coreUpdate";
 
     public async execute(params: object): Promise<any> {
-        await this.cliManager.runCommand("update");
+        await this.cliManager.runCommand("update", "--force");
         return {};
     }
 }


### PR DESCRIPTION
## Summary

Use --force flag on update CLI command call to prevent asking for user input. 

## Checklist

- [x] Ready to be merged