### PR TITLE
fix(core): fix check for new version

### DIFF
--- a/packages/core-cli/__tests__/services/updater.test.ts
+++ b/packages/core-cli/__tests__/services/updater.test.ts
@@ -10,7 +10,6 @@ import execa from "../__mocks__/execa";
 import { versionNext } from "./__fixtures__/latest-version";
 
 let cli;
-// let processManager;
 let updater;
 let config;
 
@@ -18,7 +17,6 @@ beforeEach(() => {
     nock.cleanAll();
 
     cli = new Console();
-    // processManager = cli.app.get(Container.Identifiers.ProcessManager);
     updater = cli.app.resolve(Updater);
     config = cli.app.get(Container.Identifiers.Config);
 });
@@ -53,14 +51,6 @@ describe("Updater", () => {
 
         it("should return false if the latest version is already installed", async () => {
             nock(/.*/).get("/@arkecosystem%2Fcore").reply(200, versionNext);
-
-            await expect(updater.check()).resolves.toBeFalse();
-        });
-
-        it("should return false if the last check has been within the last 24 hours ago", async () => {
-            nock(/.*/).get("/@arkecosystem%2Fcore").reply(200, versionNext);
-
-            config.set("lastUpdateCheck", Date.now());
 
             await expect(updater.check()).resolves.toBeFalse();
         });

--- a/packages/core-cli/src/services/updater.ts
+++ b/packages/core-cli/src/services/updater.ts
@@ -11,8 +11,6 @@ import { Identifiers, inject, injectable } from "../ioc";
 import { Installer } from "./installer";
 import { ProcessManager } from "./process-manager";
 
-const ONE_DAY = 1000 * 60 * 60 * 24;
-
 /**
  * @export
  * @class Updater
@@ -61,13 +59,6 @@ export class Updater implements Contracts.Updater {
 
     /**
      * @private
-     * @type {*}
-     * @memberof Updater
-     */
-    private updateCheckInterval: any = ONE_DAY;
-
-    /**
-     * @private
      * @type {(string | undefined)}
      * @memberof Updater
      */
@@ -94,10 +85,6 @@ export class Updater implements Contracts.Updater {
 
         if (this.latestVersion) {
             this.config.forget("latestVersion"); // ? shouldn't it be moved after lastUpdateCheck
-        }
-
-        if (Date.now() - this.config.get<number>("lastUpdateCheck") < this.updateCheckInterval) {
-            return false;
         }
 
         const latestVersion: string | undefined = await this.getLatestVersion();

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -1,4 +1,12 @@
-import { ApplicationFactory, Commands, Container, Contracts, InputParser, Plugins } from "@arkecosystem/core-cli";
+import {
+    ApplicationFactory,
+    Commands,
+    Components,
+    Container,
+    Contracts,
+    InputParser,
+    Plugins,
+} from "@arkecosystem/core-cli";
 import envPaths from "env-paths";
 import { readJSONSync } from "fs-extra";
 import moduleAlias from "module-alias";
@@ -58,7 +66,11 @@ export class CommandLineInterface {
         this.app = ApplicationFactory.make(new Container.Container(), pkg);
 
         // Check for updates
-        this.app.get<Contracts.Updater>(Container.Identifiers.Updater).check();
+        if (await this.app.get<Contracts.Updater>(Container.Identifiers.Updater).check()) {
+            this.app
+                .get<Components.ComponentFactory>(Container.Identifiers.ComponentFactory)
+                .info("New version is available");
+        }
 
         // Parse arguments and flags
         const parsedArgv = InputParser.parseArgv(this.argv);


### PR DESCRIPTION
## Summary

- await version check on cli and render if new version is available
- check can be skipped with `--skipVersionCheck` flag 
- remove check period from updated *


*Keeping check period results in false check and it may cause troubles with detecting latest version. 

## Checklist

- [x] Tests
- [x] Ready to be merged
