### PR TITLE
fix(core): detect network from config path

### DIFF
--- a/__tests__/unit/core/cli.test.ts
+++ b/__tests__/unit/core/cli.test.ts
@@ -1,14 +1,14 @@
 import "jest-extended";
 
-import { CommandLineInterface } from "@packages/core/src/cli";
 import { Commands, Services } from "@packages/core-cli";
-import prompts from "prompts";
+import { CommandLineInterface } from "@packages/core/src/cli";
 import envPaths from "env-paths";
 import { join } from "path";
+import prompts from "prompts";
 
 beforeEach(() => {
     process.exitCode = undefined;
-})
+});
 
 afterEach(() => jest.clearAllMocks());
 
@@ -31,7 +31,7 @@ describe("CLI", () => {
 
         const cli = new CommandLineInterface(["hello"]);
         prompts.inject([false]);
-        await cli.execute("./packages/core/dist")
+        await cli.execute("./packages/core/dist");
 
         expect(spyOnCheck).toBeCalled();
         expect(message).toContain(`is not a ark command.`);
@@ -112,10 +112,10 @@ describe("CLI", () => {
             const cli = new CommandLineInterface(["help"]);
             await expect(cli.execute("./packages/core/dist")).toResolve();
 
-            expect(spyOnDiscoverNetwork).toHaveBeenCalled();
             expect(spyOnDiscoverPlugins).toHaveBeenCalledWith(
                 join(envPaths("ark", { suffix: "core" }).data, "testnet", "plugins"),
             );
+            expect(spyOnDiscoverNetwork).toHaveBeenCalledWith(envPaths("ark", { suffix: "core" }).config);
         });
     });
 });

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -7,6 +7,7 @@ import {
     Plugins,
     Services,
 } from "@arkecosystem/core-cli";
+import envPaths from "env-paths";
 import { existsSync } from "fs-extra";
 import { platform } from "os";
 import { join, resolve } from "path";
@@ -146,7 +147,11 @@ export class CommandLineInterface {
         }
 
         try {
-            tempFlags.network = await this.app.resolve(Commands.DiscoverNetwork).discover(tempFlags.token);
+            tempFlags.network = await this.app.resolve(Commands.DiscoverNetwork).discover(
+                envPaths(tempFlags.token, {
+                    suffix: "core",
+                }).config,
+            );
         } catch {}
 
         return tempFlags;
@@ -159,6 +164,9 @@ export class CommandLineInterface {
         const pluginsDiscoverer = this.app.resolve(Commands.DiscoverPlugins);
 
         const tempFlags = await this.detectNetworkAndToken(flags);
+
+        console.log("Flags: ", tempFlags);
+
         const path = join(
             this.app
                 .get<Services.Environment>(Container.Identifiers.Environment)

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -165,8 +165,6 @@ export class CommandLineInterface {
 
         const tempFlags = await this.detectNetworkAndToken(flags);
 
-        console.log("Flags: ", tempFlags);
-
         const path = join(
             this.app
                 .get<Services.Environment>(Container.Identifiers.Environment)


### PR DESCRIPTION
## Summary

Detect network from config paths. If only single network folder exists, then this is valid network. Network detection is used to load plugins from valid network, without using --network flag. 

## Checklist

- [x] Tests
- [x] Ready to be merged