### PR TITLE
chore(core-blockchain): rearrange word order in error message

### DIFF
--- a/packages/core-blockchain/src/state-machine/actions/initialize.ts
+++ b/packages/core-blockchain/src/state-machine/actions/initialize.ts
@@ -50,7 +50,7 @@ export class Initialize implements Action {
             // only genesis block? special case of first round needs to be dealt with
             if (block.data.height === 1) {
                 if (block.data.payloadHash !== Managers.configManager.get("network.nethash")) {
-                    this.logger.error("FATAL: The genesis block payload hash is different from configured the nethash");
+                    this.logger.error("FATAL: The genesis block payload hash is different from the configured nethash");
 
                     return this.blockchain.dispatch("FAILURE");
                 }


### PR DESCRIPTION
## Summary

The error message `FATAL: The genesis block payload hash is different from configured the nethash` does not make sense so I rearranged the word order so it makes sense: `FATAL: The genesis block payload hash is different from the configured nethash`.

## Checklist

- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
