### PR TITLE
test: import core packages using @packages 

### DIFF
--- a/__tests__/functional/core-database/__support__/index.ts
+++ b/__tests__/functional/core-database/__support__/index.ts
@@ -1,10 +1,10 @@
-import { Container, Providers } from "@arkecosystem/core-kernel";
-import { Sandbox } from "@arkecosystem/core-test-framework";
-import { Interfaces, Transactions } from "@arkecosystem/crypto";
+import { Container, Providers } from "@packages/core-kernel";
+import { Sandbox } from "@packages/core-test-framework";
+import { Interfaces, Transactions } from "@packages/crypto";
 import { Connection, createConnection } from "typeorm";
 
-import { Block } from "../../../../packages/core-database/src/models/block";
-import { SnakeNamingStrategy } from "../../../../packages/core-database/src/utils/snake-naming-strategy";
+import { Block } from "@packages/core-database/src/models/block";
+import { SnakeNamingStrategy } from "@packages/core-database/src/utils/snake-naming-strategy";
 
 export const getCoreDatabasePluginConfiguration = async (): Promise<Providers.PluginConfiguration> => {
     const sandbox: Sandbox = new Sandbox();

--- a/__tests__/functional/core-database/repositories/block-repository.test.ts
+++ b/__tests__/functional/core-database/repositories/block-repository.test.ts
@@ -1,4 +1,4 @@
-import { Blocks, Managers, Utils } from "@arkecosystem/crypto";
+import { Blocks, Managers, Utils } from "@packages/crypto";
 import { Connection } from "typeorm";
 import { getCustomRepository } from "typeorm";
 
@@ -8,8 +8,8 @@ import {
     toBlockModel,
     toBlockModelWithTransactions,
 } from "../__support__";
-import { BlockRepository } from "../../../../packages/core-database/src/repositories/block-repository";
-import { BIP39 } from "../../../../packages/core-forger/src/methods/bip39";
+import { BlockRepository } from "@packages/core-database/src/repositories/block-repository";
+import { BIP39 } from "@packages/core-forger/src/methods/bip39";
 
 let connection: Connection | undefined;
 

--- a/__tests__/functional/core-database/repositories/round-repository.test.ts
+++ b/__tests__/functional/core-database/repositories/round-repository.test.ts
@@ -1,9 +1,9 @@
-import { Contracts } from "@arkecosystem/core-kernel";
-import { Utils } from "@arkecosystem/crypto";
+import { Contracts } from "@packages/core-kernel";
+import { Utils } from "@packages/crypto";
 import { Connection, getCustomRepository } from "typeorm";
 
 import { clearCoreDatabase, getCoreDatabaseConnection } from "../__support__";
-import { RoundRepository } from "../../../../packages/core-database/src/repositories/round-repository";
+import { RoundRepository } from "@packages/core-database/src/repositories/round-repository";
 
 class DelegateWalletMock {
     public readonly publicKey: string;

--- a/__tests__/functional/core-database/repositories/transaction-repository.test.ts
+++ b/__tests__/functional/core-database/repositories/transaction-repository.test.ts
@@ -1,12 +1,12 @@
-import { Contracts } from "@arkecosystem/core-kernel";
-import { Blocks, Crypto, Enums, Identities, Managers, Transactions, Utils } from "@arkecosystem/crypto";
+import { Contracts } from "@packages/core-kernel";
+import { Blocks, Crypto, Enums, Identities, Managers, Transactions, Utils } from "@packages/crypto";
 import { Connection } from "typeorm";
 import { getCustomRepository } from "typeorm";
 
 import { clearCoreDatabase, getCoreDatabaseConnection } from "../__support__";
-import { BlockRepository } from "../../../../packages/core-database/src/repositories/block-repository";
-import { TransactionRepository } from "../../../../packages/core-database/src/repositories/transaction-repository";
-import { BIP39 } from "../../../../packages/core-forger/src/methods/bip39";
+import { BlockRepository } from "@packages/core-database/src/repositories/block-repository";
+import { TransactionRepository } from "@packages/core-database/src/repositories/transaction-repository";
+import { BIP39 } from "@packages/core-forger/src/methods/bip39";
 
 let connection: Connection | undefined;
 

--- a/__tests__/functional/transaction-forging/__support__/index.ts
+++ b/__tests__/functional/transaction-forging/__support__/index.ts
@@ -1,7 +1,7 @@
 import "jest-extended";
 
-import { Container, Contracts } from "@arkecosystem/core-kernel";
-import { Managers } from "@arkecosystem/crypto";
+import { Container, Contracts } from "@packages/core-kernel";
+import { Managers } from "@packages/crypto";
 import delay from "delay";
 import { EventEmitter } from "events";
 
@@ -9,8 +9,8 @@ EventEmitter.prototype.constructor = Object.prototype.constructor;
 
 jest.setTimeout(1200000);
 
-import { StateBuilder } from "@arkecosystem/core-state/src/state-builder";
-import { Sandbox } from "@packages/core-test-framework/src";
+import { StateBuilder } from "@packages/core-state/src/state-builder";
+import { Sandbox } from "@packages/core-test-framework";
 
 const sandbox: Sandbox = new Sandbox();
 

--- a/__tests__/functional/transaction-forging/bridgechain-registration.test.ts
+++ b/__tests__/functional/transaction-forging/bridgechain-registration.test.ts
@@ -1,7 +1,7 @@
 import "@packages/core-test-framework/src/matchers";
 
-import { Contracts } from "@arkecosystem/core-kernel";
-import { Identities } from "@arkecosystem/crypto";
+import { Contracts } from "@packages/core-kernel";
+import { Identities } from "@packages/crypto";
 import secrets from "@packages/core-test-framework/src/internal/passphrases.json";
 import { snoozeForBlock, TransactionFactory } from "@packages/core-test-framework/src/utils";
 import { generateMnemonic } from "bip39";

--- a/__tests__/functional/transaction-forging/bridgechain-resignation.test.ts
+++ b/__tests__/functional/transaction-forging/bridgechain-resignation.test.ts
@@ -1,7 +1,7 @@
 import "@packages/core-test-framework/src/matchers";
 
-import { Contracts } from "@arkecosystem/core-kernel";
-import { Identities } from "@arkecosystem/crypto";
+import { Contracts } from "@packages/core-kernel";
+import { Identities } from "@packages/crypto";
 import secrets from "@packages/core-test-framework/src/internal/passphrases.json";
 import { snoozeForBlock, TransactionFactory } from "@packages/core-test-framework/src/utils";
 import { generateMnemonic } from "bip39";

--- a/__tests__/functional/transaction-forging/bridgechain-update.test.ts
+++ b/__tests__/functional/transaction-forging/bridgechain-update.test.ts
@@ -1,7 +1,7 @@
 import "@packages/core-test-framework/src/matchers";
 
-import { Contracts } from "@arkecosystem/core-kernel";
-import { Identities } from "@arkecosystem/crypto";
+import { Contracts } from "@packages/core-kernel";
+import { Identities } from "@packages/crypto";
 import secrets from "@packages/core-test-framework/src/internal/passphrases.json";
 import { snoozeForBlock, TransactionFactory } from "@packages/core-test-framework/src/utils";
 import { generateMnemonic } from "bip39";

--- a/__tests__/functional/transaction-forging/business-registration.test.ts
+++ b/__tests__/functional/transaction-forging/business-registration.test.ts
@@ -1,7 +1,7 @@
 import "@packages/core-test-framework/src/matchers";
 
-import { Contracts } from "@arkecosystem/core-kernel";
-import { Identities } from "@arkecosystem/crypto";
+import { Contracts } from "@packages/core-kernel";
+import { Identities } from "@packages/crypto";
 import secrets from "@packages/core-test-framework/src/internal/passphrases.json";
 import { snoozeForBlock, TransactionFactory } from "@packages/core-test-framework/src/utils";
 import { generateMnemonic } from "bip39";

--- a/__tests__/functional/transaction-forging/business-resignation.test.ts
+++ b/__tests__/functional/transaction-forging/business-resignation.test.ts
@@ -1,7 +1,7 @@
 import "@packages/core-test-framework/src/matchers";
 
-import { Contracts } from "@arkecosystem/core-kernel";
-import { Identities } from "@arkecosystem/crypto";
+import { Contracts } from "@packages/core-kernel";
+import { Identities } from "@packages/crypto";
 import secrets from "@packages/core-test-framework/src/internal/passphrases.json";
 import { snoozeForBlock, TransactionFactory } from "@packages/core-test-framework/src/utils";
 import { generateMnemonic } from "bip39";

--- a/__tests__/functional/transaction-forging/business-update.test.ts
+++ b/__tests__/functional/transaction-forging/business-update.test.ts
@@ -1,7 +1,7 @@
 import "@packages/core-test-framework/src/matchers";
 
-import { Contracts } from "@arkecosystem/core-kernel";
-import { Identities } from "@arkecosystem/crypto";
+import { Contracts } from "@packages/core-kernel";
+import { Identities } from "@packages/crypto";
 import secrets from "@packages/core-test-framework/src/internal/passphrases.json";
 import { snoozeForBlock, TransactionFactory } from "@packages/core-test-framework/src/utils";
 import { generateMnemonic } from "bip39";

--- a/__tests__/functional/transaction-forging/delegate-registration.test.ts
+++ b/__tests__/functional/transaction-forging/delegate-registration.test.ts
@@ -1,7 +1,7 @@
 import "@packages/core-test-framework/src/matchers";
 
-import { Contracts } from "@arkecosystem/core-kernel";
-import { Identities } from "@arkecosystem/crypto";
+import { Contracts } from "@packages/core-kernel";
+import { Identities } from "@packages/crypto";
 import secrets from "@packages/core-test-framework/src/internal/passphrases.json";
 import { snoozeForBlock, TransactionFactory } from "@packages/core-test-framework/src/utils";
 

--- a/__tests__/functional/transaction-forging/delegate-resignation.test.ts
+++ b/__tests__/functional/transaction-forging/delegate-resignation.test.ts
@@ -1,7 +1,7 @@
 import "@packages/core-test-framework/src/matchers";
 
-import { Container, Contracts } from "@arkecosystem/core-kernel";
-import { Identities } from "@arkecosystem/crypto";
+import { Container, Contracts } from "@packages/core-kernel";
+import { Identities } from "@packages/crypto";
 import secrets from "@packages/core-test-framework/src/internal/passphrases.json";
 import { snoozeForBlock, TransactionFactory } from "@packages/core-test-framework/src/utils";
 import { generateMnemonic } from "bip39";

--- a/__tests__/functional/transaction-forging/entity-register.test.ts
+++ b/__tests__/functional/transaction-forging/entity-register.test.ts
@@ -1,10 +1,10 @@
-import "@arkecosystem/core-test-framework/src/matchers";
+import "@packages/core-test-framework/src/matchers";
 
-import { Contracts } from "@arkecosystem/core-kernel";
-import { Enums } from "@arkecosystem/core-magistrate-crypto";
-import secrets from "@arkecosystem/core-test-framework/src/internal/passphrases.json";
-import { snoozeForBlock, TransactionFactory } from "@arkecosystem/core-test-framework/src/utils";
-import { Identities, Utils } from "@arkecosystem/crypto";
+import { Contracts } from "@packages/core-kernel";
+import { Enums } from "@packages/core-magistrate-crypto";
+import secrets from "@packages/core-test-framework/src/internal/passphrases.json";
+import { snoozeForBlock, TransactionFactory } from "@packages/core-test-framework/src/utils";
+import { Identities, Utils } from "@packages/crypto";
 import { generateMnemonic } from "bip39";
 
 import * as support from "./__support__";

--- a/__tests__/functional/transaction-forging/entity-resign.test.ts
+++ b/__tests__/functional/transaction-forging/entity-resign.test.ts
@@ -1,12 +1,12 @@
-import "@arkecosystem/core-test-framework/src/matchers";
+import "@packages/core-test-framework/src/matchers";
 
-import { Contracts } from "@arkecosystem/core-kernel";
-import secrets from "@arkecosystem/core-test-framework/src/internal/passphrases.json";
-import { snoozeForBlock, TransactionFactory } from "@arkecosystem/core-test-framework/src/utils";
+import { Contracts } from "@packages/core-kernel";
+import secrets from "@packages/core-test-framework/src/internal/passphrases.json";
+import { snoozeForBlock, TransactionFactory } from "@packages/core-test-framework/src/utils";
 
 import * as support from "./__support__";
-import { Enums } from "@arkecosystem/core-magistrate-crypto";
-import { Identities } from "@arkecosystem/crypto";
+import { Enums } from "@packages/core-magistrate-crypto";
+import { Identities } from "@packages/crypto";
 import { generateMnemonic } from "bip39";
 
 let app: Contracts.Kernel.Application;

--- a/__tests__/functional/transaction-forging/entity-update.test.ts
+++ b/__tests__/functional/transaction-forging/entity-update.test.ts
@@ -1,12 +1,12 @@
-import "@arkecosystem/core-test-framework/src/matchers";
+import "@packages/core-test-framework/src/matchers";
 
-import { Contracts } from "@arkecosystem/core-kernel";
-import secrets from "@arkecosystem/core-test-framework/src/internal/passphrases.json";
-import { snoozeForBlock, TransactionFactory } from "@arkecosystem/core-test-framework/src/utils";
+import { Contracts } from "@packages/core-kernel";
+import secrets from "@packages/core-test-framework/src/internal/passphrases.json";
+import { snoozeForBlock, TransactionFactory } from "@packages/core-test-framework/src/utils";
 
 import * as support from "./__support__";
-import { Enums } from "@arkecosystem/core-magistrate-crypto";
-import { Identities } from "@arkecosystem/crypto";
+import { Enums } from "@packages/core-magistrate-crypto";
+import { Identities } from "@packages/crypto";
 import { generateMnemonic } from "bip39";
 
 let app: Contracts.Kernel.Application;

--- a/__tests__/functional/transaction-forging/htlc-claim.test.ts
+++ b/__tests__/functional/transaction-forging/htlc-claim.test.ts
@@ -1,7 +1,7 @@
 import "@packages/core-test-framework/src/matchers";
 
-import { Contracts } from "@arkecosystem/core-kernel";
-import { Crypto, Enums, Identities } from "@arkecosystem/crypto";
+import { Contracts } from "@packages/core-kernel";
+import { Crypto, Enums, Identities } from "@packages/crypto";
 import secrets from "@packages/core-test-framework/src/internal/passphrases.json";
 import { snoozeForBlock, TransactionFactory } from "@packages/core-test-framework/src/utils";
 

--- a/__tests__/functional/transaction-forging/htlc-lock.test.ts
+++ b/__tests__/functional/transaction-forging/htlc-lock.test.ts
@@ -1,7 +1,7 @@
 import "@packages/core-test-framework/src/matchers";
 
-import { Contracts } from "@arkecosystem/core-kernel";
-import { Crypto, Enums, Identities, Utils } from "@arkecosystem/crypto";
+import { Contracts } from "@packages/core-kernel";
+import { Crypto, Enums, Identities, Utils } from "@packages/crypto";
 import secrets from "@packages/core-test-framework/src/internal/passphrases.json";
 import { ApiHelpers, snoozeForBlock, TransactionFactory } from "@packages/core-test-framework/src/utils";
 import got from "got";

--- a/__tests__/functional/transaction-forging/htlc-refund.test.ts
+++ b/__tests__/functional/transaction-forging/htlc-refund.test.ts
@@ -1,7 +1,7 @@
 import "@packages/core-test-framework/src/matchers";
 
-import { Contracts } from "@arkecosystem/core-kernel";
-import { Crypto, Enums, Identities } from "@arkecosystem/crypto";
+import { Contracts } from "@packages/core-kernel";
+import { Crypto, Enums, Identities } from "@packages/crypto";
 import secrets from "@packages/core-test-framework/src/internal/passphrases.json";
 import { snoozeForBlock, TransactionFactory } from "@packages/core-test-framework/src/utils";
 

--- a/__tests__/functional/transaction-forging/ipfs.test.ts
+++ b/__tests__/functional/transaction-forging/ipfs.test.ts
@@ -1,7 +1,7 @@
 import "@packages/core-test-framework/src/matchers";
 
-import { Contracts } from "@arkecosystem/core-kernel";
-import { Identities } from "@arkecosystem/crypto";
+import { Contracts } from "@packages/core-kernel";
+import { Identities } from "@packages/crypto";
 import secrets from "@packages/core-test-framework/src/internal/passphrases.json";
 import { snoozeForBlock, TransactionFactory } from "@packages/core-test-framework/src/utils";
 

--- a/__tests__/functional/transaction-forging/multi-payment.test.ts
+++ b/__tests__/functional/transaction-forging/multi-payment.test.ts
@@ -1,7 +1,7 @@
 import "@packages/core-test-framework/src/matchers";
 
-import { Contracts } from "@arkecosystem/core-kernel";
-import { Identities, Managers, Utils } from "@arkecosystem/crypto";
+import { Contracts } from "@packages/core-kernel";
+import { Identities, Managers, Utils } from "@packages/crypto";
 import secrets from "@packages/core-test-framework/src/internal/passphrases.json";
 import { snoozeForBlock, TransactionFactory } from "@packages/core-test-framework/src/utils";
 

--- a/__tests__/functional/transaction-forging/multi-signature-registration.test.ts
+++ b/__tests__/functional/transaction-forging/multi-signature-registration.test.ts
@@ -1,7 +1,7 @@
 import "@packages/core-test-framework/src/matchers";
 
-import { Container, Contracts, Services } from "@arkecosystem/core-kernel";
-import { Identities, Interfaces, Managers } from "@arkecosystem/crypto";
+import { Container, Contracts, Services } from "@packages/core-kernel";
+import { Identities, Interfaces, Managers } from "@packages/crypto";
 import secrets from "@packages/core-test-framework/src/internal/passphrases.json";
 import {
     getLastHeight,

--- a/__tests__/functional/transaction-forging/second-signature-registration.test.ts
+++ b/__tests__/functional/transaction-forging/second-signature-registration.test.ts
@@ -1,7 +1,7 @@
 import "@packages/core-test-framework/src/matchers";
 
-import { Contracts } from "@arkecosystem/core-kernel";
-import { Identities } from "@arkecosystem/crypto";
+import { Contracts } from "@packages/core-kernel";
+import { Identities } from "@packages/crypto";
 import secrets from "@packages/core-test-framework/src/internal/passphrases.json";
 import { snoozeForBlock, TransactionFactory } from "@packages/core-test-framework/src/utils";
 

--- a/__tests__/functional/transaction-forging/transfer.test.ts
+++ b/__tests__/functional/transaction-forging/transfer.test.ts
@@ -1,7 +1,7 @@
 import "@packages/core-test-framework/src/matchers";
 
-import { Container, Contracts, Services } from "@arkecosystem/core-kernel";
-import { Identities, Interfaces, Managers } from "@arkecosystem/crypto";
+import { Container, Contracts, Services } from "@packages/core-kernel";
+import { Identities, Interfaces, Managers } from "@packages/crypto";
 import secrets from "@packages/core-test-framework/src/internal/passphrases.json";
 import {
     getLastHeight,

--- a/__tests__/functional/transaction-forging/vote.test.ts
+++ b/__tests__/functional/transaction-forging/vote.test.ts
@@ -1,7 +1,7 @@
 import "@packages/core-test-framework/src/matchers";
 
-import { Contracts } from "@arkecosystem/core-kernel";
-import { Identities } from "@arkecosystem/crypto";
+import { Contracts } from "@packages/core-kernel";
+import { Identities } from "@packages/crypto";
 import secrets from "@packages/core-test-framework/src/internal/passphrases.json";
 import { snoozeForBlock, TransactionFactory } from "@packages/core-test-framework/src/utils";
 

--- a/__tests__/integration/core-api/__support__/setup.ts
+++ b/__tests__/integration/core-api/__support__/setup.ts
@@ -1,7 +1,7 @@
-import { Application, Container, Contracts, Utils as AppUtils } from "@arkecosystem/core-kernel";
-import { Managers, Utils } from "@arkecosystem/crypto";
-import { ServiceProvider } from "@packages/core-api/src";
-import { Sandbox } from "@packages/core-test-framework/src";
+import { Application, Container, Contracts, Utils as AppUtils } from "@packages/core-kernel";
+import { Managers, Utils } from "@packages/crypto";
+import { ServiceProvider } from "@packages/core-api";
+import { Sandbox } from "@packages/core-test-framework";
 import { EventEmitter } from "events";
 import { resolve } from "path";
 

--- a/__tests__/integration/core-api/api.test.ts
+++ b/__tests__/integration/core-api/api.test.ts
@@ -1,6 +1,6 @@
-import { Application } from "@arkecosystem/core-kernel";
-import { ApiInjectClient } from "@arkecosystem/core-test-framework";
-import { Utils } from "@arkecosystem/crypto";
+import { Application } from "@packages/core-kernel";
+import { ApiInjectClient } from "@packages/core-test-framework";
+import { Utils } from "@packages/crypto";
 
 import { setUp, tearDown } from "./__support__/setup";
 

--- a/__tests__/integration/core-api/controllers/delegates.test.ts
+++ b/__tests__/integration/core-api/controllers/delegates.test.ts
@@ -1,5 +1,5 @@
-import { Application } from "@arkecosystem/core-kernel";
-import { ApiInjectClient } from "@arkecosystem/core-test-framework";
+import { Application } from "@packages/core-kernel";
+import { ApiInjectClient } from "@packages/core-test-framework";
 
 import { setUp, tearDown } from "../__support__/setup";
 

--- a/__tests__/integration/core-api/controllers/locks.test.ts
+++ b/__tests__/integration/core-api/controllers/locks.test.ts
@@ -1,6 +1,6 @@
-import { Application, Container, Contracts } from "@arkecosystem/core-kernel";
-import { ApiInjectClient } from "@arkecosystem/core-test-framework";
-import { Enums, Identities, Managers, Utils } from "@arkecosystem/crypto";
+import { Application, Container, Contracts } from "@packages/core-kernel";
+import { ApiInjectClient } from "@packages/core-test-framework";
+import { Enums, Identities, Managers, Utils } from "@packages/crypto";
 
 import { setUp, tearDown } from "../__support__/setup";
 

--- a/__tests__/integration/core-api/controllers/wallets.test.ts
+++ b/__tests__/integration/core-api/controllers/wallets.test.ts
@@ -1,6 +1,6 @@
-import { Application } from "@arkecosystem/core-kernel";
-import { ApiInjectClient } from "@arkecosystem/core-test-framework";
-import { Utils } from "@arkecosystem/crypto";
+import { Application } from "@packages/core-kernel";
+import { ApiInjectClient } from "@packages/core-test-framework";
+import { Utils } from "@packages/crypto";
 
 import { setUp, tearDown } from "../__support__/setup";
 

--- a/__tests__/integration/core-api/handlers/blockchain.test.ts
+++ b/__tests__/integration/core-api/handlers/blockchain.test.ts
@@ -1,6 +1,6 @@
 import "@packages/core-test-framework/src/matchers";
 
-import { Contracts } from "@arkecosystem/core-kernel";
+import { Contracts } from "@packages/core-kernel";
 import { ApiHelpers } from "@packages/core-test-framework/src";
 
 import { setUp, tearDown } from "../__support__/setup";

--- a/__tests__/integration/core-api/handlers/blocks.test.ts
+++ b/__tests__/integration/core-api/handlers/blocks.test.ts
@@ -1,7 +1,7 @@
 import "@packages/core-test-framework/src/matchers";
 
-import { Contracts } from "@arkecosystem/core-kernel";
-import { Managers } from "@arkecosystem/crypto";
+import { Contracts } from "@packages/core-kernel";
+import { Managers } from "@packages/crypto";
 import { ApiHelpers } from "@packages/core-test-framework/src";
 
 import { setUp, tearDown } from "../__support__/setup";

--- a/__tests__/integration/core-api/handlers/delegates.test.ts
+++ b/__tests__/integration/core-api/handlers/delegates.test.ts
@@ -1,9 +1,9 @@
 import "@packages/core-test-framework/src/matchers";
 
-import { Repositories } from "@arkecosystem/core-database";
-import { Container, Contracts, Utils as AppUtils } from "@arkecosystem/core-kernel";
-import { Interfaces, Managers } from "@arkecosystem/crypto";
-import { ApiHelpers, Factories } from "@packages/core-test-framework/src";
+import { Repositories } from "@packages/core-database";
+import { Container, Contracts, Utils as AppUtils } from "@packages/core-kernel";
+import { Interfaces, Managers } from "@packages/crypto";
+import { ApiHelpers, Factories } from "@packages/core-test-framework";
 
 import { calculateRanks, setUp, tearDown } from "../__support__/setup";
 

--- a/__tests__/integration/core-api/handlers/locks.test.ts
+++ b/__tests__/integration/core-api/handlers/locks.test.ts
@@ -1,8 +1,8 @@
 import "@packages/core-test-framework/src/matchers";
 
-import { Repositories } from "@arkecosystem/core-database";
-import { Container, Contracts } from "@arkecosystem/core-kernel";
-import { Identities, Managers, Utils } from "@arkecosystem/crypto";
+import { Repositories } from "@packages/core-database";
+import { Container, Contracts } from "@packages/core-kernel";
+import { Identities, Managers, Utils } from "@packages/crypto";
 import { ApiHelpers, TransactionFactory } from "@packages/core-test-framework/src";
 
 import { setUp, tearDown } from "../__support__/setup";

--- a/__tests__/integration/core-api/handlers/node.test.ts
+++ b/__tests__/integration/core-api/handlers/node.test.ts
@@ -1,7 +1,7 @@
 import "@packages/core-test-framework/src/matchers";
 
-import { Contracts } from "@arkecosystem/core-kernel";
-import { Managers } from "@arkecosystem/crypto";
+import { Contracts } from "@packages/core-kernel";
+import { Managers } from "@packages/crypto";
 import { ApiHelpers } from "@packages/core-test-framework/src";
 
 import { setUp, tearDown } from "../__support__/setup";

--- a/__tests__/integration/core-api/handlers/peers.test.ts
+++ b/__tests__/integration/core-api/handlers/peers.test.ts
@@ -1,7 +1,7 @@
 import "@packages/core-test-framework/src/matchers";
 
-import { Container, Contracts } from "@arkecosystem/core-kernel";
-import { Peer } from "@arkecosystem/core-p2p/src/peer";
+import { Container, Contracts } from "@packages/core-kernel";
+import { Peer } from "@packages/core-p2p/src/peer";
 import { ApiHelpers } from "@packages/core-test-framework/src";
 
 import { setUp, tearDown } from "../__support__/setup";

--- a/__tests__/integration/core-api/handlers/rounds.test.ts
+++ b/__tests__/integration/core-api/handlers/rounds.test.ts
@@ -1,6 +1,6 @@
 import "@packages/core-test-framework/src/matchers";
 
-import { Contracts } from "@arkecosystem/core-kernel";
+import { Contracts } from "@packages/core-kernel";
 import { ApiHelpers } from "@packages/core-test-framework/src";
 
 import { calculateRanks, setUp, tearDown } from "../__support__/setup";

--- a/__tests__/integration/core-api/handlers/transactions.test.ts
+++ b/__tests__/integration/core-api/handlers/transactions.test.ts
@@ -1,7 +1,7 @@
 import "@packages/core-test-framework/src/matchers";
 
-import { Contracts } from "@arkecosystem/core-kernel";
-import { Identities, Managers } from "@arkecosystem/crypto";
+import { Contracts } from "@packages/core-kernel";
+import { Identities, Managers } from "@packages/crypto";
 import { ApiHelpers, getWalletNonce } from "@packages/core-test-framework/src";
 import secrets from "@packages/core-test-framework/src/internal/passphrases.json";
 import { TransactionFactory } from "@packages/core-test-framework/src/utils/transaction-factory";

--- a/__tests__/integration/core-api/handlers/votes.test.ts
+++ b/__tests__/integration/core-api/handlers/votes.test.ts
@@ -1,6 +1,6 @@
 import "@packages/core-test-framework/src/matchers";
 
-import { Contracts } from "@arkecosystem/core-kernel";
+import { Contracts } from "@packages/core-kernel";
 import { ApiHelpers } from "@packages/core-test-framework/src";
 
 import { setUp, tearDown } from "../__support__/setup";

--- a/__tests__/integration/core-api/handlers/wallets.test.ts
+++ b/__tests__/integration/core-api/handlers/wallets.test.ts
@@ -1,7 +1,7 @@
 import "@packages/core-test-framework/src/matchers";
 
-import { Contracts } from "@arkecosystem/core-kernel";
-import { Identities } from "@arkecosystem/crypto";
+import { Contracts } from "@packages/core-kernel";
+import { Identities } from "@packages/crypto";
 import { ApiHelpers } from "@packages/core-test-framework/src";
 
 import { setUp, tearDown } from "../__support__/setup";

--- a/__tests__/integration/core-api/services/__support__/setup.ts
+++ b/__tests__/integration/core-api/services/__support__/setup.ts
@@ -1,7 +1,7 @@
-import { ServiceProvider as ApiServiceProvider } from "@arkecosystem/core-api/src";
-import { Application, Container, Providers, Services } from "@arkecosystem/core-kernel";
-import { ServiceProvider as StateServiceProvider } from "@arkecosystem/core-state";
-import { ServiceProvider as TransactionsServiceProvider } from "@arkecosystem/core-transactions";
+import { ServiceProvider as ApiServiceProvider } from "@packages/core-api/src";
+import { Application, Container, Providers, Services } from "@packages/core-kernel";
+import { ServiceProvider as StateServiceProvider } from "@packages/core-state";
+import { ServiceProvider as TransactionsServiceProvider } from "@packages/core-transactions";
 
 export const setUp = async (): Promise<Application> => {
     const app = new Application(new Container.Container());

--- a/__tests__/integration/core-api/services/delegate-search-service.test.ts
+++ b/__tests__/integration/core-api/services/delegate-search-service.test.ts
@@ -1,6 +1,6 @@
-import { DelegateSearchService, Identifiers as ApiIdentifiers } from "@arkecosystem/core-api/src";
-import { Container, Contracts } from "@arkecosystem/core-kernel";
-import { Identities, Utils } from "@arkecosystem/crypto";
+import { DelegateSearchService, Identifiers as ApiIdentifiers } from "@packages/core-api/src";
+import { Container, Contracts } from "@packages/core-kernel";
+import { Identities, Utils } from "@packages/crypto";
 
 import { setUp } from "./__support__/setup";
 

--- a/__tests__/integration/core-api/services/lock-search-service.test.ts
+++ b/__tests__/integration/core-api/services/lock-search-service.test.ts
@@ -1,6 +1,6 @@
-import { Identifiers as ApiIdentifiers, LockSearchService } from "@arkecosystem/core-api/src";
-import { Container, Contracts } from "@arkecosystem/core-kernel";
-import { Enums, Identities, Utils } from "@arkecosystem/crypto";
+import { Identifiers as ApiIdentifiers, LockSearchService } from "@packages/core-api/src";
+import { Container, Contracts } from "@packages/core-kernel";
+import { Enums, Identities, Utils } from "@packages/crypto";
 
 import { setUp } from "./__support__/setup";
 

--- a/__tests__/integration/core-api/services/wallet-search-service.test.ts
+++ b/__tests__/integration/core-api/services/wallet-search-service.test.ts
@@ -1,6 +1,6 @@
-import { Identifiers as ApiIdentifiers, WalletSearchService } from "@arkecosystem/core-api/src";
-import { Container, Contracts } from "@arkecosystem/core-kernel";
-import { Identities, Utils } from "@arkecosystem/crypto";
+import { Identifiers as ApiIdentifiers, WalletSearchService } from "@packages/core-api";
+import { Container, Contracts } from "@packages/core-kernel";
+import { Identities, Utils } from "@packages/crypto";
 
 import { setUp } from "./__support__/setup";
 

--- a/__tests__/integration/core-magistrate-api/__support__/set-indexes.ts
+++ b/__tests__/integration/core-magistrate-api/__support__/set-indexes.ts
@@ -1,4 +1,4 @@
-import { Contracts } from "@arkecosystem/core-kernel";
+import { Contracts } from "@packages/core-kernel";
 import { Interfaces as MagistrateInterfaces } from "@packages/core-magistrate-crypto";
 
 export const setIndexes = (

--- a/__tests__/integration/core-magistrate-api/__support__/setup.ts
+++ b/__tests__/integration/core-magistrate-api/__support__/setup.ts
@@ -1,5 +1,5 @@
-import { Application, Utils as AppUtils } from "@arkecosystem/core-kernel";
-import { Managers } from "@arkecosystem/crypto";
+import { Application, Utils as AppUtils } from "@packages/core-kernel";
+import { Managers } from "@packages/crypto";
 import { ServiceProvider } from "@packages/core-magistrate-api/src";
 import { Sandbox } from "@packages/core-test-framework/src";
 import { EventEmitter } from "events";

--- a/__tests__/integration/core-magistrate-api/controllers/entities.test.ts
+++ b/__tests__/integration/core-magistrate-api/controllers/entities.test.ts
@@ -1,7 +1,7 @@
-import { Application, Container, Contracts } from "@arkecosystem/core-kernel";
-import { Enums } from "@arkecosystem/core-magistrate-crypto";
-import { ApiInjectClient } from "@arkecosystem/core-test-framework";
-import { Managers } from "@arkecosystem/crypto";
+import { Application, Container, Contracts } from "@packages/core-kernel";
+import { Enums } from "@packages/core-magistrate-crypto";
+import { ApiInjectClient } from "@packages/core-test-framework";
+import { Managers } from "@packages/crypto";
 
 import { setUp, tearDown } from "../__support__/setup";
 import { setIndexes } from "../__support__/set-indexes";

--- a/__tests__/integration/core-magistrate-api/services/__support__/setup.ts
+++ b/__tests__/integration/core-magistrate-api/services/__support__/setup.ts
@@ -1,9 +1,9 @@
-import { ServiceProvider as ApiServiceProvider } from "@arkecosystem/core-api";
-import { ServiceProvider as MagistrateApiServiceProvider } from "@arkecosystem/core-magistrate-api/src";
-import { Application, Container, Providers, Services } from "@arkecosystem/core-kernel";
-import { ServiceProvider as StateServiceProvider } from "@arkecosystem/core-state";
-import { ServiceProvider as TransactionsServiceProvider } from "@arkecosystem/core-transactions";
-import { ServiceProvider as MagistrateTransactionsServiceProvider } from "@arkecosystem/core-magistrate-transactions";
+import { ServiceProvider as ApiServiceProvider } from "@packages/core-api";
+import { ServiceProvider as MagistrateApiServiceProvider } from "@packages/core-magistrate-api";
+import { Application, Container, Providers, Services } from "@packages/core-kernel";
+import { ServiceProvider as StateServiceProvider } from "@packages/core-state";
+import { ServiceProvider as TransactionsServiceProvider } from "@packages/core-transactions";
+import { ServiceProvider as MagistrateTransactionsServiceProvider } from "@packages/core-magistrate-transactions";
 
 export const setUp = async (): Promise<Application> => {
     const app = new Application(new Container.Container());

--- a/__tests__/integration/core-magistrate-api/services/entity-search-service.test.ts
+++ b/__tests__/integration/core-magistrate-api/services/entity-search-service.test.ts
@@ -1,10 +1,10 @@
-import { EntitySearchService, Identifiers as MagistrateApiIdentifiers } from "@arkecosystem/core-magistrate-api/src";
-import { Container, Contracts } from "@arkecosystem/core-kernel";
+import { EntitySearchService, Identifiers as MagistrateApiIdentifiers } from "@packages/core-magistrate-api";
+import { Container, Contracts } from "@packages/core-kernel";
 
 import { setUp } from "./__support__/setup";
 import { setIndexes } from "../__support__/set-indexes";
-import { Enums } from "@arkecosystem/core-magistrate-crypto";
-import { Identities } from "@arkecosystem/crypto";
+import { Enums } from "@packages/core-magistrate-crypto";
+import { Identities } from "@packages/crypto";
 
 const entityId1 = "2a2498072a798318f5e321b312dfc7dcb87f33e10a251baf07ed8f950bd499ec";
 const entityAttribute1 = {

--- a/__tests__/integration/core-state/__support__/setup.ts
+++ b/__tests__/integration/core-state/__support__/setup.ts
@@ -1,6 +1,6 @@
-import { Application, Container, Utils as AppUtils } from "@arkecosystem/core-kernel";
-import { Sandbox } from "@arkecosystem/core-test-framework";
-import { Managers } from "@arkecosystem/crypto";
+import { Application, Container, Utils as AppUtils } from "@packages/core-kernel";
+import { Sandbox } from "@packages/core-test-framework";
+import { Managers } from "@packages/crypto";
 import { EventEmitter } from "events";
 
 EventEmitter.prototype.constructor = Object.prototype.constructor;

--- a/__tests__/integration/core-state/__support__/utils.ts
+++ b/__tests__/integration/core-state/__support__/utils.ts
@@ -1,5 +1,5 @@
-import { Contracts, Utils as AppUtils } from "@arkecosystem/core-kernel";
-import { Utils } from "@arkecosystem/crypto";
+import { Contracts, Utils as AppUtils } from "@packages/core-kernel";
+import { Utils } from "@packages/crypto";
 
 export const getExpectedVoteBalances = (
     walletRepository: Contracts.State.WalletRepository,

--- a/__tests__/integration/core-state/block-state/lock-then-claim.test.ts
+++ b/__tests__/integration/core-state/block-state/lock-then-claim.test.ts
@@ -1,9 +1,9 @@
 import { createHash } from "crypto";
-import { Application, Container, Contracts } from "@arkecosystem/core-kernel";
-import { Utils, Transactions, Identities, Enums } from "@arkecosystem/crypto";
-import { Repositories } from "@arkecosystem/core-database";
-import { delegates } from "@arkecosystem/core-test-framework";
-import { BIP39 } from "../../../../packages/core-forger/src/methods/bip39";
+import { Application, Container, Contracts } from "@packages/core-kernel";
+import { Utils, Transactions, Identities, Enums } from "@packages/crypto";
+import { Repositories } from "@packages/core-database";
+import { delegates } from "@packages/core-test-framework";
+import { BIP39 } from "@packages/core-forger/src/methods/bip39";
 
 import { setUp, tearDown } from "../__support__/setup";
 import { getActualVoteBalances, getExpectedVoteBalances } from "../__support__/utils";

--- a/__tests__/integration/core-state/block-state/lock-then-refund.test.ts
+++ b/__tests__/integration/core-state/block-state/lock-then-refund.test.ts
@@ -1,9 +1,9 @@
 import { createHash } from "crypto";
-import { Application, Container, Contracts } from "@arkecosystem/core-kernel";
-import { Utils, Transactions, Identities, Enums } from "@arkecosystem/crypto";
-import { Repositories } from "@arkecosystem/core-database";
-import { delegates } from "@arkecosystem/core-test-framework";
-import { BIP39 } from "../../../../packages/core-forger/src/methods/bip39";
+import { Application, Container, Contracts } from "@packages/core-kernel";
+import { Utils, Transactions, Identities, Enums } from "@packages/crypto";
+import { Repositories } from "@packages/core-database";
+import { delegates } from "@packages/core-test-framework";
+import { BIP39 } from "@packages/core-forger/src/methods/bip39";
 
 import { setUp, tearDown } from "../__support__/setup";
 import { getActualVoteBalances, getExpectedVoteBalances } from "../__support__/utils";

--- a/__tests__/integration/core-state/block-state/multi-payment.test.ts
+++ b/__tests__/integration/core-state/block-state/multi-payment.test.ts
@@ -1,7 +1,7 @@
-import { Application, Container, Contracts } from "@arkecosystem/core-kernel";
-import { Utils, Transactions, Identities } from "@arkecosystem/crypto";
-import { delegates } from "@arkecosystem/core-test-framework";
-import { BIP39 } from "../../../../packages/core-forger/src/methods/bip39";
+import { Application, Container, Contracts } from "@packages/core-kernel";
+import { Utils, Transactions, Identities } from "@packages/crypto";
+import { delegates } from "@packages/core-test-framework";
+import { BIP39 } from "@packages/core-forger/src/methods/bip39";
 
 import { setUp, tearDown } from "../__support__/setup";
 import { getActualVoteBalances, getExpectedVoteBalances } from "../__support__/utils";

--- a/__tests__/integration/core-state/block-state/transfer.test.ts
+++ b/__tests__/integration/core-state/block-state/transfer.test.ts
@@ -1,7 +1,7 @@
-import { Application, Container, Contracts } from "@arkecosystem/core-kernel";
-import { Utils, Transactions, Identities } from "@arkecosystem/crypto";
-import { delegates } from "@arkecosystem/core-test-framework";
-import { BIP39 } from "../../../../packages/core-forger/src/methods/bip39";
+import { Application, Container, Contracts } from "@packages/core-kernel";
+import { Utils, Transactions, Identities } from "@packages/crypto";
+import { delegates } from "@packages/core-test-framework";
+import { BIP39 } from "@packages/core-forger/src/methods/bip39";
 
 import { setUp, tearDown } from "../__support__/setup";
 import { getActualVoteBalances, getExpectedVoteBalances } from "../__support__/utils";

--- a/__tests__/integration/core-state/block-state/unvote-by-forger-then-vote-by-forger.test.ts
+++ b/__tests__/integration/core-state/block-state/unvote-by-forger-then-vote-by-forger.test.ts
@@ -1,7 +1,7 @@
-import { Application, Container, Contracts } from "@arkecosystem/core-kernel";
-import { Utils, Transactions } from "@arkecosystem/crypto";
-import { delegates } from "@arkecosystem/core-test-framework";
-import { BIP39 } from "../../../../packages/core-forger/src/methods/bip39";
+import { Application, Container, Contracts } from "@packages/core-kernel";
+import { Utils, Transactions } from "@packages/crypto";
+import { delegates } from "@packages/core-test-framework";
+import { BIP39 } from "@packages/core-forger/src/methods/bip39";
 
 import { setUp, tearDown } from "../__support__/setup";
 import { getActualVoteBalances, getExpectedVoteBalances } from "../__support__/utils";

--- a/__tests__/integration/core-state/block-state/unvote-by-forger-vote-by-forger-twice.test.ts
+++ b/__tests__/integration/core-state/block-state/unvote-by-forger-vote-by-forger-twice.test.ts
@@ -1,7 +1,7 @@
-import { Application, Container, Contracts } from "@arkecosystem/core-kernel";
-import { Utils, Transactions } from "@arkecosystem/crypto";
-import { delegates } from "@arkecosystem/core-test-framework";
-import { BIP39 } from "../../../../packages/core-forger/src/methods/bip39";
+import { Application, Container, Contracts } from "@packages/core-kernel";
+import { Utils, Transactions } from "@packages/crypto";
+import { delegates } from "@packages/core-test-framework";
+import { BIP39 } from "@packages/core-forger/src/methods/bip39";
 
 import { setUp, tearDown } from "../__support__/setup";
 import { getActualVoteBalances, getExpectedVoteBalances } from "../__support__/utils";

--- a/__tests__/integration/core-state/block-state/unvote-then-vote-unvote.test.ts
+++ b/__tests__/integration/core-state/block-state/unvote-then-vote-unvote.test.ts
@@ -1,7 +1,7 @@
-import { Application, Container, Contracts } from "@arkecosystem/core-kernel";
-import { Utils, Transactions } from "@arkecosystem/crypto";
-import { delegates } from "@arkecosystem/core-test-framework";
-import { BIP39 } from "../../../../packages/core-forger/src/methods/bip39";
+import { Application, Container, Contracts } from "@packages/core-kernel";
+import { Utils, Transactions } from "@packages/crypto";
+import { delegates } from "@packages/core-test-framework";
+import { BIP39 } from "@packages/core-forger/src/methods/bip39";
 
 import { setUp, tearDown } from "../__support__/setup";
 import { getActualVoteBalances, getExpectedVoteBalances } from "../__support__/utils";

--- a/__tests__/integration/core-state/block-state/unvote-then-vote.test.ts
+++ b/__tests__/integration/core-state/block-state/unvote-then-vote.test.ts
@@ -1,7 +1,7 @@
-import { Application, Container, Contracts } from "@arkecosystem/core-kernel";
-import { Utils, Transactions } from "@arkecosystem/crypto";
-import { delegates } from "@arkecosystem/core-test-framework";
-import { BIP39 } from "../../../../packages/core-forger/src/methods/bip39";
+import { Application, Container, Contracts } from "@packages/core-kernel";
+import { Utils, Transactions } from "@packages/crypto";
+import { delegates } from "@packages/core-test-framework";
+import { BIP39 } from "@packages/core-forger/src/methods/bip39";
 
 import { setUp, tearDown } from "../__support__/setup";
 import { getActualVoteBalances, getExpectedVoteBalances } from "../__support__/utils";

--- a/__tests__/integration/core-state/block-state/unvote-vote-by-forger.test.ts
+++ b/__tests__/integration/core-state/block-state/unvote-vote-by-forger.test.ts
@@ -1,7 +1,7 @@
-import { Application, Container, Contracts } from "@arkecosystem/core-kernel";
-import { Utils, Transactions } from "@arkecosystem/crypto";
-import { delegates } from "@arkecosystem/core-test-framework";
-import { BIP39 } from "../../../../packages/core-forger/src/methods/bip39";
+import { Application, Container, Contracts } from "@packages/core-kernel";
+import { Utils, Transactions } from "@packages/crypto";
+import { delegates } from "@packages/core-test-framework";
+import { BIP39 } from "@packages/core-forger/src/methods/bip39";
 
 import { setUp, tearDown } from "../__support__/setup";
 import { getActualVoteBalances, getExpectedVoteBalances } from "../__support__/utils";

--- a/__tests__/integration/core-state/block-state/unvote-vote.test.ts
+++ b/__tests__/integration/core-state/block-state/unvote-vote.test.ts
@@ -1,7 +1,7 @@
-import { Application, Container, Contracts } from "@arkecosystem/core-kernel";
-import { Utils, Transactions } from "@arkecosystem/crypto";
-import { delegates } from "@arkecosystem/core-test-framework";
-import { BIP39 } from "../../../../packages/core-forger/src/methods/bip39";
+import { Application, Container, Contracts } from "@packages/core-kernel";
+import { Utils, Transactions } from "@packages/crypto";
+import { delegates } from "@packages/core-test-framework";
+import { BIP39 } from "@packages/core-forger/src/methods/bip39";
 
 import { setUp, tearDown } from "../__support__/setup";
 import { getActualVoteBalances, getExpectedVoteBalances } from "../__support__/utils";

--- a/__tests__/integration/core-test-framework/utils/__support__/echo-controller.ts
+++ b/__tests__/integration/core-test-framework/utils/__support__/echo-controller.ts
@@ -1,5 +1,5 @@
 import Hapi from "@hapi/hapi";
-import { Container } from "@arkecosystem/core-kernel";
+import { Container } from "@packages/core-kernel";
 
 @Container.injectable()
 export class EchoController {

--- a/__tests__/integration/core-test-framework/utils/__support__/setup.ts
+++ b/__tests__/integration/core-test-framework/utils/__support__/setup.ts
@@ -1,8 +1,8 @@
-import { Identifiers as ApiIdentifiers, Server } from "@arkecosystem/core-api";
-import { Application, Utils as AppUtils } from "@arkecosystem/core-kernel";
-import { Managers } from "@arkecosystem/crypto";
+import { Identifiers as ApiIdentifiers, Server } from "@packages/core-api";
+import { Application, Utils as AppUtils } from "@packages/core-kernel";
+import { Managers } from "@packages/crypto";
 import Hapi from "@hapi/hapi";
-import { Sandbox } from "@packages/core-test-framework/src";
+import { Sandbox } from "@packages/core-test-framework";
 import { EventEmitter } from "events";
 
 import { EchoController } from "./echo-controller";

--- a/__tests__/integration/core-test-framework/utils/api-http-client.test.ts
+++ b/__tests__/integration/core-test-framework/utils/api-http-client.test.ts
@@ -1,5 +1,5 @@
-import { Application } from "@arkecosystem/core-kernel";
-import { ApiHttpClient } from "@arkecosystem/core-test-framework/src/utils";
+import { Application } from "@packages/core-kernel";
+import { ApiHttpClient } from "@packages/core-test-framework/src/utils";
 
 import { setUp, tearDown } from "./__support__/setup";
 

--- a/__tests__/integration/core-test-framework/utils/api-inject-client.test.ts
+++ b/__tests__/integration/core-test-framework/utils/api-inject-client.test.ts
@@ -1,5 +1,5 @@
-import { Application } from "@arkecosystem/core-kernel";
-import { ApiInjectClient } from "@arkecosystem/core-test-framework/src/utils";
+import { Application } from "@packages/core-kernel";
+import { ApiInjectClient } from "@packages/core-test-framework/src/utils";
 
 import { setUp, tearDown } from "./__support__/setup";
 

--- a/packages/core-api/__tests__/controllers/blocks.test.ts
+++ b/packages/core-api/__tests__/controllers/blocks.test.ts
@@ -1,6 +1,6 @@
 import "jest-extended";
 
-import { Contracts } from "@arkecosystem/core-kernel";
+import { Contracts } from "@packages/core-kernel";
 import Hapi from "@hapi/hapi";
 import { BlocksController } from "@packages/core-api/src/controllers/blocks";
 import { Block } from "@packages/core-database/src/models";

--- a/packages/core-api/__tests__/controllers/delegates.test.ts
+++ b/packages/core-api/__tests__/controllers/delegates.test.ts
@@ -1,8 +1,8 @@
-import { DelegateSearchService, Resources, WalletSearchService } from "@arkecosystem/core-api";
-import { DelegatesController } from "@arkecosystem/core-api/src/controllers/delegates";
-import { Identifiers } from "@arkecosystem/core-api/src/identifiers";
-import { Application, Container, Contracts, Providers } from "@arkecosystem/core-kernel";
-import { Enums, Utils } from "@arkecosystem/crypto";
+import { DelegateSearchService, Resources, WalletSearchService } from "@packages/core-api";
+import { DelegatesController } from "@packages/core-api/src/controllers/delegates";
+import { Identifiers } from "@packages/core-api/src/identifiers";
+import { Application, Container, Contracts, Providers } from "@packages/core-kernel";
+import { Enums, Utils } from "@packages/crypto";
 import { Boom } from "@hapi/boom";
 
 const jestfn = <T extends (...args: unknown[]) => unknown>(

--- a/packages/core-api/__tests__/controllers/locks.test.ts
+++ b/packages/core-api/__tests__/controllers/locks.test.ts
@@ -1,8 +1,8 @@
-import { LockSearchService, Resources } from "@arkecosystem/core-api";
-import { LocksController } from "@arkecosystem/core-api/src/controllers/locks";
-import { Identifiers } from "@arkecosystem/core-api/src/identifiers";
-import { Application, Container, Contracts, Providers } from "@arkecosystem/core-kernel";
-import { Enums, Utils } from "@arkecosystem/crypto";
+import { LockSearchService, Resources } from "@packages/core-api";
+import { LocksController } from "@packages/core-api/src/controllers/locks";
+import { Identifiers } from "@packages/core-api/src/identifiers";
+import { Application, Container, Contracts, Providers } from "@packages/core-kernel";
+import { Enums, Utils } from "@packages/crypto";
 import { Boom } from "@hapi/boom";
 
 const jestfn = <T extends (...args: unknown[]) => unknown>(

--- a/packages/core-api/__tests__/controllers/wallets.test.ts
+++ b/packages/core-api/__tests__/controllers/wallets.test.ts
@@ -1,8 +1,8 @@
-import { LockSearchService, Resources, WalletSearchService } from "@arkecosystem/core-api";
-import { WalletsController } from "@arkecosystem/core-api/src/controllers/wallets";
-import { Identifiers } from "@arkecosystem/core-api/src/identifiers";
-import { Application, Container, Contracts, Providers, Services } from "@arkecosystem/core-kernel";
-import { Enums, Utils } from "@arkecosystem/crypto";
+import { LockSearchService, Resources, WalletSearchService } from "@packages/core-api";
+import { WalletsController } from "@packages/core-api/src/controllers/wallets";
+import { Identifiers } from "@packages/core-api/src/identifiers";
+import { Application, Container, Contracts, Providers, Services } from "@packages/core-kernel";
+import { Enums, Utils } from "@packages/crypto";
 import { Boom } from "@hapi/boom";
 
 const jestfn = <T extends (...args: unknown[]) => unknown>(

--- a/packages/core-api/__tests__/resources-new/wallet.test.ts
+++ b/packages/core-api/__tests__/resources-new/wallet.test.ts
@@ -1,6 +1,6 @@
-import { Utils } from "@arkecosystem/crypto";
+import { Utils } from "@packages/crypto";
 
-import { walletCriteriaSchemaObject } from "../../../../packages/core-api/src/resources-new/wallet";
+import { walletCriteriaSchemaObject } from "@packages/core-api/src/resources-new/wallet";
 
 describe("walletCriteriaSchemaObject.address", () => {
     it("should allow correct address", () => {

--- a/packages/core-api/__tests__/resources/block-with-transactions.test.ts
+++ b/packages/core-api/__tests__/resources/block-with-transactions.test.ts
@@ -1,8 +1,8 @@
 import "jest-extended";
 
-import { Container, Contracts, Utils } from "@arkecosystem/core-kernel";
-import { Sandbox } from "@arkecosystem/core-test-framework";
-import { Interfaces } from "@arkecosystem/crypto";
+import { Container, Contracts, Utils } from "@packages/core-kernel";
+import { Sandbox } from "@packages/core-test-framework";
+import { Interfaces } from "@packages/crypto";
 import { BlockWithTransactionsResource } from "@packages/core-api/src/resources";
 import { cloneDeep } from "lodash";
 

--- a/packages/core-api/__tests__/resources/block.test.ts
+++ b/packages/core-api/__tests__/resources/block.test.ts
@@ -1,7 +1,7 @@
 import "jest-extended";
 
-import { Utils } from "@arkecosystem/core-kernel";
-import { Interfaces } from "@arkecosystem/crypto";
+import { Utils } from "@packages/core-kernel";
+import { Interfaces } from "@packages/crypto";
 import { BlockResource } from "@packages/core-api/src/resources";
 
 let resource: BlockResource;

--- a/packages/core-api/__tests__/resources/ports.test.ts
+++ b/packages/core-api/__tests__/resources/ports.test.ts
@@ -1,6 +1,6 @@
 import "jest-extended";
 
-import { Transactions } from "@arkecosystem/crypto";
+import { Transactions } from "@packages/crypto";
 import { ServiceProvider as CoreApiServiceProvider } from "@packages/core-api/src";
 import { defaults } from "@packages/core-api/src/defaults";
 import { PortsResource } from "@packages/core-api/src/resources";

--- a/packages/core-api/__tests__/resources/round.test.ts
+++ b/packages/core-api/__tests__/resources/round.test.ts
@@ -1,6 +1,6 @@
 import "jest-extended";
 
-import { Utils } from "@arkecosystem/core-kernel";
+import { Utils } from "@packages/core-kernel";
 import { RoundResource } from "@packages/core-api/src/resources";
 
 let resource: RoundResource;

--- a/packages/core-api/__tests__/resources/transaction-with-blocks.test.ts
+++ b/packages/core-api/__tests__/resources/transaction-with-blocks.test.ts
@@ -1,7 +1,7 @@
 import "jest-extended";
 
-import { Container } from "@arkecosystem/core-kernel";
-import { Sandbox } from "@arkecosystem/core-test-framework";
+import { Container } from "@packages/core-kernel";
+import { Sandbox } from "@packages/core-test-framework";
 import { TransactionWithBlockResource } from "@packages/core-api/src/resources";
 import { Interfaces, Utils } from "@packages/crypto";
 import { cloneDeep } from "lodash";

--- a/packages/core-api/__tests__/routes/blockchain.test.ts
+++ b/packages/core-api/__tests__/routes/blockchain.test.ts
@@ -1,4 +1,4 @@
-import { Container } from "@arkecosystem/core-kernel";
+import { Container } from "@packages/core-kernel";
 import { BlockchainController } from "@packages/core-api/src/controllers/blockchain";
 import { register } from "@packages/core-api/src/routes/blockchain";
 import { Server } from "@packages/core-api/src/server";

--- a/packages/core-api/__tests__/routes/blocks.test.ts
+++ b/packages/core-api/__tests__/routes/blocks.test.ts
@@ -1,4 +1,4 @@
-import { Container } from "@arkecosystem/core-kernel";
+import { Container } from "@packages/core-kernel";
 import { BlocksController } from "@packages/core-api/src/controllers/blocks";
 import { register } from "@packages/core-api/src/routes/blocks";
 import { Server } from "@packages/core-api/src/server";

--- a/packages/core-api/__tests__/routes/delegates.test.ts
+++ b/packages/core-api/__tests__/routes/delegates.test.ts
@@ -1,4 +1,4 @@
-import { Container } from "@arkecosystem/core-kernel";
+import { Container } from "@packages/core-kernel";
 import { DelegatesController } from "@packages/core-api/src/controllers/delegates";
 import { register } from "@packages/core-api/src/routes/delegates";
 import { Server } from "@packages/core-api/src/server";

--- a/packages/core-api/__tests__/routes/locks.test.ts
+++ b/packages/core-api/__tests__/routes/locks.test.ts
@@ -1,4 +1,4 @@
-import { Container } from "@arkecosystem/core-kernel";
+import { Container } from "@packages/core-kernel";
 import { LocksController } from "@packages/core-api/src/controllers/locks";
 import { register } from "@packages/core-api/src/routes/locks";
 import { Server } from "@packages/core-api/src/server";

--- a/packages/core-api/__tests__/routes/node.test.ts
+++ b/packages/core-api/__tests__/routes/node.test.ts
@@ -1,4 +1,4 @@
-import { Container } from "@arkecosystem/core-kernel";
+import { Container } from "@packages/core-kernel";
 import { NodeController } from "@packages/core-api/src/controllers/node";
 import { register } from "@packages/core-api/src/routes/node";
 import { Server } from "@packages/core-api/src/server";

--- a/packages/core-api/__tests__/routes/peers.test.ts
+++ b/packages/core-api/__tests__/routes/peers.test.ts
@@ -1,4 +1,4 @@
-import { Container } from "@arkecosystem/core-kernel";
+import { Container } from "@packages/core-kernel";
 import { PeersController } from "@packages/core-api/src/controllers/peers";
 import { register } from "@packages/core-api/src/routes/peers";
 import { Server } from "@packages/core-api/src/server";

--- a/packages/core-api/__tests__/routes/rounds.test.ts
+++ b/packages/core-api/__tests__/routes/rounds.test.ts
@@ -1,4 +1,4 @@
-import { Container } from "@arkecosystem/core-kernel";
+import { Container } from "@packages/core-kernel";
 import { RoundsController } from "@packages/core-api/src/controllers/rounds";
 import { register } from "@packages/core-api/src/routes/rounds";
 import { Server } from "@packages/core-api/src/server";

--- a/packages/core-api/__tests__/routes/transactions.test.ts
+++ b/packages/core-api/__tests__/routes/transactions.test.ts
@@ -1,4 +1,4 @@
-import { Container } from "@arkecosystem/core-kernel";
+import { Container } from "@packages/core-kernel";
 import { TransactionsController } from "@packages/core-api/src/controllers/transactions";
 import { register } from "@packages/core-api/src/routes/transactions";
 import { Server } from "@packages/core-api/src/server";

--- a/packages/core-api/__tests__/routes/votes.test.ts
+++ b/packages/core-api/__tests__/routes/votes.test.ts
@@ -1,4 +1,4 @@
-import { Container } from "@arkecosystem/core-kernel";
+import { Container } from "@packages/core-kernel";
 import { VotesController } from "@packages/core-api/src/controllers/votes";
 import { register } from "@packages/core-api/src/routes/votes";
 import { Server } from "@packages/core-api/src/server";

--- a/packages/core-api/__tests__/routes/wallets.test.ts
+++ b/packages/core-api/__tests__/routes/wallets.test.ts
@@ -1,4 +1,4 @@
-import { Container } from "@arkecosystem/core-kernel";
+import { Container } from "@packages/core-kernel";
 import { WalletsController } from "@packages/core-api/src/controllers/wallets";
 import { register } from "@packages/core-api/src/routes/wallets";
 import { Server } from "@packages/core-api/src/server";

--- a/packages/core-api/__tests__/schemas.test.ts
+++ b/packages/core-api/__tests__/schemas.test.ts
@@ -4,8 +4,8 @@ import {
     createSortingSchema,
     nonNegativeBigNumber,
     positiveBigNumber,
-} from "@arkecosystem/core-api/src/schemas";
-import { Utils } from "@arkecosystem/core-kernel";
+} from "@packages/core-api/src/schemas";
+import { Utils } from "@packages/core-kernel";
 import Joi from "joi";
 
 describe("bigNumber", () => {

--- a/packages/core-api/__tests__/services/wallet-search-service.test.ts
+++ b/packages/core-api/__tests__/services/wallet-search-service.test.ts
@@ -1,6 +1,6 @@
-import { WalletSearchService } from "@arkecosystem/core-api/src/services/wallet-search-service";
-import { Container, Contracts, Services } from "@arkecosystem/core-kernel";
-import { Utils } from "@arkecosystem/crypto";
+import { WalletSearchService } from "@packages/core-api/src/services/wallet-search-service";
+import { Container, Contracts, Services } from "@packages/core-kernel";
+import { Utils } from "@packages/crypto";
 
 const jestfn = <T extends (...args: unknown[]) => unknown>(
     implementation?: (...args: Parameters<T>) => ReturnType<T>,

--- a/packages/core-blockchain/__tests__/blockchain.test.ts
+++ b/packages/core-blockchain/__tests__/blockchain.test.ts
@@ -1,9 +1,9 @@
 import "jest-extended";
 
-import { ProcessBlocksJob } from "@arkecosystem/core-blockchain/src/process-blocks-job";
-import { Queue } from "@arkecosystem/core-kernel/dist/contracts/kernel";
-import { Identifiers, interfaces } from "@arkecosystem/core-kernel/dist/ioc";
-import { MemoryQueue } from "@arkecosystem/core-kernel/src/services/queue/drivers/memory";
+import { ProcessBlocksJob } from "@packages/core-blockchain/src/process-blocks-job";
+import { Queue } from "@packages/core-kernel/dist/contracts/kernel";
+import { Identifiers, interfaces } from "@packages/core-kernel/dist/ioc";
+import { MemoryQueue } from "@packages/core-kernel/src/services/queue/drivers/memory";
 import { ProcessBlockAction } from "@packages/core-blockchain/src/actions";
 import { Blockchain } from "@packages/core-blockchain/src/blockchain";
 import { Container, Enums, Services, Utils as AppUtils } from "@packages/core-kernel";

--- a/packages/core-blockchain/__tests__/processor/handlers/already-forged-handler.test.ts
+++ b/packages/core-blockchain/__tests__/processor/handlers/already-forged-handler.test.ts
@@ -1,7 +1,7 @@
-import { Container } from "@arkecosystem/core-kernel";
+import { Container } from "@packages/core-kernel";
 import { AlreadyForgedHandler } from "@packages/core-blockchain/src/processor/handlers/already-forged-handler";
 import { BlockProcessorResult } from "@packages/core-blockchain/src/processor";
-import { Interfaces } from "@arkecosystem/crypto";
+import { Interfaces } from "@packages/crypto";
 
 describe("AlreadyForgedHandler", () => {
     const container = new Container.Container();

--- a/packages/core-blockchain/__tests__/processor/handlers/incompatible-transactions-handler.test.ts
+++ b/packages/core-blockchain/__tests__/processor/handlers/incompatible-transactions-handler.test.ts
@@ -1,7 +1,7 @@
-import { Container } from "@arkecosystem/core-kernel";
-import { IncompatibleTransactionsHandler } from "../../../../../packages/core-blockchain/src/processor/handlers/incompatible-transactions-handler";
-import { BlockProcessorResult } from "../../../../../packages/core-blockchain/src/processor";
-import { Interfaces } from "@arkecosystem/crypto";
+import { Container } from "@packages/core-kernel";
+import { IncompatibleTransactionsHandler } from "@packages/core-blockchain/src/processor/handlers/incompatible-transactions-handler";
+import { BlockProcessorResult } from "@packages/core-blockchain/src/processor";
+import { Interfaces } from "@packages/crypto";
 
 describe("IncompatibleTransactionsHandler", () => {
     const container = new Container.Container();

--- a/packages/core-blockchain/__tests__/processor/handlers/invalid-generator-handler.test.ts
+++ b/packages/core-blockchain/__tests__/processor/handlers/invalid-generator-handler.test.ts
@@ -1,7 +1,7 @@
-import { Container } from "@arkecosystem/core-kernel";
-import { InvalidGeneratorHandler } from "../../../../../packages/core-blockchain/src/processor/handlers/invalid-generator-handler";
-import { BlockProcessorResult } from "../../../../../packages/core-blockchain/src/processor";
-import { Interfaces } from "@arkecosystem/crypto";
+import { Container } from "@packages/core-kernel";
+import { InvalidGeneratorHandler } from "@packages/core-blockchain/src/processor/handlers/invalid-generator-handler";
+import { BlockProcessorResult } from "@packages/core-blockchain/src/processor";
+import { Interfaces } from "@packages/crypto";
 
 describe("InvalidGeneratorHandler", () => {
     const container = new Container.Container();

--- a/packages/core-blockchain/__tests__/processor/handlers/nonce-out-of-order-handler.test.ts
+++ b/packages/core-blockchain/__tests__/processor/handlers/nonce-out-of-order-handler.test.ts
@@ -1,7 +1,7 @@
-import { Container } from "@arkecosystem/core-kernel";
-import { NonceOutOfOrderHandler } from "../../../../../packages/core-blockchain/src/processor/handlers/nonce-out-of-order-handler";
-import { BlockProcessorResult } from "../../../../../packages/core-blockchain/src/processor";
-import { Interfaces } from "@arkecosystem/crypto";
+import { Container } from "@packages/core-kernel";
+import { NonceOutOfOrderHandler } from "@packages/core-blockchain/src/processor/handlers/nonce-out-of-order-handler";
+import { BlockProcessorResult } from "@packages/core-blockchain/src/processor";
+import { Interfaces } from "@packages/crypto";
 
 describe("NonceOutOfOrderHandler", () => {
     const container = new Container.Container();

--- a/packages/core-blockchain/__tests__/processor/handlers/revert-block-handler.test.ts
+++ b/packages/core-blockchain/__tests__/processor/handlers/revert-block-handler.test.ts
@@ -1,5 +1,5 @@
-import { Container } from "@arkecosystem/core-kernel";
-import { Interfaces } from "@arkecosystem/crypto";
+import { Container } from "@packages/core-kernel";
+import { Interfaces } from "@packages/crypto";
 import { BlockProcessorResult } from "@packages/core-blockchain/src/processor";
 import { RevertBlockHandler } from "@packages/core-blockchain/src/processor/handlers/revert-block-handler";
 

--- a/packages/core-blockchain/__tests__/processor/handlers/unchained-handler.test.ts
+++ b/packages/core-blockchain/__tests__/processor/handlers/unchained-handler.test.ts
@@ -1,4 +1,4 @@
-import { Container, Services } from "@arkecosystem/core-kernel";
+import { Container, Services } from "@packages/core-kernel";
 import { BlockProcessorResult } from "@packages/core-blockchain/src/processor";
 import { UnchainedHandler } from "@packages/core-blockchain/src/processor/handlers/unchained-handler";
 import { GetActiveDelegatesAction } from "@packages/core-state/src/actions";

--- a/packages/core-blockchain/__tests__/processor/handlers/verification-failed-handler.test.ts
+++ b/packages/core-blockchain/__tests__/processor/handlers/verification-failed-handler.test.ts
@@ -1,7 +1,7 @@
-import { Container } from "@arkecosystem/core-kernel";
-import { VerificationFailedHandler } from "../../../../../packages/core-blockchain/src/processor/handlers/verification-failed-handler";
-import { BlockProcessorResult } from "../../../../../packages/core-blockchain/src/processor";
-import { Interfaces } from "@arkecosystem/crypto";
+import { Container } from "@packages/core-kernel";
+import { VerificationFailedHandler } from "@packages/core-blockchain/src/processor/handlers/verification-failed-handler";
+import { BlockProcessorResult } from "@packages/core-blockchain/src/processor";
+import { Interfaces } from "@packages/crypto";
 
 describe("VerificationFailedHandler", () => {
     const container = new Container.Container();

--- a/packages/core-blockchain/__tests__/state-machine/actions/blockchain-ready.test.ts
+++ b/packages/core-blockchain/__tests__/state-machine/actions/blockchain-ready.test.ts
@@ -1,4 +1,4 @@
-import { Container, Enums } from "@arkecosystem/core-kernel";
+import { Container, Enums } from "@packages/core-kernel";
 import { BlockchainReady } from "@packages/core-blockchain/src/state-machine/actions/blockchain-ready";
 
 describe("BlockchainReady", () => {

--- a/packages/core-blockchain/__tests__/state-machine/actions/check-last-block-synced.test.ts
+++ b/packages/core-blockchain/__tests__/state-machine/actions/check-last-block-synced.test.ts
@@ -1,5 +1,5 @@
-import { Container } from "@arkecosystem/core-kernel";
-import { CheckLastBlockSynced } from "../../../../../packages/core-blockchain/src/state-machine/actions/check-last-block-synced";
+import { Container } from "@packages/core-kernel";
+import { CheckLastBlockSynced } from "@packages/core-blockchain/src/state-machine/actions/check-last-block-synced";
 
 describe("CheckLastBlockSynced", () => {
     const container = new Container.Container();

--- a/packages/core-blockchain/__tests__/state-machine/actions/download-finished.test.ts
+++ b/packages/core-blockchain/__tests__/state-machine/actions/download-finished.test.ts
@@ -1,4 +1,4 @@
-import { Container } from "@arkecosystem/core-kernel";
+import { Container } from "@packages/core-kernel";
 import { DownloadFinished } from "@packages/core-blockchain/src/state-machine/actions/download-finished";
 
 describe("DownloadFinished", () => {

--- a/packages/core-blockchain/__tests__/state-machine/actions/download-paused.test.ts
+++ b/packages/core-blockchain/__tests__/state-machine/actions/download-paused.test.ts
@@ -1,5 +1,5 @@
-import { Container } from "@arkecosystem/core-kernel";
-import { DownloadPaused } from "../../../../../packages/core-blockchain/src/state-machine/actions/download-paused";
+import { Container } from "@packages/core-kernel";
+import { DownloadPaused } from "@packages/core-blockchain/src/state-machine/actions/download-paused";
 
 describe("DownloadPaused", () => {
     const container = new Container.Container();

--- a/packages/core-blockchain/__tests__/state-machine/actions/exit-app.test.ts
+++ b/packages/core-blockchain/__tests__/state-machine/actions/exit-app.test.ts
@@ -1,5 +1,5 @@
-import { Container } from "@arkecosystem/core-kernel";
-import { ExitApp } from "../../../../../packages/core-blockchain/src/state-machine/actions/exit-app";
+import { Container } from "@packages/core-kernel";
+import { ExitApp } from "@packages/core-blockchain/src/state-machine/actions/exit-app";
 
 describe("ExitApp", () => {
     const container = new Container.Container();

--- a/packages/core-blockchain/__tests__/state-machine/actions/rollback-database.test.ts
+++ b/packages/core-blockchain/__tests__/state-machine/actions/rollback-database.test.ts
@@ -1,4 +1,4 @@
-import { Container } from "@arkecosystem/core-kernel";
+import { Container } from "@packages/core-kernel";
 import { RollbackDatabase } from "@packages/core-blockchain/src/state-machine/actions/rollback-database";
 
 describe("RollbackDatabase", () => {

--- a/packages/core-blockchain/__tests__/state-machine/actions/stopped.test.ts
+++ b/packages/core-blockchain/__tests__/state-machine/actions/stopped.test.ts
@@ -1,5 +1,5 @@
-import { Container } from "@arkecosystem/core-kernel";
-import { Stopped } from "../../../../../packages/core-blockchain/src/state-machine/actions/stopped";
+import { Container } from "@packages/core-kernel";
+import { Stopped } from "@packages/core-blockchain/src/state-machine/actions/stopped";
 
 describe("Stopped", () => {
     const container = new Container.Container();

--- a/packages/core-blockchain/__tests__/state-machine/actions/syncing-complete.test.ts
+++ b/packages/core-blockchain/__tests__/state-machine/actions/syncing-complete.test.ts
@@ -1,5 +1,5 @@
-import { Container } from "@arkecosystem/core-kernel";
-import { SyncingComplete } from "../../../../../packages/core-blockchain/src/state-machine/actions/syncing-complete";
+import { Container } from "@packages/core-kernel";
+import { SyncingComplete } from "@packages/core-blockchain/src/state-machine/actions/syncing-complete";
 
 describe("Stopped", () => {
     const container = new Container.Container();

--- a/packages/core-blockchain/__tests__/state-machine/state-machine.test.ts
+++ b/packages/core-blockchain/__tests__/state-machine/state-machine.test.ts
@@ -1,4 +1,4 @@
-import { Container } from "@arkecosystem/core-kernel";
+import { Container } from "@packages/core-kernel";
 import { blockchainMachine } from "@packages/core-blockchain/src/state-machine/machine";
 import { StateMachine } from "@packages/core-blockchain/src/state-machine/state-machine";
 import { Sandbox } from "@packages/core-test-framework";

--- a/packages/core-blockchain/package.json
+++ b/packages/core-blockchain/package.json
@@ -32,7 +32,8 @@
         "xstate": "4.23.4"
     },
     "devDependencies": {
-        "@types/async": "3.2.7"
+        "@types/async": "3.2.7",
+        "delay": "5.0.0"
     },
     "engines": {
         "node": ">=10.x"

--- a/packages/core-cli/__tests__/action-factory.test.ts
+++ b/packages/core-cli/__tests__/action-factory.test.ts
@@ -1,4 +1,4 @@
-import { Console } from "@arkecosystem/core-test-framework";
+import { Console } from "@packages/core-test-framework";
 import { ActionFactory, Container } from "@packages/core-cli/src";
 
 let cli;

--- a/packages/core-cli/__tests__/actions/abort-errored-process.test.ts
+++ b/packages/core-cli/__tests__/actions/abort-errored-process.test.ts
@@ -1,5 +1,5 @@
-import { Container } from "@arkecosystem/core-cli";
-import { Console } from "@arkecosystem/core-test-framework";
+import { Container } from "@packages/core-cli";
+import { Console } from "@packages/core-test-framework";
 import { AbortErroredProcess } from "@packages/core-cli/src/actions";
 
 const processName: string = "ark-core";

--- a/packages/core-cli/__tests__/actions/abort-missing-process.test.ts
+++ b/packages/core-cli/__tests__/actions/abort-missing-process.test.ts
@@ -1,5 +1,5 @@
-import { Container } from "@arkecosystem/core-cli";
-import { Console } from "@arkecosystem/core-test-framework";
+import { Container } from "@packages/core-cli";
+import { Console } from "@packages/core-test-framework";
 import { AbortMissingProcess } from "@packages/core-cli/src/actions";
 
 const processName: string = "ark-core";

--- a/packages/core-cli/__tests__/actions/abort-running-process.test.ts
+++ b/packages/core-cli/__tests__/actions/abort-running-process.test.ts
@@ -1,5 +1,5 @@
-import { Container } from "@arkecosystem/core-cli";
-import { Console } from "@arkecosystem/core-test-framework";
+import { Container } from "@packages/core-cli";
+import { Console } from "@packages/core-test-framework";
 import { AbortRunningProcess } from "@packages/core-cli/src/actions";
 
 const processName: string = "ark-core";

--- a/packages/core-cli/__tests__/actions/abort-stopped-process.test.ts
+++ b/packages/core-cli/__tests__/actions/abort-stopped-process.test.ts
@@ -1,5 +1,5 @@
-import { Container } from "@arkecosystem/core-cli";
-import { Console } from "@arkecosystem/core-test-framework";
+import { Container } from "@packages/core-cli";
+import { Console } from "@packages/core-test-framework";
 import { AbortStoppedProcess } from "@packages/core-cli/src/actions";
 
 const processName: string = "ark-core";

--- a/packages/core-cli/__tests__/actions/abort-unknown-process.test.ts
+++ b/packages/core-cli/__tests__/actions/abort-unknown-process.test.ts
@@ -1,5 +1,5 @@
-import { Container } from "@arkecosystem/core-cli";
-import { Console } from "@arkecosystem/core-test-framework";
+import { Container } from "@packages/core-cli";
+import { Console } from "@packages/core-test-framework";
 import { AbortUnknownProcess } from "@packages/core-cli/src/actions";
 
 const processName: string = "ark-core";

--- a/packages/core-cli/__tests__/actions/daemonize-process.test.ts
+++ b/packages/core-cli/__tests__/actions/daemonize-process.test.ts
@@ -1,5 +1,5 @@
-import { Container } from "@arkecosystem/core-cli";
-import { Console } from "@arkecosystem/core-test-framework";
+import { Container } from "@packages/core-cli";
+import { Console } from "@packages/core-test-framework";
 import { DaemonizeProcess } from "@packages/core-cli/src/actions";
 import os from "os";
 

--- a/packages/core-cli/__tests__/actions/restart-process.test.ts
+++ b/packages/core-cli/__tests__/actions/restart-process.test.ts
@@ -1,5 +1,5 @@
-import { Container } from "@arkecosystem/core-cli";
-import { Console } from "@arkecosystem/core-test-framework";
+import { Container } from "@packages/core-cli";
+import { Console } from "@packages/core-test-framework";
 import { RestartProcess } from "@packages/core-cli/src/actions";
 
 const processName: string = "ark-core";

--- a/packages/core-cli/__tests__/actions/restart-running-process-with-prompt.test.ts
+++ b/packages/core-cli/__tests__/actions/restart-running-process-with-prompt.test.ts
@@ -1,5 +1,5 @@
-import { Container } from "@arkecosystem/core-cli";
-import { Console } from "@arkecosystem/core-test-framework";
+import { Container } from "@packages/core-cli";
+import { Console } from "@packages/core-test-framework";
 import { RestartRunningProcessWithPrompt } from "@packages/core-cli/src/actions";
 import prompts from "prompts";
 

--- a/packages/core-cli/__tests__/actions/restart-running-process.test.ts
+++ b/packages/core-cli/__tests__/actions/restart-running-process.test.ts
@@ -1,5 +1,5 @@
-import { Container } from "@arkecosystem/core-cli";
-import { Console } from "@arkecosystem/core-test-framework";
+import { Container } from "@packages/core-cli";
+import { Console } from "@packages/core-test-framework";
 import { RestartRunningProcess } from "@packages/core-cli/src/actions";
 
 const processName: string = "ark-core";

--- a/packages/core-cli/__tests__/commands/__stubs__/command-without-definition.ts
+++ b/packages/core-cli/__tests__/commands/__stubs__/command-without-definition.ts
@@ -1,4 +1,4 @@
-import { Commands, Container } from "@arkecosystem/core-cli";
+import { Commands, Container } from "@packages/core-cli";
 
 @Container.injectable()
 export class CommandWithoutDefinition extends Commands.Command {

--- a/packages/core-cli/__tests__/commands/__stubs__/command.ts
+++ b/packages/core-cli/__tests__/commands/__stubs__/command.ts
@@ -1,4 +1,4 @@
-import { Commands, Container } from "@arkecosystem/core-cli";
+import { Commands, Container } from "@packages/core-cli";
 import Joi from "joi";
 
 @Container.injectable()

--- a/packages/core-cli/__tests__/commands/command-help.test.ts
+++ b/packages/core-cli/__tests__/commands/command-help.test.ts
@@ -1,4 +1,4 @@
-import { Console } from "@arkecosystem/core-test-framework";
+import { Console } from "@packages/core-test-framework";
 import { CommandHelp } from "@packages/core-cli/src/commands";
 import { setGracefulCleanup } from "tmp";
 

--- a/packages/core-cli/__tests__/commands/command.test.ts
+++ b/packages/core-cli/__tests__/commands/command.test.ts
@@ -1,5 +1,5 @@
-import { Container } from "@arkecosystem/core-cli";
-import { Console } from "@arkecosystem/core-test-framework";
+import { Container } from "@packages/core-cli";
+import { Console } from "@packages/core-test-framework";
 import { Command, DiscoverConfig, DiscoverNetwork } from "@packages/core-cli/src/commands";
 import Joi from "joi";
 import { setGracefulCleanup } from "tmp";

--- a/packages/core-cli/__tests__/commands/discover-commands.test.ts
+++ b/packages/core-cli/__tests__/commands/discover-commands.test.ts
@@ -1,4 +1,4 @@
-import { Console } from "@arkecosystem/core-test-framework";
+import { Console } from "@packages/core-test-framework";
 import { DiscoverCommands } from "@packages/core-cli/src/commands";
 import { resolve } from "path";
 import { setGracefulCleanup } from "tmp";

--- a/packages/core-cli/__tests__/commands/discover-config.test.ts
+++ b/packages/core-cli/__tests__/commands/discover-config.test.ts
@@ -1,4 +1,4 @@
-import { Console } from "@arkecosystem/core-test-framework";
+import { Console } from "@packages/core-test-framework";
 import { DiscoverConfig } from "@packages/core-cli/src/commands";
 import { ensureDirSync, writeJSON } from "fs-extra";
 import { join } from "path";

--- a/packages/core-cli/__tests__/commands/discover-network.test.ts
+++ b/packages/core-cli/__tests__/commands/discover-network.test.ts
@@ -1,4 +1,4 @@
-import { Console } from "@arkecosystem/core-test-framework";
+import { Console } from "@packages/core-test-framework";
 import { DiscoverNetwork } from "@packages/core-cli/src/commands";
 import { ensureDirSync } from "fs-extra";
 import prompts from "prompts";

--- a/packages/core-cli/__tests__/component-factory.test.ts
+++ b/packages/core-cli/__tests__/component-factory.test.ts
@@ -1,4 +1,4 @@
-import { Console } from "@arkecosystem/core-test-framework";
+import { Console } from "@packages/core-test-framework";
 import { ComponentFactory, Container } from "@packages/core-cli/src";
 
 let cli;

--- a/packages/core-cli/__tests__/components/app-header.test.ts
+++ b/packages/core-cli/__tests__/components/app-header.test.ts
@@ -1,5 +1,5 @@
-import { Container } from "@arkecosystem/core-cli";
-import { Console } from "@arkecosystem/core-test-framework";
+import { Container } from "@packages/core-cli";
+import { Console } from "@packages/core-test-framework";
 import { AppHeader } from "@packages/core-cli/src/components";
 import { red, white } from "kleur";
 import os from "os";

--- a/packages/core-cli/__tests__/components/ask-date.test.ts
+++ b/packages/core-cli/__tests__/components/ask-date.test.ts
@@ -1,5 +1,5 @@
-import { Container } from "@arkecosystem/core-cli";
-import { Console } from "@arkecosystem/core-test-framework";
+import { Container } from "@packages/core-cli";
+import { Console } from "@packages/core-test-framework";
 import { AskDate } from "@packages/core-cli/src/components";
 import prompts from "prompts";
 

--- a/packages/core-cli/__tests__/components/ask-hidden.test.ts
+++ b/packages/core-cli/__tests__/components/ask-hidden.test.ts
@@ -1,5 +1,5 @@
-import { Container } from "@arkecosystem/core-cli";
-import { Console } from "@arkecosystem/core-test-framework";
+import { Container } from "@packages/core-cli";
+import { Console } from "@packages/core-test-framework";
 import { AskHidden } from "@packages/core-cli/src/components";
 import prompts from "prompts";
 

--- a/packages/core-cli/__tests__/components/ask-number.test.ts
+++ b/packages/core-cli/__tests__/components/ask-number.test.ts
@@ -1,5 +1,5 @@
-import { Container } from "@arkecosystem/core-cli";
-import { Console } from "@arkecosystem/core-test-framework";
+import { Container } from "@packages/core-cli";
+import { Console } from "@packages/core-test-framework";
 import { AskNumber } from "@packages/core-cli/src/components";
 import prompts from "prompts";
 

--- a/packages/core-cli/__tests__/components/ask-password.test.ts
+++ b/packages/core-cli/__tests__/components/ask-password.test.ts
@@ -1,5 +1,5 @@
-import { Container } from "@arkecosystem/core-cli";
-import { Console } from "@arkecosystem/core-test-framework";
+import { Container } from "@packages/core-cli";
+import { Console } from "@packages/core-test-framework";
 import { AskPassword } from "@packages/core-cli/src/components";
 import prompts from "prompts";
 

--- a/packages/core-cli/__tests__/components/ask.test.ts
+++ b/packages/core-cli/__tests__/components/ask.test.ts
@@ -1,5 +1,5 @@
-import { Container } from "@arkecosystem/core-cli";
-import { Console } from "@arkecosystem/core-test-framework";
+import { Container } from "@packages/core-cli";
+import { Console } from "@packages/core-test-framework";
 import { Ask } from "@packages/core-cli/src/components";
 import prompts from "prompts";
 

--- a/packages/core-cli/__tests__/components/auto-complete.test.ts
+++ b/packages/core-cli/__tests__/components/auto-complete.test.ts
@@ -1,5 +1,5 @@
-import { Container } from "@arkecosystem/core-cli";
-import { Console } from "@arkecosystem/core-test-framework";
+import { Container } from "@packages/core-cli";
+import { Console } from "@packages/core-test-framework";
 import { AutoComplete } from "@packages/core-cli/src/components";
 import prompts from "prompts";
 

--- a/packages/core-cli/__tests__/components/box.test.ts
+++ b/packages/core-cli/__tests__/components/box.test.ts
@@ -1,5 +1,5 @@
-import { Container } from "@arkecosystem/core-cli";
-import { Console } from "@arkecosystem/core-test-framework";
+import { Container } from "@packages/core-cli";
+import { Console } from "@packages/core-test-framework";
 import { Box } from "@packages/core-cli/src/components";
 
 let cli;

--- a/packages/core-cli/__tests__/components/clear.test.ts
+++ b/packages/core-cli/__tests__/components/clear.test.ts
@@ -1,5 +1,5 @@
-import { Container } from "@arkecosystem/core-cli";
-import { Console } from "@arkecosystem/core-test-framework";
+import { Container } from "@packages/core-cli";
+import { Console } from "@packages/core-test-framework";
 import { Clear } from "@packages/core-cli/src/components";
 
 let cli;

--- a/packages/core-cli/__tests__/components/confirm.test.ts
+++ b/packages/core-cli/__tests__/components/confirm.test.ts
@@ -1,7 +1,7 @@
 import "jest-extended";
 
-import { Container } from "@arkecosystem/core-cli";
-import { Console } from "@arkecosystem/core-test-framework";
+import { Container } from "@packages/core-cli";
+import { Console } from "@packages/core-test-framework";
 import { Confirm } from "@packages/core-cli/src/components";
 import prompts from "prompts";
 

--- a/packages/core-cli/__tests__/components/error.test.ts
+++ b/packages/core-cli/__tests__/components/error.test.ts
@@ -1,5 +1,5 @@
-import { Container } from "@arkecosystem/core-cli";
-import { Console } from "@arkecosystem/core-test-framework";
+import { Container } from "@packages/core-cli";
+import { Console } from "@packages/core-test-framework";
 import { Error } from "@packages/core-cli/src/components";
 import { white } from "kleur";
 

--- a/packages/core-cli/__tests__/components/fatal.test.ts
+++ b/packages/core-cli/__tests__/components/fatal.test.ts
@@ -1,5 +1,5 @@
-import { Container } from "@arkecosystem/core-cli";
-import { Console } from "@arkecosystem/core-test-framework";
+import { Container } from "@packages/core-cli";
+import { Console } from "@packages/core-test-framework";
 import { Fatal } from "@packages/core-cli/src/components";
 import { white } from "kleur";
 

--- a/packages/core-cli/__tests__/components/info.test.ts
+++ b/packages/core-cli/__tests__/components/info.test.ts
@@ -1,5 +1,5 @@
-import { Container } from "@arkecosystem/core-cli";
-import { Console } from "@arkecosystem/core-test-framework";
+import { Container } from "@packages/core-cli";
+import { Console } from "@packages/core-test-framework";
 import { Info } from "@packages/core-cli/src/components";
 import { white } from "kleur";
 

--- a/packages/core-cli/__tests__/components/listing.test.ts
+++ b/packages/core-cli/__tests__/components/listing.test.ts
@@ -1,5 +1,5 @@
-import { Container } from "@arkecosystem/core-cli";
-import { Console } from "@arkecosystem/core-test-framework";
+import { Container } from "@packages/core-cli";
+import { Console } from "@packages/core-test-framework";
 import { Listing } from "@packages/core-cli/src/components";
 
 let cli;

--- a/packages/core-cli/__tests__/components/log.test.ts
+++ b/packages/core-cli/__tests__/components/log.test.ts
@@ -1,5 +1,5 @@
-import { Container } from "@arkecosystem/core-cli";
-import { Console } from "@arkecosystem/core-test-framework";
+import { Container } from "@packages/core-cli";
+import { Console } from "@packages/core-test-framework";
 import { Log } from "@packages/core-cli/src/components";
 
 let cli;

--- a/packages/core-cli/__tests__/components/multi-select.test.ts
+++ b/packages/core-cli/__tests__/components/multi-select.test.ts
@@ -1,5 +1,5 @@
-import { Container } from "@arkecosystem/core-cli";
-import { Console } from "@arkecosystem/core-test-framework";
+import { Container } from "@packages/core-cli";
+import { Console } from "@packages/core-test-framework";
 import { MultiSelect } from "@packages/core-cli/src/components";
 import prompts from "prompts";
 

--- a/packages/core-cli/__tests__/components/new-line.test.ts
+++ b/packages/core-cli/__tests__/components/new-line.test.ts
@@ -1,5 +1,5 @@
-import { Container } from "@arkecosystem/core-cli";
-import { Console } from "@arkecosystem/core-test-framework";
+import { Container } from "@packages/core-cli";
+import { Console } from "@packages/core-test-framework";
 import { NewLine } from "@packages/core-cli/src/components";
 
 let cli;

--- a/packages/core-cli/__tests__/components/prompt.test.ts
+++ b/packages/core-cli/__tests__/components/prompt.test.ts
@@ -1,5 +1,5 @@
-import { Container } from "@arkecosystem/core-cli";
-import { Console } from "@arkecosystem/core-test-framework";
+import { Container } from "@packages/core-cli";
+import { Console } from "@packages/core-test-framework";
 import { Prompt } from "@packages/core-cli/src/components";
 import prompts from "prompts";
 

--- a/packages/core-cli/__tests__/components/select.test.ts
+++ b/packages/core-cli/__tests__/components/select.test.ts
@@ -1,5 +1,5 @@
-import { Container } from "@arkecosystem/core-cli";
-import { Console } from "@arkecosystem/core-test-framework";
+import { Container } from "@packages/core-cli";
+import { Console } from "@packages/core-test-framework";
 import { Select } from "@packages/core-cli/src/components";
 import prompts from "prompts";
 

--- a/packages/core-cli/__tests__/components/spinner.test.ts
+++ b/packages/core-cli/__tests__/components/spinner.test.ts
@@ -1,5 +1,5 @@
-import { Container } from "@arkecosystem/core-cli";
-import { Console } from "@arkecosystem/core-test-framework";
+import { Container } from "@packages/core-cli";
+import { Console } from "@packages/core-test-framework";
 import { Spinner } from "@packages/core-cli/src/components";
 
 let cli;

--- a/packages/core-cli/__tests__/components/success.test.ts
+++ b/packages/core-cli/__tests__/components/success.test.ts
@@ -1,5 +1,5 @@
-import { Container } from "@arkecosystem/core-cli";
-import { Console } from "@arkecosystem/core-test-framework";
+import { Container } from "@packages/core-cli";
+import { Console } from "@packages/core-test-framework";
 import { Success } from "@packages/core-cli/src/components";
 import { white } from "kleur";
 

--- a/packages/core-cli/__tests__/components/table.test.ts
+++ b/packages/core-cli/__tests__/components/table.test.ts
@@ -1,5 +1,5 @@
-import { Container } from "@arkecosystem/core-cli";
-import { Console } from "@arkecosystem/core-test-framework";
+import { Container } from "@packages/core-cli";
+import { Console } from "@packages/core-test-framework";
 import { Table } from "@packages/core-cli/src/components";
 
 let cli;

--- a/packages/core-cli/__tests__/components/task-list.test.ts
+++ b/packages/core-cli/__tests__/components/task-list.test.ts
@@ -1,5 +1,5 @@
-import { Container } from "@arkecosystem/core-cli";
-import { Console } from "@arkecosystem/core-test-framework";
+import { Container } from "@packages/core-cli";
+import { Console } from "@packages/core-test-framework";
 import { TaskList } from "@packages/core-cli/src/components";
 
 let cli;

--- a/packages/core-cli/__tests__/components/title.test.ts
+++ b/packages/core-cli/__tests__/components/title.test.ts
@@ -1,5 +1,5 @@
-import { Container } from "@arkecosystem/core-cli";
-import { Console } from "@arkecosystem/core-test-framework";
+import { Container } from "@packages/core-cli";
+import { Console } from "@packages/core-test-framework";
 import { Title } from "@packages/core-cli/src/components";
 import { yellow } from "kleur";
 

--- a/packages/core-cli/__tests__/components/toggle.test.ts
+++ b/packages/core-cli/__tests__/components/toggle.test.ts
@@ -1,5 +1,5 @@
-import { Container } from "@arkecosystem/core-cli";
-import { Console } from "@arkecosystem/core-test-framework";
+import { Container } from "@packages/core-cli";
+import { Console } from "@packages/core-test-framework";
 import { Toggle } from "@packages/core-cli/src/components";
 import prompts from "prompts";
 

--- a/packages/core-cli/__tests__/components/warning.test.ts
+++ b/packages/core-cli/__tests__/components/warning.test.ts
@@ -1,5 +1,5 @@
-import { Container } from "@arkecosystem/core-cli";
-import { Console } from "@arkecosystem/core-test-framework";
+import { Container } from "@packages/core-cli";
+import { Console } from "@packages/core-test-framework";
 import { Warning } from "@packages/core-cli/src/components";
 import { white } from "kleur";
 

--- a/packages/core-cli/__tests__/input/input.test.ts
+++ b/packages/core-cli/__tests__/input/input.test.ts
@@ -1,6 +1,6 @@
 import "jest-extended";
 
-import { Console } from "@arkecosystem/core-test-framework";
+import { Console } from "@packages/core-test-framework";
 import Joi from "joi";
 import { Input, InputDefinition } from "@packages/core-cli/src/input";
 

--- a/packages/core-cli/__tests__/input/validator.test.ts
+++ b/packages/core-cli/__tests__/input/validator.test.ts
@@ -1,6 +1,6 @@
 import "jest-extended";
 
-import { Console } from "@arkecosystem/core-test-framework";
+import { Console } from "@packages/core-test-framework";
 import Joi from "joi";
 import { InputValidator } from "@packages/core-cli/src/input";
 

--- a/packages/core-cli/__tests__/output/output.test.ts
+++ b/packages/core-cli/__tests__/output/output.test.ts
@@ -1,7 +1,7 @@
 // public mute() {
 // public unmute() {
 
-import { Console } from "@arkecosystem/core-test-framework";
+import { Console } from "@packages/core-test-framework";
 import { Output } from "@packages/core-cli/src/output";
 
 let cli;

--- a/packages/core-cli/__tests__/plugins/suggest.test.ts
+++ b/packages/core-cli/__tests__/plugins/suggest.test.ts
@@ -1,5 +1,5 @@
-import { Container } from "@arkecosystem/core-cli";
-import { Console } from "@arkecosystem/core-test-framework";
+import { Container } from "@packages/core-cli";
+import { Console } from "@packages/core-test-framework";
 import { SuggestCommand } from "@packages/core-cli/src/plugins/suggest";
 import { blue, red } from "kleur";
 import prompts from "prompts";

--- a/packages/core-cli/__tests__/services/config.test.ts
+++ b/packages/core-cli/__tests__/services/config.test.ts
@@ -1,6 +1,6 @@
 import "jest-extended";
 
-import { Console } from "@arkecosystem/core-test-framework";
+import { Console } from "@packages/core-test-framework";
 import { Config } from "@packages/core-cli/src/services";
 import { writeFileSync } from "fs";
 import { setGracefulCleanup } from "tmp";

--- a/packages/core-cli/__tests__/services/environment.test.ts
+++ b/packages/core-cli/__tests__/services/environment.test.ts
@@ -1,6 +1,6 @@
 import "jest-extended";
 
-import { Console } from "@arkecosystem/core-test-framework";
+import { Console } from "@packages/core-test-framework";
 import { Environment } from "@packages/core-cli/src/services";
 import envfile from "envfile";
 import fs from "fs-extra";

--- a/packages/core-cli/__tests__/services/installer.test.ts
+++ b/packages/core-cli/__tests__/services/installer.test.ts
@@ -1,7 +1,6 @@
 import "jest-extended";
 
-import { Console } from "@arkecosystem/core-test-framework";
-// import path from "path";
+import { Console } from "@packages/core-test-framework";
 import { Installer } from "@packages/core-cli/src/services";
 import { setGracefulCleanup } from "tmp";
 

--- a/packages/core-cli/__tests__/services/logger.test.ts
+++ b/packages/core-cli/__tests__/services/logger.test.ts
@@ -1,5 +1,5 @@
-import { Container } from "@arkecosystem/core-cli";
-import { Console } from "@arkecosystem/core-test-framework";
+import { Container } from "@packages/core-cli";
+import { Console } from "@packages/core-test-framework";
 import { Logger } from "@packages/core-cli/src/services";
 
 let cli;

--- a/packages/core-cli/__tests__/services/plugin-manager.test.ts
+++ b/packages/core-cli/__tests__/services/plugin-manager.test.ts
@@ -1,4 +1,4 @@
-import { Console } from "@arkecosystem/core-test-framework";
+import { Console } from "@packages/core-test-framework";
 import { PluginManager } from "@packages/core-cli/src/services";
 import fs from "fs-extra";
 import { join } from "path";

--- a/packages/core-cli/__tests__/services/process-manager.test.ts
+++ b/packages/core-cli/__tests__/services/process-manager.test.ts
@@ -1,7 +1,7 @@
 import "jest-extended";
 
-import { Contracts } from "@arkecosystem/core-cli";
-import { Console } from "@arkecosystem/core-test-framework";
+import { Contracts } from "@packages/core-cli";
+import { Console } from "@packages/core-test-framework";
 import { ProcessManager } from "@packages/core-cli/src/services";
 import execa from "execa";
 

--- a/packages/core-cli/__tests__/utils/process.test.ts
+++ b/packages/core-cli/__tests__/utils/process.test.ts
@@ -1,5 +1,5 @@
-import { Container } from "@arkecosystem/core-cli";
-import { Console } from "@arkecosystem/core-test-framework";
+import { Container } from "@packages/core-cli";
+import { Console } from "@packages/core-test-framework";
 import { Process } from "@packages/core-cli/src/utils";
 import { fileSync, setGracefulCleanup } from "tmp";
 

--- a/packages/core-database/__tests__/__fixtures__/block1760000.ts
+++ b/packages/core-database/__tests__/__fixtures__/block1760000.ts
@@ -1,4 +1,4 @@
-import { Utils } from "@arkecosystem/crypto";
+import { Utils } from "@packages/crypto";
 
 export default {
     id: "17605317082329008056",

--- a/packages/core-database/__tests__/block-filter.test.ts
+++ b/packages/core-database/__tests__/block-filter.test.ts
@@ -1,7 +1,7 @@
-import { Container } from "@arkecosystem/core-kernel";
-import { Utils } from "@arkecosystem/crypto";
+import { Container } from "@packages/core-kernel";
+import { Utils } from "@packages/crypto";
 
-import { BlockFilter } from "../../../packages/core-database/src/block-filter";
+import { BlockFilter } from "@packages/core-database/src/block-filter";
 
 const container = new Container.Container();
 

--- a/packages/core-database/__tests__/block-history-service.test.ts
+++ b/packages/core-database/__tests__/block-history-service.test.ts
@@ -1,6 +1,6 @@
-import { Container, Contracts } from "@arkecosystem/core-kernel";
+import { Container, Contracts } from "@packages/core-kernel";
 
-import { BlockHistoryService } from "../../../packages/core-database/src/block-history-service";
+import { BlockHistoryService } from "@packages/core-database/src/block-history-service";
 
 const defaultBlockSorting: Contracts.Search.Sorting = [{ property: "height", direction: "asc" }];
 

--- a/packages/core-database/__tests__/database-service.test.ts
+++ b/packages/core-database/__tests__/database-service.test.ts
@@ -1,7 +1,7 @@
-import { Container } from "@arkecosystem/core-kernel";
-import { Blocks } from "@arkecosystem/crypto";
+import { Container } from "@packages/core-kernel";
+import { Blocks } from "@packages/crypto";
 
-import { DatabaseService } from "../../../packages/core-database/src/database-service";
+import { DatabaseService } from "@packages/core-database/src/database-service";
 import block1760000 from "./__fixtures__/block1760000";
 
 const app = {

--- a/packages/core-database/__tests__/model-converter.test.ts
+++ b/packages/core-database/__tests__/model-converter.test.ts
@@ -1,7 +1,7 @@
-import { Container } from "@arkecosystem/core-kernel";
-import { Blocks, Utils } from "@arkecosystem/crypto";
+import { Container } from "@packages/core-kernel";
+import { Blocks, Utils } from "@packages/crypto";
 
-import { ModelConverter } from "../../../packages/core-database/src/model-converter";
+import { ModelConverter } from "@packages/core-database/src/model-converter";
 import block1760000 from "./__fixtures__/block1760000";
 
 const container = new Container.Container();

--- a/packages/core-database/__tests__/transaction-history-service.test.ts
+++ b/packages/core-database/__tests__/transaction-history-service.test.ts
@@ -1,8 +1,8 @@
-import { Repositories } from "@arkecosystem/core-database";
-import { Container, Contracts } from "@arkecosystem/core-kernel";
-import { Interfaces } from "@arkecosystem/crypto";
+import { Repositories } from "@packages/core-database";
+import { Container, Contracts } from "@packages/core-kernel";
+import { Interfaces } from "@packages/crypto";
 
-import { TransactionHistoryService } from "../../../packages/core-database/src/transaction-history-service";
+import { TransactionHistoryService } from "@packages/core-database/src/transaction-history-service";
 
 const jestfn = <T extends (...args: unknown[]) => unknown>(
     implementation?: (...args: Parameters<T>) => ReturnType<T>,

--- a/packages/core-database/__tests__/utils/transform.test.ts
+++ b/packages/core-database/__tests__/utils/transform.test.ts
@@ -1,7 +1,7 @@
-import { Utils } from "@arkecosystem/crypto";
+import { Utils } from "@packages/crypto";
 import { FindOperator } from "typeorm";
 
-import { transformBigInt, transformVendorField } from "../../../../packages/core-database/src/utils/transform";
+import { transformBigInt, transformVendorField } from "@packages/core-database/src/utils/transform";
 
 describe("transformBigInt.from", () => {
     it("should transform string value to BigNumber", () => {

--- a/packages/core-forger/__tests__/client.test.ts
+++ b/packages/core-forger/__tests__/client.test.ts
@@ -1,8 +1,8 @@
 import "jest-extended";
 
-import { Client } from "@arkecosystem/core-forger/src/client";
-import { Application, Container } from "@arkecosystem/core-kernel";
-import { NetworkStateStatus, Nes, Codecs } from "@arkecosystem/core-p2p";
+import { Client } from "@packages/core-forger/src/client";
+import { Application, Container } from "@packages/core-kernel";
+import { NetworkStateStatus, Nes, Codecs } from "@packages/core-p2p";
 
 import { forgedBlockWithTransactions } from "./__utils__/create-block-with-transactions";
 

--- a/packages/core-forger/__tests__/methods/bip38.test.ts
+++ b/packages/core-forger/__tests__/methods/bip38.test.ts
@@ -1,4 +1,4 @@
-import { Identities } from "@arkecosystem/crypto";
+import { Identities } from "@packages/crypto";
 import { BIP38 } from "@packages/core-forger/src/methods/bip38";
 
 import { dummy, expectedBlock, optionsDefault, transactions } from "../__utils__/create-block-with-transactions";

--- a/packages/core-forger/__tests__/process-actions/current-delegate.test.ts
+++ b/packages/core-forger/__tests__/process-actions/current-delegate.test.ts
@@ -1,7 +1,7 @@
 import "jest-extended";
 
-import { Container } from "@arkecosystem/core-kernel";
-import { Sandbox } from "@arkecosystem/core-test-framework/src";
+import { Container } from "@packages/core-kernel";
+import { Sandbox } from "@packages/core-test-framework";
 import { CurrentDelegateProcessAction } from "@packages/core-forger/src/process-actions/current-delegate";
 
 let sandbox: Sandbox;

--- a/packages/core-forger/__tests__/process-actions/last-forged-block.test.ts
+++ b/packages/core-forger/__tests__/process-actions/last-forged-block.test.ts
@@ -1,7 +1,7 @@
 import "jest-extended";
 
-import { Container } from "@arkecosystem/core-kernel";
-import { Sandbox } from "@arkecosystem/core-test-framework/src";
+import { Container } from "@packages/core-kernel";
+import { Sandbox } from "@packages/core-test-framework";
 import { LastForgedBlockRemoteAction } from "@packages/core-forger/src/process-actions/last-forged-block";
 
 let sandbox: Sandbox;

--- a/packages/core-forger/__tests__/process-actions/next-slot.test.ts
+++ b/packages/core-forger/__tests__/process-actions/next-slot.test.ts
@@ -1,7 +1,7 @@
 import "jest-extended";
 
-import { Container } from "@arkecosystem/core-kernel";
-import { Sandbox } from "@arkecosystem/core-test-framework/src";
+import { Container } from "@packages/core-kernel";
+import { Sandbox } from "@packages/core-test-framework";
 import { NextSlotProcessAction } from "@packages/core-forger/src/process-actions/next-slot";
 
 let sandbox: Sandbox;

--- a/packages/core-kernel/__tests__/__stubs__/stub-plugin-with-defaults/dist/service-provider.js
+++ b/packages/core-kernel/__tests__/__stubs__/stub-plugin-with-defaults/dist/service-provider.js
@@ -1,6 +1,6 @@
 const {
     Providers
-} = require("@arkecosystem/core-kernel");
+} = require("@packages/core-kernel");
 
 class ServiceProvider extends Providers.ServiceProvider {
     async register() {

--- a/packages/core-kernel/__tests__/__stubs__/stub-plugin/dist/service-provider.js
+++ b/packages/core-kernel/__tests__/__stubs__/stub-plugin/dist/service-provider.js
@@ -1,6 +1,6 @@
 const {
     Providers
-} = require("@arkecosystem/core-kernel");
+} = require("@packages/core-kernel");
 
 class ServiceProvider extends Providers.ServiceProvider {
     async register() {

--- a/packages/core-kernel/__tests__/services/search/errors.test.ts
+++ b/packages/core-kernel/__tests__/services/search/errors.test.ts
@@ -2,7 +2,7 @@ import {
     InvalidCriteria,
     UnexpectedError,
     UnsupportedValue,
-} from "@arkecosystem/core-kernel/src/services/search/errors";
+} from "@packages/core-kernel/src/services/search/errors";
 
 describe("InvalidCriteria", () => {
     it("should create", () => {

--- a/packages/core-kernel/__tests__/services/search/pagination-service.test.ts
+++ b/packages/core-kernel/__tests__/services/search/pagination-service.test.ts
@@ -1,6 +1,6 @@
-import { Container } from "@arkecosystem/core-kernel";
-import { PaginationService } from "@arkecosystem/core-kernel/src/services/search/pagination-service";
-import { Utils } from "@arkecosystem/crypto";
+import { Container } from "@packages/core-kernel";
+import { PaginationService } from "@packages/core-kernel/src/services/search/pagination-service";
+import { Utils } from "@packages/crypto";
 
 const container = new Container.Container();
 

--- a/packages/core-kernel/__tests__/utils/assert.test.ts
+++ b/packages/core-kernel/__tests__/utils/assert.test.ts
@@ -1,4 +1,4 @@
-import { Blocks, Interfaces, Managers } from "@arkecosystem/crypto";
+import { Blocks, Interfaces, Managers } from "@packages/crypto";
 import { assert } from "@packages/core-kernel/src/utils/assert";
 import { Generators } from "@packages/core-test-framework/src";
 

--- a/packages/core-kernel/__tests__/utils/delegate-calculator.test.ts
+++ b/packages/core-kernel/__tests__/utils/delegate-calculator.test.ts
@@ -1,10 +1,10 @@
 import "jest-extended";
 
-import { Container, Contracts, Services } from "@arkecosystem/core-kernel";
-import { Wallets } from "@arkecosystem/core-state";
-import { Managers, Utils } from "@arkecosystem/crypto";
+import { Container, Contracts, Services } from "@packages/core-kernel";
+import { Wallets } from "@packages/core-state";
+import { Managers, Utils } from "@packages/crypto";
 import { calculateApproval, calculateForgedTotal } from "@packages/core-kernel/src/utils/delegate-calculator";
-import { Sandbox } from "@packages/core-test-framework/src";
+import { Sandbox } from "@packages/core-test-framework";
 
 let sandbox: Sandbox;
 

--- a/packages/core-kernel/__tests__/utils/expiration-calculator.test.ts
+++ b/packages/core-kernel/__tests__/utils/expiration-calculator.test.ts
@@ -1,6 +1,6 @@
 import "jest-extended";
 
-import { Enums, Interfaces } from "@arkecosystem/crypto";
+import { Enums, Interfaces } from "@packages/crypto";
 import {
     calculateLockExpirationStatus,
     calculateTransactionExpiration,

--- a/packages/core-kernel/__tests__/utils/is-blocked-chained.test.ts
+++ b/packages/core-kernel/__tests__/utils/is-blocked-chained.test.ts
@@ -1,6 +1,6 @@
 import "jest-extended";
 
-import { Crypto, Interfaces } from "@arkecosystem/crypto";
+import { Crypto, Interfaces } from "@packages/crypto";
 import { getBlockNotChainedErrorMessage, isBlockChained } from "@packages/core-kernel/src/utils/is-block-chained";
 
 const mockGetBlockTimeLookup = (height: number) => {

--- a/packages/core-kernel/__tests__/utils/round-calculator/is-new-round.test.ts
+++ b/packages/core-kernel/__tests__/utils/round-calculator/is-new-round.test.ts
@@ -1,6 +1,6 @@
 import "jest-extended";
 
-import { Managers } from "@arkecosystem/crypto";
+import { Managers } from "@packages/crypto";
 import { isNewRound } from "@packages/core-kernel/src/utils/round-calculator";
 
 describe("Round Calculator", () => {

--- a/packages/core-kernel/__tests__/utils/supply-calculator.test.ts
+++ b/packages/core-kernel/__tests__/utils/supply-calculator.test.ts
@@ -1,6 +1,6 @@
 import "jest-extended";
 
-import { Managers, Utils } from "@arkecosystem/crypto";
+import { Managers, Utils } from "@packages/crypto";
 import { calculate } from "@packages/core-kernel/src/utils/supply-calculator";
 
 const toString = (value) => Utils.BigNumber.make(value).toFixed();

--- a/packages/core-logger-pino/__tests__/driver.test.ts
+++ b/packages/core-logger-pino/__tests__/driver.test.ts
@@ -1,6 +1,6 @@
 import "jest-extended";
 
-import { Utils, Application } from "@arkecosystem/core-kernel";
+import { Utils, Application } from "@packages/core-kernel";
 import { Logger } from "@packages/core-kernel/src/contracts/kernel/log";
 import { Container, Identifiers } from "@packages/core-kernel/src/ioc";
 import { PinoLogger } from "@packages/core-logger-pino/src/driver";

--- a/packages/core-logger-pino/__tests__/driver.test.ts
+++ b/packages/core-logger-pino/__tests__/driver.test.ts
@@ -1,7 +1,6 @@
 import "jest-extended";
 
-import { sleep } from "@arkecosystem/utils";
-import { Application } from "@packages/core-kernel/src/application";
+import { Utils, Application } from "@arkecosystem/core-kernel";
 import { Logger } from "@packages/core-kernel/src/contracts/kernel/log";
 import { Container, Identifiers } from "@packages/core-kernel/src/ioc";
 import { PinoLogger } from "@packages/core-logger-pino/src/driver";
@@ -154,7 +153,7 @@ describe("Logger", () => {
 
         writableMock.destroy(new Error("Test error"));
 
-        await sleep(100);
+        await Utils.sleep(100);
 
         expect(message).toMatch("File stream closed due to an error: Error: Test error");
 
@@ -168,7 +167,7 @@ describe("Logger", () => {
         app.useLogPath(dirSync().name);
 
         const ms = new Date().getMilliseconds();
-        await sleep(1000 - ms + 400);
+        await Utils.sleep(1000 - ms + 400);
 
         const logger = await app.resolve(PinoLogger).make({
             levels: {
@@ -183,7 +182,7 @@ describe("Logger", () => {
         for (let i = 0; i < 3; i++) {
             logger.info(`Test ${i + 1}`);
 
-            await sleep(900);
+            await Utils.sleep(900);
         }
 
         const files = readdirSync(app.logPath());

--- a/packages/core-logger-pino/__tests__/service-provider.test.ts
+++ b/packages/core-logger-pino/__tests__/service-provider.test.ts
@@ -5,8 +5,8 @@ import { ServiceProvider } from "@packages/core-logger-pino/src";
 import { defaults } from "@packages/core-logger-pino/src/defaults";
 import { AnySchema } from "joi";
 import { dirSync } from "tmp";
-import { Identifiers, interfaces } from "@arkecosystem/core-kernel/dist/ioc";
-import { LogManager } from "@arkecosystem/core-kernel/dist/services/log";
+import { Identifiers, interfaces } from "@packages/core-kernel/dist/ioc";
+import { LogManager } from "@packages/core-kernel/dist/services/log";
 
 let app: Application;
 

--- a/packages/core-magistrate-api/__tests__/__support__/index.ts
+++ b/packages/core-magistrate-api/__tests__/__support__/index.ts
@@ -23,7 +23,7 @@ import { One, Two } from "@packages/core-transactions/src/handlers";
 import { TransactionHandlerProvider } from "@packages/core-transactions/src/handlers/handler-provider";
 import { TransactionHandlerRegistry } from "@packages/core-transactions/src/handlers/handler-registry";
 import { Identities, Utils } from "@packages/crypto";
-import { EntityTransactionHandler } from "@arkecosystem/core-magistrate-transactions/src/handlers/entity";
+import { EntityTransactionHandler } from "@packages/core-magistrate-transactions/src/handlers/entity";
 
 export type PaginatedResponse = {
     totalCount: number;

--- a/packages/core-magistrate-api/__tests__/controllers/entities.test.ts
+++ b/packages/core-magistrate-api/__tests__/controllers/entities.test.ts
@@ -1,8 +1,8 @@
-import { Container, Contracts } from "@arkecosystem/core-kernel";
-import { EntitySearchService, Resources } from "@arkecosystem/core-magistrate-api";
-import { EntityController } from "@arkecosystem/core-magistrate-api/src/controllers/entities";
-import { Identifiers } from "@arkecosystem/core-magistrate-api/src/identifiers";
-import { Enums } from "@arkecosystem/core-magistrate-crypto";
+import { Container, Contracts } from "@packages/core-kernel";
+import { EntitySearchService, Resources } from "@packages/core-magistrate-api";
+import { EntityController } from "@packages/core-magistrate-api/src/controllers/entities";
+import { Identifiers } from "@packages/core-magistrate-api/src/identifiers";
+import { Enums } from "@packages/core-magistrate-crypto";
 import { Boom } from "@hapi/boom";
 
 const jestfn = <T extends (...args: unknown[]) => unknown>(

--- a/packages/core-magistrate-crypto/__tests__/fixtures/entity/assets/generate.ts
+++ b/packages/core-magistrate-crypto/__tests__/fixtures/entity/assets/generate.ts
@@ -1,5 +1,5 @@
-import { IEntityAsset } from "@arkecosystem/core-magistrate-crypto/dist/interfaces";
-import { EntityAction, EntityType } from "@arkecosystem/core-magistrate-crypto/src/enums";
+import { IEntityAsset } from "@packages/core-magistrate-crypto/dist/interfaces";
+import { EntityAction, EntityType } from "@packages/core-magistrate-crypto/src/enums";
 
 // valid types already assigned (in enum EntityType) + other "custom" but valid types (in range 0-255)
 const allTypes = [

--- a/packages/core-magistrate-crypto/__tests__/fixtures/entity/schemas/register.ts
+++ b/packages/core-magistrate-crypto/__tests__/fixtures/entity/schemas/register.ts
@@ -1,4 +1,4 @@
-import { Enums, Interfaces } from "@arkecosystem/core-magistrate-crypto/src";
+import { Enums, Interfaces } from "@packages/core-magistrate-crypto/src";
 import { invalidAssetData, validAssetData } from "./utils";
 
 export const validRegisters: Interfaces.IEntityAsset[] = [

--- a/packages/core-magistrate-crypto/__tests__/fixtures/entity/schemas/resign.ts
+++ b/packages/core-magistrate-crypto/__tests__/fixtures/entity/schemas/resign.ts
@@ -1,4 +1,4 @@
-import { Enums, Interfaces } from "@arkecosystem/core-magistrate-crypto/src";
+import { Enums, Interfaces } from "@packages/core-magistrate-crypto/src";
 import { invalidAssetData, validAssetData } from "./utils";
 
 export const validResigns: Interfaces.IEntityAsset[] = [

--- a/packages/core-magistrate-crypto/__tests__/fixtures/entity/schemas/update.ts
+++ b/packages/core-magistrate-crypto/__tests__/fixtures/entity/schemas/update.ts
@@ -1,4 +1,4 @@
-import { Enums, Interfaces } from "@arkecosystem/core-magistrate-crypto/src";
+import { Enums, Interfaces } from "@packages/core-magistrate-crypto/src";
 import { invalidAssetData, validAssetData } from "./utils";
 
 export const validUpdates: Interfaces.IEntityAsset[] = [

--- a/packages/core-magistrate-crypto/__tests__/fixtures/entity/schemas/utils.ts
+++ b/packages/core-magistrate-crypto/__tests__/fixtures/entity/schemas/utils.ts
@@ -1,7 +1,7 @@
 // export valid and invalid asset data for registration and update
 // excluding `name` property as it is not allowed for update
 
-import { Interfaces } from "@arkecosystem/core-magistrate-crypto/src";
+import { Interfaces } from "@packages/core-magistrate-crypto/src";
 
 export const validAssetData: Interfaces.IEntityAssetData[] = [
     { ipfsData: "Qmbw6QmF6tuZpyV6WyEsTmExkEG3rW4khattQidPfbpmNZ" },

--- a/packages/core-magistrate-crypto/__tests__/transactions/entity.test.ts
+++ b/packages/core-magistrate-crypto/__tests__/transactions/entity.test.ts
@@ -1,9 +1,9 @@
 import "jest-extended";
 
-import { Interfaces } from "@arkecosystem/core-magistrate-crypto";
-import { EntityBuilder } from "@arkecosystem/core-magistrate-crypto/src/builders";
-import { EntityTransaction } from "@arkecosystem/core-magistrate-crypto/src/transactions";
-import { Managers, Transactions, Validation } from "@arkecosystem/crypto";
+import { Interfaces } from "@packages/core-magistrate-crypto";
+import { EntityBuilder } from "@packages/core-magistrate-crypto/src/builders";
+import { EntityTransaction } from "@packages/core-magistrate-crypto/src/transactions";
+import { Managers, Transactions, Validation } from "@packages/crypto";
 
 import { generateAssets, generateSpecialAssets } from "../fixtures/entity/assets/generate";
 import { invalidRegisters, validRegisters } from "../fixtures/entity/schemas/register";

--- a/packages/core-magistrate-transactions/__tests__/handlers/__fixtures__/entity/register.ts
+++ b/packages/core-magistrate-transactions/__tests__/handlers/__fixtures__/entity/register.ts
@@ -1,5 +1,5 @@
-import { Interfaces } from "@arkecosystem/core-magistrate-crypto/src";
-import { EntityAction, EntityType } from "@arkecosystem/core-magistrate-crypto/src/enums";
+import { Interfaces } from "@packages/core-magistrate-crypto/src";
+import { EntityAction, EntityType } from "@packages/core-magistrate-crypto/src/enums";
 export const validRegisters: Interfaces.IEntityAsset[] = [
     // array of register assets
     // we expect to have the wallet state like { entities: { [txId]: { ...asset.data } } } after

--- a/packages/core-magistrate-transactions/__tests__/handlers/__fixtures__/entity/resign.ts
+++ b/packages/core-magistrate-transactions/__tests__/handlers/__fixtures__/entity/resign.ts
@@ -1,5 +1,5 @@
-import { Interfaces } from "@arkecosystem/core-magistrate-crypto/src";
-import { EntityAction, EntityType } from "@arkecosystem/core-magistrate-crypto/src/enums";
+import { Interfaces } from "@packages/core-magistrate-crypto/src";
+import { EntityAction, EntityType } from "@packages/core-magistrate-crypto/src/enums";
 export const validResigns: Interfaces.IEntityAsset[] = [
     // array of register assets
     // we expect to have the wallet with the entity removed after

--- a/packages/core-magistrate-transactions/__tests__/handlers/__fixtures__/entity/update.ts
+++ b/packages/core-magistrate-transactions/__tests__/handlers/__fixtures__/entity/update.ts
@@ -1,5 +1,5 @@
-import { Interfaces } from "@arkecosystem/core-magistrate-crypto/src";
-import { EntityAction, EntityType } from "@arkecosystem/core-magistrate-crypto/src/enums";
+import { Interfaces } from "@packages/core-magistrate-crypto/src";
+import { EntityAction, EntityType } from "@packages/core-magistrate-crypto/src/enums";
 export const validUpdates: Interfaces.IEntityAsset[] = [
     // array of update assets
     // we expect to have the wallet updated accordingly after

--- a/packages/core-magistrate-transactions/__tests__/handlers/__mocks__/transaction-handler.ts
+++ b/packages/core-magistrate-transactions/__tests__/handlers/__mocks__/transaction-handler.ts
@@ -1,5 +1,5 @@
 import { walletRepository } from "./wallet-repository";
-import { Container } from "@arkecosystem/core-kernel";
+import { Container } from "@packages/core-kernel";
 import { transactionReader } from "./transaction-reader";
 
 @Container.injectable()

--- a/packages/core-magistrate-transactions/__tests__/handlers/entity.test.ts
+++ b/packages/core-magistrate-transactions/__tests__/handlers/entity.test.ts
@@ -27,7 +27,7 @@ import { walletRepository } from "./__mocks__/wallet-repository";
 
 // mocking the abstract TransactionHandler class
 // because I could not make it work using the real abstract class + custom ioc binding
-jest.mock("@arkecosystem/core-transactions", () => ({
+jest.mock("@packages/core-transactions", () => ({
     Handlers: {
         TransactionHandler: require("./__mocks__/transaction-handler").TransactionHandler,
     },

--- a/packages/core-p2p/__tests__/actions/validate-and-accept-peer.test.ts
+++ b/packages/core-p2p/__tests__/actions/validate-and-accept-peer.test.ts
@@ -1,4 +1,4 @@
-import { ValidateAndAcceptPeerAction } from "@arkecosystem/core-p2p/src/actions/validate-and-accept-peer";
+import { ValidateAndAcceptPeerAction } from "@packages/core-p2p/src/actions/validate-and-accept-peer";
 
 describe("ValidateAndAcceptPeerAction", () => {
     let validateAndAcceptPeerAction: ValidateAndAcceptPeerAction;

--- a/packages/core-p2p/__tests__/event-listener.test.ts
+++ b/packages/core-p2p/__tests__/event-listener.test.ts
@@ -1,7 +1,7 @@
-import { Container, Enums } from "@arkecosystem/core-kernel";
+import { Container, Enums } from "@packages/core-kernel";
 
-import { EventListener } from "@arkecosystem/core-p2p/src/event-listener";
-import { DisconnectPeer } from "@arkecosystem/core-p2p/src/listeners";
+import { EventListener } from "@packages/core-p2p/src/event-listener";
+import { DisconnectPeer } from "@packages/core-p2p/src/listeners";
 
 describe("EventListener", () => {
     let eventListener: EventListener;

--- a/packages/core-p2p/__tests__/listeners.test.ts
+++ b/packages/core-p2p/__tests__/listeners.test.ts
@@ -1,6 +1,6 @@
-import { Container } from "@arkecosystem/core-kernel";
-import { DisconnectInvalidPeers, DisconnectPeer } from "@arkecosystem/core-p2p/src/listeners";
-import { Peer } from "@arkecosystem/core-p2p/src/peer";
+import { Container } from "@packages/core-kernel";
+import { DisconnectInvalidPeers, DisconnectPeer } from "@packages/core-p2p/src/listeners";
+import { Peer } from "@packages/core-p2p/src/peer";
 
 describe("DisconnectInvalidPeers", () => {
     let disconnectInvalidPeers: DisconnectInvalidPeers;

--- a/packages/core-p2p/__tests__/peer-communicator.test.ts
+++ b/packages/core-p2p/__tests__/peer-communicator.test.ts
@@ -1,24 +1,24 @@
 import "jest-extended";
 
-import { Container, Utils as KernelUtils } from "@arkecosystem/core-kernel";
-import { constants } from "@arkecosystem/core-p2p/src/constants";
+import { Container, Utils as KernelUtils } from "@packages/core-kernel";
+import { constants } from "@packages/core-p2p/src/constants";
 import {
     PeerPingTimeoutError,
     PeerStatusResponseError,
     PeerVerificationFailedError,
-} from "@arkecosystem/core-p2p/src/errors";
-import { Peer } from "@arkecosystem/core-p2p/src/peer";
-import { PeerCommunicator } from "@arkecosystem/core-p2p/src/peer-communicator";
-import { PeerVerificationResult } from "@arkecosystem/core-p2p/src/peer-verifier";
-import { replySchemas } from "@arkecosystem/core-p2p/src/schemas";
-import { Blocks, Identities, Managers, Transactions, Utils } from "@arkecosystem/crypto";
+} from "@packages/core-p2p/src/errors";
+import { Peer } from "@packages/core-p2p/src/peer";
+import { PeerCommunicator } from "@packages/core-p2p/src/peer-communicator";
+import { PeerVerificationResult } from "@packages/core-p2p/src/peer-verifier";
+import { replySchemas } from "@packages/core-p2p/src/schemas";
+import { Blocks, Identities, Managers, Transactions, Utils } from "@packages/crypto";
 import delay from "delay";
 
-jest.mock("@arkecosystem/core-p2p/src/socket-server/utils/get-codec", () => ({
+jest.mock("@packages/core-p2p/src/socket-server/utils/get-codec", () => ({
     getCodec: () => ({ request: { serialize: (obj) => obj }, response: { deserialize: (obj) => obj } }),
 }));
 
-jest.mock("@arkecosystem/core-p2p/src/socket-server/utils/get-codec", () => ({
+jest.mock("@packages/core-p2p/src/socket-server/utils/get-codec", () => ({
     getCodec: () => ({ request: { serialize: (obj) => obj }, response: { deserialize: (obj) => obj } }),
 }));
 

--- a/packages/core-p2p/__tests__/peer-connector.test.ts
+++ b/packages/core-p2p/__tests__/peer-connector.test.ts
@@ -1,6 +1,6 @@
 import "jest-extended";
 
-import { Container } from "@arkecosystem/core-kernel";
+import { Container } from "@packages/core-kernel";
 import * as Nes from "@packages/core-p2p/src/hapi-nes";
 import { Peer } from "@packages/core-p2p/src/peer";
 import { PeerConnector } from "@packages/core-p2p/src/peer-connector";

--- a/packages/core-p2p/__tests__/peer-processor.test.ts
+++ b/packages/core-p2p/__tests__/peer-processor.test.ts
@@ -1,8 +1,8 @@
 import "jest-extended";
 
-import { Container, Enums } from "@arkecosystem/core-kernel";
-import { Peer } from "@arkecosystem/core-p2p/src/peer";
-import { PeerProcessor } from "@arkecosystem/core-p2p/src/peer-processor";
+import { Container, Enums } from "@packages/core-kernel";
+import { Peer } from "@packages/core-p2p/src/peer";
+import { PeerProcessor } from "@packages/core-p2p/src/peer-processor";
 
 describe("PeerProcessor", () => {
     let peerProcessor: PeerProcessor;

--- a/packages/core-p2p/__tests__/peer-repository.test.ts
+++ b/packages/core-p2p/__tests__/peer-repository.test.ts
@@ -1,7 +1,7 @@
-import { Container } from "@arkecosystem/core-kernel";
+import { Container } from "@packages/core-kernel";
 
-import { PeerRepository } from "@arkecosystem/core-p2p/src/peer-repository";
-import { Peer } from "@arkecosystem/core-p2p/src/peer";
+import { PeerRepository } from "@packages/core-p2p/src/peer-repository";
+import { Peer } from "@packages/core-p2p/src/peer";
 
 describe("PeerRepository", () => {
     let peerStorage: PeerRepository;

--- a/packages/core-p2p/__tests__/peer.test.ts
+++ b/packages/core-p2p/__tests__/peer.test.ts
@@ -1,7 +1,7 @@
-import { Peer } from "@arkecosystem/core-p2p/src/peer";
-import { PeerVerificationResult } from "@arkecosystem/core-p2p/src/peer-verifier";
+import { Peer } from "@packages/core-p2p/src/peer";
+import { PeerVerificationResult } from "@packages/core-p2p/src/peer-verifier";
 import dayjs from "dayjs";
-import { Contracts } from "@arkecosystem/core-kernel";
+import { Contracts } from "@packages/core-kernel";
 
 describe("Peer", () => {
     let peer: Peer;

--- a/packages/core-p2p/__tests__/rate-limiter.test.ts
+++ b/packages/core-p2p/__tests__/rate-limiter.test.ts
@@ -1,4 +1,4 @@
-import { RateLimiter } from "@arkecosystem/core-p2p/src/rate-limiter";
+import { RateLimiter } from "@packages/core-p2p/src/rate-limiter";
 import { cloneDeep } from "lodash";
 
 describe("RateLimiter", () => {

--- a/packages/core-p2p/__tests__/socket-server/codecs/transactions.test.ts
+++ b/packages/core-p2p/__tests__/socket-server/codecs/transactions.test.ts
@@ -1,4 +1,4 @@
-import { postTransactions } from "@arkecosystem/core-p2p/src/socket-server/codecs/transactions";
+import { postTransactions } from "@packages/core-p2p/src/socket-server/codecs/transactions";
 
 describe("Transactions codec tests", () => {
     describe("postTransactions ser/deser", () => {

--- a/packages/core-p2p/__tests__/socket-server/plugins/accept-peer.test.ts
+++ b/packages/core-p2p/__tests__/socket-server/plugins/accept-peer.test.ts
@@ -1,8 +1,8 @@
 import { Server } from "@hapi/hapi";
 import Joi from "joi";
-import { Container } from "@arkecosystem/core-kernel";
+import { Container } from "@packages/core-kernel";
 
-import { AcceptPeerPlugin } from "@arkecosystem/core-p2p/src/socket-server/plugins/accept-peer";
+import { AcceptPeerPlugin } from "@packages/core-p2p/src/socket-server/plugins/accept-peer";
 
 afterEach(() => {
     jest.clearAllMocks();

--- a/packages/core-p2p/__tests__/socket-server/plugins/rate-limit.test.ts
+++ b/packages/core-p2p/__tests__/socket-server/plugins/rate-limit.test.ts
@@ -1,9 +1,9 @@
 import { Server } from "@hapi/hapi";
 import Joi from "joi";
-import { Container } from "@arkecosystem/core-kernel";
+import { Container } from "@packages/core-kernel";
 
-import { RateLimitPlugin } from "@arkecosystem/core-p2p/src/socket-server/plugins/rate-limit";
-import * as utils from "@arkecosystem/core-p2p/src/utils/build-rate-limiter";
+import { RateLimitPlugin } from "@packages/core-p2p/src/socket-server/plugins/rate-limit";
+import * as utils from "@packages/core-p2p/src/utils/build-rate-limiter";
 
 afterEach(() => {
     jest.clearAllMocks();

--- a/packages/core-p2p/__tests__/socket-server/plugins/validate.test.ts
+++ b/packages/core-p2p/__tests__/socket-server/plugins/validate.test.ts
@@ -1,9 +1,9 @@
 import { Server } from "@hapi/hapi";
 import Joi from "joi";
-import { Container } from "@arkecosystem/core-kernel";
+import { Container } from "@packages/core-kernel";
 
-import { ValidatePlugin } from "@arkecosystem/core-p2p/src/socket-server/plugins/validate";
-import * as utils from "@arkecosystem/core-p2p/src/utils";
+import { ValidatePlugin } from "@packages/core-p2p/src/socket-server/plugins/validate";
+import * as utils from "@packages/core-p2p/src/utils";
 
 const spyIsValidVersion = jest.spyOn(utils, "isValidVersion").mockReturnValue(true);
 

--- a/packages/core-p2p/__tests__/socket-server/routes/internal.test.ts
+++ b/packages/core-p2p/__tests__/socket-server/routes/internal.test.ts
@@ -1,6 +1,6 @@
-import { Container } from "@arkecosystem/core-kernel";
+import { Container } from "@packages/core-kernel";
 
-import { InternalRoute } from "@arkecosystem/core-p2p/src/socket-server/routes/internal";
+import { InternalRoute } from "@packages/core-p2p/src/socket-server/routes/internal";
 
 describe("InternalRoute", () => {
     let internalRoute: InternalRoute;

--- a/packages/core-p2p/__tests__/socket-server/routes/peer.test.ts
+++ b/packages/core-p2p/__tests__/socket-server/routes/peer.test.ts
@@ -1,6 +1,6 @@
-import { Container } from "@arkecosystem/core-kernel";
+import { Container } from "@packages/core-kernel";
 
-import { PeerRoute } from "@arkecosystem/core-p2p/src/socket-server/routes/peer";
+import { PeerRoute } from "@packages/core-p2p/src/socket-server/routes/peer";
 
 describe("PeerRoute", () => {
     let peerRoute: PeerRoute;

--- a/packages/core-p2p/__tests__/socket-server/server.test.ts
+++ b/packages/core-p2p/__tests__/socket-server/server.test.ts
@@ -1,6 +1,6 @@
-import { Container } from "@arkecosystem/core-kernel";
-import * as Nes from "@arkecosystem/core-p2p/src/hapi-nes";
-import { Server } from "@arkecosystem/core-p2p/src/socket-server/server";
+import { Container } from "@packages/core-kernel";
+import * as Nes from "@packages/core-p2p/src/hapi-nes";
+import { Server } from "@packages/core-p2p/src/socket-server/server";
 import hapi from "@hapi/hapi";
 
 import { NesClient } from "../mocks/nes";

--- a/packages/core-p2p/__tests__/socket-server/utils/get-headers.test.ts
+++ b/packages/core-p2p/__tests__/socket-server/utils/get-headers.test.ts
@@ -1,5 +1,5 @@
-import { Container } from "@arkecosystem/core-kernel";
-import { getHeaders } from "@arkecosystem/core-p2p/src/socket-server/utils/get-headers";
+import { Container } from "@packages/core-kernel";
+import { getHeaders } from "@packages/core-p2p/src/socket-server/utils/get-headers";
 
 describe("getHeaders", () => {
     const version = "3.0.9";

--- a/packages/core-p2p/__tests__/socket-server/utils/get-peer-config.test.ts
+++ b/packages/core-p2p/__tests__/socket-server/utils/get-peer-config.test.ts
@@ -1,6 +1,6 @@
-import { Container } from "@arkecosystem/core-kernel";
-import { getPeerConfig } from "@arkecosystem/core-p2p/src/socket-server/utils/get-peer-config";
-import { Managers } from "@arkecosystem/crypto";
+import { Container } from "@packages/core-kernel";
+import { getPeerConfig } from "@packages/core-p2p/src/socket-server/utils/get-peer-config";
+import { Managers } from "@packages/crypto";
 
 let mockConfig;
 let version;

--- a/packages/core-p2p/__tests__/socket-server/utils/map-addr.test.ts
+++ b/packages/core-p2p/__tests__/socket-server/utils/map-addr.test.ts
@@ -1,4 +1,4 @@
-import { mapAddr } from "@arkecosystem/core-p2p/src/socket-server/utils/map-addr";
+import { mapAddr } from "@packages/core-p2p/src/socket-server/utils/map-addr";
 
 describe("mapAddr", () => {
     it("should map IP 'v6' to IP v4 counterpart", () => {

--- a/packages/core-p2p/__tests__/socket-server/utils/validate.test.ts
+++ b/packages/core-p2p/__tests__/socket-server/utils/validate.test.ts
@@ -1,6 +1,6 @@
-import { Validation } from "@arkecosystem/crypto";
-import { SocketErrors } from "@arkecosystem/core-p2p/src/enums";
-import { validate } from "@arkecosystem/core-p2p/src/socket-server/utils/validate";
+import { Validation } from "@packages/crypto";
+import { SocketErrors } from "@packages/core-p2p/src/enums";
+import { validate } from "@packages/core-p2p/src/socket-server/utils/validate";
 
 describe("validate", () => {
     it("should validate using crypto validate()", () => {

--- a/packages/core-p2p/__tests__/transaction-broadcaster.test.ts
+++ b/packages/core-p2p/__tests__/transaction-broadcaster.test.ts
@@ -1,7 +1,7 @@
-import { Container } from "@arkecosystem/core-kernel";
-import { Interfaces, Transactions } from "@arkecosystem/crypto";
+import { Container } from "@packages/core-kernel";
+import { Interfaces, Transactions } from "@packages/crypto";
 
-import { TransactionBroadcaster } from "../../../packages/core-p2p/src/transaction-broadcaster";
+import { TransactionBroadcaster } from "@packages/core-p2p/src/transaction-broadcaster";
 
 describe("TransactionBroadcaster", () => {
     const container = new Container.Container();

--- a/packages/core-p2p/__tests__/utils/check-dns.test.ts
+++ b/packages/core-p2p/__tests__/utils/check-dns.test.ts
@@ -1,4 +1,4 @@
-import { checkDNS } from "@arkecosystem/core-p2p/src/utils/check-dns";
+import { checkDNS } from "@packages/core-p2p/src/utils/check-dns";
 
 const app = {
     log: { error: jest.fn() },

--- a/packages/core-p2p/__tests__/utils/check-ntp.test.ts
+++ b/packages/core-p2p/__tests__/utils/check-ntp.test.ts
@@ -1,5 +1,5 @@
-import { Container } from "@arkecosystem/core-kernel";
-import { checkNTP } from "@arkecosystem/core-p2p/src/utils/check-ntp";
+import { Container } from "@packages/core-kernel";
+import { checkNTP } from "@packages/core-p2p/src/utils/check-ntp";
 
 jest.mock("@hapi/sntp", () => {
     return {

--- a/packages/core-p2p/__tests__/utils/is-valid-version.test.ts
+++ b/packages/core-p2p/__tests__/utils/is-valid-version.test.ts
@@ -1,8 +1,8 @@
 import "jest-extended";
 
-import { isValidVersion } from "@arkecosystem/core-p2p/src/utils/is-valid-version";
-import { Peer } from "@arkecosystem/core-p2p/src/peer";
-import { Managers } from "@arkecosystem/crypto";
+import { isValidVersion } from "@packages/core-p2p/src/utils/is-valid-version";
+import { Peer } from "@packages/core-p2p/src/peer";
+import { Managers } from "@packages/crypto";
 
 let peerMock: Peer;
 const app = {
@@ -28,7 +28,7 @@ describe.each([[true], [false]])("isValidVersion", (withMilestones) => {
     afterEach(() => {
         spyGetMilestone.mockRestore();
     })
-    
+
     it.each([["2.6.0"], ["2.6.666"], ["2.7.0"], ["2.8.0"], ["2.9.0"], ["2.9.934"]])(
         "should be a valid version",
         (version) => {

--- a/packages/core-snapshots/__tests__/__fixtures__/assets.ts
+++ b/packages/core-snapshots/__tests__/__fixtures__/assets.ts
@@ -1,4 +1,4 @@
-import { Models } from "@arkecosystem/core-database";
+import { Models } from "@packages/core-database";
 import { BigNumber } from "@arkecosystem/utils";
 import { Meta } from "@packages/core-snapshots/src/contracts";
 

--- a/packages/core-snapshots/__tests__/filesystem/filesystem.test.ts
+++ b/packages/core-snapshots/__tests__/filesystem/filesystem.test.ts
@@ -1,6 +1,6 @@
 import "jest-extended";
 
-import { Container } from "@arkecosystem/core-kernel";
+import { Container } from "@packages/core-kernel";
 import { LocalFilesystem } from "@packages/core-kernel/src/services/filesystem/drivers/local";
 import { Filesystem } from "@packages/core-snapshots/src/filesystem/filesystem";
 import { Identifiers } from "@packages/core-snapshots/src/ioc";

--- a/packages/core-snapshots/__tests__/verifier.test.ts
+++ b/packages/core-snapshots/__tests__/verifier.test.ts
@@ -1,7 +1,7 @@
 import "jest-extended";
 
-import { Verifier } from "@arkecosystem/core-snapshots/src/verifier";
-import { Crypto, Transactions } from "@arkecosystem/crypto";
+import { Verifier } from "@packages/core-snapshots/src/verifier";
+import { Crypto, Transactions } from "@packages/crypto";
 
 import { Assets } from "./__fixtures__";
 

--- a/packages/core-snapshots/package.json
+++ b/packages/core-snapshots/package.json
@@ -34,6 +34,7 @@
         "xcase": "2.0.1"
     },
     "devDependencies": {
+        "@arkecosystem/utils": "1.3.0",
         "@types/fs-extra": "8.1.2"
     },
     "engines": {

--- a/packages/core-state/__tests__/__fixtures__/block1760000.ts
+++ b/packages/core-state/__tests__/__fixtures__/block1760000.ts
@@ -1,4 +1,4 @@
-import { Utils } from "@arkecosystem/crypto";
+import { Utils } from "@packages/crypto";
 
 export default {
     id: "17605317082329008056",

--- a/packages/core-state/__tests__/setup.ts
+++ b/packages/core-state/__tests__/setup.ts
@@ -16,7 +16,7 @@ import { registerIndexers } from "@packages/core-state/src/wallets/indexers";
 import { Sandbox } from "@packages/core-test-framework/src";
 import { Factories, FactoryBuilder } from "@packages/core-test-framework/src/factories";
 import { Managers, Utils } from "@packages/crypto/src";
-import { walletFactory } from "@arkecosystem/core-state/src/wallets/wallet-factory";
+import { walletFactory } from "@packages/core-state/src/wallets/wallet-factory";
 
 export interface Spies {
     applySpy: jest.SpyInstance;

--- a/packages/core-state/__tests__/stores/state.test.ts
+++ b/packages/core-state/__tests__/stores/state.test.ts
@@ -1,10 +1,9 @@
 import "jest-extended";
 
-import { Container } from "@packages/core-kernel/src";
+import { Container, Utils } from "@packages/core-kernel";
 import { StateStore } from "@packages/core-state/src/stores/state";
 import { FactoryBuilder } from "@packages/core-test-framework/src/factories";
 import { IBlock, IBlockData, ITransactionData } from "@packages/crypto/src/interfaces";
-import delay from "delay";
 
 import { makeChainedBlocks } from "../__utils__/make-chained-block";
 import { setUp } from "../setup";
@@ -485,7 +484,7 @@ describe("State Storage", () => {
                 last: currentTime,
                 block: blocks[5].data,
             };
-            await delay(20);
+            await Utils.sleep(20);
 
             expect(stateStorage.pingBlock(blocks[5].data)).toBeTrue();
 
@@ -579,7 +578,7 @@ describe("State Storage", () => {
 
             expect(stateStorage.isWakeUpTimeoutSet()).toBeTrue();
 
-            await delay(200);
+            await Utils.sleep(200);
 
             expect(stateStorage.isWakeUpTimeoutSet()).toBeFalse();
         });
@@ -592,7 +591,7 @@ describe("State Storage", () => {
 
             stateStorage.setWakeUpTimeout(callbackFn, 100);
 
-            await delay(200);
+            await Utils.sleep(200);
 
             expect(callbackFn).toHaveBeenCalled();
             expect(spyOnClearWakeUpTimeout).toHaveBeenCalled();

--- a/packages/core-state/__tests__/wallets/wallet-repository-clone.test.ts
+++ b/packages/core-state/__tests__/wallets/wallet-repository-clone.test.ts
@@ -1,6 +1,6 @@
 import "jest-extended";
 
-import { Utils } from "@arkecosystem/crypto";
+import { Utils } from "@packages/crypto";
 import { Container, Contracts, Services } from "@packages/core-kernel";
 import {
     addressesIndexer,

--- a/packages/core-state/__tests__/wallets/wallet.test.ts
+++ b/packages/core-state/__tests__/wallets/wallet.test.ts
@@ -1,8 +1,7 @@
 import "jest-extended";
 
-import { Container, Contracts } from "@arkecosystem/core-kernel";
-import { Utils } from "@arkecosystem/crypto";
-import { Services } from "@packages/core-kernel";
+import { Container, Contracts, Services } from "@packages/core-kernel";
+import { Utils } from "@packages/crypto";
 import { Wallet, WalletEvent } from "@packages/core-state/src/wallets";
 import { getWalletAttributeSet } from "@packages/core-test-framework/src/internal/wallet-attributes";
 

--- a/packages/core-test-framework/__tests__/matchers/functional/entity.test.ts
+++ b/packages/core-test-framework/__tests__/matchers/functional/entity.test.ts
@@ -1,6 +1,6 @@
 import "@packages/core-test-framework/src/matchers/functional/entity";
 
-import { EntityType } from "@arkecosystem/core-magistrate-crypto/src/enums";
+import { EntityType } from "@packages/core-magistrate-crypto/src/enums";
 import got from "got";
 import _ from "lodash";
 

--- a/packages/core-test-framework/__tests__/matchers/functional/unconfirmed.test.ts
+++ b/packages/core-test-framework/__tests__/matchers/functional/unconfirmed.test.ts
@@ -1,6 +1,6 @@
 import "@packages/core-test-framework/src/matchers/functional/unconfirmed";
 
-import { Interfaces } from "@arkecosystem/crypto";
+import { Interfaces } from "@packages/crypto";
 import got from "got";
 
 let transactions: Partial<Interfaces.ITransactionData>[];

--- a/packages/core-test-framework/__tests__/mocks/transaction-repository.test.ts
+++ b/packages/core-test-framework/__tests__/mocks/transaction-repository.test.ts
@@ -1,6 +1,6 @@
 import "jest-extended";
 
-import { Utils } from "@arkecosystem/crypto";
+import { Utils } from "@packages/crypto";
 import { Models } from "@packages/core-database";
 import { TransactionRepository } from "@packages/core-test-framework/src/mocks";
 

--- a/packages/core-test-framework/__tests__/utils/api-http-client.test.ts
+++ b/packages/core-test-framework/__tests__/utils/api-http-client.test.ts
@@ -1,6 +1,6 @@
 import "jest-extended";
 
-import { Utils } from "@arkecosystem/core-kernel";
+import { Utils } from "@packages/core-kernel";
 import { Identifiers } from "@packages/core-api";
 import { Sandbox } from "@packages/core-test-framework";
 import { ApiHttpClient } from "@packages/core-test-framework/src/utils";

--- a/packages/core-test-framework/__tests__/utils/mapper.test.ts
+++ b/packages/core-test-framework/__tests__/utils/mapper.test.ts
@@ -1,7 +1,7 @@
 import "jest-extended";
 
-import { Models } from "@arkecosystem/core-database";
-import { Interfaces, Utils } from "@arkecosystem/crypto";
+import { Models } from "@packages/core-database";
+import { Interfaces, Utils } from "@packages/crypto";
 import { mapTransactionToModel } from "@packages/core-test-framework/src/utils/mapper";
 
 let transaction: Interfaces.ITransaction;

--- a/packages/core-test-framework/__tests__/utils/transaction-factory.test.ts
+++ b/packages/core-test-framework/__tests__/utils/transaction-factory.test.ts
@@ -4,7 +4,7 @@ import { Sandbox } from "@packages/core-test-framework";
 import { Generators } from "@packages/core-test-framework/src";
 import passphrases from "@packages/core-test-framework/src/internal/passphrases.json";
 import { TransactionFactory } from "@packages/core-test-framework/src/utils/transaction-factory";
-import { Identities, Managers, Utils } from "@arkecosystem/crypto";
+import { Identities, Managers, Utils } from "@packages/crypto";
 
 import {
     bridgechainRegistrationAsset,

--- a/packages/core-transaction-pool/__tests__/collator.test.ts
+++ b/packages/core-transaction-pool/__tests__/collator.test.ts
@@ -1,9 +1,9 @@
-import { Container } from "@arkecosystem/core-kernel";
-import { Managers } from "@arkecosystem/crypto";
+import { Container } from "@packages/core-kernel";
+import { Managers } from "@packages/crypto";
 
-import { Collator } from "../../../packages/core-transaction-pool/src/collator";
+import { Collator } from "@packages/core-transaction-pool/src/collator";
 
-jest.mock("@arkecosystem/crypto");
+jest.mock("@packages/crypto");
 
 const validator = { validate: jest.fn() };
 const createTransactionValidator = jest.fn();

--- a/packages/core-transaction-pool/__tests__/dynamic-fee-matcher.test.ts
+++ b/packages/core-transaction-pool/__tests__/dynamic-fee-matcher.test.ts
@@ -1,13 +1,13 @@
 import "jest-extended";
 
-import { Container, Contracts } from "@arkecosystem/core-kernel";
-import { Interfaces, Utils } from "@arkecosystem/crypto";
+import { Container, Contracts } from "@packages/core-kernel";
+import { Interfaces, Utils } from "@packages/crypto";
 
-import { DynamicFeeMatcher } from "../../../packages/core-transaction-pool/src/dynamic-fee-matcher";
+import { DynamicFeeMatcher } from "@packages/core-transaction-pool/src/dynamic-fee-matcher";
 import {
     TransactionFeeToHighError,
     TransactionFeeToLowError,
-} from "../../../packages/core-transaction-pool/src/errors";
+} from "@packages/core-transaction-pool/src/errors";
 
 const handler = { dynamicFee: jest.fn() };
 const configuration = { getRequired: jest.fn() };

--- a/packages/core-transaction-pool/__tests__/errors.test.ts
+++ b/packages/core-transaction-pool/__tests__/errors.test.ts
@@ -1,5 +1,5 @@
-import { Contracts } from "@arkecosystem/core-kernel";
-import { Identities, Managers, Transactions, Utils } from "@arkecosystem/crypto";
+import { Contracts } from "@packages/core-kernel";
+import { Identities, Managers, Transactions, Utils } from "@packages/crypto";
 
 import {
     InvalidTransactionDataError,
@@ -14,7 +14,7 @@ import {
     TransactionFromWrongNetworkError,
     TransactionHasExpiredError,
     TransactionPoolFullError,
-} from "../../../packages/core-transaction-pool/src/errors";
+} from "@packages/core-transaction-pool/src/errors";
 
 Managers.configManager.getMilestone().aip11 = true;
 const transaction = Transactions.BuilderFactory.transfer()

--- a/packages/core-transaction-pool/__tests__/expiration-service.test.ts
+++ b/packages/core-transaction-pool/__tests__/expiration-service.test.ts
@@ -1,7 +1,7 @@
-import { Container, Utils } from "@arkecosystem/core-kernel";
-import { Crypto, Interfaces, Managers } from "@arkecosystem/crypto";
+import { Container, Utils } from "@packages/core-kernel";
+import { Crypto, Interfaces, Managers } from "@packages/crypto";
 
-import { ExpirationService } from "../../../packages/core-transaction-pool/src/expiration-service";
+import { ExpirationService } from "@packages/core-transaction-pool/src/expiration-service";
 
 const configuration = { getRequired: jest.fn() };
 const stateStore = { getLastHeight: jest.fn() };

--- a/packages/core-transaction-pool/__tests__/mempool.test.ts
+++ b/packages/core-transaction-pool/__tests__/mempool.test.ts
@@ -1,7 +1,7 @@
-import { Container } from "@arkecosystem/core-kernel";
-import { Identities, Interfaces } from "@arkecosystem/crypto";
+import { Container } from "@packages/core-kernel";
+import { Identities, Interfaces } from "@packages/crypto";
 
-import { Mempool } from "../../../packages/core-transaction-pool/src/mempool";
+import { Mempool } from "@packages/core-transaction-pool/src/mempool";
 
 const createSenderMempool = jest.fn();
 const logger = { debug: jest.fn() };

--- a/packages/core-transaction-pool/__tests__/query.test.ts
+++ b/packages/core-transaction-pool/__tests__/query.test.ts
@@ -1,7 +1,7 @@
-import { Container } from "@arkecosystem/core-kernel";
-import { Enums, Identities, Managers, Transactions } from "@arkecosystem/crypto";
+import { Container } from "@packages/core-kernel";
+import { Enums, Identities, Managers, Transactions } from "@packages/crypto";
 
-import { Query, QueryIterable } from "../../../packages/core-transaction-pool/src/query";
+import { Query, QueryIterable } from "@packages/core-transaction-pool/src/query";
 
 const mempool = {
     getSenderMempools: jest.fn(),

--- a/packages/core-transaction-pool/__tests__/sender-mempool.test.ts
+++ b/packages/core-transaction-pool/__tests__/sender-mempool.test.ts
@@ -1,7 +1,7 @@
-import { Container, Contracts } from "@arkecosystem/core-kernel";
-import { Identities, Managers, Transactions } from "@arkecosystem/crypto";
+import { Container, Contracts } from "@packages/core-kernel";
+import { Identities, Managers, Transactions } from "@packages/crypto";
 
-import { SenderMempool } from "../../../packages/core-transaction-pool/src/sender-mempool";
+import { SenderMempool } from "@packages/core-transaction-pool/src/sender-mempool";
 
 const configuration = { getRequired: jest.fn(), getOptional: jest.fn() };
 const senderState = { apply: jest.fn(), revert: jest.fn() };

--- a/packages/core-transaction-pool/__tests__/sender-state.test.ts
+++ b/packages/core-transaction-pool/__tests__/sender-state.test.ts
@@ -1,7 +1,7 @@
 import { Container, Contracts, Enums } from "@packages/core-kernel";
 import { Crypto, Interfaces, Managers } from "@packages/crypto";
 
-import { SenderState } from "@ackages/core-transaction-pool/src/sender-state";
+import { SenderState } from "@packages/core-transaction-pool/src/sender-state";
 
 jest.mock("@packages/crypto");
 

--- a/packages/core-transaction-pool/__tests__/sender-state.test.ts
+++ b/packages/core-transaction-pool/__tests__/sender-state.test.ts
@@ -1,7 +1,7 @@
-import { Container, Contracts, Enums } from "@arkecosystem/core-kernel";
-import { Crypto, Interfaces, Managers } from "@arkecosystem/crypto";
+import { Container, Contracts, Enums } from "@packages/core-kernel";
+import { Crypto, Interfaces, Managers } from "@packages/crypto";
 
-import { SenderState } from "../../../packages/core-transaction-pool/src/sender-state";
+import { SenderState } from "@ackages/core-transaction-pool/src/sender-state";
 
 jest.mock("@packages/crypto");
 

--- a/packages/core-transaction-pool/__tests__/service-provider.test.ts
+++ b/packages/core-transaction-pool/__tests__/service-provider.test.ts
@@ -1,6 +1,6 @@
 import "jest-extended";
 
-import { Application, Container, Contracts, Services } from "@arkecosystem/core-kernel";
+import { Application, Container, Contracts, Services } from "@packages/core-kernel";
 import { ServiceProvider } from "@packages/core-transaction-pool/src";
 import { fork } from "child_process";
 import { AnySchema } from "joi";

--- a/packages/core-transaction-pool/__tests__/service.test.ts
+++ b/packages/core-transaction-pool/__tests__/service.test.ts
@@ -1,7 +1,7 @@
-import { Container, Contracts, Enums } from "@arkecosystem/core-kernel";
-import { Identities, Managers, Transactions } from "@arkecosystem/crypto";
+import { Container, Contracts, Enums } from "@packages/core-kernel";
+import { Identities, Managers, Transactions } from "@packages/crypto";
 
-import { Service } from "../../../packages/core-transaction-pool/src/service";
+import { Service } from "@packages/core-transaction-pool/src/service";
 
 const configuration = {
     getRequired: jest.fn(),

--- a/packages/core-transaction-pool/__tests__/storage.test.ts
+++ b/packages/core-transaction-pool/__tests__/storage.test.ts
@@ -1,8 +1,8 @@
-import { Container } from "@arkecosystem/core-kernel";
-import { Identities, Managers, Transactions } from "@arkecosystem/crypto";
+import { Container } from "@packages/core-kernel";
+import { Identities, Managers, Transactions } from "@packages/crypto";
 import { ensureFileSync } from "fs-extra";
 
-import { Storage } from "../../../packages/core-transaction-pool/src/storage";
+import { Storage } from "@packages/core-transaction-pool/src/storage";
 
 jest.mock("fs-extra");
 

--- a/packages/core-transaction-pool/__tests__/worker-pool.test.ts
+++ b/packages/core-transaction-pool/__tests__/worker-pool.test.ts
@@ -1,7 +1,7 @@
-import { Container } from "@arkecosystem/core-kernel";
-import { Enums } from "@arkecosystem/crypto";
+import { Container } from "@packages/core-kernel";
+import { Enums } from "@packages/crypto";
 
-import { WorkerPool } from "../../../packages/core-transaction-pool/src/worker-pool";
+import { WorkerPool } from "@packages/core-transaction-pool/src/worker-pool";
 
 const createWorker = jest.fn();
 const pluginConfiguration = { getRequired: jest.fn() };

--- a/packages/core-transactions/__tests__/handlers/two/transaction.test.ts
+++ b/packages/core-transactions/__tests__/handlers/two/transaction.test.ts
@@ -1,7 +1,7 @@
 import "jest-extended";
 
-import { TransactionTypeGroup } from "@arkecosystem/crypto/dist/enums";
-import { TransactionSchema } from "@arkecosystem/crypto/dist/transactions/types/schemas";
+import { TransactionTypeGroup } from "@packages/crypto/dist/enums";
+import { TransactionSchema } from "@packages/crypto/dist/transactions/types/schemas";
 import { Application, Contracts } from "@packages/core-kernel";
 import { Identifiers } from "@packages/core-kernel/src/ioc";
 import { Wallets } from "@packages/core-state";

--- a/packages/core-webhooks/__tests__/server/utils.test.ts
+++ b/packages/core-webhooks/__tests__/server/utils.test.ts
@@ -1,7 +1,7 @@
 import "jest-extended";
 
-import { Enums } from "@arkecosystem/core-kernel";
-import { Webhook } from "@arkecosystem/core-webhooks/src/interfaces";
+import { Enums } from "@packages/core-kernel";
+import { Webhook } from "@packages/core-webhooks/src/interfaces";
 import { respondWithResource } from "@packages/core-webhooks/src/server/utils";
 
 const data: Webhook = {

--- a/packages/core/__tests__/__support__/app.ts
+++ b/packages/core/__tests__/__support__/app.ts
@@ -1,4 +1,4 @@
-import { ApplicationFactory, Commands, Container, Services } from "@arkecosystem/core-cli";
+import { ApplicationFactory, Commands, Container, Services } from "@packages/core-cli";
 
 export const executeCommand = async (command): Promise<void> => {
     const app = ApplicationFactory.make(new Container.Container(), {

--- a/packages/core/__tests__/commands/config-cli.test.ts
+++ b/packages/core/__tests__/commands/config-cli.test.ts
@@ -1,5 +1,5 @@
-import { Container } from "@arkecosystem/core-cli";
-import { Console } from "@arkecosystem/core-test-framework";
+import { Container } from "@packages/core-cli";
+import { Console } from "@packages/core-test-framework";
 import { Command } from "@packages/core/src/commands/config-cli";
 
 import execa from "../../../../__mocks__/execa";

--- a/packages/core/__tests__/commands/config-forger-bip38.test.ts
+++ b/packages/core/__tests__/commands/config-forger-bip38.test.ts
@@ -1,5 +1,5 @@
-import { Container } from "@arkecosystem/core-cli";
-import { Console } from "@arkecosystem/core-test-framework";
+import { Container } from "@packages/core-cli";
+import { Console } from "@packages/core-test-framework";
 import { Command } from "@packages/core/src/commands/config-forger-bip38";
 import { writeJSONSync } from "fs-extra";
 import prompts from "prompts";

--- a/packages/core/__tests__/commands/config-forger-bip39.test.ts
+++ b/packages/core/__tests__/commands/config-forger-bip39.test.ts
@@ -1,4 +1,4 @@
-import { Console } from "@arkecosystem/core-test-framework";
+import { Console } from "@packages/core-test-framework";
 import { Command } from "@packages/core/src/commands/config-forger-bip39";
 import { writeJSONSync } from "fs-extra";
 import prompts from "prompts";

--- a/packages/core/__tests__/commands/config-publish.test.ts
+++ b/packages/core/__tests__/commands/config-publish.test.ts
@@ -1,5 +1,5 @@
-import { Container } from "@arkecosystem/core-cli";
-import { Console } from "@arkecosystem/core-test-framework";
+import { Container } from "@packages/core-cli";
+import { Console } from "@packages/core-test-framework";
 import { Command } from "@packages/core/src/commands/config-publish";
 import fs from "fs-extra";
 import { dirSync, setGracefulCleanup } from "tmp";

--- a/packages/core/__tests__/commands/core-log.test.ts
+++ b/packages/core/__tests__/commands/core-log.test.ts
@@ -1,4 +1,4 @@
-import { Console } from "@arkecosystem/core-test-framework";
+import { Console } from "@packages/core-test-framework";
 import { Command } from "@packages/core/src/commands/core-log";
 
 let cli;

--- a/packages/core/__tests__/commands/core-restart.test.ts
+++ b/packages/core/__tests__/commands/core-restart.test.ts
@@ -1,5 +1,5 @@
-import { Container } from "@arkecosystem/core-cli";
-import { Console } from "@arkecosystem/core-test-framework";
+import { Container } from "@packages/core-cli";
+import { Console } from "@packages/core-test-framework";
 import { Command } from "@packages/core/src/commands/core-restart";
 
 let cli;

--- a/packages/core/__tests__/commands/core-run.test.ts
+++ b/packages/core/__tests__/commands/core-run.test.ts
@@ -9,7 +9,7 @@ const app = {
     boot: jest.fn(),
 };
 
-jest.mock("@arkecosystem/core-kernel", () => ({
+jest.mock("@packages/core-kernel", () => ({
     __esModule: true,
     Application: jest.fn(() => app),
     Container: {

--- a/packages/core/__tests__/commands/core-start.test.ts
+++ b/packages/core/__tests__/commands/core-start.test.ts
@@ -1,5 +1,5 @@
-import { Container } from "@arkecosystem/core-cli";
-import { Console } from "@arkecosystem/core-test-framework";
+import { Container } from "@packages/core-cli";
+import { Console } from "@packages/core-test-framework";
 import { Command } from "@packages/core/src/commands/core-start";
 import { writeJSONSync } from "fs-extra";
 import os from "os";

--- a/packages/core/__tests__/commands/core-status.test.ts
+++ b/packages/core/__tests__/commands/core-status.test.ts
@@ -1,7 +1,7 @@
 import "jest-extended";
 
-import { Container } from "@arkecosystem/core-cli";
-import { Console } from "@arkecosystem/core-test-framework";
+import { Container } from "@packages/core-cli";
+import { Console } from "@packages/core-test-framework";
 import { Command } from "@packages/core/src/commands/core-status";
 
 let cli;

--- a/packages/core/__tests__/commands/core-stop.test.ts
+++ b/packages/core/__tests__/commands/core-stop.test.ts
@@ -1,5 +1,5 @@
-import { Container } from "@arkecosystem/core-cli";
-import { Console } from "@arkecosystem/core-test-framework";
+import { Container } from "@packages/core-cli";
+import { Console } from "@packages/core-test-framework";
 import { Command } from "@packages/core/src/commands/core-stop";
 
 let cli;

--- a/packages/core/__tests__/commands/env-get.test.ts
+++ b/packages/core/__tests__/commands/env-get.test.ts
@@ -1,4 +1,4 @@
-import { Console } from "@arkecosystem/core-test-framework";
+import { Console } from "@packages/core-test-framework";
 import { Command } from "@packages/core/src/commands/env-get";
 import { ensureDirSync, ensureFileSync, writeFileSync } from "fs-extra";
 import { dirSync, setGracefulCleanup } from "tmp";

--- a/packages/core/__tests__/commands/env-list.test.ts
+++ b/packages/core/__tests__/commands/env-list.test.ts
@@ -1,4 +1,4 @@
-import { Console } from "@arkecosystem/core-test-framework";
+import { Console } from "@packages/core-test-framework";
 import { Command } from "@packages/core/src/commands/env-list";
 import { removeSync, writeFileSync } from "fs-extra";
 import { dirSync, setGracefulCleanup } from "tmp";

--- a/packages/core/__tests__/commands/env-paths.test.ts
+++ b/packages/core/__tests__/commands/env-paths.test.ts
@@ -1,4 +1,4 @@
-import { Console } from "@arkecosystem/core-test-framework";
+import { Console } from "@packages/core-test-framework";
 import { Command } from "@packages/core/src/commands/env-paths";
 import envPaths, { Paths } from "env-paths";
 

--- a/packages/core/__tests__/commands/env-set.test.ts
+++ b/packages/core/__tests__/commands/env-set.test.ts
@@ -1,4 +1,4 @@
-import { Console } from "@arkecosystem/core-test-framework";
+import { Console } from "@packages/core-test-framework";
 import { Command } from "@packages/core/src/commands/env-set";
 import envfile from "envfile";
 import { ensureFileSync, removeSync } from "fs-extra";

--- a/packages/core/__tests__/commands/forger-log.test.ts
+++ b/packages/core/__tests__/commands/forger-log.test.ts
@@ -1,4 +1,4 @@
-import { Console } from "@arkecosystem/core-test-framework";
+import { Console } from "@packages/core-test-framework";
 import { Command } from "@packages/core/src/commands/forger-log";
 
 let cli;

--- a/packages/core/__tests__/commands/forger-restart.test.ts
+++ b/packages/core/__tests__/commands/forger-restart.test.ts
@@ -1,5 +1,5 @@
-import { Container } from "@arkecosystem/core-cli";
-import { Console } from "@arkecosystem/core-test-framework";
+import { Container } from "@packages/core-cli";
+import { Console } from "@packages/core-test-framework";
 import { Command } from "@packages/core/src/commands/forger-restart";
 
 let cli;

--- a/packages/core/__tests__/commands/forger-run.test.ts
+++ b/packages/core/__tests__/commands/forger-run.test.ts
@@ -9,7 +9,7 @@ const app = {
     boot: jest.fn(),
 };
 
-jest.mock("@arkecosystem/core-kernel", () => ({
+jest.mock("@packages/core-kernel", () => ({
     __esModule: true,
     Application: jest.fn(() => app),
     Container: {

--- a/packages/core/__tests__/commands/forger-start.test.ts
+++ b/packages/core/__tests__/commands/forger-start.test.ts
@@ -1,5 +1,5 @@
-import { Container } from "@arkecosystem/core-cli";
-import { Console } from "@arkecosystem/core-test-framework";
+import { Container } from "@packages/core-cli";
+import { Console } from "@packages/core-test-framework";
 import { Command } from "@packages/core/src/commands/forger-start";
 import { writeJSONSync } from "fs-extra";
 import os from "os";

--- a/packages/core/__tests__/commands/forger-status.test.ts
+++ b/packages/core/__tests__/commands/forger-status.test.ts
@@ -1,7 +1,7 @@
 import "jest-extended";
 
-import { Container } from "@arkecosystem/core-cli";
-import { Console } from "@arkecosystem/core-test-framework";
+import { Container } from "@packages/core-cli";
+import { Console } from "@packages/core-test-framework";
 import { Command } from "@packages/core/src/commands/forger-status";
 
 let cli;

--- a/packages/core/__tests__/commands/forger-stop.test.ts
+++ b/packages/core/__tests__/commands/forger-stop.test.ts
@@ -1,5 +1,5 @@
-import { Container } from "@arkecosystem/core-cli";
-import { Console } from "@arkecosystem/core-test-framework";
+import { Container } from "@packages/core-cli";
+import { Console } from "@packages/core-test-framework";
 import { Command } from "@packages/core/src/commands/forger-stop";
 
 let cli;

--- a/packages/core/__tests__/commands/help.test.ts
+++ b/packages/core/__tests__/commands/help.test.ts
@@ -1,7 +1,7 @@
 import "jest-extended";
 
-import { Container } from "@arkecosystem/core-cli";
-import { Console } from "@arkecosystem/core-test-framework";
+import { Container } from "@packages/core-cli";
+import { Console } from "@packages/core-test-framework";
 import { Command } from "@packages/core/src/commands/help";
 
 let cli;

--- a/packages/core/__tests__/commands/network-generate.test.ts
+++ b/packages/core/__tests__/commands/network-generate.test.ts
@@ -1,6 +1,6 @@
 import "jest-extended";
 
-import { Console } from "@arkecosystem/core-test-framework";
+import { Console } from "@packages/core-test-framework";
 import { Command } from "@packages/core/src/commands/network-generate";
 import envPaths from "env-paths";
 import fs from "fs-extra";

--- a/packages/core/__tests__/commands/plugin-remove.test.ts
+++ b/packages/core/__tests__/commands/plugin-remove.test.ts
@@ -2,7 +2,7 @@ import "jest-extended";
 
 import { Console } from "@packages/core-test-framework";
 import { Command } from "@packages/core/src/commands/plugin-remove";
-import { Container } from "@arkecosystem/core-cli";
+import { Container } from "@packages/core-cli";
 
 let cli;
 let spyOnRemove;

--- a/packages/core/__tests__/commands/plugin-update.test.ts
+++ b/packages/core/__tests__/commands/plugin-update.test.ts
@@ -2,7 +2,7 @@ import "jest-extended";
 
 import { Console } from "@packages/core-test-framework";
 import { Command } from "@packages/core/src/commands/plugin-update";
-import { Container } from "@arkecosystem/core-cli";
+import { Container } from "@packages/core-cli";
 
 let cli;
 let spyOnUpdate;

--- a/packages/core/__tests__/commands/reinstall.test.ts
+++ b/packages/core/__tests__/commands/reinstall.test.ts
@@ -1,7 +1,7 @@
 import "jest-extended";
 
-import { Container } from "@arkecosystem/core-cli";
-import { Console } from "@arkecosystem/core-test-framework";
+import { Container } from "@packages/core-cli";
+import { Console } from "@packages/core-test-framework";
 import { Command } from "@packages/core/src/commands/reinstall";
 import prompts from "prompts";
 

--- a/packages/core/__tests__/commands/relay-log.test.ts
+++ b/packages/core/__tests__/commands/relay-log.test.ts
@@ -1,5 +1,5 @@
-import { Container } from "@arkecosystem/core-cli";
-import { Console } from "@arkecosystem/core-test-framework";
+import { Container } from "@packages/core-cli";
+import { Console } from "@packages/core-test-framework";
 import { Command } from "@packages/core/src/commands/relay-log";
 import { fileSync, setGracefulCleanup } from "tmp";
 

--- a/packages/core/__tests__/commands/relay-restart.test.ts
+++ b/packages/core/__tests__/commands/relay-restart.test.ts
@@ -1,5 +1,5 @@
-import { Container } from "@arkecosystem/core-cli";
-import { Console } from "@arkecosystem/core-test-framework";
+import { Container } from "@packages/core-cli";
+import { Console } from "@packages/core-test-framework";
 import { Command } from "@packages/core/src/commands/relay-restart";
 
 let cli;

--- a/packages/core/__tests__/commands/relay-run.test.ts
+++ b/packages/core/__tests__/commands/relay-run.test.ts
@@ -8,7 +8,7 @@ const app = {
     boot: jest.fn(),
 };
 
-jest.mock("@arkecosystem/core-kernel", () => ({
+jest.mock("@packages/core-kernel", () => ({
     __esModule: true,
     Application: jest.fn(() => app),
     Container: {

--- a/packages/core/__tests__/commands/relay-share.test.ts
+++ b/packages/core/__tests__/commands/relay-share.test.ts
@@ -1,4 +1,4 @@
-import { Console } from "@arkecosystem/core-test-framework";
+import { Console } from "@packages/core-test-framework";
 import { Command } from "@packages/core/src/commands/relay-share";
 import ngrok from "ngrok";
 

--- a/packages/core/__tests__/commands/relay-start.test.ts
+++ b/packages/core/__tests__/commands/relay-start.test.ts
@@ -1,5 +1,5 @@
-import { Container } from "@arkecosystem/core-cli";
-import { Console } from "@arkecosystem/core-test-framework";
+import { Container } from "@packages/core-cli";
+import { Console } from "@packages/core-test-framework";
 import { Command } from "@packages/core/src/commands/relay-start";
 import os from "os";
 import { resolve } from "path";

--- a/packages/core/__tests__/commands/relay-status.test.ts
+++ b/packages/core/__tests__/commands/relay-status.test.ts
@@ -1,7 +1,7 @@
 import "jest-extended";
 
-import { Container } from "@arkecosystem/core-cli";
-import { Console } from "@arkecosystem/core-test-framework";
+import { Container } from "@packages/core-cli";
+import { Console } from "@packages/core-test-framework";
 import { Command } from "@packages/core/src/commands/relay-status";
 
 let cli;

--- a/packages/core/__tests__/commands/relay-stop.test.ts
+++ b/packages/core/__tests__/commands/relay-stop.test.ts
@@ -1,5 +1,5 @@
-import { Container } from "@arkecosystem/core-cli";
-import { Console } from "@arkecosystem/core-test-framework";
+import { Container } from "@packages/core-cli";
+import { Console } from "@packages/core-test-framework";
 import { Command } from "@packages/core/src/commands/relay-stop";
 
 let cli;

--- a/packages/core/__tests__/commands/snapshot-restore.test.ts
+++ b/packages/core/__tests__/commands/snapshot-restore.test.ts
@@ -1,7 +1,7 @@
 import { Console, Sandbox } from "@packages/core-test-framework";
 import { Command } from "@packages/core/src/commands/snapshot-restore";
-import { Container } from "@arkecosystem/core-kernel";
-import { Utils } from "@arkecosystem/core-cli";
+import { Container } from "@packages/core-kernel";
+import { Utils } from "@packages/core-cli";
 
 jest.mock("@packages/core-cli", () => {
     const originalModule = jest.requireActual("@packages/core-cli");

--- a/packages/core/__tests__/commands/snapshot-truncate.test.ts
+++ b/packages/core/__tests__/commands/snapshot-truncate.test.ts
@@ -1,5 +1,5 @@
-import { Utils } from "@arkecosystem/core-cli";
-import { Container } from "@arkecosystem/core-kernel";
+import { Utils } from "@packages/core-cli";
+import { Container } from "@packages/core-kernel";
 import { Console, Sandbox } from "@packages/core-test-framework";
 import { Command } from "@packages/core/src/commands/snapshot-truncate";
 

--- a/packages/core/__tests__/commands/snapshot-verify.test.ts
+++ b/packages/core/__tests__/commands/snapshot-verify.test.ts
@@ -1,4 +1,4 @@
-import { Container } from "@arkecosystem/core-kernel";
+import { Container } from "@packages/core-kernel";
 import { Utils } from "@packages/core-cli";
 import { Console, Sandbox } from "@packages/core-test-framework";
 import { Command } from "@packages/core/src/commands/snapshot-verify";

--- a/packages/core/__tests__/commands/top.test.ts
+++ b/packages/core/__tests__/commands/top.test.ts
@@ -1,7 +1,7 @@
 import "jest-extended";
 
-import { Container } from "@arkecosystem/core-cli";
-import { Console } from "@arkecosystem/core-test-framework";
+import { Container } from "@packages/core-cli";
+import { Console } from "@packages/core-test-framework";
 import { Command } from "@packages/core/src/commands/top";
 
 let cli;

--- a/packages/core/__tests__/commands/uninstall.test.ts
+++ b/packages/core/__tests__/commands/uninstall.test.ts
@@ -1,4 +1,4 @@
-import { Console } from "@arkecosystem/core-test-framework";
+import { Console } from "@packages/core-test-framework";
 import { Command } from "@packages/core/src/commands/uninstall";
 
 let cli;

--- a/packages/core/__tests__/commands/update.test.ts
+++ b/packages/core/__tests__/commands/update.test.ts
@@ -1,7 +1,7 @@
 import "jest-extended";
 
-import { Container } from "@arkecosystem/core-cli";
-import { Console } from "@arkecosystem/core-test-framework";
+import { Container } from "@packages/core-cli";
+import { Console } from "@packages/core-test-framework";
 import { Command } from "@packages/core/src/commands/update";
 import nock from "nock";
 import prompts from "prompts";

--- a/packages/core/__tests__/commands/version.test.ts
+++ b/packages/core/__tests__/commands/version.test.ts
@@ -1,4 +1,4 @@
-import { Console } from "@arkecosystem/core-test-framework";
+import { Console } from "@packages/core-test-framework";
 import { Command } from "@packages/core/src/commands/version";
 
 let cli;

--- a/packages/crypto/__tests__/blocks/__fixtures__/wallet.ts
+++ b/packages/crypto/__tests__/blocks/__fixtures__/wallet.ts
@@ -1,6 +1,6 @@
-import { Wallets } from "@arkecosystem/core-state";
+import { Wallets } from "@packages/core-state";
 
-import { BigNumber } from "../../../../../packages/crypto/src/utils";
+import { BigNumber } from "@packages/crypto/src/utils";
 
 export const wallet = {
     address: "DTRdbaUW3RQQSL5By4G43JVaeHiqfVp9oh",

--- a/packages/crypto/__tests__/blocks/block.test.ts
+++ b/packages/crypto/__tests__/blocks/block.test.ts
@@ -1,6 +1,6 @@
 import "jest-extended";
 
-import { Interfaces, Managers, Utils } from "@arkecosystem/crypto";
+import { Interfaces, Managers, Utils } from "@packages/crypto";
 import { BIP39 } from "@packages/core-forger/src/methods/bip39";
 import { TransactionFactory } from "@packages/core-test-framework/src/utils/transaction-factory";
 import { Block, BlockFactory, Deserializer, Serializer } from "@packages/crypto/src/blocks";

--- a/packages/crypto/__tests__/fixtures/block.ts
+++ b/packages/crypto/__tests__/fixtures/block.ts
@@ -1,4 +1,4 @@
-import { Utils } from "@arkecosystem/crypto";
+import { Utils } from "@packages/crypto";
 
 export const dummyBlock = {
     id: "17605317082329008056",

--- a/packages/crypto/__tests__/fixtures/transaction.ts
+++ b/packages/crypto/__tests__/fixtures/transaction.ts
@@ -1,4 +1,4 @@
-import { Utils } from "@arkecosystem/crypto";
+import { Utils } from "@packages/crypto";
 
 export const transaction = {
     id: "0db225779a7da86bdeaf3a24494fcf3cae7bfe74451fdc3bcb866f62319badeb",

--- a/packages/crypto/__tests__/identities/address.test.ts
+++ b/packages/crypto/__tests__/identities/address.test.ts
@@ -1,11 +1,11 @@
 import "jest-extended";
 
-import { PublicKey } from "@arkecosystem/crypto/src/identities";
+import { PublicKey } from "@packages/crypto/src/identities";
 import { Errors } from "@arkecosystem/crypto-identities";
 
-import { Address } from "../../../../packages/crypto/src/identities/address";
-import { Keys } from "../../../../packages/crypto/src/identities/keys";
-import { configManager } from "../../../../packages/crypto/src/managers";
+import { Address } from "@packages/crypto/src/identities/address";
+import { Keys } from "@packages/crypto/src/identities/keys";
+import { configManager } from "@packages/crypto/src/managers";
 import { data, passphrase } from "./fixture.json";
 
 describe("Identities - Address", () => {

--- a/packages/crypto/__tests__/identities/keys.test.ts
+++ b/packages/crypto/__tests__/identities/keys.test.ts
@@ -3,8 +3,8 @@ import "jest-extended";
 import { Errors } from "@arkecosystem/crypto-identities";
 import wif from "wif";
 
-import { Address } from "../../../../packages/crypto/src/identities/address";
-import { Keys } from "../../../../packages/crypto/src/identities/keys";
+import { Address } from "@packages/crypto/src/identities/address";
+import { Keys } from "@packages/crypto/src/identities/keys";
 import { data, passphrase } from "./fixture.json";
 
 describe("Identities - Keys", () => {

--- a/packages/crypto/__tests__/identities/public-key.test.ts
+++ b/packages/crypto/__tests__/identities/public-key.test.ts
@@ -2,7 +2,7 @@ import "jest-extended";
 
 import { Errors } from "@arkecosystem/crypto-identities";
 
-import { PublicKey } from "../../../../packages/crypto/src/identities/public-key";
+import { PublicKey } from "@packages/crypto/src/identities/public-key";
 import { data, passphrase } from "./fixture.json";
 
 describe("Identities - Public Key", () => {

--- a/packages/crypto/__tests__/transactions/__fixtures__/transaction.ts
+++ b/packages/crypto/__tests__/transactions/__fixtures__/transaction.ts
@@ -1,4 +1,4 @@
-import { Utils } from "@arkecosystem/crypto";
+import { Utils } from "@packages/crypto";
 
 export const transaction = {
     version: 1,

--- a/packages/crypto/__tests__/transactions/__fixtures__/wallet.ts
+++ b/packages/crypto/__tests__/transactions/__fixtures__/wallet.ts
@@ -1,5 +1,5 @@
-import { Wallets } from "@arkecosystem/core-state";
-import { Utils } from "@arkecosystem/crypto";
+import { Wallets } from "@packages/core-state";
+import { Utils } from "@packages/crypto";
 
 export const wallet = {
     address: "ANBkoGqWeTSiaEVgVzSKZd3jS7UWzv9PSo",

--- a/packages/crypto/__tests__/transactions/__support__/index.ts
+++ b/packages/crypto/__tests__/transactions/__support__/index.ts
@@ -1,10 +1,10 @@
 import "jest-extended";
 
-import { TransactionTypeError } from "@arkecosystem/crypto/src/errors";
-import { Keys } from "@arkecosystem/crypto/src/identities";
-import { ITransaction } from "@arkecosystem/crypto/src/interfaces";
-import { configManager } from "@arkecosystem/crypto/src/managers";
-import { BuilderFactory } from "@arkecosystem/crypto/src/transactions";
+import { TransactionTypeError } from "@packages/crypto/src/errors";
+import { Keys } from "@packages/crypto/src/identities";
+import { ITransaction } from "@packages/crypto/src/interfaces";
+import { configManager } from "@packages/crypto/src/managers";
+import { BuilderFactory } from "@packages/crypto/src/transactions";
 
 export const createRandomTx = (type) => {
     let transaction: ITransaction;

--- a/packages/crypto/__tests__/transactions/builders/transactions/ipfs.test.ts
+++ b/packages/crypto/__tests__/transactions/builders/transactions/ipfs.test.ts
@@ -1,6 +1,6 @@
 import "jest-extended";
 
-import { Utils } from "@arkecosystem/crypto";
+import { Utils } from "@packages/crypto";
 import { Generators } from "@packages/core-test-framework/src";
 import { TransactionType } from "@packages/crypto/src/enums";
 import { configManager } from "@packages/crypto/src/managers";

--- a/packages/crypto/__tests__/transactions/builders/transactions/second-signature.test.ts
+++ b/packages/crypto/__tests__/transactions/builders/transactions/second-signature.test.ts
@@ -1,6 +1,6 @@
 import "jest-extended";
 
-import { Utils } from "@arkecosystem/crypto";
+import { Utils } from "@packages/crypto";
 import { Factories, Generators } from "@packages/core-test-framework/src";
 import { TransactionType } from "@packages/crypto/src/enums";
 import { Keys } from "@packages/crypto/src/identities";

--- a/packages/crypto/__tests__/transactions/builders/transactions/transfer.test.ts
+++ b/packages/crypto/__tests__/transactions/builders/transactions/transfer.test.ts
@@ -1,6 +1,6 @@
 import "jest-extended";
 
-import { Utils } from "@arkecosystem/crypto";
+import { Utils } from "@packages/crypto";
 import { Factories, Generators } from "@packages/core-test-framework/src";
 import { TransactionType } from "@packages/crypto/src/enums";
 import { Keys, WIF } from "@packages/crypto/src/identities";

--- a/packages/crypto/__tests__/transactions/factory.test.ts
+++ b/packages/crypto/__tests__/transactions/factory.test.ts
@@ -1,20 +1,20 @@
 import "jest-extended";
 
-import { Interfaces, Utils } from "@arkecosystem/crypto";
+import { Interfaces, Utils } from "@packages/crypto";
 
 import {
     InvalidTransactionBytesError,
     TransactionSchemaError,
     UnkownTransactionError,
-} from "../../../../packages/crypto/src/errors";
-import { ITransactionData } from "../../../../packages/crypto/src/interfaces";
-import { configManager } from "../../../../packages/crypto/src/managers";
+} from "@packages/crypto/src/errors";
+import { ITransactionData } from "@packages/crypto/src/interfaces";
+import { configManager } from "@packages/crypto/src/managers";
 import {
     Serializer,
     Transaction,
     TransactionFactory,
     Utils as TransactionUtils,
-} from "../../../../packages/crypto/src/transactions";
+} from "@packages/crypto/src/transactions";
 import { transaction as transactionFixture } from "../fixtures/transaction";
 import { transaction as transactionDataFixture } from "../fixtures/transaction";
 import { createRandomTx } from "./__support__";

--- a/packages/crypto/__tests__/transactions/utils.test.ts
+++ b/packages/crypto/__tests__/transactions/utils.test.ts
@@ -1,6 +1,6 @@
 import "jest-extended";
 
-import { Utils } from "@arkecosystem/crypto";
+import { Utils } from "@packages/crypto";
 import { Generators } from "@packages/core-test-framework/src";
 import { TransactionFactory as TestTransactionFactory } from "@packages/core-test-framework/src/utils/transaction-factory";
 
@@ -8,16 +8,16 @@ import {
     InvalidTransactionBytesError,
     TransactionTypeError,
     TransactionVersionError,
-} from "../../../../packages/crypto/src/errors";
-import { Keys } from "../../../../packages/crypto/src/identities";
-import { ITransaction, ITransactionData } from "../../../../packages/crypto/src/interfaces";
-import { configManager } from "../../../../packages/crypto/src/managers";
+} from "@packages/crypto/src/errors";
+import { Keys } from "@packages/crypto/src/identities";
+import { ITransaction, ITransactionData } from "@packages/crypto/src/interfaces";
+import { configManager } from "@packages/crypto/src/managers";
 import {
     BuilderFactory,
     Transaction,
     TransactionFactory,
     Utils as TransactionUtils,
-} from "../../../../packages/crypto/src/transactions";
+} from "@packages/crypto/src/transactions";
 import { transaction as transactionDataFixture } from "../fixtures/transaction";
 
 let transactionData: ITransactionData;

--- a/packages/crypto/__tests__/transactions/verifier.test.ts
+++ b/packages/crypto/__tests__/transactions/verifier.test.ts
@@ -1,14 +1,14 @@
 import "jest-extended";
 
-import { Identities } from "@arkecosystem/crypto";
-import { Hash } from "@arkecosystem/crypto/src/crypto";
-import { TransactionVersionError } from "@arkecosystem/crypto/src/errors";
-import { Keys } from "@arkecosystem/crypto/src/identities";
-import { BuilderFactory, Utils as TransactionUtils, Verifier } from "@arkecosystem/crypto/src/transactions";
+import { Identities } from "@packages/crypto";
+import { Hash } from "@packages/crypto/src/crypto";
+import { TransactionVersionError } from "@packages/crypto/src/errors";
+import { Keys } from "@packages/crypto/src/identities";
+import { BuilderFactory, Utils as TransactionUtils, Verifier } from "@packages/crypto/src/transactions";
 import { Generators } from "@packages/core-test-framework/src";
 import { TransactionFactory } from "@packages/core-test-framework/src/utils/transaction-factory";
 
-import { configManager } from "../../../../packages/crypto/src/managers";
+import { configManager } from "@packages/crypto/src/managers";
 import { createRandomTx } from "./__support__";
 
 beforeEach(() => {


### PR DESCRIPTION
## Summary

Import core packages using @packages. When yarn will be replaced with pnpm @arkecosystem import will no longer work for tests.

## Checklist

- [x] Tests
- [x] Ready to be merged
