### PR TITLE
fix(core-api): fix `/api/lock/unlocked` payload validation

### DIFF
--- a/__tests__/integration/core-api/controllers/locks.test.ts
+++ b/__tests__/integration/core-api/controllers/locks.test.ts
@@ -88,3 +88,14 @@ describe("/locks", () => {
         }
     });
 });
+
+describe("/locks/unlocked", () => {
+    it("should return 422 response status when payload is empty object", async () => {
+        const client = app.resolve(ApiInjectClient);
+        const response = await client.post("/locks/unlocked", {});
+
+        expect(response).toMatchObject({
+            status: 422,
+        });
+    });
+});

--- a/__tests__/unit/core-api/routes/locks.test.ts
+++ b/__tests__/unit/core-api/routes/locks.test.ts
@@ -66,7 +66,7 @@ describe("Locks", () => {
             const injectOptions = {
                 method: "POST",
                 url: "/locks/unlocked",
-                payload: {},
+                payload: { ids: ["bc3ee5fe72cb4c73521aef576d6d53ba3323dd9cb652f33bf613d22e7f7185a8"] },
             };
 
             const result = await server.inject(injectOptions);

--- a/packages/core-api/src/routes/locks.ts
+++ b/packages/core-api/src/routes/locks.ts
@@ -46,8 +46,8 @@ export const register = (server: Hapi.Server): void => {
                     orderBy: server.app.schemas.orderBy,
                 }).concat(Schemas.pagination),
                 payload: Joi.object({
-                    ids: Joi.array().unique().min(1).max(25).items(Joi.string().hex().length(64)),
-                }),
+                    ids: Joi.array().unique().min(1).max(25).items(Joi.string().hex().length(64)).required(),
+                }).required(),
             },
             plugins: {
                 pagination: {


### PR DESCRIPTION
## Summary

Require `/api/lock/unlocked` payload to be object and that it has `ids` property. Fixes #4481.

## Checklist

- [x] Tests
- [x] Ready to be merged
