### PR TITLE
chore(core-magistrate-transactions): use EntityNamesTypes index

### DIFF
--- a/__tests__/integration/core-magistrate-api/__support__/set-indexes.ts
+++ b/__tests__/integration/core-magistrate-api/__support__/set-indexes.ts
@@ -1,0 +1,15 @@
+import { Contracts } from "@arkecosystem/core-kernel";
+import { Interfaces as MagistrateInterfaces } from "@packages/core-magistrate-crypto";
+
+export const setIndexes = (
+    walletRepository: Contracts.State.WalletRepository,
+    wallet: Contracts.State.Wallet,
+): void => {
+    for (const entityId of Object.keys(wallet.getAttribute("entities"))) {
+        walletRepository.setOnIndex("entities", entityId, wallet);
+    }
+
+    for (const entity of Object.values(wallet.getAttribute("entities")) as MagistrateInterfaces.IEntityAsset[]) {
+        walletRepository.setOnIndex("entityNamesTypes", `${entity.data.name}-${entity.type}`, wallet);
+    }
+};

--- a/__tests__/integration/core-magistrate-api/controllers/entities.test.ts
+++ b/__tests__/integration/core-magistrate-api/controllers/entities.test.ts
@@ -4,6 +4,7 @@ import { ApiInjectClient } from "@arkecosystem/core-test-framework";
 import { Managers } from "@arkecosystem/crypto";
 
 import { setUp, tearDown } from "../__support__/setup";
+import { setIndexes } from "../__support__/set-indexes";
 
 let app: Application;
 
@@ -45,7 +46,7 @@ beforeAll(async () => {
         };
 
         wallet.setAttribute("entities", walletEntities);
-        walletRepository.index(wallet);
+        setIndexes(walletRepository, wallet);
 
         entityType = ++entityType % 4;
         entitySubType = ++entitySubType % 3;

--- a/__tests__/integration/core-magistrate-api/services/entity-search-service.test.ts
+++ b/__tests__/integration/core-magistrate-api/services/entity-search-service.test.ts
@@ -2,6 +2,7 @@ import { EntitySearchService, Identifiers as MagistrateApiIdentifiers } from "@a
 import { Container, Contracts } from "@arkecosystem/core-kernel";
 
 import { setUp } from "./__support__/setup";
+import { setIndexes } from "../__support__/set-indexes";
 import { Enums } from "@arkecosystem/core-magistrate-crypto";
 import { Identities } from "@arkecosystem/crypto";
 
@@ -40,7 +41,7 @@ describe("EntitySearchService.getEntity", () => {
     it("should return entity", () => {
         const wallet1 = walletRepository.findByPublicKey(Identities.PublicKey.fromPassphrase("wallet1"));
         wallet1.setAttribute("entities", { [entityId1]: entityAttribute1 });
-        walletRepository.index(wallet1);
+        setIndexes(walletRepository, wallet1);
 
         const entityResource1 = entitySearchService.getEntity(entityId1);
 
@@ -58,11 +59,11 @@ describe("EntitySearchService.getEntitiesPage", () => {
     it("should return all entities", () => {
         const wallet1 = walletRepository.findByPublicKey(Identities.PublicKey.fromPassphrase("wallet1"));
         wallet1.setAttribute("entities", { [entityId1]: entityAttribute1 });
-        walletRepository.index(wallet1);
+        setIndexes(walletRepository, wallet1);
 
         const wallet2 = walletRepository.findByPublicKey(Identities.PublicKey.fromPassphrase("wallet2"));
         wallet2.setAttribute("entities", { [entityId2]: entityAttribute2 });
-        walletRepository.index(wallet2);
+        setIndexes(walletRepository, wallet2);
 
         const entitiesPage = entitySearchService.getEntitiesPage({ offset: 0, limit: 100 }, []);
 
@@ -74,11 +75,11 @@ describe("EntitySearchService.getEntitiesPage", () => {
     it("should entities that match criteria", () => {
         const wallet1 = walletRepository.findByPublicKey(Identities.PublicKey.fromPassphrase("wallet1"));
         wallet1.setAttribute("entities", { [entityId1]: entityAttribute1 });
-        walletRepository.index(wallet1);
+        setIndexes(walletRepository, wallet1);
 
         const wallet2 = walletRepository.findByPublicKey(Identities.PublicKey.fromPassphrase("wallet2"));
         wallet2.setAttribute("entities", { [entityId2]: entityAttribute2 });
-        walletRepository.index(wallet2);
+        setIndexes(walletRepository, wallet2);
 
         const entitiesPage = entitySearchService.getEntitiesPage({ offset: 0, limit: 100 }, [], {
             data: { name: "entity 1" },

--- a/__tests__/unit/core-magistrate-api/__support__/index.ts
+++ b/__tests__/unit/core-magistrate-api/__support__/index.ts
@@ -8,6 +8,7 @@ import {
     bridgechainIndexer,
     businessIndexer,
     MagistrateIndex,
+    entityIndexer,
 } from "@packages/core-magistrate-transactions/src/wallet-indexes";
 import { Wallets } from "@packages/core-state";
 import {
@@ -130,6 +131,12 @@ export const initApp = (): Application => {
     app.bind<Contracts.State.WalletIndexerIndex>(Container.Identifiers.WalletRepositoryIndexerIndex).toConstantValue({
         name: MagistrateIndex.Bridgechains,
         indexer: bridgechainIndexer,
+        autoIndex: true,
+    });
+
+    app.bind<Contracts.State.WalletIndexerIndex>(Container.Identifiers.WalletRepositoryIndexerIndex).toConstantValue({
+        name: MagistrateIndex.Entities,
+        indexer: entityIndexer,
         autoIndex: true,
     });
 

--- a/__tests__/unit/core-magistrate-api/__support__/index.ts
+++ b/__tests__/unit/core-magistrate-api/__support__/index.ts
@@ -8,7 +8,6 @@ import {
     bridgechainIndexer,
     businessIndexer,
     MagistrateIndex,
-    entityIndexer,
 } from "@packages/core-magistrate-transactions/src/wallet-indexes";
 import { Wallets } from "@packages/core-state";
 import {
@@ -131,12 +130,6 @@ export const initApp = (): Application => {
     app.bind<Contracts.State.WalletIndexerIndex>(Container.Identifiers.WalletRepositoryIndexerIndex).toConstantValue({
         name: MagistrateIndex.Bridgechains,
         indexer: bridgechainIndexer,
-        autoIndex: true,
-    });
-
-    app.bind<Contracts.State.WalletIndexerIndex>(Container.Identifiers.WalletRepositoryIndexerIndex).toConstantValue({
-        name: MagistrateIndex.Entities,
-        indexer: entityIndexer,
         autoIndex: true,
     });
 

--- a/__tests__/unit/core-magistrate-transactions/__support__/app.ts
+++ b/__tests__/unit/core-magistrate-transactions/__support__/app.ts
@@ -4,7 +4,6 @@ import { NullEventDispatcher } from "@packages/core-kernel/src/services/events/d
 import {
     bridgechainIndexer,
     businessIndexer,
-    entityIndexer,
     entityNameTypeIndexer,
     MagistrateIndex,
 } from "@packages/core-magistrate-transactions/src/wallet-indexes";
@@ -96,12 +95,6 @@ export const initApp = (): Application => {
     app.bind<Contracts.State.WalletIndexerIndex>(Container.Identifiers.WalletRepositoryIndexerIndex).toConstantValue({
         name: MagistrateIndex.Bridgechains,
         indexer: bridgechainIndexer,
-        autoIndex: true,
-    });
-
-    app.bind<Contracts.State.WalletIndexerIndex>(Container.Identifiers.WalletRepositoryIndexerIndex).toConstantValue({
-        name: MagistrateIndex.Entities,
-        indexer: entityIndexer,
         autoIndex: true,
     });
 

--- a/__tests__/unit/core-magistrate-transactions/__support__/app.ts
+++ b/__tests__/unit/core-magistrate-transactions/__support__/app.ts
@@ -4,6 +4,7 @@ import { NullEventDispatcher } from "@packages/core-kernel/src/services/events/d
 import {
     bridgechainIndexer,
     businessIndexer,
+    entityIndexer,
     entityNameTypeIndexer,
     MagistrateIndex,
 } from "@packages/core-magistrate-transactions/src/wallet-indexes";
@@ -95,6 +96,12 @@ export const initApp = (): Application => {
     app.bind<Contracts.State.WalletIndexerIndex>(Container.Identifiers.WalletRepositoryIndexerIndex).toConstantValue({
         name: MagistrateIndex.Bridgechains,
         indexer: bridgechainIndexer,
+        autoIndex: true,
+    });
+
+    app.bind<Contracts.State.WalletIndexerIndex>(Container.Identifiers.WalletRepositoryIndexerIndex).toConstantValue({
+        name: MagistrateIndex.Entities,
+        indexer: entityIndexer,
         autoIndex: true,
     });
 

--- a/__tests__/unit/core-magistrate-transactions/__support__/app.ts
+++ b/__tests__/unit/core-magistrate-transactions/__support__/app.ts
@@ -102,13 +102,13 @@ export const initApp = (): Application => {
     app.bind<Contracts.State.WalletIndexerIndex>(Container.Identifiers.WalletRepositoryIndexerIndex).toConstantValue({
         name: MagistrateIndex.Entities,
         indexer: entityIndexer,
-        autoIndex: true,
+        autoIndex: false,
     });
 
     app.bind<Contracts.State.WalletIndexerIndex>(Container.Identifiers.WalletRepositoryIndexerIndex).toConstantValue({
         name: MagistrateIndex.EntityNamesTypes,
         indexer: entityNameTypeIndexer,
-        autoIndex: true,
+        autoIndex: false,
     });
 
     app.bind(Identifiers.WalletFactory).toFactory<Contracts.State.Wallet>(

--- a/__tests__/unit/core-magistrate-transactions/__support__/app.ts
+++ b/__tests__/unit/core-magistrate-transactions/__support__/app.ts
@@ -5,6 +5,7 @@ import {
     bridgechainIndexer,
     businessIndexer,
     entityIndexer,
+    entityNameTypeIndexer,
     MagistrateIndex,
 } from "@packages/core-magistrate-transactions/src/wallet-indexes";
 import { Wallets } from "@packages/core-state";
@@ -101,6 +102,12 @@ export const initApp = (): Application => {
     app.bind<Contracts.State.WalletIndexerIndex>(Container.Identifiers.WalletRepositoryIndexerIndex).toConstantValue({
         name: MagistrateIndex.Entities,
         indexer: entityIndexer,
+        autoIndex: true,
+    });
+
+    app.bind<Contracts.State.WalletIndexerIndex>(Container.Identifiers.WalletRepositoryIndexerIndex).toConstantValue({
+        name: MagistrateIndex.EntityNamesTypes,
+        indexer: entityNameTypeIndexer,
         autoIndex: true,
     });
 

--- a/__tests__/unit/core-magistrate-transactions/handlers/__mocks__/wallet-repository.ts
+++ b/__tests__/unit/core-magistrate-transactions/handlers/__mocks__/wallet-repository.ts
@@ -2,4 +2,5 @@ export const walletRepository = {
     findByPublicKey: (publicKey) => {},
     index: () => {},
     allByIndex: () => [],
+    hasByIndex: () => false,
 };

--- a/__tests__/unit/core-magistrate-transactions/handlers/__mocks__/wallet-repository.ts
+++ b/__tests__/unit/core-magistrate-transactions/handlers/__mocks__/wallet-repository.ts
@@ -3,4 +3,6 @@ export const walletRepository = {
     index: () => {},
     allByIndex: () => [],
     hasByIndex: () => false,
+    setOnIndex: () => {},
+    forgetOnIndex: () => {},
 };

--- a/__tests__/unit/core-magistrate-transactions/handlers/entity.test.ts
+++ b/__tests__/unit/core-magistrate-transactions/handlers/entity.test.ts
@@ -176,7 +176,11 @@ describe("Entity handler", () => {
         });
 
         it("should resolve", async () => {
+            const setOnIndex = jest.spyOn(walletRepository, "setOnIndex");
+
             await expect(entityHandler.bootstrap()).toResolve();
+
+            expect(setOnIndex).toHaveBeenCalled();
         });
     });
 
@@ -307,6 +311,8 @@ describe("Entity handler", () => {
     describe("register", () => {
         describe("applyToSender", () => {
             it.each([validRegisters])("should set the wallet attribute", async (asset) => {
+                const setOnIndex = jest.spyOn(walletRepository, "setOnIndex");
+
                 const builder = new EntityBuilder();
                 const transaction = builder.asset(asset).sign("passphrase").build();
 
@@ -329,11 +335,15 @@ describe("Entity handler", () => {
                         },
                     },
                 });
+
+                expect(setOnIndex).toHaveBeenCalled();
             });
         });
 
         describe("revertForSender", () => {
             it.each([validRegisters])("should delete the wallet attribute", async (asset) => {
+                const forgetOnIndex = jest.spyOn(walletRepository, "forgetOnIndex");
+
                 const builder = new EntityBuilder();
                 const transaction = builder.asset(asset).sign("passphrase").build();
 
@@ -345,6 +355,8 @@ describe("Entity handler", () => {
 
                 expect(wallet.setAttribute).toBeCalledWith("entities", {});
                 expect(walletAttributes).toEqual({ entities: {} });
+
+                expect(forgetOnIndex).toHaveBeenCalled();
             });
         });
 
@@ -493,6 +505,8 @@ describe("Entity handler", () => {
     describe("resign", () => {
         describe("applyToSender", () => {
             it.each([validResigns])("should set the wallet entity attribute to resigned", async (asset) => {
+                const setOnIndex = jest.spyOn(walletRepository, "setOnIndex");
+
                 const builder = new EntityBuilder();
                 const transaction = builder.asset(asset).fee(updateAndResignFee).sign("passphrase").build();
 
@@ -513,11 +527,15 @@ describe("Entity handler", () => {
                 expect(walletAttributes).toEqual({
                     entities: { [asset.registrationId]: { ...entityNotResigned, resigned: true } },
                 });
+
+                expect(setOnIndex).not.toHaveBeenCalled();
             });
         });
 
         describe("revertForSender", () => {
             it.each([validResigns])("should delete the wallet entity 'resigned' attribute", async (asset) => {
+                const forgetOnIndex = jest.spyOn(walletRepository, "forgetOnIndex");
+
                 const builder = new EntityBuilder();
                 const transaction = builder.asset(asset).fee(updateAndResignFee).sign("passphrase").build();
 
@@ -534,6 +552,8 @@ describe("Entity handler", () => {
 
                 expect(wallet.setAttribute).toBeCalledWith("entities", { [asset.registrationId]: entityNotResigned });
                 expect(walletAttributes).toEqual({ entities: { [asset.registrationId]: entityNotResigned } });
+
+                expect(forgetOnIndex).not.toHaveBeenCalled();
             });
         });
 
@@ -647,6 +667,8 @@ describe("Entity handler", () => {
     describe("update", () => {
         describe("applyToSender", () => {
             it.each([validUpdates])("should apply the changes to the wallet entity", async (asset) => {
+                const setOnIndex = jest.spyOn(walletRepository, "setOnIndex");
+
                 const builder = new EntityBuilder();
                 const transaction = builder.asset(asset).fee(updateAndResignFee).sign("passphrase").build();
 
@@ -671,11 +693,15 @@ describe("Entity handler", () => {
                 expect(wallet.setAttribute).toBeCalledWith("entities", { [asset.registrationId]: expectedEntityAfter });
 
                 expect(walletAttributes).toEqual({ entities: { [asset.registrationId]: expectedEntityAfter } });
+
+                expect(setOnIndex).not.toHaveBeenCalled();
             });
         });
 
         describe("revertForSender", () => {
             it.each([validUpdates])("should restore the wallet to its previous state", async (asset) => {
+                const forgetOnIndex = jest.spyOn(walletRepository, "forgetOnIndex");
+
                 const builder = new EntityBuilder();
                 const transaction = builder.asset(asset).fee(updateAndResignFee).sign("passphrase").build();
 
@@ -727,6 +753,8 @@ describe("Entity handler", () => {
                         },
                     },
                 });
+
+                expect(forgetOnIndex).not.toHaveBeenCalled();
             });
         });
 

--- a/__tests__/unit/core-magistrate-transactions/handlers/entity.test.ts
+++ b/__tests__/unit/core-magistrate-transactions/handlers/entity.test.ts
@@ -180,7 +180,7 @@ describe("Entity handler", () => {
 
             await expect(entityHandler.bootstrap()).toResolve();
 
-            expect(setOnIndex).toHaveBeenCalled();
+            expect(setOnIndex).toHaveBeenCalledTimes(2); // EntityNamesTypes & Entities
         });
     });
 
@@ -336,7 +336,7 @@ describe("Entity handler", () => {
                     },
                 });
 
-                expect(setOnIndex).toHaveBeenCalled();
+                expect(setOnIndex).toHaveBeenCalledTimes(2); // EntityNamesTypes & Entities
             });
         });
 
@@ -356,7 +356,7 @@ describe("Entity handler", () => {
                 expect(wallet.setAttribute).toBeCalledWith("entities", {});
                 expect(walletAttributes).toEqual({ entities: {} });
 
-                expect(forgetOnIndex).toHaveBeenCalled();
+                expect(forgetOnIndex).toHaveBeenCalledTimes(2); // EntityNamesTypes & Entities
             });
         });
 

--- a/__tests__/unit/core-magistrate-transactions/handlers/entity.test.ts
+++ b/__tests__/unit/core-magistrate-transactions/handlers/entity.test.ts
@@ -403,18 +403,7 @@ describe("Entity handler", () => {
                     const builder = new EntityBuilder();
                     const transaction = builder.asset(asset).sign("passphrase").build();
 
-                    const walletSameEntityName = {
-                        hasAttribute: () => true,
-                        getAttribute: () => ({
-                            "7950c6a0d096eeb4883237feec12b9f37f36ab9343ff3640904befc75ce32ec2": {
-                                type: asset.type,
-                                subType: (asset.subType + 1) % 255, // different subType but still in the range [0, 255]
-                                data: asset.data,
-                            },
-                        }),
-                    };
-                    //@ts-ignore
-                    jest.spyOn(walletRepository, "allByIndex").mockReturnValueOnce([walletSameEntityName]);
+                    jest.spyOn(walletRepository, "hasByIndex").mockReturnValueOnce(true);
 
                     entityHandler = container.resolve(EntityTransactionHandler);
                     await expect(entityHandler.throwIfCannotBeApplied(transaction, wallet)).rejects.toBeInstanceOf(
@@ -428,20 +417,6 @@ describe("Entity handler", () => {
                 async (asset) => {
                     const builder = new EntityBuilder();
                     const transaction = builder.asset(asset).sign("passphrase").build();
-
-                    const walletSameEntityName = {
-                        hasAttribute: () => true,
-                        getAttribute: () => ({
-                            "7950c6a0d096eeb4883237feec12b9f37f36ab9343ff3640904befc75ce32ec2": {
-                                type: (asset.type + 1) % 255, // different type but still in the range [0, 255]
-                                subType: asset.subType,
-                                data: asset.data,
-                            },
-                        }),
-                    };
-
-                    //@ts-ignore
-                    jest.spyOn(walletRepository, "allByIndex").mockReturnValueOnce([walletSameEntityName]);
 
                     entityHandler = container.resolve(EntityTransactionHandler);
                     await expect(entityHandler.throwIfCannotBeApplied(transaction, wallet)).toResolve();

--- a/packages/core-magistrate-transactions/src/handlers/entity.ts
+++ b/packages/core-magistrate-transactions/src/handlers/entity.ts
@@ -110,20 +110,8 @@ export class EntityTransactionHandler extends Handlers.TransactionHandler {
                 throw new EntityAlreadyRegisteredError();
             }
 
-            for (const wallet of this.walletRepository.allByIndex(MagistrateIndex.Entities)) {
-                if (wallet.hasAttribute("entities")) {
-                    const entityValues: IEntityWallet[] = Object.values(wallet.getAttribute("entities"));
-
-                    if (
-                        entityValues.some(
-                            (entity) =>
-                                entity.data.name!.toLowerCase() === transaction.data.asset!.data.name.toLowerCase() &&
-                                entity.type === transaction.data.asset!.type,
-                        )
-                    ) {
-                        throw new EntityNameAlreadyRegisteredError();
-                    }
-                }
+            if (this.walletRepository.hasByIndex(MagistrateIndex.EntityNamesTypes, `${transaction.data.asset.data.name}-${transaction.data.asset.type}`)) {
+                throw new EntityNameAlreadyRegisteredError();
             }
 
             // specific check for Delegate entity to ensure that the sender delegate username matches the entity name

--- a/packages/core-magistrate-transactions/src/handlers/entity.ts
+++ b/packages/core-magistrate-transactions/src/handlers/entity.ts
@@ -172,6 +172,7 @@ export class EntityTransactionHandler extends Handlers.TransactionHandler {
                     MagistrateIndex.EntityNamesTypes,
                     `${transaction.data.asset.data.name}-${transaction.data.asset.type}`,
                 );
+                this.walletRepository.forgetOnIndex(MagistrateIndex.Entities, transaction.id!);
                 break;
             case Enums.EntityAction.Update:
                 return this.revertForSenderUpdate(transaction, this.walletRepository);
@@ -267,6 +268,7 @@ export class EntityTransactionHandler extends Handlers.TransactionHandler {
                     `${transaction.asset.data.name}-${transaction.asset.type}`,
                     wallet,
                 );
+                this.walletRepository.setOnIndex(MagistrateIndex.Entities, transaction.id!, wallet);
                 break;
             case Enums.EntityAction.Update:
                 entities[transaction.asset!.registrationId] = {

--- a/packages/core-magistrate-transactions/src/handlers/entity.ts
+++ b/packages/core-magistrate-transactions/src/handlers/entity.ts
@@ -108,7 +108,12 @@ export class EntityTransactionHandler extends Handlers.TransactionHandler {
                 throw new EntityAlreadyRegisteredError();
             }
 
-            if (this.walletRepository.hasByIndex(MagistrateIndex.EntityNamesTypes, `${transaction.data.asset.data.name}-${transaction.data.asset.type}`)) {
+            if (
+                this.walletRepository.hasByIndex(
+                    MagistrateIndex.EntityNamesTypes,
+                    `${transaction.data.asset.data.name}-${transaction.data.asset.type}`,
+                )
+            ) {
                 throw new EntityNameAlreadyRegisteredError();
             }
 
@@ -163,7 +168,10 @@ export class EntityTransactionHandler extends Handlers.TransactionHandler {
             case Enums.EntityAction.Register:
                 delete entities[transaction.id!];
 
-                this.walletRepository.forgetOnIndex(MagistrateIndex.EntityNamesTypes, `${transaction.data.asset.data.name}-${transaction.data.asset.type}`)
+                this.walletRepository.forgetOnIndex(
+                    MagistrateIndex.EntityNamesTypes,
+                    `${transaction.data.asset.data.name}-${transaction.data.asset.type}`,
+                );
                 break;
             case Enums.EntityAction.Update:
                 return this.revertForSenderUpdate(transaction, this.walletRepository);
@@ -254,7 +262,11 @@ export class EntityTransactionHandler extends Handlers.TransactionHandler {
                     data: transaction.asset!.data,
                 };
 
-                this.walletRepository.setOnIndex(MagistrateIndex.EntityNamesTypes, `${transaction.asset.data.name}-${transaction.asset.type}`, wallet)
+                this.walletRepository.setOnIndex(
+                    MagistrateIndex.EntityNamesTypes,
+                    `${transaction.asset.data.name}-${transaction.asset.type}`,
+                    wallet,
+                );
                 break;
             case Enums.EntityAction.Update:
                 entities[transaction.asset!.registrationId] = {

--- a/packages/core-magistrate-transactions/src/service-provider.ts
+++ b/packages/core-magistrate-transactions/src/service-provider.ts
@@ -35,6 +35,6 @@ export class ServiceProvider extends Providers.ServiceProvider {
 
         this.app
             .bind<Contracts.State.WalletIndexerIndex>(Container.Identifiers.WalletRepositoryIndexerIndex)
-            .toConstantValue({ name: MagistrateIndex.EntityNamesTypes, indexer: entityNameTypeIndexer, autoIndex: true });
+            .toConstantValue({ name: MagistrateIndex.EntityNamesTypes, indexer: entityNameTypeIndexer, autoIndex: false });
     }
 }

--- a/packages/core-magistrate-transactions/src/service-provider.ts
+++ b/packages/core-magistrate-transactions/src/service-provider.ts
@@ -35,7 +35,7 @@ export class ServiceProvider extends Providers.ServiceProvider {
 
         this.app
             .bind<Contracts.State.WalletIndexerIndex>(Container.Identifiers.WalletRepositoryIndexerIndex)
-            .toConstantValue({ name: MagistrateIndex.Entities, indexer: entityIndexer, autoIndex: true });
+            .toConstantValue({ name: MagistrateIndex.Entities, indexer: entityIndexer, autoIndex: false });
 
         this.app
             .bind<Contracts.State.WalletIndexerIndex>(Container.Identifiers.WalletRepositoryIndexerIndex)

--- a/packages/core-magistrate-transactions/src/service-provider.ts
+++ b/packages/core-magistrate-transactions/src/service-provider.ts
@@ -9,7 +9,7 @@ import {
     BusinessUpdateTransactionHandler,
     EntityTransactionHandler,
 } from "./handlers";
-import { bridgechainIndexer, businessIndexer, entityIndexer, entityNameTypeIndexer, MagistrateIndex } from "./wallet-indexes";
+import { bridgechainIndexer, businessIndexer, entityNameTypeIndexer, MagistrateIndex } from "./wallet-indexes";
 
 export class ServiceProvider extends Providers.ServiceProvider {
     public async register(): Promise<void> {
@@ -32,10 +32,6 @@ export class ServiceProvider extends Providers.ServiceProvider {
         this.app
             .bind<Contracts.State.WalletIndexerIndex>(Container.Identifiers.WalletRepositoryIndexerIndex)
             .toConstantValue({ name: MagistrateIndex.Bridgechains, indexer: bridgechainIndexer, autoIndex: true });
-
-        this.app
-            .bind<Contracts.State.WalletIndexerIndex>(Container.Identifiers.WalletRepositoryIndexerIndex)
-            .toConstantValue({ name: MagistrateIndex.Entities, indexer: entityIndexer, autoIndex: true });
 
         this.app
             .bind<Contracts.State.WalletIndexerIndex>(Container.Identifiers.WalletRepositoryIndexerIndex)

--- a/packages/core-magistrate-transactions/src/service-provider.ts
+++ b/packages/core-magistrate-transactions/src/service-provider.ts
@@ -9,7 +9,7 @@ import {
     BusinessUpdateTransactionHandler,
     EntityTransactionHandler,
 } from "./handlers";
-import { bridgechainIndexer, businessIndexer, entityNameTypeIndexer, MagistrateIndex } from "./wallet-indexes";
+import { bridgechainIndexer, businessIndexer, entityIndexer, entityNameTypeIndexer, MagistrateIndex } from "./wallet-indexes";
 
 export class ServiceProvider extends Providers.ServiceProvider {
     public async register(): Promise<void> {
@@ -32,6 +32,10 @@ export class ServiceProvider extends Providers.ServiceProvider {
         this.app
             .bind<Contracts.State.WalletIndexerIndex>(Container.Identifiers.WalletRepositoryIndexerIndex)
             .toConstantValue({ name: MagistrateIndex.Bridgechains, indexer: bridgechainIndexer, autoIndex: true });
+
+        this.app
+            .bind<Contracts.State.WalletIndexerIndex>(Container.Identifiers.WalletRepositoryIndexerIndex)
+            .toConstantValue({ name: MagistrateIndex.Entities, indexer: entityIndexer, autoIndex: true });
 
         this.app
             .bind<Contracts.State.WalletIndexerIndex>(Container.Identifiers.WalletRepositoryIndexerIndex)

--- a/packages/core-magistrate-transactions/src/service-provider.ts
+++ b/packages/core-magistrate-transactions/src/service-provider.ts
@@ -9,7 +9,7 @@ import {
     BusinessUpdateTransactionHandler,
     EntityTransactionHandler,
 } from "./handlers";
-import { bridgechainIndexer, businessIndexer, entityIndexer, MagistrateIndex } from "./wallet-indexes";
+import { bridgechainIndexer, businessIndexer, entityIndexer, entityNameTypeIndexer, MagistrateIndex } from "./wallet-indexes";
 
 export class ServiceProvider extends Providers.ServiceProvider {
     public async register(): Promise<void> {
@@ -36,5 +36,9 @@ export class ServiceProvider extends Providers.ServiceProvider {
         this.app
             .bind<Contracts.State.WalletIndexerIndex>(Container.Identifiers.WalletRepositoryIndexerIndex)
             .toConstantValue({ name: MagistrateIndex.Entities, indexer: entityIndexer, autoIndex: true });
+
+        this.app
+            .bind<Contracts.State.WalletIndexerIndex>(Container.Identifiers.WalletRepositoryIndexerIndex)
+            .toConstantValue({ name: MagistrateIndex.EntityNamesTypes, indexer: entityNameTypeIndexer, autoIndex: true });
     }
 }

--- a/packages/core-magistrate-transactions/src/wallet-indexes.ts
+++ b/packages/core-magistrate-transactions/src/wallet-indexes.ts
@@ -1,9 +1,11 @@
 import { Contracts, Utils } from "@arkecosystem/core-kernel";
+import { Interfaces as MagistrateInterfaces } from "@arkecosystem/core-magistrate-crypto";
 
 export enum MagistrateIndex {
     Businesses = "businesses",
     Bridgechains = "bridgechains",
     Entities = "entities",
+    EntityNamesTypes = "entityNamesTypes",
 }
 
 export const businessIndexer = (index: Contracts.State.WalletIndex, wallet: Contracts.State.Wallet): void => {
@@ -26,6 +28,14 @@ export const entityIndexer = (index: Contracts.State.WalletIndex, wallet: Contra
     if (wallet.hasAttribute("entities")) {
         for (const id of Object.keys(wallet.getAttribute("entities"))) {
             index.set(id, wallet);
+        }
+    }
+};
+
+export const entityNameTypeIndexer = (index: Contracts.State.WalletIndex, wallet: Contracts.State.Wallet): void => {
+    if (wallet.hasAttribute("entities")) {
+        for (const asset of Object.values(wallet.getAttribute("entities") as MagistrateInterfaces.IEntityAsset)) {
+            index.set(`${asset.data.name}-${asset.type}` , wallet);
         }
     }
 };

--- a/packages/core-magistrate-transactions/src/wallet-indexes.ts
+++ b/packages/core-magistrate-transactions/src/wallet-indexes.ts
@@ -24,14 +24,6 @@ export const bridgechainIndexer = (index: Contracts.State.WalletIndex, wallet: C
     }
 };
 
-export const entityIndexer = (index: Contracts.State.WalletIndex, wallet: Contracts.State.Wallet): void => {
-    if (wallet.hasAttribute("entities")) {
-        for (const id of Object.keys(wallet.getAttribute("entities"))) {
-            index.set(id, wallet);
-        }
-    }
-};
-
 export const entityNameTypeIndexer = (index: Contracts.State.WalletIndex, wallet: Contracts.State.Wallet): void => {
     if (wallet.hasAttribute("entities")) {
         for (const asset of Object.values(wallet.getAttribute("entities") as MagistrateInterfaces.IEntityAsset)) {

--- a/packages/core-magistrate-transactions/src/wallet-indexes.ts
+++ b/packages/core-magistrate-transactions/src/wallet-indexes.ts
@@ -24,6 +24,14 @@ export const bridgechainIndexer = (index: Contracts.State.WalletIndex, wallet: C
     }
 };
 
+export const entityIndexer = (index: Contracts.State.WalletIndex, wallet: Contracts.State.Wallet): void => {
+    if (wallet.hasAttribute("entities")) {
+        for (const id of Object.keys(wallet.getAttribute("entities"))) {
+            index.set(id, wallet);
+        }
+    }
+};
+
 export const entityNameTypeIndexer = (index: Contracts.State.WalletIndex, wallet: Contracts.State.Wallet): void => {
     if (wallet.hasAttribute("entities")) {
         for (const asset of Object.values(wallet.getAttribute("entities") as MagistrateInterfaces.IEntityAsset)) {


### PR DESCRIPTION
## Summary

Use EntityNamesTypes instad foreach to improve performance.  AutoIndex is set to false. 

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged
