### PR TITLE
refactor(core-crypto): simple reader/writer

### DIFF
--- a/packages/crypto/src/index.ts
+++ b/packages/crypto/src/index.ts
@@ -7,6 +7,7 @@ export * as Identities from "./identities";
 export * as Interfaces from "./interfaces";
 export * as Managers from "./managers";
 export * as Networks from "./networks";
+export * as Serde from "./serde";
 export * as Transactions from "./transactions";
 export * as Types from "./types";
 export * as Utils from "./utils";

--- a/packages/crypto/src/interfaces/index.ts
+++ b/packages/crypto/src/interfaces/index.ts
@@ -4,4 +4,5 @@ export * from "./identities";
 export * from "./managers";
 export * from "./message";
 export * from "./networks";
+export * from "./serde";
 export * from "./transactions";

--- a/packages/crypto/src/interfaces/serde.ts
+++ b/packages/crypto/src/interfaces/serde.ts
@@ -5,6 +5,7 @@ export interface IAddress {
     readonly network: number;
 
     toString(format?: "base58" | "base58c"): string;
+    toJSON(): string;
 }
 
 export interface IReader {

--- a/packages/crypto/src/interfaces/serde.ts
+++ b/packages/crypto/src/interfaces/serde.ts
@@ -1,0 +1,72 @@
+import ByteBuffer from "bytebuffer";
+
+export interface IAddress {
+    readonly serialized: Buffer;
+    readonly network: number;
+
+    toString(format?: "base58" | "base58c"): string;
+}
+
+export interface IReader {
+    readonly buffer: Buffer;
+    readonly offset: number;
+
+    jump(length: number): void;
+
+    readInt8(): number;
+    readInt16BE(): number;
+    readInt16LE(): number;
+    readInt32BE(): number;
+    readInt32LE(): number;
+    readBigInt64BE(): bigint;
+    readBigInt64LE(): bigint;
+
+    readUInt8(): number;
+    readUInt16BE(): number;
+    readUInt16LE(): number;
+    readUInt32BE(): number;
+    readUInt32LE(): number;
+    readBigUInt64BE(): bigint;
+    readBigUInt64LE(): bigint;
+
+    readBuffer(length: number): Buffer;
+    readPublicKey(): Buffer;
+    readEcdsaSignature(): Buffer;
+    readSchnorrSignature(): Buffer;
+    readAddress(): IAddress;
+
+    readWithByteBufferBE<T>(cb: (byteBuffer: ByteBuffer) => T): T;
+    readWithByteBufferLE<T>(cb: (byteBuffer: ByteBuffer) => T): T;
+}
+
+export interface IWriter {
+    readonly buffer: Buffer;
+    readonly offset: number;
+
+    jump(length: number): void;
+
+    writeInt8(value: number): void;
+    writeInt16BE(value: number): void;
+    writeInt16LE(value: number): void;
+    writeInt32BE(value: number): void;
+    writeInt32LE(value: number): void;
+    writeBigInt64BE(value: bigint): void;
+    writeBigInt64LE(value: bigint): void;
+
+    writeUInt8(value: number): void;
+    writeUInt16BE(value: number): void;
+    writeUInt16LE(value: number): void;
+    writeUInt32BE(value: number): void;
+    writeUInt32LE(value: number): void;
+    writeBigUInt64BE(value: bigint): void;
+    writeBigUInt64LE(value: bigint): void;
+
+    writeBuffer(value: Buffer): void;
+    writePublicKey(value: Buffer): void;
+    writeEcdsaSignature(value: Buffer): void;
+    writeSchnorrSignature(value: Buffer): void;
+    writeAddress(value: IAddress): void;
+
+    writeWithByteBufferBE<T>(cb: (byteBuffer: ByteBuffer) => T): T;
+    writeWithByteBufferLE<T>(cb: (byteBuffer: ByteBuffer) => T): T;
+}

--- a/packages/crypto/src/interfaces/serde.ts
+++ b/packages/crypto/src/interfaces/serde.ts
@@ -38,6 +38,8 @@ export interface IReader {
 
     readWithByteBufferBE<T>(cb: (byteBuffer: ByteBuffer) => T): T;
     readWithByteBufferLE<T>(cb: (byteBuffer: ByteBuffer) => T): T;
+
+    getRemainder(): Buffer;
 }
 
 export interface IWriter {
@@ -70,4 +72,6 @@ export interface IWriter {
 
     writeWithByteBufferBE<T>(cb: (byteBuffer: ByteBuffer) => T): T;
     writeWithByteBufferLE<T>(cb: (byteBuffer: ByteBuffer) => T): T;
+
+    getResult(): Buffer;
 }

--- a/packages/crypto/src/serde/address.ts
+++ b/packages/crypto/src/serde/address.ts
@@ -16,7 +16,7 @@ export class Address {
         this.network = serialized.readUInt8(0);
     }
 
-    public toString(format: "base58" | "base58c" = "base58c"): string {
+    public toString(format: "base58" | "base58c" = "base58"): string {
         if (format === "base58") {
             return base58.encode(this.serialized);
         }
@@ -31,5 +31,9 @@ export class Address {
         }
 
         throw new Error("Unknown format.");
+    }
+
+    public toJSON(): string {
+        return this.toString("base58c");
     }
 }

--- a/packages/crypto/src/serde/address.ts
+++ b/packages/crypto/src/serde/address.ts
@@ -1,0 +1,35 @@
+import base58 from "bcrypto/lib/encoding/base58";
+import Hash256 from "bcrypto/lib/hash256";
+
+export class Address {
+    public readonly serialized: Buffer;
+    public readonly network: number;
+
+    private checksum?: Buffer;
+
+    public constructor(serialized: Buffer) {
+        if (serialized.length !== 21) {
+            throw new Error("Invalid length.");
+        }
+
+        this.serialized = serialized;
+        this.network = serialized.readUInt8(0);
+    }
+
+    public toString(format: "base58" | "base58c" = "base58c"): string {
+        if (format === "base58") {
+            return base58.encode(this.serialized);
+        }
+
+        if (format === "base58c") {
+            if (!this.checksum) {
+                const digest = Hash256.digest(this.serialized) as Buffer;
+                this.checksum = Buffer.from([digest[0], digest[1], digest[2], digest[3]]);
+            }
+
+            return base58.encode(Buffer.concat([this.serialized, this.checksum]));
+        }
+
+        throw new Error("Unknown format.");
+    }
+}

--- a/packages/crypto/src/serde/factory.ts
+++ b/packages/crypto/src/serde/factory.ts
@@ -1,0 +1,18 @@
+import { IAddress, IReader, IWriter } from "../interfaces";
+import { Address } from "./address";
+import { Reader } from "./reader";
+import { Writer } from "./writer";
+
+export class Factory {
+    public static createAddress(serialized: Buffer): IAddress {
+        return new Address(serialized);
+    }
+
+    public static createReader(buffer: Buffer): IReader {
+        return new Reader(buffer);
+    }
+
+    public static createWriter(buffer: Buffer): IWriter {
+        return new Writer(buffer);
+    }
+}

--- a/packages/crypto/src/serde/index.ts
+++ b/packages/crypto/src/serde/index.ts
@@ -1,0 +1,1 @@
+export * from "./factory";

--- a/packages/crypto/src/serde/reader.ts
+++ b/packages/crypto/src/serde/reader.ts
@@ -1,0 +1,165 @@
+import ByteBuffer from "bytebuffer";
+
+import { IAddress, IReader } from "../interfaces";
+import { Factory } from "./factory";
+
+export class Reader implements IReader {
+    public readonly buffer: Buffer;
+    public offset = 0;
+
+    public constructor(buffer: Buffer) {
+        this.buffer = buffer;
+    }
+
+    public jump(length: number): void {
+        if (length < -this.offset || length > this.buffer.length - this.offset) {
+            throw new RangeError("Jump over buffer boundary.");
+        }
+
+        this.offset += length;
+    }
+
+    public readInt8(): number {
+        const value = this.buffer.readInt8(this.offset);
+        this.offset += 1;
+        return value;
+    }
+
+    public readInt16BE(): number {
+        const value = this.buffer.readInt16BE(this.offset);
+        this.offset += 2;
+        return value;
+    }
+
+    public readInt16LE(): number {
+        const value = this.buffer.readInt16LE(this.offset);
+        this.offset += 2;
+        return value;
+    }
+
+    public readInt32BE(): number {
+        const value = this.buffer.readInt32BE(this.offset);
+        this.offset += 4;
+        return value;
+    }
+
+    public readInt32LE(): number {
+        const value = this.buffer.readInt32LE(this.offset);
+        this.offset += 4;
+        return value;
+    }
+
+    public readBigInt64BE(): bigint {
+        const value = this.buffer.readBigInt64BE(this.offset);
+        this.offset += 8;
+        return value;
+    }
+
+    public readBigInt64LE(): bigint {
+        const value = this.buffer.readBigInt64LE(this.offset);
+        this.offset += 8;
+        return value;
+    }
+
+    public readUInt8(): number {
+        const value = this.buffer.readUInt8(this.offset);
+        this.offset += 1;
+        return value;
+    }
+
+    public readUInt16BE(): number {
+        const value = this.buffer.readUInt16BE(this.offset);
+        this.offset += 2;
+        return value;
+    }
+
+    public readUInt16LE(): number {
+        const value = this.buffer.readUInt16LE(this.offset);
+        this.offset += 2;
+        return value;
+    }
+
+    public readUInt32BE(): number {
+        const value = this.buffer.readUInt32BE(this.offset);
+        this.offset += 4;
+        return value;
+    }
+
+    public readUInt32LE(): number {
+        const value = this.buffer.readUInt32LE(this.offset);
+        this.offset += 4;
+        return value;
+    }
+
+    public readBigUInt64BE(): bigint {
+        const value = this.buffer.readBigUInt64BE(this.offset);
+        this.offset += 8;
+        return value;
+    }
+
+    public readBigUInt64LE(): bigint {
+        const value = this.buffer.readBigUInt64LE(this.offset);
+        this.offset += 8;
+        return value;
+    }
+
+    public readBuffer(length: number): Buffer {
+        if (length > this.buffer.length - this.offset) {
+            throw new Error("Read over buffer boundary.");
+        }
+
+        const value = this.buffer.slice(this.offset, this.offset + length);
+        this.offset += length;
+        return value;
+    }
+
+    public readPublicKey(): Buffer {
+        try {
+            return this.readBuffer(33);
+        } catch (error) {
+            throw new Error(`Cannot read public key. ${error.message}`);
+        }
+    }
+
+    public readEcdsaSignature(): Buffer {
+        try {
+            if (this.buffer.readUInt8(this.offset + 0) !== 0x30) {
+                throw new Error("Invalid marker.");
+            }
+
+            return this.readBuffer(2 + this.buffer.readUInt8(this.offset + 1));
+        } catch (error) {
+            throw new Error(`Cannot read ECDSA signature. ${error.message}`);
+        }
+    }
+
+    public readSchnorrSignature(): Buffer {
+        try {
+            return this.readBuffer(64);
+        } catch (error) {
+            throw new Error(`Cannot read Schnorr signature. ${error.message}`);
+        }
+    }
+
+    public readAddress(): IAddress {
+        try {
+            return Factory.createAddress(this.readBuffer(21));
+        } catch (error) {
+            throw new Error(`Cannot read address. ${error.message}`);
+        }
+    }
+
+    public readWithByteBufferBE<T>(cb: (byteBuffer: ByteBuffer) => T): T {
+        const byteBuffer = ByteBuffer.wrap(this.buffer.slice(this.offset), undefined, false);
+        const result = cb(byteBuffer);
+        this.offset += byteBuffer.offset;
+        return result;
+    }
+
+    public readWithByteBufferLE<T>(cb: (byteBuffer: ByteBuffer) => T): T {
+        const byteBuffer = ByteBuffer.wrap(this.buffer.slice(this.offset), undefined, true);
+        const result = cb(byteBuffer);
+        this.offset += byteBuffer.offset;
+        return result;
+    }
+}

--- a/packages/crypto/src/serde/reader.ts
+++ b/packages/crypto/src/serde/reader.ts
@@ -162,4 +162,8 @@ export class Reader implements IReader {
         this.offset += byteBuffer.offset;
         return result;
     }
+
+    public getRemainder(): Buffer {
+        return this.buffer.slice(this.offset);
+    }
 }

--- a/packages/crypto/src/serde/writer.ts
+++ b/packages/crypto/src/serde/writer.ts
@@ -1,0 +1,146 @@
+import ByteBuffer from "bytebuffer";
+
+import { IAddress, IWriter } from "../interfaces";
+
+export class Writer implements IWriter {
+    public readonly buffer: Buffer;
+    public offset = 0;
+
+    public constructor(buffer: Buffer) {
+        this.buffer = buffer;
+    }
+
+    public jump(length: number): void {
+        if (length < -this.offset || length > this.buffer.length - this.offset) {
+            throw new RangeError("Jump over buffer boundary.");
+        }
+
+        this.offset += length;
+    }
+
+    public writeInt8(value: number): void {
+        this.offset = this.buffer.writeInt8(value, this.offset);
+    }
+
+    public writeInt16BE(value: number): void {
+        this.offset = this.buffer.writeInt16BE(value, this.offset);
+    }
+
+    public writeInt16LE(value: number): void {
+        this.offset = this.buffer.writeInt16LE(value, this.offset);
+    }
+
+    public writeInt32BE(value: number): void {
+        this.offset = this.buffer.writeInt32BE(value, this.offset);
+    }
+
+    public writeInt32LE(value: number): void {
+        this.offset = this.buffer.writeInt32LE(value, this.offset);
+    }
+
+    public writeBigInt64BE(value: bigint): void {
+        this.offset = this.buffer.writeBigInt64BE(value, this.offset);
+    }
+
+    public writeBigInt64LE(value: bigint): void {
+        this.offset = this.buffer.writeBigInt64LE(value, this.offset);
+    }
+
+    public writeUInt8(value: number): void {
+        this.offset = this.buffer.writeUInt8(value, this.offset);
+    }
+
+    public writeUInt16BE(value: number): void {
+        this.offset = this.buffer.writeUInt16BE(value, this.offset);
+    }
+
+    public writeUInt16LE(value: number): void {
+        this.offset = this.buffer.writeUInt16LE(value, this.offset);
+    }
+
+    public writeUInt32BE(value: number): void {
+        this.offset = this.buffer.writeUInt32BE(value, this.offset);
+    }
+
+    public writeUInt32LE(value: number): void {
+        this.offset = this.buffer.writeUInt32LE(value, this.offset);
+    }
+
+    public writeBigUInt64BE(value: bigint): void {
+        this.offset = this.buffer.writeBigUInt64BE(value, this.offset);
+    }
+
+    public writeBigUInt64LE(value: bigint): void {
+        this.offset = this.buffer.writeBigUInt64LE(value, this.offset);
+    }
+
+    public writeBuffer(value: Buffer): void {
+        if (value.length > this.buffer.length - this.offset) {
+            throw new Error("Write over buffer boundary.");
+        }
+
+        this.offset += value.copy(this.buffer, this.offset);
+    }
+
+    public writePublicKey(value: Buffer): void {
+        try {
+            if (value.length !== 33) {
+                throw new Error("Invalid length.");
+            }
+
+            this.writeBuffer(value);
+        } catch (error) {
+            throw new Error(`Cannot write public key. ${error.message}`);
+        }
+    }
+
+    public writeEcdsaSignature(value: Buffer): void {
+        try {
+            if (value.readUInt8(0) !== 0x30) {
+                throw new Error("Invalid marker.");
+            }
+
+            if (value.readUInt8(1) !== value.length - 2) {
+                throw new Error("Invalid length.");
+            }
+
+            this.writeBuffer(value);
+        } catch (error) {
+            throw new Error(`Cannot write ECDSA signature. ${error.message}`);
+        }
+    }
+
+    public writeSchnorrSignature(value: Buffer): void {
+        try {
+            if (value.length !== 64) {
+                throw new Error("Invalid length.");
+            }
+
+            this.writeBuffer(value);
+        } catch (error) {
+            throw new Error(`Cannot write Schnorr signature. ${error.message}`);
+        }
+    }
+
+    public writeAddress(value: IAddress): void {
+        try {
+            this.writeBuffer(value.serialized);
+        } catch (error) {
+            throw new Error(`Cannot write address. ${error.message}`);
+        }
+    }
+
+    public writeWithByteBufferBE<T>(cb: (byteBuffer: ByteBuffer) => T): T {
+        const byteBuffer = ByteBuffer.wrap(this.buffer.slice(this.offset), undefined, false);
+        const result = cb(byteBuffer);
+        this.offset += byteBuffer.offset;
+        return result;
+    }
+
+    public writeWithByteBufferLE<T>(cb: (byteBuffer: ByteBuffer) => T): T {
+        const byteBuffer = ByteBuffer.wrap(this.buffer.slice(this.offset), undefined, true);
+        const result = cb(byteBuffer);
+        this.offset += byteBuffer.offset;
+        return result;
+    }
+}

--- a/packages/crypto/src/serde/writer.ts
+++ b/packages/crypto/src/serde/writer.ts
@@ -143,4 +143,8 @@ export class Writer implements IWriter {
         this.offset += byteBuffer.offset;
         return result;
     }
+
+    public getResult(): Buffer {
+        return this.buffer.slice(0, this.offset);
+    }
 }


### PR DESCRIPTION
## Summary

Implemented simple `Reader` and `Writer` because of bugs in `ByteBuffer`. `Reader` and `Writer` are tailored for our needs. They contain methods to read/write public key, ecdsa signature, schnorr signature, and address. It's still possible to delegate read/write to `ByteBuffer` for compatibility reasons.

## Checklist

- [ ] Tests
- [ ] Ready to be merged
