### PR TITLE
chore(core): install specific version of plugin

### DIFF
--- a/__tests__/unit/core/commands/plugin-install.test.ts
+++ b/__tests__/unit/core/commands/plugin-install.test.ts
@@ -4,11 +4,9 @@ import { Console } from "@arkecosystem/core-test-framework";
 import { Command } from "@packages/core/src/commands/plugin-install";
 import { setGracefulCleanup } from "tmp";
 
-let called = false;
-let packageExists = true;
 const packageName = "dummyPackageName";
-const install = () => (called = true);
-const exists = async () => packageExists;
+const install = jest.fn();
+const exists = jest.fn().mockReturnValue(false);
 
 jest.mock("@packages/core/src/source-providers/npm", () => ({
     NPM: jest.fn().mockImplementation(() => ({
@@ -45,20 +43,24 @@ afterEach(() => {
 
 describe("PluginInstallCommand", () => {
     it("should throw an error when package name is not provided", async () => {
-        packageExists = false;
         const errorMessage = `"package" is required`;
         await expect(cli.execute(Command)).rejects.toThrow(errorMessage);
-        expect(called).toEqual(false);
+
+        expect(exists).not.toHaveBeenCalled();
+        expect(install).not.toHaveBeenCalled();
     });
 
     it("should throw an error when package doesn't exist", async () => {
-        packageExists = false;
         const errorMessage = `The given package [${packageName}] is neither a git nor a npm package.`;
         await expect(cli.withArgs([packageName]).execute(Command)).rejects.toThrow(errorMessage);
-        expect(called).toEqual(false);
+
+        expect(exists).toHaveBeenCalledWith(packageName, undefined);
+        expect(install).not.toHaveBeenCalled();
     });
 
     it("should throw any errors while installing", async () => {
+        exists.mockReturnValue(true);
+
         jest.spyOn(cli.app, "getCorePath").mockImplementationOnce(() => {
             throw Error("Fake Error");
         });
@@ -67,8 +69,21 @@ describe("PluginInstallCommand", () => {
     });
 
     it("should call install on existing packages", async () => {
-        packageExists = true;
+        exists.mockReturnValue(true);
+
         await expect(cli.withArgs([packageName]).execute(Command)).toResolve();
-        expect(called).toEqual(true);
+
+        expect(exists).toHaveBeenCalledWith(packageName, undefined);
+        expect(install).toHaveBeenCalledWith(packageName, undefined);
+    });
+
+    it("should call install on existing packages with --version flag", async () => {
+        exists.mockReturnValue(true);
+
+        const version = "3.0.0";
+        await expect(cli.withArgs([packageName]).withFlags({ version }).execute(Command)).toResolve();
+
+        expect(exists).toHaveBeenCalledWith(packageName, version);
+        expect(install).toHaveBeenCalledWith(packageName, version);
     });
 });

--- a/__tests__/unit/core/source-providers/npm.test.ts
+++ b/__tests__/unit/core/source-providers/npm.test.ts
@@ -1,11 +1,11 @@
 import "jest-extended";
 
 import { NPM } from "@packages/core/src/source-providers";
+import execa from "execa";
 import fs from "fs-extra";
 import nock from "nock";
 import { join, resolve } from "path";
 import { dirSync, setGracefulCleanup } from "tmp";
-import execa from "execa";
 
 let dataPath: string;
 let tempPath: string;
@@ -50,6 +50,50 @@ describe("NPM", () => {
                 });
 
             await expect(source.exists("@arkecosystem/utils")).resolves.toBeTrue();
+        });
+
+        it("should return true if the file by version exists", async () => {
+            nock(/.*/)
+                .get("/@arkecosystem/utils")
+                .reply(200, {
+                    name: "@arkecosystem/utils",
+                    "dist-tags": {
+                        latest: "0.9.1",
+                    },
+                    versions: {
+                        "0.9.1": {
+                            name: "@arkecosystem/utils",
+                            version: "0.9.1",
+                            dist: {
+                                tarball: "https://registry.npmjs.org/@arkecosystem/utils/-/utils-0.9.1.tgz",
+                            },
+                        },
+                    },
+                });
+
+            await expect(source.exists("@arkecosystem/utils", "0.9.1")).resolves.toBeTrue();
+        });
+
+        it("should return false if the file by version doesn't exists", async () => {
+            nock(/.*/)
+                .get("/@arkecosystem/utils")
+                .reply(200, {
+                    name: "@arkecosystem/utils",
+                    "dist-tags": {
+                        latest: "0.9.1",
+                    },
+                    versions: {
+                        "0.9.1": {
+                            name: "@arkecosystem/utils",
+                            version: "0.9.1",
+                            dist: {
+                                tarball: "https://registry.npmjs.org/@arkecosystem/utils/-/utils-0.9.1.tgz",
+                            },
+                        },
+                    },
+                });
+
+            await expect(source.exists("@arkecosystem/utils", "0.5.5")).resolves.toBeFalse();
         });
 
         it("should return false if the file does not exists", async () => {

--- a/packages/core/src/commands/plugin-install.ts
+++ b/packages/core/src/commands/plugin-install.ts
@@ -37,6 +37,7 @@ export class Command extends Commands.Command {
         this.definition
             .setFlag("token", "The name of the token.", Joi.string().default("ark"))
             .setFlag("network", "The name of the network.", Joi.string().valid(...Object.keys(Networks)))
+            .setFlag("version", "The version of the package.", Joi.string())
             .setArgument("package", "The name of the package.", Joi.string().required());
     }
 
@@ -48,9 +49,10 @@ export class Command extends Commands.Command {
      */
     public async execute(): Promise<void> {
         const pkg: string = this.getArgument("package");
+        const version: string | undefined = this.getFlag("version");
 
         try {
-            return await this.install(pkg);
+            return await this.install(pkg, version);
         } catch (error) {
             throw new Error(error.message);
         }
@@ -59,18 +61,19 @@ export class Command extends Commands.Command {
     /**
      * @private
      * @param {string} pkg
+     * @param version
      * @returns {Promise<void>}
      * @memberof Command
      */
-    private async install(pkg: string): Promise<void> {
+    private async install(pkg: string, version?: string): Promise<void> {
         for (const Instance of [File, Git, NPM]) {
             const source: Source = new Instance({
                 data: this.app.getCorePath("data", "plugins"),
                 temp: this.app.getCorePath("temp", "plugins"),
             });
 
-            if (await source.exists(pkg)) {
-                return source.install(pkg);
+            if (await source.exists(pkg, version)) {
+                return source.install(pkg, version);
             }
         }
 

--- a/packages/core/src/source-providers/abstract-source.ts
+++ b/packages/core/src/source-providers/abstract-source.ts
@@ -1,8 +1,9 @@
+import execa from "execa";
+import { ensureDirSync, moveSync, readJSONSync, removeSync } from "fs-extra";
+import { join } from "path";
+
 import { Source } from "./contracts";
 import { InvalidPackageJson } from "./errors";
-import { ensureDirSync, readJSONSync, moveSync, removeSync } from "fs-extra";
-import execa from "execa";
-import { join } from "path";
 
 export abstract class AbstractSource implements Source {
     protected readonly dataPath: string;
@@ -15,12 +16,12 @@ export abstract class AbstractSource implements Source {
         ensureDirSync(this.dataPath);
     }
 
-    public async install(value: string): Promise<void> {
+    public async install(value: string, version?: string): Promise<void> {
         const origin = this.getOriginPath();
 
         removeSync(origin);
 
-        await this.preparePackage(value);
+        await this.preparePackage(value, version);
 
         const packageName = this.getPackageName(origin);
         this.removeInstalledPackage(packageName);
@@ -56,9 +57,9 @@ export abstract class AbstractSource implements Source {
         removeSync(this.getDestPath(packageName));
     }
 
-    public abstract async exists(value: string): Promise<boolean>;
+    public abstract async exists(value: string, version?: string): Promise<boolean>;
 
     public abstract async update(value: string): Promise<void>;
 
-    protected abstract async preparePackage(value: string): Promise<void>;
+    protected abstract async preparePackage(value: string, version?: string): Promise<void>;
 }

--- a/packages/core/src/source-providers/contracts.ts
+++ b/packages/core/src/source-providers/contracts.ts
@@ -3,9 +3,9 @@
  * @interface Source
  */
 export interface Source {
-    exists(value: string): Promise<boolean>;
+    exists(value: string, version?: string): Promise<boolean>;
 
-    install(value: string): Promise<void>;
+    install(value: string, version?: string): Promise<void>;
 
     update(value: string): Promise<void>;
 }


### PR DESCRIPTION
## Summary

Support installation of specific version of plugin. `ark plugin:install` command implements additional `--version` flag. 

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged