### PR TITLE
fix(core-api): use new set-value package

### DIFF
--- a/packages/core-api/package.json
+++ b/packages/core-api/package.json
@@ -42,6 +42,9 @@
         "@types/semver": "6.2.3",
         "lodash.clonedeep": "4.5.0"
     },
+    "resolutions": {
+        "nanomatch/snapdragon/base/cache-base/**/set-value": "^4.1.0"
+    },
     "engines": {
         "node": ">=10.x"
     },


### PR DESCRIPTION
## Summary

Although vulnerability of old `set-value` package cannot be exploited, it's still better to update it.

## Checklist

- [ ] Ready to be merged
