### PR TITLE
refactor(core): implements crypto exceptions and skipPrompts flag

### DIFF
--- a/__tests__/unit/core/commands/core-start.test.ts
+++ b/__tests__/unit/core/commands/core-start.test.ts
@@ -30,7 +30,7 @@ describe("StartCommand", () => {
 
         expect(spyStart).toHaveBeenCalledWith(
             {
-                args: "core:run --token='ark' --network='testnet' --v=0 --env='production'",
+                args: "core:run --token='ark' --network='testnet' --v=0 --env='production' --skipPrompts=false",
                 env: {
                     CORE_ENV: "production",
                     NODE_ENV: "production",

--- a/__tests__/unit/core/commands/forger-start.test.ts
+++ b/__tests__/unit/core/commands/forger-start.test.ts
@@ -30,7 +30,7 @@ describe("StartCommand", () => {
 
         expect(spyStart).toHaveBeenCalledWith(
             {
-                args: "forger:run --token='ark' --network='testnet' --v=0 --env='production'",
+                args: "forger:run --token='ark' --network='testnet' --v=0 --env='production' --skipPrompts=false",
                 env: {
                     CORE_ENV: "production",
                     NODE_ENV: "production",

--- a/__tests__/unit/core/internal/crypto.test.ts
+++ b/__tests__/unit/core/internal/crypto.test.ts
@@ -69,14 +69,20 @@ describe("buildBIP38", () => {
         );
     });
 
+    it("should throw if no bip38 password is provided and skipPrompts is true", async () => {
+        writeJSONSync(`${process.env.CORE_PATH_CONFIG}/delegates.json`, { bip38: "bip38" });
+
+        await expect(buildBIP38({ token: "ark", network: "mainnet", skipPrompts: true })).rejects.toThrow(
+            new Crypto.InvalidPassword(),
+        );
+    });
+
     it("should throw if no bip38 password is provided", async () => {
         writeJSONSync(`${process.env.CORE_PATH_CONFIG}/delegates.json`, { bip38: "bip38" });
 
         prompts.inject([null, true]);
 
-        await expect(buildBIP38({ token: "ark", network: "mainnet" })).rejects.toThrow(
-            "We've detected that you are using BIP38 but have not provided a valid password.",
-        );
+        await expect(buildBIP38({ token: "ark", network: "mainnet" })).rejects.toThrow(new Crypto.InvalidPassword());
     });
 
     it("should throw if no confirmation is provided", async () => {

--- a/__tests__/unit/core/internal/crypto.test.ts
+++ b/__tests__/unit/core/internal/crypto.test.ts
@@ -1,3 +1,4 @@
+import { Crypto } from "@packages/core/src/exceptions";
 import { buildBIP38 } from "@packages/core/src/internal/crypto";
 import { writeJSONSync } from "fs-extra";
 import prompts from "prompts";
@@ -37,7 +38,7 @@ describe("buildBIP38", () => {
 
     it("should throw if the delegate configuration does not exist", async () => {
         await expect(buildBIP38({ token: "ark", network: "mainnet" })).rejects.toThrow(
-            `The ${process.env.CORE_PATH_CONFIG}/delegates.json file does not exist.`,
+            new Crypto.MissingConfigFile(process.env.CORE_PATH_CONFIG + "/delegates.json"),
         );
     });
 
@@ -56,7 +57,7 @@ describe("buildBIP38", () => {
         writeJSONSync(`${process.env.CORE_PATH_CONFIG}/delegates.json`, { secrets: [] });
 
         await expect(buildBIP38({ token: "ark", network: "mainnet" })).rejects.toThrow(
-            "We were unable to detect a BIP38 or BIP39 passphrase.",
+            new Crypto.PassphraseNotDetected(),
         );
     });
 
@@ -64,7 +65,7 @@ describe("buildBIP38", () => {
         writeJSONSync(`${process.env.CORE_PATH_CONFIG}/delegates.json`, {});
 
         await expect(buildBIP38({ token: "ark", network: "mainnet" })).rejects.toThrow(
-            "We were unable to detect a BIP38 or BIP39 passphrase.",
+            new Crypto.PassphraseNotDetected(),
         );
     });
 

--- a/packages/core/src/commands/core-run.ts
+++ b/packages/core/src/commands/core-run.ts
@@ -45,7 +45,8 @@ export class Command extends Commands.Command {
             .setFlag("launchMode", "The mode the relay will be launched in (seed only at the moment).", Joi.string())
             .setFlag("bip38", "", Joi.string())
             .setFlag("bip39", "A delegate plain text passphrase. Referred to as BIP39.", Joi.string())
-            .setFlag("password", "A custom password that encrypts the BIP39. Referred to as BIP38.", Joi.string());
+            .setFlag("password", "A custom password that encrypts the BIP39. Referred to as BIP38.", Joi.string())
+            .setFlag("skipPrompts", "Skip prompts.", Joi.boolean().default(false));
     }
 
     /**

--- a/packages/core/src/commands/core-start.ts
+++ b/packages/core/src/commands/core-start.ts
@@ -47,7 +47,8 @@ export class Command extends Commands.Command {
             .setFlag("bip38", "", Joi.string())
             .setFlag("bip39", "A delegate plain text passphrase. Referred to as BIP39.", Joi.string())
             .setFlag("password", "A custom password that encrypts the BIP39. Referred to as BIP38.", Joi.string())
-            .setFlag("daemon", "Start the Core process as a daemon.", Joi.boolean().default(true));
+            .setFlag("daemon", "Start the Core process as a daemon.", Joi.boolean().default(true))
+            .setFlag("skipPrompts", "Skip prompts.", Joi.boolean().default(false));
     }
 
     /**

--- a/packages/core/src/commands/forger-run.ts
+++ b/packages/core/src/commands/forger-run.ts
@@ -40,7 +40,8 @@ export class Command extends Commands.Command {
             .setFlag("env", "", Joi.string().default("production"))
             .setFlag("bip38", "", Joi.string())
             .setFlag("bip39", "A delegate plain text passphrase. Referred to as BIP39.", Joi.string())
-            .setFlag("password", "A custom password that encrypts the BIP39. Referred to as BIP38.", Joi.string());
+            .setFlag("password", "A custom password that encrypts the BIP39. Referred to as BIP38.", Joi.string())
+            .setFlag("skipPrompts", "Skip prompts.", Joi.boolean().default(false));
     }
 
     /**

--- a/packages/core/src/commands/forger-start.ts
+++ b/packages/core/src/commands/forger-start.ts
@@ -47,7 +47,8 @@ export class Command extends Commands.Command {
             .setFlag("bip38", "", Joi.string())
             .setFlag("bip39", "A delegate plain text passphrase. Referred to as BIP39.", Joi.string())
             .setFlag("password", "A custom password that encrypts the BIP39. Referred to as BIP38.", Joi.string())
-            .setFlag("daemon", "Start the Forger process as a daemon.", Joi.boolean().default(true));
+            .setFlag("daemon", "Start the Forger process as a daemon.", Joi.boolean().default(true))
+            .setFlag("skipPrompts", "Skip prompts.", Joi.boolean().default(false));
     }
 
     /**

--- a/packages/core/src/exceptions/base.ts
+++ b/packages/core/src/exceptions/base.ts
@@ -1,0 +1,24 @@
+export class Exception extends Error {
+    /**
+     * Creates an instance of Exception.
+     *
+     * @param {string} message
+     * @param {string} [code]
+     * @memberof Exception
+     */
+    public constructor(message: string, code?: string) {
+        super(message);
+
+        Object.defineProperty(this, "message", {
+            enumerable: false,
+            value: code ? `${code}: ${message}` : message,
+        });
+
+        Object.defineProperty(this, "name", {
+            enumerable: false,
+            value: this.constructor.name,
+        });
+
+        Error.captureStackTrace(this, this.constructor);
+    }
+}

--- a/packages/core/src/exceptions/crypto.ts
+++ b/packages/core/src/exceptions/crypto.ts
@@ -13,3 +13,9 @@ export class PassphraseNotDetected extends Bip38Exception {
         super(`We were unable to detect a BIP38 or BIP39 passphrase.`);
     }
 }
+
+export class InvalidPassword extends Bip38Exception {
+    public constructor() {
+        super(`We've detected that you are using BIP38 but have not provided a valid password.`);
+    }
+}

--- a/packages/core/src/exceptions/crypto.ts
+++ b/packages/core/src/exceptions/crypto.ts
@@ -1,0 +1,15 @@
+import { Exception } from "./base";
+
+export class Bip38Exception extends Exception {}
+
+export class MissingConfigFile extends Bip38Exception {
+    public constructor(filePath: string) {
+        super(`The ${filePath} file does not exist.`);
+    }
+}
+
+export class PassphraseNotDetected extends Bip38Exception {
+    public constructor() {
+        super(`We were unable to detect a BIP38 or BIP39 passphrase.`);
+    }
+}

--- a/packages/core/src/exceptions/index.ts
+++ b/packages/core/src/exceptions/index.ts
@@ -1,0 +1,2 @@
+export * as Base from "./base";
+export * as Crypto from "./crypto";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./cli";
+export * from "./exceptions";

--- a/packages/core/src/internal/crypto.ts
+++ b/packages/core/src/internal/crypto.ts
@@ -2,6 +2,8 @@ import { existsSync } from "fs-extra";
 import { join } from "path";
 import prompts from "prompts";
 
+import { MissingConfigFile, PassphraseNotDetected } from "../exceptions/crypto";
+
 // todo: review the implementation
 export const buildBIP38 = async (flags, config?: string): Promise<Record<string, string | undefined>> => {
     if (!config && process.env.CORE_PATH_CONFIG) {
@@ -24,7 +26,7 @@ export const buildBIP38 = async (flags, config?: string): Promise<Record<string,
     const configDelegates = join(config!, "delegates.json");
 
     if (!existsSync(configDelegates)) {
-        throw new Error(`The ${configDelegates} file does not exist.`);
+        throw new MissingConfigFile(configDelegates);
     }
 
     const delegates = require(configDelegates);
@@ -34,7 +36,7 @@ export const buildBIP38 = async (flags, config?: string): Promise<Record<string,
     }
 
     if (!bip38 && !delegates.secrets?.length) {
-        throw new Error("We were unable to detect a BIP38 or BIP39 passphrase.");
+        throw new PassphraseNotDetected();
     }
 
     if (bip38 && !password) {


### PR DESCRIPTION
## Summary

Implement and export custom crypto exceptions.

Use **skipPrompts** flag on:
- forger:run
- forger:start
- core:run
- core:start

## Checklist

- [x] Tests
- [x] Ready to be merged
