### PR TITLE
chore(core-p2p): implements await block processing plugin

### DIFF
--- a/__tests__/unit/core-p2p/socket-server/plugins/await-block.test.ts
+++ b/__tests__/unit/core-p2p/socket-server/plugins/await-block.test.ts
@@ -1,0 +1,177 @@
+import { Server } from "@hapi/hapi";
+import { Container } from "@packages/core-kernel";
+import { AwaitBlockPlugin } from "@packages/core-p2p/src/socket-server/plugins/await-block";
+import Joi from "joi";
+
+afterEach(() => {
+    jest.clearAllMocks();
+});
+
+describe("AwaitBlockPlugin", () => {
+    const responsePayload = { status: "ok" };
+    const mockRouteByPath = {
+        "/p2p/peer/mockroute_internal": {
+            id: "p2p.peer.getPeers",
+            handler: () => responsePayload,
+            validation: Joi.object().max(0),
+        },
+    };
+    const mockRouteInternal = {
+        method: "POST",
+        path: "/p2p/peer/mockroute_internal",
+        config: {
+            id: mockRouteByPath["/p2p/peer/mockroute_internal"].id,
+            handler: mockRouteByPath["/p2p/peer/mockroute_internal"].handler,
+        },
+    };
+
+    const mockRoute = {
+        method: "POST",
+        path: "/p2p/peer/mockroute",
+        config: {
+            id: mockRouteByPath["/p2p/peer/mockroute_internal"].id,
+            handler: mockRouteByPath["/p2p/peer/mockroute_internal"].handler,
+        },
+    };
+
+    const app = {
+        resolve: jest.fn().mockReturnValue({ getRoutesConfigByPath: () => mockRouteByPath }),
+    };
+
+    let awaitBlockPlugin: AwaitBlockPlugin;
+    let container: Container.Container;
+    let queue;
+    let blockchain;
+    let stateStore;
+
+    beforeEach(() => {
+        queue = {
+            isRunning: jest.fn().mockReturnValue(true),
+            once: jest.fn().mockImplementation((event, callback) => {
+                setTimeout(() => {
+                    callback();
+                }, 10);
+            }),
+        };
+
+        blockchain = {
+            getQueue: () => {
+                return queue;
+            },
+        };
+
+        stateStore = {
+            getBlockchain: jest.fn().mockReturnValue({
+                value: "newBlock",
+            }),
+        };
+
+        container = new Container.Container();
+        container.bind(Container.Identifiers.Application).toConstantValue(app);
+        container.bind(Container.Identifiers.BlockchainService).toConstantValue(blockchain);
+        container.bind(Container.Identifiers.StateStore).toConstantValue(stateStore);
+
+        awaitBlockPlugin = container.resolve<AwaitBlockPlugin>(AwaitBlockPlugin);
+    });
+
+    it("should continue if route is internal", async () => {
+        const server = new Server({ port: 4100 });
+        server.route(mockRouteInternal);
+
+        const spyExt = jest.spyOn(server, "ext");
+
+        awaitBlockPlugin.register(server);
+
+        expect(spyExt).toBeCalledWith(expect.objectContaining({ type: "onPreAuth" }));
+
+        // try the route with a valid payload
+        const remoteAddress = "187.166.55.44";
+        const responseValid = await server.inject({
+            method: "POST",
+            url: "/p2p/peer/mockroute_internal",
+            payload: {},
+            remoteAddress,
+        });
+        expect(JSON.parse(responseValid.payload)).toEqual(responsePayload);
+        expect(responseValid.statusCode).toBe(200);
+        expect(stateStore.getBlockchain).not.toBeCalled();
+        expect(queue.isRunning).not.toBeCalled();
+        expect(queue.once).not.toBeCalled();
+    });
+
+    it("should continue if state !== newBlock", async () => {
+        stateStore.getBlockchain.mockReturnValue({
+            value: "syncing",
+        });
+
+        const server = new Server({ port: 4100 });
+        server.route(mockRoute);
+
+        const spyExt = jest.spyOn(server, "ext");
+
+        awaitBlockPlugin.register(server);
+
+        expect(spyExt).toBeCalledWith(expect.objectContaining({ type: "onPreAuth" }));
+
+        // try the route with a valid payload
+        const remoteAddress = "187.166.55.44";
+        const responseValid = await server.inject({
+            method: "POST",
+            url: "/p2p/peer/mockroute",
+            payload: {},
+            remoteAddress,
+        });
+        expect(JSON.parse(responseValid.payload)).toEqual(responsePayload);
+        expect(responseValid.statusCode).toBe(200);
+        expect(stateStore.getBlockchain).toBeCalled();
+        expect(queue.isRunning).not.toBeCalled();
+        expect(queue.once).not.toBeCalled();
+    });
+
+    it("should continue if queue is not running", async () => {
+        queue.isRunning.mockReturnValue(false);
+
+        const server = new Server({ port: 4100 });
+        server.route(mockRoute);
+
+        const spyExt = jest.spyOn(server, "ext");
+
+        awaitBlockPlugin.register(server);
+
+        expect(spyExt).toBeCalledWith(expect.objectContaining({ type: "onPreAuth" }));
+
+        // try the route with a valid payload
+        const remoteAddress = "187.166.55.44";
+        const responseValid = await server.inject({
+            method: "POST",
+            url: "/p2p/peer/mockroute",
+            payload: {},
+            remoteAddress,
+        });
+        expect(JSON.parse(responseValid.payload)).toEqual(responsePayload);
+        expect(responseValid.statusCode).toBe(200);
+        expect(stateStore.getBlockchain).toBeCalled();
+        expect(queue.isRunning).toBeCalled();
+        expect(queue.once).not.toBeCalled();
+    });
+
+    it("should await block processing", async () => {
+        const server = new Server({ port: 4100 });
+        server.route(mockRoute);
+        awaitBlockPlugin.register(server);
+
+        // try the route with a valid payload
+        const remoteAddress = "187.166.55.44";
+        const responseValid = await server.inject({
+            method: "POST",
+            url: "/p2p/peer/mockroute",
+            payload: {},
+            remoteAddress,
+        });
+
+        expect(responseValid.statusCode).toBe(200);
+        expect(stateStore.getBlockchain).toBeCalled();
+        expect(queue.isRunning).toBeCalled();
+        expect(queue.once).toBeCalled();
+    });
+});

--- a/packages/core-p2p/src/socket-server/plugins/await-block.ts
+++ b/packages/core-p2p/src/socket-server/plugins/await-block.ts
@@ -1,0 +1,46 @@
+import { Container, Contracts } from "@arkecosystem/core-kernel";
+import { Server } from "@hapi/hapi";
+
+import { InternalRoute } from "../routes/internal";
+
+@Container.injectable()
+export class AwaitBlockPlugin {
+    @Container.inject(Container.Identifiers.Application)
+    protected readonly app!: Contracts.Kernel.Application;
+
+    @Container.inject(Container.Identifiers.BlockchainService)
+    private readonly blockchain!: Contracts.Blockchain.Blockchain;
+
+    @Container.inject(Container.Identifiers.StateStore)
+    private readonly stateStore!: Contracts.State.StateStore;
+
+    public register(server: Server): void {
+        const peerRoutesConfigByPath = this.app.resolve(InternalRoute).getRoutesConfigByPath();
+
+        server.ext({
+            type: "onPreAuth",
+            method: async (request, h) => {
+                if (peerRoutesConfigByPath[request.path]) {
+                    return h.continue;
+                }
+
+                if (this.stateStore.getBlockchain().value !== "newBlock") {
+                    return h.continue;
+                }
+
+                const queue = this.blockchain.getQueue();
+                if (!queue.isRunning()) {
+                    return h.continue;
+                }
+
+                await new Promise((resolve) => {
+                    queue.once("drain", () => {
+                        resolve();
+                    });
+                });
+
+                return h.continue;
+            },
+        });
+    }
+}

--- a/packages/core-p2p/src/socket-server/server.ts
+++ b/packages/core-p2p/src/socket-server/server.ts
@@ -3,6 +3,7 @@ import { Server as HapiServer, ServerInjectOptions, ServerInjectResponse, Server
 
 import { plugin as hapiNesPlugin } from "../hapi-nes";
 import { AcceptPeerPlugin } from "./plugins/accept-peer";
+import { AwaitBlockPlugin } from "./plugins/await-block";
 import { CodecPlugin } from "./plugins/codec";
 import { IsAppReadyPlugin } from "./plugins/is-app-ready";
 import { RateLimitPlugin } from "./plugins/rate-limit";
@@ -75,6 +76,7 @@ export class Server {
         // onPreAuth
         this.app.resolve(WhitelistForgerPlugin).register(this.server);
         this.app.resolve(RateLimitPlugin).register(this.server);
+        this.app.resolve(AwaitBlockPlugin).register(this.server);
 
         // onPostAuth
         this.app.resolve(CodecPlugin).register(this.server);


### PR DESCRIPTION
## Summary

Implements await block processing plugin that delays non internal p2p server calls and prioritize block processing over request processing until block is applied. Implementation makes DoS attacks over P2P harder. 

Delay is not applied when downloading blocks, but only when node is synced. Delay is in rage of few milliseconds. 

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged