### PR TITLE
refactor(core-state): remove index method to forget wallet

### DIFF
--- a/packages/core-kernel/src/contracts/state/wallets.ts
+++ b/packages/core-kernel/src/contracts/state/wallets.ts
@@ -10,7 +10,6 @@ export interface WalletIndex {
     get(key: string): Wallet | undefined;
     set(key: string, wallet: Wallet): void;
     forget(key: string): void;
-    forgetWallet(wallet: Wallet): void;
     entries(): ReadonlyArray<[string, Wallet]>;
     values(): ReadonlyArray<Wallet>;
     keys(): string[];

--- a/packages/core-state/src/wallets/wallet-index.ts
+++ b/packages/core-state/src/wallets/wallet-index.ts
@@ -28,6 +28,16 @@ export class WalletIndex implements Contracts.State.WalletIndex {
     }
 
     public index(wallet: Contracts.State.Wallet): void {
+        const keys = this.keysByWallet.get(wallet)!;
+
+        if (keys) {
+            for (const key of keys) {
+                this.walletByKey.delete(key);
+            }
+
+            this.keysByWallet.delete(wallet);
+        }
+
         this.indexer(this, wallet);
     }
 
@@ -70,18 +80,6 @@ export class WalletIndex implements Contracts.State.WalletIndex {
             existingKeys.delete(key);
 
             this.walletByKey.delete(key);
-        }
-    }
-
-    public forgetWallet(wallet: Contracts.State.Wallet): void {
-        const keys = this.keysByWallet.get(wallet)!;
-
-        if (keys) {
-            for (const key of keys) {
-                this.walletByKey.delete(key);
-            }
-
-            this.keysByWallet.delete(wallet);
         }
     }
 

--- a/packages/core-state/src/wallets/wallet-repository-clone.ts
+++ b/packages/core-state/src/wallets/wallet-repository-clone.ts
@@ -138,13 +138,13 @@ export class WalletRepositoryClone extends WalletRepository {
         }
     }
 
-    protected indexWallet(wallet: Contracts.State.Wallet): void {
+    public index(wallet: Contracts.State.Wallet): void {
         const indexKeys = {};
         for (const indexName of this.getIndexNames()) {
             indexKeys[indexName] = this.getIndex(indexName).walletKeys(wallet);
         }
 
-        super.indexWallet(wallet);
+        super.index(wallet);
 
         for (const indexName of this.getIndexNames()) {
             const walletKeys = this.getIndex(indexName).walletKeys(wallet);

--- a/packages/core-state/src/wallets/wallet-repository.ts
+++ b/packages/core-state/src/wallets/wallet-repository.ts
@@ -126,12 +126,10 @@ export class WalletRepository implements Contracts.State.WalletRepository {
         return Utils.BigNumber.ZERO;
     }
 
-    public index(wallets: Contracts.State.Wallet | Contracts.State.Wallet[]): void {
-        if (!Array.isArray(wallets)) {
-            this.indexWallet(wallets);
-        } else {
-            for (const wallet of wallets) {
-                this.indexWallet(wallet);
+    public index(wallet: Contracts.State.Wallet): void {
+        for (const index of Object.values(this.indexes)) {
+            if (index.autoIndex) {
+                index.index(wallet);
             }
         }
     }
@@ -166,12 +164,5 @@ export class WalletRepository implements Contracts.State.WalletRepository {
         }
 
         return walletClone;
-    }
-
-    protected indexWallet(wallet: Contracts.State.Wallet): void {
-        for (const index of Object.values(this.indexes).filter((index) => index.autoIndex)) {
-            index.forgetWallet(wallet);
-            index.index(wallet);
-        }
     }
 }


### PR DESCRIPTION
## Summary

In 2.x pool had only a single instance of wallet repository. It had `forget` method that was necessary to prevent memory leaks. Otherwise it was possible add/remove transactions that would create wallet objects that gonna be stuck forever in pool.

In 3.x pool separate instances of wallet repository are created and destroyed for each sender. There is no `forget` method anymore. Yet there are still various _forget_ functions. Having them significantly increases complexity of wallet repository clone.

---

Remove `WalletIndex.forgetWallet()` method. Users should always call `WalletIndex.index()` method.

## Checklist

- [ ] Tests
- [ ] Ready to be merged
