### PR TITLE
fix(core-cli): wrap string flags in single quotes

### DIFF
--- a/__tests__/unit/core-cli/services/process-manager.test.ts
+++ b/__tests__/unit/core-cli/services/process-manager.test.ts
@@ -187,7 +187,7 @@ describe("ProcessManager", () => {
 
             // Assert...
             expect(failed).toBeFalse();
-            expect(spySync).toHaveBeenCalledWith("pm2 start stub.js --name=stub", { shell: true });
+            expect(spySync).toHaveBeenCalledWith("pm2 start stub.js --name='stub'", { shell: true });
         });
 
         it("should respect the given node_args", () => {
@@ -210,7 +210,7 @@ describe("ProcessManager", () => {
             // Assert...
             expect(failed).toBeFalse();
             expect(spySync).toHaveBeenCalledWith(
-                'pm2 start stub.js --node-args="--max_old_space_size=500" --name=stub',
+                "pm2 start stub.js --node-args=\"--max_old_space_size=500\" --name='stub'",
                 { shell: true },
             );
         });
@@ -234,7 +234,7 @@ describe("ProcessManager", () => {
 
             // Assert...
             expect(failed).toBeFalse();
-            expect(spySync).toHaveBeenCalledWith("pm2 start stub.js --name=stub -- core:run --daemon", { shell: true });
+            expect(spySync).toHaveBeenCalledWith("pm2 start stub.js --name='stub' -- core:run --daemon", { shell: true });
         });
 
         it("should ignore the flags if they are undefined", () => {
@@ -289,7 +289,7 @@ describe("ProcessManager", () => {
 
             // Assert...
             expect(failed).toBeFalse();
-            expect(spySync).toHaveBeenCalledWith("pm2 stop stub --key=value", { shell: true });
+            expect(spySync).toHaveBeenCalledWith("pm2 stop stub --key='value'", { shell: true });
         });
     });
 
@@ -323,7 +323,7 @@ describe("ProcessManager", () => {
 
             // Assert...
             expect(failed).toBeFalse();
-            expect(spySync).toHaveBeenCalledWith("pm2 restart stub --key=value", { shell: true });
+            expect(spySync).toHaveBeenCalledWith("pm2 restart stub --key='value'", { shell: true });
         });
 
         it("should ignore the flags if they are empty", () => {

--- a/__tests__/unit/core-cli/utils/flags.test.ts
+++ b/__tests__/unit/core-cli/utils/flags.test.ts
@@ -6,7 +6,7 @@ describe("castFlagsToString", () => {
             castFlagsToString({
                 key: "value",
             }),
-        ).toEqual("--key=value");
+        ).toEqual("--key='value'");
     });
 
     it("should handle strings with spaces", () => {
@@ -14,7 +14,7 @@ describe("castFlagsToString", () => {
             castFlagsToString({
                 key: "hello world",
             }),
-        ).toEqual('--key="hello world"');
+        ).toEqual("--key='hello world'");
     });
 
     it("should handle integers", () => {
@@ -42,6 +42,6 @@ describe("castFlagsToString", () => {
                 },
                 ["ignore"],
             ),
-        ).toEqual("--key=value");
+        ).toEqual("--key='value'");
     });
 });

--- a/__tests__/unit/core/commands/core-start.test.ts
+++ b/__tests__/unit/core/commands/core-start.test.ts
@@ -30,7 +30,7 @@ describe("StartCommand", () => {
 
         expect(spyStart).toHaveBeenCalledWith(
             {
-                args: "core:run --token=ark --network=testnet --v=0 --env=production",
+                args: "core:run --token='ark' --network='testnet' --v=0 --env='production'",
                 env: {
                     CORE_ENV: "production",
                     NODE_ENV: "production",

--- a/__tests__/unit/core/commands/forger-run.test.ts
+++ b/__tests__/unit/core/commands/forger-run.test.ts
@@ -37,7 +37,7 @@ describe("RunCommand", () => {
         await new Promise((resolve) => {
             setTimeout(() => {
                 resolve();
-            }, 50);
+            }, 200);
         });
 
         expect(spyBootstrap).toHaveBeenCalled();

--- a/__tests__/unit/core/commands/forger-start.test.ts
+++ b/__tests__/unit/core/commands/forger-start.test.ts
@@ -30,7 +30,7 @@ describe("StartCommand", () => {
 
         expect(spyStart).toHaveBeenCalledWith(
             {
-                args: "forger:run --token=ark --network=testnet --v=0 --env=production",
+                args: "forger:run --token='ark' --network='testnet' --v=0 --env='production'",
                 env: {
                     CORE_ENV: "production",
                     NODE_ENV: "production",

--- a/__tests__/unit/core/commands/relay-start.test.ts
+++ b/__tests__/unit/core/commands/relay-start.test.ts
@@ -22,7 +22,7 @@ describe("StartCommand", () => {
 
         expect(spyStart).toHaveBeenCalledWith(
             {
-                args: "relay:run --token=ark --network=testnet --v=0 --env=production",
+                args: "relay:run --token='ark' --network='testnet' --v=0 --env='production'",
                 env: {
                     CORE_ENV: "production",
                     NODE_ENV: "production",

--- a/packages/core-cli/src/utils/flags.ts
+++ b/packages/core-cli/src/utils/flags.ts
@@ -8,7 +8,7 @@ export const castFlagsToString = (flags: AnyObject, ignoreKeys: string[] = []): 
             if (value === true) {
                 stringFlags.push(`--${key}`);
             } else if (typeof value === "string") {
-                stringFlags.push(value.includes(" ") ? `--${key}="${value}"` : `--${key}=${value}`);
+                stringFlags.push(`--${key}='${value}'`);
             } else {
                 stringFlags.push(`--${key}=${value}`);
             }


### PR DESCRIPTION
## Summary

Wrap flags, which are of type string in single quotes. This fix solves issues, when flag value includes [special characters](https://www.oreilly.com/library/view/learning-the-bash/1565923472/ch01s09.html). 

Single quote is exception and should be escaped with backslash character. 

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged