### PR TITLE
chore(core-p2p): remove unnecessary transactions.length check

### DIFF
--- a/packages/core-p2p/src/socket-server/controllers/blocks.ts
+++ b/packages/core-p2p/src/socket-server/controllers/blocks.ts
@@ -59,13 +59,6 @@ export class BlocksController extends Controller {
             }
         }
 
-        if (
-            block.transactions &&
-            block.transactions.length > Managers.configManager.getMilestone().block.maxTransactions
-        ) {
-            throw new TooManyTransactionsError(block);
-        }
-
         this.logger.info(
             `Received new block at height ${block.height.toLocaleString()} with ${Utils.pluralize(
                 "transaction",


### PR DESCRIPTION
## Summary

Remove unnecessary `transactions.length` check and unstable test. There is no way to deserialize `block.transactions` so its `length` will not match `block.data.numberOfTransactions`.

## Checklist

- [x] Ready to be merged
