### PR TITLE
chore(core-kernel): Queue extends EventEmitter

### DIFF
--- a/__tests__/functional/transaction-forging/__support__/index.ts
+++ b/__tests__/functional/transaction-forging/__support__/index.ts
@@ -3,6 +3,9 @@ import "jest-extended";
 import { Container, Contracts } from "@arkecosystem/core-kernel";
 import { Managers } from "@arkecosystem/crypto";
 import delay from "delay";
+import { EventEmitter } from "events";
+
+EventEmitter.prototype.constructor = Object.prototype.constructor;
 
 jest.setTimeout(1200000);
 

--- a/__tests__/integration/core-api/__support__/setup.ts
+++ b/__tests__/integration/core-api/__support__/setup.ts
@@ -2,7 +2,10 @@ import { Application, Container, Contracts, Utils as AppUtils } from "@arkecosys
 import { Managers, Utils } from "@arkecosystem/crypto";
 import { ServiceProvider } from "@packages/core-api/src";
 import { Sandbox } from "@packages/core-test-framework/src";
+import { EventEmitter } from "events";
 import { resolve } from "path";
+
+EventEmitter.prototype.constructor = Object.prototype.constructor;
 
 const sandbox: Sandbox = new Sandbox();
 

--- a/__tests__/integration/core-magistrate-api/__support__/setup.ts
+++ b/__tests__/integration/core-magistrate-api/__support__/setup.ts
@@ -2,7 +2,10 @@ import { Application, Utils as AppUtils } from "@arkecosystem/core-kernel";
 import { Managers } from "@arkecosystem/crypto";
 import { ServiceProvider } from "@packages/core-magistrate-api/src";
 import { Sandbox } from "@packages/core-test-framework/src";
+import { EventEmitter } from "events";
 import { resolve } from "path";
+
+EventEmitter.prototype.constructor = Object.prototype.constructor;
 
 const sandbox: Sandbox = new Sandbox();
 

--- a/__tests__/integration/core-state/__support__/setup.ts
+++ b/__tests__/integration/core-state/__support__/setup.ts
@@ -1,6 +1,9 @@
-import { Application, Utils as AppUtils, Container } from "@arkecosystem/core-kernel";
-import { Managers } from "@arkecosystem/crypto";
+import { Application, Container, Utils as AppUtils } from "@arkecosystem/core-kernel";
 import { Sandbox } from "@arkecosystem/core-test-framework";
+import { Managers } from "@arkecosystem/crypto";
+import { EventEmitter } from "events";
+
+EventEmitter.prototype.constructor = Object.prototype.constructor;
 
 const sandbox: Sandbox = new Sandbox();
 

--- a/__tests__/integration/core-test-framework/utils/__support__/setup.ts
+++ b/__tests__/integration/core-test-framework/utils/__support__/setup.ts
@@ -1,9 +1,13 @@
-import { Server, Identifiers as ApiIdentifiers } from "@arkecosystem/core-api";
+import { Identifiers as ApiIdentifiers, Server } from "@arkecosystem/core-api";
 import { Application, Utils as AppUtils } from "@arkecosystem/core-kernel";
 import { Managers } from "@arkecosystem/crypto";
-import { Sandbox } from "@packages/core-test-framework/src";
-import { EchoController } from "./echo-controller";
 import Hapi from "@hapi/hapi";
+import { Sandbox } from "@packages/core-test-framework/src";
+import { EventEmitter } from "events";
+
+import { EchoController } from "./echo-controller";
+
+EventEmitter.prototype.constructor = Object.prototype.constructor;
 
 const sandbox: Sandbox = new Sandbox();
 

--- a/__tests__/unit/core-blockchain/blockchain.test.ts
+++ b/__tests__/unit/core-blockchain/blockchain.test.ts
@@ -11,6 +11,9 @@ import { GetActiveDelegatesAction } from "@packages/core-state/src/actions";
 import { Sandbox } from "@packages/core-test-framework";
 import { Crypto, Interfaces, Managers, Networks, Utils } from "@packages/crypto";
 import delay from "delay";
+import { EventEmitter } from "events";
+
+EventEmitter.prototype.constructor = Object.prototype.constructor;
 
 describe("Blockchain", () => {
     let sandbox: Sandbox;

--- a/__tests__/unit/core-kernel/ioc/decorator.test.ts
+++ b/__tests__/unit/core-kernel/ioc/decorator.test.ts
@@ -1,0 +1,26 @@
+import { Container } from "@packages/core-kernel/src/ioc";
+import { decorateInjectable } from "@packages/core-kernel/src/ioc/decorator";
+
+class ThirdPartyClass {}
+const container = new Container();
+
+describe("decorateInjectable", () => {
+    it("should throw error when resolving class without injectable decoration", () => {
+        expect(() => {
+            container.resolve(ThirdPartyClass);
+        }).toThrowError("Missing required @injectable annotation in: ThirdPartyClass.");
+    });
+
+    it("should resolve after decorating class", () => {
+        decorateInjectable(ThirdPartyClass);
+
+        expect(container.resolve(ThirdPartyClass)).toBeInstanceOf(ThirdPartyClass);
+    });
+
+    it("should allow multiple calls for same class", () => {
+        decorateInjectable(ThirdPartyClass);
+        decorateInjectable(ThirdPartyClass);
+
+        expect(container.resolve(ThirdPartyClass)).toBeInstanceOf(ThirdPartyClass);
+    });
+});

--- a/__tests__/unit/core-kernel/services/queue/drivers/null.test.ts
+++ b/__tests__/unit/core-kernel/services/queue/drivers/null.test.ts
@@ -100,27 +100,3 @@ describe("NullQueue.isRunning", () => {
         expect(result).toBe(false);
     });
 });
-
-describe("NullQueue.onData", () => {
-    it("should accept function", async () => {
-        const driver = new NullQueue();
-        const onData = jest.fn();
-        driver.onData(onData);
-    });
-});
-
-describe("NullQueue.onError", () => {
-    it("should accept function", async () => {
-        const driver = new NullQueue();
-        const onError = jest.fn();
-        driver.onError(onError);
-    });
-});
-
-describe("NullQueue.onDrain", () => {
-    it("should accept function", async () => {
-        const driver = new NullQueue();
-        const onDrain = jest.fn();
-        driver.onDrain(onDrain);
-    });
-});

--- a/__tests__/unit/core-kernel/services/queue/service-provider.test.ts
+++ b/__tests__/unit/core-kernel/services/queue/service-provider.test.ts
@@ -5,6 +5,9 @@ import { Container, Identifiers } from "@packages/core-kernel/src/ioc";
 import { ServiceProvider } from "@packages/core-kernel/src/services/queue";
 import { MemoryQueue } from "@packages/core-kernel/src/services/queue/drivers/memory";
 import { QueueFactory } from "@packages/core-kernel/src/types";
+import { EventEmitter } from "events";
+
+EventEmitter.prototype.constructor = Object.prototype.constructor;
 
 let app: Application;
 

--- a/__tests__/unit/core-snapshots/database-service.test.ts
+++ b/__tests__/unit/core-snapshots/database-service.test.ts
@@ -17,6 +17,8 @@ import { Connection } from "typeorm";
 
 import { Assets } from "./__fixtures__";
 
+EventEmitter.prototype.constructor = Object.prototype.constructor;
+
 let sandbox: Sandbox;
 let database: SnapshotDatabaseService;
 let filesystem: Filesystem;

--- a/packages/core-blockchain/src/blockchain.ts
+++ b/packages/core-blockchain/src/blockchain.ts
@@ -69,11 +69,11 @@ export class Blockchain implements Contracts.Blockchain.Blockchain {
 
         this.queue = await this.app.get<Types.QueueFactory>(Container.Identifiers.QueueFactory)();
 
-        this.queue.onDrain(() => {
+        this.queue.on("drain", () => {
             this.dispatch("PROCESSFINISHED");
         });
 
-        this.queue.onError((job, error) => {
+        this.queue.on("jobError", (job, error) => {
             const blocks = (job as ProcessBlocksJob).getBlocks();
 
             this.logger.error(

--- a/packages/core-kernel/src/contracts/kernel/queue.ts
+++ b/packages/core-kernel/src/contracts/kernel/queue.ts
@@ -7,12 +7,6 @@ export interface QueueJob {
     handle(): Promise<void>;
 }
 
-export type QueueOnDrainFunction = () => void;
-
-export type QueueOnErrorFunction = (job: QueueJob, error: Error) => void;
-
-export type QueueOnDataFunction = (job: QueueJob, data: any) => void;
-
 /**
  * @export
  * @interface Queue
@@ -111,10 +105,4 @@ export interface Queue extends EventEmitter {
     isStarted(): boolean;
 
     isRunning(): boolean;
-
-    onData(callback: QueueOnDataFunction): void;
-
-    onError(callback: QueueOnErrorFunction): void;
-
-    onDrain(callback: QueueOnDrainFunction): void;
 }

--- a/packages/core-kernel/src/contracts/kernel/queue.ts
+++ b/packages/core-kernel/src/contracts/kernel/queue.ts
@@ -1,3 +1,5 @@
+import { EventEmitter } from "events";
+
 /**
  * @interface QueueJob
  */
@@ -15,7 +17,7 @@ export type QueueOnDataFunction = (job: QueueJob, data: any) => void;
  * @export
  * @interface Queue
  */
-export interface Queue {
+export interface Queue extends EventEmitter {
     /**
      * Create a new instance of the queue.
      *

--- a/packages/core-kernel/src/ioc/decorator.ts
+++ b/packages/core-kernel/src/ioc/decorator.ts
@@ -1,0 +1,7 @@
+import { decorate, injectable } from "inversify";
+
+export const decorateInjectable = (target: any) => {
+    try {
+        decorate(injectable(), target);
+    } catch {}
+};

--- a/packages/core-kernel/src/ioc/index.ts
+++ b/packages/core-kernel/src/ioc/index.ts
@@ -5,3 +5,5 @@ export * as Selectors from "./selectors";
 export * from "inversify";
 
 export * from "./identifiers";
+
+export * from "./decorator";

--- a/packages/core-kernel/src/services/queue/drivers/memory.ts
+++ b/packages/core-kernel/src/services/queue/drivers/memory.ts
@@ -11,11 +11,9 @@ import {
     QueueOnErrorFunction,
 } from "../../../contracts/kernel/queue";
 import { QueueEvent } from "../../../enums";
-import { decorate, Identifiers, inject, injectable } from "../../../ioc";
+import { decorateInjectable, Identifiers, inject, injectable } from "../../../ioc";
 
-try {
-    decorate(injectable(), EventEmitter);
-} catch {}
+decorateInjectable(EventEmitter);
 
 /**
  * @export

--- a/packages/core-kernel/src/services/queue/drivers/memory.ts
+++ b/packages/core-kernel/src/services/queue/drivers/memory.ts
@@ -39,6 +39,11 @@ export class MemoryQueue extends EventEmitter implements Queue {
 
     private onProcessedCallbacks: (() => void)[] = [];
 
+    public constructor() {
+        super();
+        this.setMaxListeners(0);
+    }
+
     /**
      * Create a new instance of the queue.
      *

--- a/packages/core-kernel/src/services/queue/drivers/null.ts
+++ b/packages/core-kernel/src/services/queue/drivers/null.ts
@@ -1,3 +1,5 @@
+import { EventEmitter } from "events";
+
 import {
     Queue,
     QueueJob,
@@ -5,15 +7,18 @@ import {
     QueueOnDrainFunction,
     QueueOnErrorFunction,
 } from "../../../contracts/kernel/queue";
-import { injectable } from "../../../ioc";
+import { decorate, injectable } from "../../../ioc";
 
+try {
+    decorate(injectable(), EventEmitter);
+} catch {}
 /**
  * @export
  * @class MemoryQueue
  * @implements {Queue}
  */
 @injectable()
-export class NullQueue implements Queue {
+export class NullQueue extends EventEmitter implements Queue {
     /**
      * Create a new instance of the queue.
      *

--- a/packages/core-kernel/src/services/queue/drivers/null.ts
+++ b/packages/core-kernel/src/services/queue/drivers/null.ts
@@ -7,11 +7,10 @@ import {
     QueueOnDrainFunction,
     QueueOnErrorFunction,
 } from "../../../contracts/kernel/queue";
-import { decorate, injectable } from "../../../ioc";
+import { decorateInjectable, injectable } from "../../../ioc";
 
-try {
-    decorate(injectable(), EventEmitter);
-} catch {}
+decorateInjectable(EventEmitter);
+
 /**
  * @export
  * @class MemoryQueue

--- a/packages/core-kernel/src/services/queue/drivers/null.ts
+++ b/packages/core-kernel/src/services/queue/drivers/null.ts
@@ -1,12 +1,6 @@
 import { EventEmitter } from "events";
 
-import {
-    Queue,
-    QueueJob,
-    QueueOnDataFunction,
-    QueueOnDrainFunction,
-    QueueOnErrorFunction,
-} from "../../../contracts/kernel/queue";
+import { Queue, QueueJob } from "../../../contracts/kernel/queue";
 import { decorateInjectable, injectable } from "../../../ioc";
 
 decorateInjectable(EventEmitter);
@@ -131,10 +125,4 @@ export class NullQueue extends EventEmitter implements Queue {
     public isRunning(): boolean {
         return false;
     }
-
-    public onData(callback: QueueOnDataFunction): void {}
-
-    public onError(callback: QueueOnErrorFunction): void {}
-
-    public onDrain(callback: QueueOnDrainFunction): void {}
 }

--- a/packages/core-snapshots/src/database-service.ts
+++ b/packages/core-snapshots/src/database-service.ts
@@ -190,11 +190,11 @@ export class SnapshotDatabaseService implements Database.DatabaseService {
                 reject(err);
             };
 
-            transactionsQueue.onError((job, err) => {
+            transactionsQueue.on("jobError", (job, err) => {
                 handleError(err);
             });
 
-            roundsQueue.onError((job, err) => {
+            roundsQueue.on("jobError", (job, err) => {
                 handleError(err);
             });
 
@@ -244,7 +244,7 @@ export class SnapshotDatabaseService implements Database.DatabaseService {
                         if (!transactionsQueue.isRunning()) {
                             resolve();
                         } else {
-                            transactionsQueue.onDrain(() => {
+                            transactionsQueue.on("drain", () => {
                                 resolve();
                             });
                         }
@@ -253,7 +253,7 @@ export class SnapshotDatabaseService implements Database.DatabaseService {
                         if (!roundsQueue.isRunning()) {
                             resolve();
                         } else {
-                            roundsQueue.onDrain(() => {
+                            roundsQueue.on("drain", () => {
                                 resolve();
                             });
                         }


### PR DESCRIPTION
## Summary

Improve MemoryQueue functionality by extending EventEmitter. 

OnDrain, OnError, OnData are replaced with appropriate emits. 

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged