### PR TITLE
Send new height with postBlock response

### DIFF
--- a/__tests__/unit/core-forger/client.test.ts
+++ b/__tests__/unit/core-forger/client.test.ts
@@ -2,7 +2,7 @@ import "jest-extended";
 
 import { Client } from "@arkecosystem/core-forger/src/client";
 import { Application, Container } from "@arkecosystem/core-kernel";
-import { NetworkStateStatus, Nes } from "@arkecosystem/core-p2p";
+import { NetworkStateStatus, Nes, Codecs } from "@arkecosystem/core-p2p";
 
 import { forgedBlockWithTransactions } from "./__utils__/create-block-with-transactions";
 
@@ -103,11 +103,17 @@ describe("Client", () => {
         it("should broadcast valid blocks without error", async () => {
             client.register([host]);
 
+            nesClient.request.mockResolvedValueOnce({
+                payload: Codecs.postBlock.response.serialize({ status: true, height: 100 }),
+            });
+
             await expect(client.broadcastBlock(forgedBlockWithTransactions)).toResolve();
+
             expect(nesClient.request).toHaveBeenCalledWith({
                 path: "p2p.blocks.postBlock",
                 payload: expect.any(Buffer),
             });
+
             expect(logger.error).not.toHaveBeenCalled();
         });
 

--- a/__tests__/unit/core-p2p/peer-communicator.test.ts
+++ b/__tests__/unit/core-p2p/peer-communicator.test.ts
@@ -1,6 +1,6 @@
 import "jest-extended";
 
-import {Container, Utils as KernelUtils} from "@arkecosystem/core-kernel";
+import { Container, Utils as KernelUtils } from "@arkecosystem/core-kernel";
 import { constants } from "@arkecosystem/core-p2p/src/constants";
 import {
     PeerPingTimeoutError,
@@ -15,11 +15,11 @@ import { Blocks, Identities, Managers, Transactions, Utils } from "@arkecosystem
 import delay from "delay";
 
 jest.mock("@arkecosystem/core-p2p/src/socket-server/utils/get-codec", () => ({
-    getCodec: () => ({ request: { serialize: obj => obj }, response: { deserialize: obj => obj }})
+    getCodec: () => ({ request: { serialize: (obj) => obj }, response: { deserialize: (obj) => obj } }),
 }));
 
 jest.mock("@arkecosystem/core-p2p/src/socket-server/utils/get-codec", () => ({
-    getCodec: () => ({ request: { serialize: obj => obj }, response: { deserialize: obj => obj }})
+    getCodec: () => ({ request: { serialize: (obj) => obj }, response: { deserialize: (obj) => obj } }),
 }));
 
 Managers.configManager.getMilestone().aip11 = true;
@@ -105,7 +105,7 @@ describe("PeerCommunicator", () => {
             await peerCommunicator.postBlock(peer, payload.block);
 
             expect(connector.emit).toBeCalledTimes(1);
-            expect(connector.emit).toBeCalledWith(peer, event,  { block: expect.any(Buffer), headers }, 10000);
+            expect(connector.emit).toBeCalledWith(peer, event, { block: expect.any(Buffer), headers }, 10000);
         });
     });
 
@@ -120,7 +120,7 @@ describe("PeerCommunicator", () => {
             await jobsQueued.pop().handle(); // manually trigger the call of last job queued
 
             expect(connector.emit).toBeCalledTimes(1);
-            expect(connector.emit).toBeCalledWith(peer, event,  { ...payload, headers }, 10000);
+            expect(connector.emit).toBeCalledWith(peer, event, { ...payload, headers }, 10000);
         });
     });
     describe("ping", () => {
@@ -163,7 +163,7 @@ describe("PeerCommunicator", () => {
             await expect(peerCommunicator.ping(peer, 1000)).rejects.toThrow(PeerStatusResponseError);
 
             expect(connector.emit).toBeCalledTimes(1);
-            expect(connector.emit).toBeCalledWith(peer, event,  { headers }, 1000);
+            expect(connector.emit).toBeCalledWith(peer, event, { headers }, 1000);
         });
 
         it("should throw PeerStatusResponseError when there is no reply schema for getStatus", async () => {
@@ -180,7 +180,7 @@ describe("PeerCommunicator", () => {
             await expect(peerCommunicator.ping(peer, 1000)).rejects.toThrow(PeerStatusResponseError);
 
             expect(connector.emit).toBeCalledTimes(1);
-            expect(connector.emit).toBeCalledWith(peer, event,  { headers }, 1000);
+            expect(connector.emit).toBeCalledWith(peer, event, { headers }, 1000);
 
             replySchemas["p2p.peer.getStatus"] = getStatusReplySchema;
         });
@@ -205,7 +205,7 @@ describe("PeerCommunicator", () => {
                     await expect(peerCommunicator.ping(peer, 1000)).rejects.toThrow(PeerVerificationFailedError);
 
                     expect(connector.emit).toBeCalledTimes(1);
-                    expect(connector.emit).toBeCalledWith(peer, event,  { headers }, 1000);
+                    expect(connector.emit).toBeCalledWith(peer, event, { headers }, 1000);
                 },
             );
 
@@ -223,7 +223,7 @@ describe("PeerCommunicator", () => {
                 await expect(peerCommunicator.ping(peer, timeout)).rejects.toThrow(PeerPingTimeoutError);
 
                 expect(connector.emit).toBeCalledTimes(1);
-                expect(connector.emit).toBeCalledWith(peer, event,  { headers }, timeout);
+                expect(connector.emit).toBeCalledWith(peer, event, { headers }, timeout);
             });
 
             it("should throw PeerVerificationFailedError when verification fails", async () => {
@@ -236,7 +236,7 @@ describe("PeerCommunicator", () => {
                 await expect(peerCommunicator.ping(peer, 1000)).rejects.toThrow(PeerVerificationFailedError);
 
                 expect(connector.emit).toBeCalledTimes(1);
-                expect(connector.emit).toBeCalledWith(peer, event,  { headers }, 1000);
+                expect(connector.emit).toBeCalledWith(peer, event, { headers }, 1000);
             });
 
             it("should not throw otherwise", async () => {
@@ -250,7 +250,7 @@ describe("PeerCommunicator", () => {
                 const pingResult = await peerCommunicator.ping(peer, 6000);
 
                 expect(connector.emit).toBeCalledTimes(1);
-                expect(connector.emit).toBeCalledWith(peer, event,  { headers }, 5000);
+                expect(connector.emit).toBeCalledWith(peer, event, { headers }, 5000);
                 expect(pingResult).toEqual(baseGetStatusResponse.state);
             });
         });
@@ -270,7 +270,7 @@ describe("PeerCommunicator", () => {
                 const pingResult = await peerCommunicator.ping(peer, 1000);
 
                 expect(connector.emit).toBeCalledTimes(1);
-                expect(connector.emit).toBeCalledWith(peer, event,  { headers }, 1000);
+                expect(connector.emit).toBeCalledWith(peer, event, { headers }, 1000);
                 expect(pingResult).toEqual(baseGetStatusResponse.state);
                 expect(peer.state).toEqual(baseGetStatusResponse.state);
                 expect(peer.plugins).toEqual(baseGetStatusResponse.config.plugins);
@@ -368,7 +368,7 @@ describe("PeerCommunicator", () => {
             const getPeersResult = await peerCommunicator.getPeers(peer);
 
             expect(connector.emit).toBeCalledTimes(1);
-            expect(connector.emit).toBeCalledWith(peer, event,  { ...payload, headers }, 5000);
+            expect(connector.emit).toBeCalledWith(peer, event, { ...payload, headers }, 5000);
             expect(getPeersResult).toEqual(mockConnectorResponse.payload);
         });
 
@@ -382,7 +382,7 @@ describe("PeerCommunicator", () => {
             const getPeersResult = await peerCommunicator.getPeers(peer);
 
             expect(connector.emit).toBeCalledTimes(1);
-            expect(connector.emit).toBeCalledWith(peer, event,  { ...payload, headers }, 5000);
+            expect(connector.emit).toBeCalledWith(peer, event, { ...payload, headers }, 5000);
             expect(getPeersResult).toBeUndefined();
         });
 
@@ -396,7 +396,7 @@ describe("PeerCommunicator", () => {
             const getPeersResult = await peerCommunicator.getPeers(peer);
 
             expect(connector.emit).toBeCalledTimes(1);
-            expect(connector.emit).toBeCalledWith(peer, event,  { ...payload, headers }, 5000);
+            expect(connector.emit).toBeCalledWith(peer, event, { ...payload, headers }, 5000);
             expect(getPeersResult).toBeUndefined();
             expect(logger.debug).toBeCalledWith(expect.stringContaining("Got unexpected reply from"));
         });
@@ -413,7 +413,7 @@ describe("PeerCommunicator", () => {
             const hasCommonBlocksResult = await peerCommunicator.hasCommonBlocks(peer, payload.ids, 1000);
 
             expect(connector.emit).toBeCalledTimes(1);
-            expect(connector.emit).toBeCalledWith(peer, event,  { ...payload, headers }, 1000);
+            expect(connector.emit).toBeCalledWith(peer, event, { ...payload, headers }, 1000);
             expect(hasCommonBlocksResult).toEqual(mockConnectorResponse.payload.common);
         });
 
@@ -427,7 +427,7 @@ describe("PeerCommunicator", () => {
             const hasCommonBlocksResult = await peerCommunicator.hasCommonBlocks(peer, payload.ids, 6000);
 
             expect(connector.emit).toBeCalledTimes(1);
-            expect(connector.emit).toBeCalledWith(peer, event,  { ...payload, headers }, 5000);
+            expect(connector.emit).toBeCalledWith(peer, event, { ...payload, headers }, 5000);
             expect(hasCommonBlocksResult).toBe(false);
         });
     });
@@ -490,15 +490,19 @@ describe("PeerCommunicator", () => {
                 headers,
             };
             expect(connector.emit).toBeCalledTimes(1);
-            expect(connector.emit).toBeCalledWith(peer, event,  expectedEmitPayload, undefined);
-            expect(getPeerBlocksResult).toEqual(cloneMockConnectorResponse.payload.map((b) => ({
-                ...b,
-                transactions: b.transactions.map((transaction) => {
-                    const { data } = Transactions.TransactionFactory.fromBytesUnsafe(Buffer.from(transaction, "hex"));
-                    data.blockId = block.id;
-                    return data;
-                })
-            })));
+            expect(connector.emit).toBeCalledWith(peer, event, expectedEmitPayload, undefined);
+            expect(getPeerBlocksResult).toEqual(
+                cloneMockConnectorResponse.payload.map((b) => ({
+                    ...b,
+                    transactions: b.transactions.map((transaction) => {
+                        const { data } = Transactions.TransactionFactory.fromBytesUnsafe(
+                            Buffer.from(transaction, "hex"),
+                        );
+                        data.blockId = block.id;
+                        return data;
+                    }),
+                })),
+            );
         });
 
         it("should delete transactions field when using headersOnly==true", async () => {
@@ -523,11 +527,13 @@ describe("PeerCommunicator", () => {
                 headers,
             };
             expect(connector.emit).toBeCalledTimes(1);
-            expect(connector.emit).toBeCalledWith(peer, event,  expectedEmitPayload, undefined);
-            expect(getPeerBlocksResult).toEqual(cloneMockConnectorResponse.payload.map((b) => {
-                delete b.transactions;
-                return b;
-            }));
+            expect(connector.emit).toBeCalledWith(peer, event, expectedEmitPayload, undefined);
+            expect(getPeerBlocksResult).toEqual(
+                cloneMockConnectorResponse.payload.map((b) => {
+                    delete b.transactions;
+                    return b;
+                }),
+            );
         });
 
         it("should log a debug message when peer did not return any block", async () => {
@@ -550,7 +556,7 @@ describe("PeerCommunicator", () => {
                 headers,
             };
             expect(connector.emit).toBeCalledTimes(1);
-            expect(connector.emit).toBeCalledWith(peer, event,  expectedEmitPayload, undefined);
+            expect(connector.emit).toBeCalledWith(peer, event, expectedEmitPayload, undefined);
             expect(getPeerBlocksResult).toEqual([]);
             expect(logger.debug).toBeCalledWith(
                 `Peer ${peer.ip} did not return any blocks via height ${options.fromBlockHeight}.`,

--- a/__tests__/unit/core-p2p/socket-server/controllers/blocks.test.ts
+++ b/__tests__/unit/core-p2p/socket-server/controllers/blocks.test.ts
@@ -84,7 +84,9 @@ describe("BlocksController", () => {
 
         describe("when block is not chained", () => {
             it.each([[true], [false]])("should return false only if block is not known", async (blockPing) => {
-                blockchain.getLastDownloadedBlock = jest.fn().mockReturnValueOnce(Networks.testnet.genesisBlock);
+                blockchain.getLastHeight.mockReturnValueOnce(100);
+                blockchain.getLastDownloadedBlock.mockReturnValueOnce(Networks.testnet.genesisBlock);
+
                 const blockUnchained = deepClone(block);
                 blockUnchained.data.height = 9;
                 const blockSerialized = Blocks.Serializer.serializeWithTransactions({
@@ -93,7 +95,7 @@ describe("BlocksController", () => {
                 });
 
                 if (blockPing) {
-                    blockchain.pingBlock = jest.fn().mockReturnValueOnce(true);
+                    blockchain.pingBlock.mockReturnValueOnce(true);
                     await expect(
                         blocksController.postBlock(
                             {
@@ -113,7 +115,7 @@ describe("BlocksController", () => {
                             },
                             {},
                         ),
-                    ).resolves.toBeFalsy();
+                    ).resolves.toEqual({ status: false, height: 100 });
                 }
             });
         });

--- a/packages/core-kernel/src/contracts/p2p/blocks.ts
+++ b/packages/core-kernel/src/contracts/p2p/blocks.ts
@@ -1,0 +1,4 @@
+export type PostBlockResponse = {
+    status: boolean;
+    height: number;
+};

--- a/packages/core-kernel/src/contracts/p2p/index.ts
+++ b/packages/core-kernel/src/contracts/p2p/index.ts
@@ -1,3 +1,4 @@
+export * from "./blocks";
 export * from "./chunk-cache";
 export * from "./nes-client";
 export * from "./network-monitor";

--- a/packages/core-p2p/package.json
+++ b/packages/core-p2p/package.json
@@ -18,8 +18,8 @@
         "build": "yarn clean && yarn compile",
         "build:watch": "yarn clean && yarn compile -w",
         "build:docs": "../../node_modules/typedoc/bin/typedoc --out docs src",
-        "pbjs": "../../node_modules/protobufjs/cli/bin/pbjs -t static-module -w commonjs src/socket-server/codecs/proto/*.proto -o src/socket-server/codecs/proto/protos.js",
-        "pbts": "../../node_modules/protobufjs/cli/bin/pbts src/socket-server/codecs/proto/protos.js -o src/socket-server/codecs/proto/protos.d.ts",
+        "pbjs": "pbjs -t static-module -w commonjs src/socket-server/codecs/proto/*.proto -o src/socket-server/codecs/proto/protos.js",
+        "pbts": "pbts src/socket-server/codecs/proto/protos.js -o src/socket-server/codecs/proto/protos.d.ts",
         "build:proto": "yarn pbjs && yarn pbts",
         "clean": "rimraf dist",
         "compile": "node ../../node_modules/typescript/bin/tsc",
@@ -54,7 +54,8 @@
         "@types/fs-extra": "^8.0.1",
         "@types/hapi__sntp": "^3.1.0",
         "@types/ip": "^1.1.0",
-        "@types/semver": "^6.2.0"
+        "@types/semver": "^6.2.0",
+        "protobufjs": "^6.11.2"
     },
     "engines": {
         "node": ">=10.x"

--- a/packages/core-p2p/package.json
+++ b/packages/core-p2p/package.json
@@ -54,8 +54,7 @@
         "@types/fs-extra": "^8.0.1",
         "@types/hapi__sntp": "^3.1.0",
         "@types/ip": "^1.1.0",
-        "@types/semver": "^6.2.0",
-        "protobufjs": "^6.11.2"
+        "@types/semver": "^6.2.0"
     },
     "engines": {
         "node": ">=10.x"

--- a/packages/core-p2p/src/peer-communicator.ts
+++ b/packages/core-p2p/src/peer-communicator.ts
@@ -69,7 +69,7 @@ export class PeerCommunicator implements Contracts.P2P.PeerCommunicator {
             postBlockTimeout,
         );
 
-        if (response.height) {
+        if (response && response.height) {
             peer.state.height = response.height;
         }
     }

--- a/packages/core-p2p/src/peer-communicator.ts
+++ b/packages/core-p2p/src/peer-communicator.ts
@@ -56,7 +56,8 @@ export class PeerCommunicator implements Contracts.P2P.PeerCommunicator {
 
     public async postBlock(peer: Contracts.P2P.Peer, block: Interfaces.IBlock) {
         const postBlockTimeout = 10000;
-        return this.emit(
+
+        const response = await this.emit(
             peer,
             "p2p.blocks.postBlock",
             {
@@ -67,6 +68,10 @@ export class PeerCommunicator implements Contracts.P2P.PeerCommunicator {
             },
             postBlockTimeout,
         );
+
+        if (response.height) {
+            peer.state.height = response.height;
+        }
     }
 
     public async postTransactions(peer: Contracts.P2P.Peer, transactions: Buffer[]): Promise<void> {
@@ -232,12 +237,6 @@ export class PeerCommunicator implements Contracts.P2P.PeerCommunicator {
         return true;
     }
 
-    private parseHeaders(peer: Contracts.P2P.Peer, response): void {
-        if (response.headers && response.headers.height) {
-            peer.state.height = +response.headers.height;
-        }
-    }
-
     private validateReply(peer: Contracts.P2P.Peer, reply: any, endpoint: string): boolean {
         const schema = replySchemas[endpoint];
         if (schema === undefined) {
@@ -296,7 +295,6 @@ export class PeerCommunicator implements Contracts.P2P.PeerCommunicator {
             peer.sequentialErrorCounter = 0; // reset counter if response is successful, keep it after emit
 
             peer.latency = new Date().getTime() - timeBeforeSocketCall;
-            this.parseHeaders(peer, parsedResponsePayload);
 
             if (!this.validateReply(peer, parsedResponsePayload, event)) {
                 const validationError = new Error(

--- a/packages/core-p2p/src/schemas.ts
+++ b/packages/core-p2p/src/schemas.ts
@@ -185,7 +185,12 @@ export const replySchemas = {
         },
     },
     "p2p.blocks.postBlock": {
-        type: "boolean",
+        type: "object",
+        additionalProperties: false,
+        properties: {
+            status: { type: "boolean" },
+            height: { type: "integer", minimum: 1 },
+        },
     },
     "p2p.transactions.postTransactions": {
         type: "array",

--- a/packages/core-p2p/src/socket-server/codecs/blocks.ts
+++ b/packages/core-p2p/src/socket-server/codecs/blocks.ts
@@ -1,3 +1,4 @@
+import { Contracts } from "@arkecosystem/core-kernel";
 import { Utils } from "@arkecosystem/crypto";
 import { blocks } from "./proto/protos";
 
@@ -87,7 +88,7 @@ export const postBlock = {
         serialize: (obj: blocks.IPostBlockResponse): Buffer => {
             return Buffer.from(blocks.PostBlockResponse.encode(obj).finish());
         },
-        deserialize: (payload: Buffer): blocks.IPostBlockResponse => {
+        deserialize: (payload: Buffer): Contracts.P2P.PostBlockResponse => {
             return blocks.PostBlockResponse.decode(payload);
         },
     },

--- a/packages/core-p2p/src/socket-server/codecs/proto/blocks.proto
+++ b/packages/core-p2p/src/socket-server/codecs/proto/blocks.proto
@@ -7,6 +7,10 @@ message PostBlockRequest {
     shared.Headers headers = 2;
 }
 
+message PostBlockResponse {
+    uint32 height = 1;
+}
+
 message GetBlocksRequest {
     uint32 lastBlockHeight = 1;
     uint32 blockLimit = 2;

--- a/packages/core-p2p/src/socket-server/codecs/proto/blocks.proto
+++ b/packages/core-p2p/src/socket-server/codecs/proto/blocks.proto
@@ -8,7 +8,8 @@ message PostBlockRequest {
 }
 
 message PostBlockResponse {
-    uint32 height = 1;
+    bool status = 1;
+    uint32 height = 2;
 }
 
 message GetBlocksRequest {

--- a/packages/core-p2p/src/socket-server/codecs/proto/protos.d.ts
+++ b/packages/core-p2p/src/socket-server/codecs/proto/protos.d.ts
@@ -98,6 +98,96 @@ export namespace blocks {
         public toJSON(): { [k: string]: any };
     }
 
+    /** Properties of a PostBlockResponse. */
+    interface IPostBlockResponse {
+
+        /** PostBlockResponse height */
+        height?: (number|null);
+    }
+
+    /** Represents a PostBlockResponse. */
+    class PostBlockResponse implements IPostBlockResponse {
+
+        /**
+         * Constructs a new PostBlockResponse.
+         * @param [properties] Properties to set
+         */
+        constructor(properties?: blocks.IPostBlockResponse);
+
+        /** PostBlockResponse height. */
+        public height: number;
+
+        /**
+         * Creates a new PostBlockResponse instance using the specified properties.
+         * @param [properties] Properties to set
+         * @returns PostBlockResponse instance
+         */
+        public static create(properties?: blocks.IPostBlockResponse): blocks.PostBlockResponse;
+
+        /**
+         * Encodes the specified PostBlockResponse message. Does not implicitly {@link blocks.PostBlockResponse.verify|verify} messages.
+         * @param message PostBlockResponse message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encode(message: blocks.IPostBlockResponse, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Encodes the specified PostBlockResponse message, length delimited. Does not implicitly {@link blocks.PostBlockResponse.verify|verify} messages.
+         * @param message PostBlockResponse message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encodeDelimited(message: blocks.IPostBlockResponse, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Decodes a PostBlockResponse message from the specified reader or buffer.
+         * @param reader Reader or buffer to decode from
+         * @param [length] Message length if known beforehand
+         * @returns PostBlockResponse
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): blocks.PostBlockResponse;
+
+        /**
+         * Decodes a PostBlockResponse message from the specified reader or buffer, length delimited.
+         * @param reader Reader or buffer to decode from
+         * @returns PostBlockResponse
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): blocks.PostBlockResponse;
+
+        /**
+         * Verifies a PostBlockResponse message.
+         * @param message Plain object to verify
+         * @returns `null` if valid, otherwise the reason why it is not
+         */
+        public static verify(message: { [k: string]: any }): (string|null);
+
+        /**
+         * Creates a PostBlockResponse message from a plain object. Also converts values to their respective internal types.
+         * @param object Plain object
+         * @returns PostBlockResponse
+         */
+        public static fromObject(object: { [k: string]: any }): blocks.PostBlockResponse;
+
+        /**
+         * Creates a plain object from a PostBlockResponse message. Also converts values to other types if specified.
+         * @param message PostBlockResponse
+         * @param [options] Conversion options
+         * @returns Plain object
+         */
+        public static toObject(message: blocks.PostBlockResponse, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+        /**
+         * Converts this PostBlockResponse to JSON.
+         * @returns JSON object
+         */
+        public toJSON(): { [k: string]: any };
+    }
+
     /** Properties of a GetBlocksRequest. */
     interface IGetBlocksRequest {
 

--- a/packages/core-p2p/src/socket-server/codecs/proto/protos.d.ts
+++ b/packages/core-p2p/src/socket-server/codecs/proto/protos.d.ts
@@ -101,6 +101,9 @@ export namespace blocks {
     /** Properties of a PostBlockResponse. */
     interface IPostBlockResponse {
 
+        /** PostBlockResponse status */
+        status?: (boolean|null);
+
         /** PostBlockResponse height */
         height?: (number|null);
     }
@@ -113,6 +116,9 @@ export namespace blocks {
          * @param [properties] Properties to set
          */
         constructor(properties?: blocks.IPostBlockResponse);
+
+        /** PostBlockResponse status. */
+        public status: boolean;
 
         /** PostBlockResponse height. */
         public height: number;

--- a/packages/core-p2p/src/socket-server/codecs/proto/protos.js
+++ b/packages/core-p2p/src/socket-server/codecs/proto/protos.js
@@ -248,6 +248,7 @@ $root.blocks = (function() {
          * Properties of a PostBlockResponse.
          * @memberof blocks
          * @interface IPostBlockResponse
+         * @property {boolean|null} [status] PostBlockResponse status
          * @property {number|null} [height] PostBlockResponse height
          */
 
@@ -265,6 +266,14 @@ $root.blocks = (function() {
                     if (properties[keys[i]] != null)
                         this[keys[i]] = properties[keys[i]];
         }
+
+        /**
+         * PostBlockResponse status.
+         * @member {boolean} status
+         * @memberof blocks.PostBlockResponse
+         * @instance
+         */
+        PostBlockResponse.prototype.status = false;
 
         /**
          * PostBlockResponse height.
@@ -298,8 +307,10 @@ $root.blocks = (function() {
         PostBlockResponse.encode = function encode(message, writer) {
             if (!writer)
                 writer = $Writer.create();
+            if (message.status != null && Object.hasOwnProperty.call(message, "status"))
+                writer.uint32(/* id 1, wireType 0 =*/8).bool(message.status);
             if (message.height != null && Object.hasOwnProperty.call(message, "height"))
-                writer.uint32(/* id 1, wireType 0 =*/8).uint32(message.height);
+                writer.uint32(/* id 2, wireType 0 =*/16).uint32(message.height);
             return writer;
         };
 
@@ -335,6 +346,9 @@ $root.blocks = (function() {
                 var tag = reader.uint32();
                 switch (tag >>> 3) {
                 case 1:
+                    message.status = reader.bool();
+                    break;
+                case 2:
                     message.height = reader.uint32();
                     break;
                 default:
@@ -372,6 +386,9 @@ $root.blocks = (function() {
         PostBlockResponse.verify = function verify(message) {
             if (typeof message !== "object" || message === null)
                 return "object expected";
+            if (message.status != null && message.hasOwnProperty("status"))
+                if (typeof message.status !== "boolean")
+                    return "status: boolean expected";
             if (message.height != null && message.hasOwnProperty("height"))
                 if (!$util.isInteger(message.height))
                     return "height: integer expected";
@@ -390,6 +407,8 @@ $root.blocks = (function() {
             if (object instanceof $root.blocks.PostBlockResponse)
                 return object;
             var message = new $root.blocks.PostBlockResponse();
+            if (object.status != null)
+                message.status = Boolean(object.status);
             if (object.height != null)
                 message.height = object.height >>> 0;
             return message;
@@ -408,8 +427,12 @@ $root.blocks = (function() {
             if (!options)
                 options = {};
             var object = {};
-            if (options.defaults)
+            if (options.defaults) {
+                object.status = false;
                 object.height = 0;
+            }
+            if (message.status != null && message.hasOwnProperty("status"))
+                object.status = message.status;
             if (message.height != null && message.hasOwnProperty("height"))
                 object.height = message.height;
             return object;

--- a/packages/core-p2p/src/socket-server/codecs/proto/protos.js
+++ b/packages/core-p2p/src/socket-server/codecs/proto/protos.js
@@ -242,6 +242,193 @@ $root.blocks = (function() {
         return PostBlockRequest;
     })();
 
+    blocks.PostBlockResponse = (function() {
+
+        /**
+         * Properties of a PostBlockResponse.
+         * @memberof blocks
+         * @interface IPostBlockResponse
+         * @property {number|null} [height] PostBlockResponse height
+         */
+
+        /**
+         * Constructs a new PostBlockResponse.
+         * @memberof blocks
+         * @classdesc Represents a PostBlockResponse.
+         * @implements IPostBlockResponse
+         * @constructor
+         * @param {blocks.IPostBlockResponse=} [properties] Properties to set
+         */
+        function PostBlockResponse(properties) {
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * PostBlockResponse height.
+         * @member {number} height
+         * @memberof blocks.PostBlockResponse
+         * @instance
+         */
+        PostBlockResponse.prototype.height = 0;
+
+        /**
+         * Creates a new PostBlockResponse instance using the specified properties.
+         * @function create
+         * @memberof blocks.PostBlockResponse
+         * @static
+         * @param {blocks.IPostBlockResponse=} [properties] Properties to set
+         * @returns {blocks.PostBlockResponse} PostBlockResponse instance
+         */
+        PostBlockResponse.create = function create(properties) {
+            return new PostBlockResponse(properties);
+        };
+
+        /**
+         * Encodes the specified PostBlockResponse message. Does not implicitly {@link blocks.PostBlockResponse.verify|verify} messages.
+         * @function encode
+         * @memberof blocks.PostBlockResponse
+         * @static
+         * @param {blocks.IPostBlockResponse} message PostBlockResponse message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        PostBlockResponse.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.height != null && Object.hasOwnProperty.call(message, "height"))
+                writer.uint32(/* id 1, wireType 0 =*/8).uint32(message.height);
+            return writer;
+        };
+
+        /**
+         * Encodes the specified PostBlockResponse message, length delimited. Does not implicitly {@link blocks.PostBlockResponse.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof blocks.PostBlockResponse
+         * @static
+         * @param {blocks.IPostBlockResponse} message PostBlockResponse message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        PostBlockResponse.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a PostBlockResponse message from the specified reader or buffer.
+         * @function decode
+         * @memberof blocks.PostBlockResponse
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {blocks.PostBlockResponse} PostBlockResponse
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        PostBlockResponse.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.blocks.PostBlockResponse();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.height = reader.uint32();
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes a PostBlockResponse message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof blocks.PostBlockResponse
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {blocks.PostBlockResponse} PostBlockResponse
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        PostBlockResponse.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a PostBlockResponse message.
+         * @function verify
+         * @memberof blocks.PostBlockResponse
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        PostBlockResponse.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.height != null && message.hasOwnProperty("height"))
+                if (!$util.isInteger(message.height))
+                    return "height: integer expected";
+            return null;
+        };
+
+        /**
+         * Creates a PostBlockResponse message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof blocks.PostBlockResponse
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {blocks.PostBlockResponse} PostBlockResponse
+         */
+        PostBlockResponse.fromObject = function fromObject(object) {
+            if (object instanceof $root.blocks.PostBlockResponse)
+                return object;
+            var message = new $root.blocks.PostBlockResponse();
+            if (object.height != null)
+                message.height = object.height >>> 0;
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a PostBlockResponse message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof blocks.PostBlockResponse
+         * @static
+         * @param {blocks.PostBlockResponse} message PostBlockResponse
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        PostBlockResponse.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.defaults)
+                object.height = 0;
+            if (message.height != null && message.hasOwnProperty("height"))
+                object.height = message.height;
+            return object;
+        };
+
+        /**
+         * Converts this PostBlockResponse to JSON.
+         * @function toJSON
+         * @memberof blocks.PostBlockResponse
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        PostBlockResponse.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return PostBlockResponse;
+    })();
+
     blocks.GetBlocksRequest = (function() {
 
         /**


### PR DESCRIPTION
## Summary

Send new height with `postBlock` response. It's used to update `/api/peers` endpoint. Fixes #4448

## Checklist

- [x] Tests
- [x] Ready to be merged
