### PR TITLE
fix(core-transaction-pool): compare transaction.serialized.length with maxTransactionBytes

### DIFF
--- a/__tests__/unit/core-transaction-pool/sender-state.test.ts
+++ b/__tests__/unit/core-transaction-pool/sender-state.test.ts
@@ -47,6 +47,7 @@ const transaction = {
     id: "tx1",
     timestamp: 13600,
     data: { senderPublicKey: "sender's public key", network: 123 },
+    serialized: Buffer.alloc(10),
 } as Interfaces.ITransaction;
 
 describe("SenderState.apply", () => {

--- a/packages/core-transaction-pool/src/sender-state.ts
+++ b/packages/core-transaction-pool/src/sender-state.ts
@@ -35,7 +35,7 @@ export class SenderState implements Contracts.TransactionPool.SenderState {
 
     public async apply(transaction: Interfaces.ITransaction): Promise<void> {
         const maxTransactionBytes: number = this.configuration.getRequired<number>("maxTransactionBytes");
-        if (JSON.stringify(transaction.data).length > maxTransactionBytes) {
+        if (transaction.serialized.length > maxTransactionBytes) {
             throw new TransactionExceedsMaximumByteSizeError(transaction, maxTransactionBytes);
         }
 


### PR DESCRIPTION
## Summary

Compare length of transaction binary representation to `maxTransactionBytes`.

## Checklist

- [x] Tests
- [x] Ready to be merged
