### PR TITLE
chore(core): set `NODE_PATH`

### DIFF
--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -107,6 +107,7 @@ export class CommandLineInterface {
     }
 
     private setNodePath(): void {
+        /* istanbul ignore next */
         const delimiter = platform() === "win32" ? ";" : ":";
 
         if (!process.env.NODE_PATH) {
@@ -114,6 +115,7 @@ export class CommandLineInterface {
         }
 
         const setPathIfExists = (path: string) => {
+            /* istanbul ignore else */
             if (existsSync(path)) {
                 process.env.NODE_PATH += `${delimiter}${path}`;
             }

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -7,6 +7,8 @@ import {
     Plugins,
     Services,
 } from "@arkecosystem/core-cli";
+import { existsSync } from "fs-extra";
+import { platform } from "os";
 import { join, resolve } from "path";
 import { PackageJson } from "type-fest";
 
@@ -44,6 +46,9 @@ export class CommandLineInterface {
      * @memberof CommandLineInterface
      */
     public async execute(dirname = __dirname): Promise<void> {
+        // Set NODE_PATHS. Only required for plugins that uses @arkecosystem as peer dependencies.
+        this.setNodePath();
+
         // Load the package information. Only needed for updates and installations.
         const pkg: PackageJson = require("../package.json");
 
@@ -99,6 +104,25 @@ export class CommandLineInterface {
         commandInstance.register(this.argv);
 
         await commandInstance.run();
+    }
+
+    private setNodePath(): void {
+        const delimiter = platform() === "win32" ? ";" : ":";
+
+        if (!process.env.NODE_PATH) {
+            process.env.NODE_PATH = "";
+        }
+
+        const setPathIfExists = (path: string) => {
+            if (existsSync(path)) {
+                process.env.NODE_PATH += `${delimiter}${path}`;
+            }
+        };
+
+        setPathIfExists(join(__dirname, "../../../"));
+        setPathIfExists(join(__dirname, "../../../node_modules"));
+
+        require("module").Module._initPaths();
     }
 
     private async detectNetworkAndToken(flags: any): Promise<{ token: string; network?: string }> {


### PR DESCRIPTION
## Summary

Set NODE_PATH and reinit resolve paths. NODE_PATH is set to node_modules folder that holds @arkecosystem packages. This enables plugins to use @arkecosystem pakages as peerDependencies. 

## Checklist

- [x] Tests
- [x] Ready to be merged