### PR TITLE
chore(core): include joi in module aliases

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -106,6 +106,7 @@
         "@arkecosystem/core-state": "@arkecosystem/core-state",
         "@arkecosystem/core-transaction-pool": "@arkecosystem/core-transaction-pool",
         "@arkecosystem/core-webhooks": "@arkecosystem/core-webhooks",
-        "@arkecosystem/crypto": "@arkecosystem/crypto"
+        "@arkecosystem/crypto": "@arkecosystem/crypto",
+        "joi": "joi"
     }
 }


### PR DESCRIPTION
## Summary

Include joi in module aliases. Required by core-manager plugin. 

## Checklist

- [x] Tests
- [x] Ready to be merged