### PR TITLE
deps(core-manager): include @arkecosystem/core

### DIFF
--- a/packages/core-manager/package.json
+++ b/packages/core-manager/package.json
@@ -21,6 +21,7 @@
         "pretest": "bash ../../scripts/pre-test.sh"
     },
     "dependencies": {
+        "@arkecosystem/core": "^3.0.0-next.33",
         "@arkecosystem/core-cli": "^3.0.0-next.33",
         "@arkecosystem/core-kernel": "^3.0.0-next.33",
         "@arkecosystem/crypto": "^3.0.0-next.33",


### PR DESCRIPTION
## Summary

Include @arkecosystem/core dependency to take advantage of update action, when core-manager is installed as plugin. 

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged