### PR TITLE
test: move root mocks under packages tests

### DIFF
--- a/__mocks__/better-sqlite3.js
+++ b/__mocks__/better-sqlite3.js
@@ -1,7 +1,0 @@
-const BetterSqlite3 = jest.requireActual("better-sqlite3");
-
-module.exports = class BetterSqlite3Mock extends BetterSqlite3 {
-    constructor(path, options = {}) {
-        super(path || ":memory:", options);
-    }
-};

--- a/__mocks__/execa.js
+++ b/__mocks__/execa.js
@@ -1,1 +1,0 @@
-module.exports = jest.genMockFromModule("execa");

--- a/packages/core-cli/__tests__/__mocks__/execa.js
+++ b/packages/core-cli/__tests__/__mocks__/execa.js
@@ -1,0 +1,1 @@
+module.exports = jest.createMockFromModule("execa");

--- a/packages/core-cli/__tests__/services/installer.test.ts
+++ b/packages/core-cli/__tests__/services/installer.test.ts
@@ -1,10 +1,10 @@
 import "jest-extended";
 
-import { Console } from "@packages/core-test-framework";
 import { Installer } from "@packages/core-cli/src/services";
+import { Console } from "@packages/core-test-framework";
 import { setGracefulCleanup } from "tmp";
 
-import execa from "../../../../__mocks__/execa";
+import execa from "../__mocks__/execa";
 
 let cli;
 let installer;

--- a/packages/core-cli/__tests__/services/source-providers/git.test.ts
+++ b/packages/core-cli/__tests__/services/source-providers/git.test.ts
@@ -2,10 +2,10 @@ import "jest-extended";
 
 import { Git } from "@packages/core-cli/src/services/source-providers";
 import fs from "fs-extra";
-import { dirSync, setGracefulCleanup } from "tmp";
 import { join } from "path";
+import { dirSync, setGracefulCleanup } from "tmp";
 
-import execa from "../../../../../__mocks__/execa";
+import execa from "../../__mocks__/execa";
 
 let dataPath: string;
 let tempPath: string;
@@ -19,9 +19,9 @@ beforeEach(() => {
 
 afterEach(() => {
     jest.clearAllMocks();
-})
+});
 
-afterAll(() =>  setGracefulCleanup());
+afterAll(() => setGracefulCleanup());
 
 describe("Git", () => {
     describe("#exists", () => {
@@ -71,7 +71,9 @@ describe("Git", () => {
             // Assert
             expect(spyOnExeca).toHaveBeenCalledWith(`git`, ["reset", "--hard"], { cwd: join(dataPath, packageName) });
             expect(spyOnExeca).toHaveBeenCalledWith(`git`, ["pull"], { cwd: join(dataPath, packageName) });
-            expect(spyOnExeca).toHaveBeenCalledWith(`pnpm`, ["install", "--production"], { cwd: join(dataPath, packageName) });
+            expect(spyOnExeca).toHaveBeenCalledWith(`pnpm`, ["install", "--production"], {
+                cwd: join(dataPath, packageName),
+            });
         });
     });
 });

--- a/packages/core-cli/__tests__/services/updater.test.ts
+++ b/packages/core-cli/__tests__/services/updater.test.ts
@@ -6,7 +6,7 @@ import { Console } from "@packages/core-test-framework";
 import nock from "nock";
 import prompts from "prompts";
 
-import execa from "../../../../__mocks__/execa";
+import execa from "../__mocks__/execa";
 import { versionNext } from "./__fixtures__/latest-version";
 
 let cli;

--- a/packages/core/__tests__/__mocks__/execa.js
+++ b/packages/core/__tests__/__mocks__/execa.js
@@ -1,1 +1,0 @@
-module.exports = jest.createMockFromModule("execa");

--- a/packages/core/__tests__/__mocks__/execa.js
+++ b/packages/core/__tests__/__mocks__/execa.js
@@ -1,0 +1,1 @@
+module.exports = jest.createMockFromModule("execa");

--- a/packages/core/__tests__/commands/config-cli.test.ts
+++ b/packages/core/__tests__/commands/config-cli.test.ts
@@ -1,8 +1,7 @@
 import { Command } from "@packages/core/src/commands/config-cli";
 import { Container } from "@packages/core-cli";
 import { Console } from "@packages/core-test-framework";
-
-import execa from "../__mocks__/execa";
+import execa from "execa";
 
 let cli;
 let config;
@@ -48,7 +47,7 @@ describe("Command", () => {
             stdout: '"null"',
             stderr: undefined,
             exitCode: 0,
-        });
+        } as any);
 
         const install: jest.SpyInstance = jest
             .spyOn(cli.app.get(Container.Identifiers.Installer), "install")
@@ -75,7 +74,7 @@ describe("Command", () => {
             stdout: '"null"',
             stderr: undefined,
             exitCode: 0,
-        });
+        } as any);
 
         await cli.withFlags({ channel: "latest" }).execute(Command);
 

--- a/packages/core/__tests__/commands/config-cli.test.ts
+++ b/packages/core/__tests__/commands/config-cli.test.ts
@@ -1,8 +1,8 @@
+import { Command } from "@packages/core/src/commands/config-cli";
 import { Container } from "@packages/core-cli";
 import { Console } from "@packages/core-test-framework";
-import { Command } from "@packages/core/src/commands/config-cli";
 
-import execa from "../../../../__mocks__/execa";
+import execa from "../__mocks__/execa";
 
 let cli;
 let config;

--- a/packages/core/__tests__/commands/reinstall.test.ts
+++ b/packages/core/__tests__/commands/reinstall.test.ts
@@ -3,9 +3,8 @@ import "jest-extended";
 import { Command } from "@packages/core/src/commands/reinstall";
 import { Container } from "@packages/core-cli";
 import { Console } from "@packages/core-test-framework";
+import execa from "execa";
 import prompts from "prompts";
-
-import execa from "../__mocks__/execa";
 
 let cli;
 let processManager;
@@ -20,7 +19,7 @@ describe("ReinstallCommand", () => {
             stdout: '"null"',
             stderr: undefined,
             exitCode: 0,
-        });
+        } as any);
 
         await cli.withFlags({ force: true }).execute(Command);
 
@@ -35,7 +34,7 @@ describe("ReinstallCommand", () => {
             stdout: '"null"',
             stderr: undefined,
             exitCode: 0,
-        });
+        } as any);
 
         prompts.inject([true]);
 
@@ -52,7 +51,7 @@ describe("ReinstallCommand", () => {
             stdout: '"null"',
             stderr: undefined,
             exitCode: 0,
-        });
+        } as any);
 
         prompts.inject([false]);
 
@@ -68,7 +67,7 @@ describe("ReinstallCommand", () => {
             stdout: '"null"',
             stderr: undefined,
             exitCode: 0,
-        });
+        } as any);
 
         const isOnline = jest.spyOn(processManager, "isOnline").mockReturnValue(true);
         const restart = jest.spyOn(processManager, "restart").mockImplementation(undefined);

--- a/packages/core/__tests__/commands/reinstall.test.ts
+++ b/packages/core/__tests__/commands/reinstall.test.ts
@@ -1,11 +1,11 @@
 import "jest-extended";
 
+import { Command } from "@packages/core/src/commands/reinstall";
 import { Container } from "@packages/core-cli";
 import { Console } from "@packages/core-test-framework";
-import { Command } from "@packages/core/src/commands/reinstall";
 import prompts from "prompts";
 
-import execa from "../../../../__mocks__/execa";
+import execa from "../__mocks__/execa";
 
 let cli;
 let processManager;

--- a/packages/core/__tests__/commands/update.test.ts
+++ b/packages/core/__tests__/commands/update.test.ts
@@ -1,12 +1,12 @@
 import "jest-extended";
 
+import { Command } from "@packages/core/src/commands/update";
 import { Container } from "@packages/core-cli";
 import { Console } from "@packages/core-test-framework";
-import { Command } from "@packages/core/src/commands/update";
 import nock from "nock";
 import prompts from "prompts";
 
-import execa from "../../../../__mocks__/execa";
+import execa from "../__mocks__/execa";
 import { versionNext } from "../internal/__fixtures__/latest-version";
 
 let cli;

--- a/packages/core/__tests__/commands/update.test.ts
+++ b/packages/core/__tests__/commands/update.test.ts
@@ -3,10 +3,10 @@ import "jest-extended";
 import { Command } from "@packages/core/src/commands/update";
 import { Container } from "@packages/core-cli";
 import { Console } from "@packages/core-test-framework";
+import execa from "execa";
 import nock from "nock";
 import prompts from "prompts";
 
-import execa from "../__mocks__/execa";
 import { versionNext } from "../internal/__fixtures__/latest-version";
 
 let cli;
@@ -47,7 +47,7 @@ describe("UpdateCommand", () => {
         const sync: jest.SpyInstance = jest.spyOn(execa, "sync").mockReturnValue({
             stdout: "stdout",
             stderr: undefined,
-        });
+        } as any);
 
         prompts.inject([false]);
 
@@ -68,7 +68,7 @@ describe("UpdateCommand", () => {
             stdout: '"null"',
             stderr: undefined,
             exitCode: 0,
-        });
+        } as any);
 
         await cli.withFlags({ force: true, updateProcessManager: true }).execute(Command);
 
@@ -90,7 +90,7 @@ describe("UpdateCommand", () => {
             stdout: '"null"',
             stderr: undefined,
             exitCode: 0,
-        });
+        } as any);
 
         await cli.withFlags({ force: true, reset: true, updateProcessManager: true }).execute(Command);
 
@@ -115,7 +115,7 @@ describe("UpdateCommand", () => {
             stdout: '"null"',
             stderr: undefined,
             exitCode: 0,
-        });
+        } as any);
 
         prompts.inject([true]);
 
@@ -137,7 +137,7 @@ describe("UpdateCommand", () => {
             stdout: '"null"',
             stderr: undefined,
             exitCode: 0,
-        });
+        } as any);
         jest.spyOn(processManager, "restart").mockImplementation(undefined);
 
         await cli.withFlags({ force: true, restart: true, updateProcessManager: true }).execute(Command);
@@ -162,7 +162,7 @@ describe("UpdateCommand", () => {
             stdout: '"null"',
             stderr: undefined,
             exitCode: 0,
-        });
+        } as any);
         const isOnline = jest.spyOn(processManager, "isOnline").mockReturnValue(true);
         const restart = jest.spyOn(processManager, "restart").mockImplementation(undefined);
 
@@ -185,7 +185,7 @@ describe("UpdateCommand", () => {
             stdout: '"null"',
             stderr: undefined,
             exitCode: 0,
-        });
+        } as any);
         const isOnline = jest.spyOn(processManager, "isOnline").mockReturnValue(true);
         const restart = jest.spyOn(processManager, "restart").mockImplementation(undefined);
 
@@ -208,7 +208,7 @@ describe("UpdateCommand", () => {
             stdout: '"null"',
             stderr: undefined,
             exitCode: 0,
-        });
+        } as any);
         const isOnline = jest.spyOn(processManager, "isOnline").mockReturnValue(true);
         const restart = jest.spyOn(processManager, "restart").mockImplementation(undefined);
 
@@ -232,7 +232,7 @@ describe("UpdateCommand", () => {
             stdout: '"null"',
             stderr: undefined,
             exitCode: 0,
-        });
+        } as any);
         const isOnline = jest.spyOn(processManager, "isOnline").mockReturnValue(true);
         const restart = jest.spyOn(processManager, "restart").mockImplementation(undefined);
 


### PR DESCRIPTION
## Summary

Move root mocks under packages tests. Fixes issues with jest when single test is run from package. 

## Checklist

- [x] Tests
- [x] Ready to be merged