### PR TITLE
fix(core): disable prompts for network selection

### DIFF
--- a/packages/core-cli/src/input/parser.ts
+++ b/packages/core-cli/src/input/parser.ts
@@ -12,13 +12,8 @@ export class InputParser {
      * @memberof InputParser
      */
     public static parseArgv(args: string[]) {
-        const parsed: yargs.Arguments = yargs(args, { count: ["v"] });
+        const { _: argv, $0, ...flags } = yargs(args, { count: ["v"] });
 
-        const argv: string[] = parsed._;
-
-        // @ts-ignore
-        delete parsed._;
-
-        return { args: argv, flags: parsed };
+        return { args: argv, flags };
     }
 }

--- a/packages/core/__tests__/cli.test.ts
+++ b/packages/core/__tests__/cli.test.ts
@@ -1,7 +1,7 @@
 import "jest-extended";
 
-import { Commands, Services } from "@packages/core-cli";
 import { CommandLineInterface } from "@packages/core/src/cli";
+import { Commands, Services } from "@packages/core-cli";
 import envPaths from "env-paths";
 import prompts from "prompts";
 
@@ -106,7 +106,7 @@ describe("CLI", () => {
             await expect(cli.execute("./packages/core/dist")).toResolve();
 
             expect(spyOnList).toHaveBeenCalledWith("ark", "testnet");
-            expect(spyOnDiscoverNetwork).toHaveBeenCalledWith(envPaths("ark", { suffix: "core" }).config);
+            expect(spyOnDiscoverNetwork).toHaveBeenCalledWith(envPaths("ark", { suffix: "core" }).config, false);
         });
 
         it("should not load CLI plugins if network is not provided", async () => {

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -106,7 +106,7 @@ export class CommandLineInterface {
             return;
         }
 
-        commandInstance.register(this.appendNetworkAndToken(this.argv, flags));
+        commandInstance.register(this.argv);
 
         await commandInstance.run();
     }
@@ -147,34 +147,11 @@ export class CommandLineInterface {
                 envPaths(tempFlags.token, {
                     suffix: "core",
                 }).config,
+                false,
             );
         } catch {}
 
         return tempFlags;
-    }
-
-    private appendNetworkAndToken(argv: string[], { token, network }: TokenNetworkFlags): string[] {
-        const exists = (argv: string[], name: string): boolean => {
-            return argv.some((argument) => {
-                return argument.startsWith(`--${name}`);
-            });
-        };
-
-        const makeArgument = (argument: string, value: string): string => {
-            return `--${argument}=${value}`;
-        };
-
-        let newArgv: string[] = [];
-
-        if (!exists(argv, "token")) {
-            newArgv = [...newArgv, makeArgument("token", token)];
-        }
-
-        if (!exists(argv, "network") && network) {
-            newArgv = [...newArgv, makeArgument("network", network)];
-        }
-
-        return [...argv, ...newArgv];
     }
 
     private async discoverCommands(dirname: string, flags: TokenNetworkFlags): Promise<Contracts.CommandList> {

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -5,6 +5,15 @@ import moduleAlias from "module-alias";
 import { dirname, join, resolve } from "path";
 import { PackageJson } from "type-fest";
 
+type Flags = {
+    [args: string]: any;
+};
+
+type TokenNetworkFlags = {
+    token: string;
+    network?: string;
+} & Flags;
+
 /**
  * @export
  * @class CommandLineInterface
@@ -52,7 +61,10 @@ export class CommandLineInterface {
         this.app.get<Contracts.Updater>(Container.Identifiers.Updater).check();
 
         // Parse arguments and flags
-        const { args, flags } = InputParser.parseArgv(this.argv);
+        const parsedArgv = InputParser.parseArgv(this.argv);
+
+        const args = parsedArgv.args;
+        const flags = await this.detectNetworkAndToken(parsedArgv.flags);
 
         // Discover commands and commands from plugins
         const commands: Contracts.CommandList = await this.discoverCommands(dirname, flags);
@@ -94,7 +106,7 @@ export class CommandLineInterface {
             return;
         }
 
-        commandInstance.register(this.argv);
+        commandInstance.register(this.appendNetworkAndToken(this.argv, flags));
 
         await commandInstance.run();
     }
@@ -112,8 +124,8 @@ export class CommandLineInterface {
         }
     }
 
-    private async detectNetworkAndToken(flags: any): Promise<{ token: string; network?: string }> {
-        const tempFlags = {
+    private async detectNetworkAndToken(flags: Flags): Promise<TokenNetworkFlags> {
+        const tempFlags: TokenNetworkFlags = {
             token: "ark",
             ...flags,
         };
@@ -141,16 +153,38 @@ export class CommandLineInterface {
         return tempFlags;
     }
 
-    private async discoverCommands(dirname: string, flags: any): Promise<Contracts.CommandList> {
+    private appendNetworkAndToken(argv: string[], { token, network }: TokenNetworkFlags): string[] {
+        const exists = (argv: string[], name: string): boolean => {
+            return argv.some((argument) => {
+                return argument.startsWith(`--${name}`);
+            });
+        };
+
+        const makeArgument = (argument: string, value: string): string => {
+            return `--${argument}=${value}`;
+        };
+
+        let newArgv: string[] = [];
+
+        if (!exists(argv, "token")) {
+            newArgv = [...newArgv, makeArgument("token", token)];
+        }
+
+        if (!exists(argv, "network") && network) {
+            newArgv = [...newArgv, makeArgument("network", network)];
+        }
+
+        return [...argv, ...newArgv];
+    }
+
+    private async discoverCommands(dirname: string, flags: TokenNetworkFlags): Promise<Contracts.CommandList> {
         const commandsDiscoverer = this.app.resolve(Commands.DiscoverCommands);
         const commands: Contracts.CommandList = commandsDiscoverer.within(resolve(dirname, "./commands"));
 
-        const tempFlags = await this.detectNetworkAndToken(flags);
-
-        if (tempFlags.network) {
+        if (flags.network) {
             const plugins = await this.app
                 .get<Contracts.PluginManager>(Container.Identifiers.PluginManager)
-                .list(tempFlags.token, tempFlags.network);
+                .list(flags.token, flags.network);
 
             const commandsFromPlugins = commandsDiscoverer.from(plugins.map((plugin) => plugin.path));
 


### PR DESCRIPTION
## Summary

Disable prompts for network selection when multiple network configurations are present. 

This PR is required for core-manager and other plugins that requires running CLI command without additional prompts. 

Network selection can be achieved with --network=${network} flag to load plugins for selected network. 

## Checklist

- [x] Tests
- [x] Ready to be merged