### PR TITLE
fix(core-cli): check total memory only

### DIFF
--- a/__tests__/unit/core-cli/actions/daemonize-process.test.ts
+++ b/__tests__/unit/core-cli/actions/daemonize-process.test.ts
@@ -91,7 +91,6 @@ describe("DaemonizeProcess", () => {
         const has = jest.spyOn(processManager, "has").mockReturnValue(true);
         const isUnknown = jest.spyOn(processManager, "isUnknown").mockReturnValue(false);
         const isOnline = jest.spyOn(processManager, "isOnline").mockReturnValue(false);
-        const freemem = jest.spyOn(os, "freemem").mockReturnValue(99999999999);
         const totalmem = jest.spyOn(os, "totalmem").mockReturnValue(99999999999);
         const start = jest.spyOn(processManager, "start").mockImplementation(undefined);
 
@@ -107,7 +106,6 @@ describe("DaemonizeProcess", () => {
         expect(has).toHaveBeenCalledWith("ark-core");
         expect(isUnknown).toHaveBeenCalledWith("ark-core");
         expect(isOnline).toHaveBeenCalledWith("ark-core");
-        expect(freemem).toHaveBeenCalled();
         expect(totalmem).toHaveBeenCalled();
         expect(start).toHaveBeenCalledWith(
             {
@@ -123,7 +121,6 @@ describe("DaemonizeProcess", () => {
         has.mockClear();
         isUnknown.mockClear();
         isOnline.mockClear();
-        freemem.mockClear();
         totalmem.mockClear();
         start.mockClear();
     });
@@ -132,7 +129,6 @@ describe("DaemonizeProcess", () => {
         const has = jest.spyOn(processManager, "has").mockReturnValue(true);
         const isUnknown = jest.spyOn(processManager, "isUnknown").mockReturnValue(false);
         const isOnline = jest.spyOn(processManager, "isOnline").mockReturnValue(false);
-        const freemem = jest.spyOn(os, "freemem").mockReturnValue(99999999999);
         const totalmem = jest.spyOn(os, "totalmem").mockReturnValue(99999999999);
         const start = jest.spyOn(processManager, "start").mockImplementation(undefined);
 
@@ -148,7 +144,6 @@ describe("DaemonizeProcess", () => {
         expect(has).toHaveBeenCalledWith("ark-core");
         expect(isUnknown).toHaveBeenCalledWith("ark-core");
         expect(isOnline).toHaveBeenCalledWith("ark-core");
-        expect(freemem).toHaveBeenCalled();
         expect(totalmem).toHaveBeenCalled();
         expect(start).toHaveBeenCalledWith(
             {
@@ -164,7 +159,6 @@ describe("DaemonizeProcess", () => {
         has.mockClear();
         isUnknown.mockClear();
         isOnline.mockClear();
-        freemem.mockClear();
         totalmem.mockClear();
         start.mockClear();
     });
@@ -173,7 +167,6 @@ describe("DaemonizeProcess", () => {
         const has = jest.spyOn(processManager, "has").mockReturnValue(true);
         const isUnknown = jest.spyOn(processManager, "isUnknown").mockReturnValue(false);
         const isOnline = jest.spyOn(processManager, "isOnline").mockReturnValue(false);
-        const freemem = jest.spyOn(os, "freemem").mockReturnValue(99999999999);
         const totalmem = jest.spyOn(os, "totalmem").mockReturnValue(99999999999);
         const start = jest.spyOn(processManager, "start").mockImplementation(undefined);
 
@@ -189,7 +182,6 @@ describe("DaemonizeProcess", () => {
         expect(has).toHaveBeenCalledWith("ark-core");
         expect(isUnknown).toHaveBeenCalledWith("ark-core");
         expect(isOnline).toHaveBeenCalledWith("ark-core");
-        expect(freemem).toHaveBeenCalled();
         expect(totalmem).toHaveBeenCalled();
         expect(start).toHaveBeenCalledWith(
             {
@@ -205,7 +197,6 @@ describe("DaemonizeProcess", () => {
         has.mockClear();
         isUnknown.mockClear();
         isOnline.mockClear();
-        freemem.mockClear();
         totalmem.mockClear();
         start.mockClear();
     });
@@ -214,8 +205,7 @@ describe("DaemonizeProcess", () => {
         const has = jest.spyOn(processManager, "has").mockReturnValue(true);
         const isUnknown = jest.spyOn(processManager, "isUnknown").mockReturnValue(false);
         const isOnline = jest.spyOn(processManager, "isOnline").mockReturnValue(false);
-        const freemem = jest.spyOn(os, "freemem").mockReturnValue(1);
-        const totalmem = jest.spyOn(os, "totalmem").mockReturnValue(1);
+        const totalmem = jest.spyOn(os, "totalmem").mockReturnValue(2 * 1024 ** 3 - 1);
         const start = jest.spyOn(processManager, "start").mockImplementation(undefined);
 
         action.execute(
@@ -230,7 +220,6 @@ describe("DaemonizeProcess", () => {
         expect(has).toHaveBeenCalledWith("ark-core");
         expect(isUnknown).toHaveBeenCalledWith("ark-core");
         expect(isOnline).toHaveBeenCalledWith("ark-core");
-        expect(freemem).toHaveBeenCalled();
         expect(totalmem).toHaveBeenCalled();
         expect(start).toHaveBeenCalledWith(
             {
@@ -251,7 +240,6 @@ describe("DaemonizeProcess", () => {
         has.mockClear();
         isUnknown.mockClear();
         isOnline.mockClear();
-        freemem.mockClear();
         totalmem.mockClear();
         start.mockClear();
     });
@@ -260,7 +248,6 @@ describe("DaemonizeProcess", () => {
         const has = jest.spyOn(processManager, "has").mockReturnValue(true);
         const isUnknown = jest.spyOn(processManager, "isUnknown").mockReturnValue(false);
         const isOnline = jest.spyOn(processManager, "isOnline").mockReturnValue(false);
-        const freemem = jest.spyOn(os, "freemem").mockReturnValue(99999999999);
         const totalmem = jest.spyOn(os, "totalmem").mockReturnValue(99999999999);
         const start = jest.spyOn(processManager, "start").mockImplementation(() => {
             throw new Error("unexpected error");
@@ -280,7 +267,6 @@ describe("DaemonizeProcess", () => {
         expect(has).toHaveBeenCalledWith("ark-core");
         expect(isUnknown).toHaveBeenCalledWith("ark-core");
         expect(isOnline).toHaveBeenCalledWith("ark-core");
-        expect(freemem).toHaveBeenCalled();
         expect(totalmem).toHaveBeenCalled();
         expect(start).toHaveBeenCalledWith(
             {
@@ -296,7 +282,6 @@ describe("DaemonizeProcess", () => {
         has.mockClear();
         isUnknown.mockClear();
         isOnline.mockClear();
-        freemem.mockClear();
         totalmem.mockClear();
         start.mockClear();
     });
@@ -305,7 +290,6 @@ describe("DaemonizeProcess", () => {
         const has = jest.spyOn(processManager, "has").mockReturnValue(true);
         const isUnknown = jest.spyOn(processManager, "isUnknown").mockReturnValue(false);
         const isOnline = jest.spyOn(processManager, "isOnline").mockReturnValue(false);
-        const freemem = jest.spyOn(os, "freemem").mockReturnValue(99999999999);
         const totalmem = jest.spyOn(os, "totalmem").mockReturnValue(99999999999);
         const start = jest.spyOn(processManager, "start").mockImplementation(() => {
             const error: Error = new Error("hello world");
@@ -329,7 +313,6 @@ describe("DaemonizeProcess", () => {
         expect(has).toHaveBeenCalledWith("ark-core");
         expect(isUnknown).toHaveBeenCalledWith("ark-core");
         expect(isOnline).toHaveBeenCalledWith("ark-core");
-        expect(freemem).toHaveBeenCalled();
         expect(totalmem).toHaveBeenCalled();
         expect(start).toHaveBeenCalledWith(
             {
@@ -345,7 +328,6 @@ describe("DaemonizeProcess", () => {
         has.mockClear();
         isUnknown.mockClear();
         isOnline.mockClear();
-        freemem.mockClear();
         totalmem.mockClear();
         start.mockClear();
     });

--- a/packages/core-cli/src/actions/daemonize-process.ts
+++ b/packages/core-cli/src/actions/daemonize-process.ts
@@ -59,9 +59,7 @@ export class DaemonizeProcess {
 
             flagsProcess.name = processName;
 
-            const totalMemGb: number = totalmem() / Math.pow(1024, 3);
-            const freeMemGb: number = freemem() / Math.pow(1024, 3);
-            const potato: boolean = totalMemGb < 2 || freeMemGb < 1.5;
+            const potato: boolean = totalmem() < 2 * 1024 ** 3;
 
             this.processManager.start(
                 {

--- a/packages/core-cli/src/actions/daemonize-process.ts
+++ b/packages/core-cli/src/actions/daemonize-process.ts
@@ -1,4 +1,4 @@
-import { freemem, totalmem } from "os";
+import { totalmem } from "os";
 
 import { Application } from "../application";
 import { Spinner } from "../components";


### PR DESCRIPTION
## Summary

Available memory is unreliable indicator. Only check total memory when daemonizing the process.

## Checklist

- [x] Tests
- [x] Ready to be merged
