### PR TITLE
fix(core-cli): use global entrypoint when core is installed globaly

### DIFF
--- a/packages/core-cli/__tests__/services/setup.test.ts
+++ b/packages/core-cli/__tests__/services/setup.test.ts
@@ -42,7 +42,7 @@ describe("Setup", () => {
                 exitCode: 0,
             });
 
-            jest.spyOn(setup, "getRootPath").mockReturnValue(join(globalDir, "/path/to/package"));
+            jest.spyOn(setup, "getLocalEntrypoint").mockReturnValue(join(globalDir, "/path/to/package"));
 
             expect(setup.isGlobal()).toBeTrue();
         });
@@ -56,6 +56,36 @@ describe("Setup", () => {
             setup.isGlobal();
 
             expect(spyOnSync).toHaveBeenCalledWith("pnpm root -g dir", { shell: true });
+        });
+    });
+
+    describe("getLocalEntrypoint", () => {
+        it("should return local entrypoint", () => {
+            expect(setup.getLocalEntrypoint()).toEqual(__filename);
+        });
+    });
+
+    describe("getGlobalEntrypoint", () => {
+        it("should return global entrypoint", () => {
+            const spyOnSync = jest.spyOn(execa, "sync").mockReturnValue({
+                stdout: globalDir,
+                exitCode: 0,
+            });
+
+            expect(setup.getGlobalEntrypoint()).toEqual(join(globalDir, "@arkecosystem/core/bin/run"));
+            expect(spyOnSync).toHaveBeenCalled();
+        });
+
+        it("should throw error if pNpm is not installed", () => {
+            const spyOnSync = jest.spyOn(execa, "sync").mockReturnValue({
+                stdout: "",
+                exitCode: 1,
+            });
+
+            expect(() => {
+                setup.getGlobalEntrypoint();
+            }).toThrow("Cannot determine global pNpm dir");
+            expect(spyOnSync).toHaveBeenCalled();
         });
     });
 });

--- a/packages/core-cli/__tests__/services/setup.test.ts
+++ b/packages/core-cli/__tests__/services/setup.test.ts
@@ -1,0 +1,61 @@
+import "jest-extended";
+
+import { Setup } from "@packages/core-cli/src/services/setup";
+import { join } from "path";
+
+import execa from "../__mocks__/execa";
+
+let setup: Setup;
+const globalDir = "/pnpm/global/dir";
+
+beforeEach(() => {
+    setup = new Setup();
+});
+
+afterEach(() => {
+    jest.resetAllMocks();
+});
+
+describe("Setup", () => {
+    describe("isGlobal", () => {
+        it("should return false if package is installed locally", () => {
+            jest.spyOn(execa, "sync").mockReturnValue({
+                stdout: globalDir,
+                exitCode: 0,
+            });
+
+            expect(setup.isGlobal()).toBeFalse();
+        });
+
+        it("should return false if pnpm is not installed", () => {
+            jest.spyOn(execa, "sync").mockReturnValue({
+                stdout: "",
+                exitCode: 1,
+            });
+
+            expect(setup.isGlobal()).toBeFalse();
+        });
+
+        it("should return true if package is installed globally", () => {
+            jest.spyOn(execa, "sync").mockReturnValue({
+                stdout: globalDir,
+                exitCode: 0,
+            });
+
+            jest.spyOn(setup, "getRootPath").mockReturnValue(join(globalDir, "/path/to/package"));
+
+            expect(setup.isGlobal()).toBeTrue();
+        });
+
+        it("should get root using 'pnpm root -g dir' command", () => {
+            const spyOnSync = jest.spyOn(execa, "sync").mockReturnValue({
+                stdout: globalDir,
+                exitCode: 0,
+            });
+
+            setup.isGlobal();
+
+            expect(spyOnSync).toHaveBeenCalledWith("pnpm root -g dir", { shell: true });
+        });
+    });
+});

--- a/packages/core-cli/src/actions/daemonize-process.ts
+++ b/packages/core-cli/src/actions/daemonize-process.ts
@@ -4,7 +4,7 @@ import { Application } from "../application";
 import { Spinner } from "../components";
 import { ProcessOptions } from "../contracts";
 import { Identifiers, inject, injectable } from "../ioc";
-import { ProcessManager } from "../services";
+import { ProcessManager, Setup } from "../services";
 import { AbortRunningProcess } from "./abort-running-process";
 import { AbortUnknownProcess } from "./abort-unknown-process";
 
@@ -29,6 +29,9 @@ export class DaemonizeProcess {
      */
     @inject(Identifiers.ProcessManager)
     private readonly processManager!: ProcessManager;
+
+    @inject(Identifiers.Setup)
+    private readonly setup!: Setup;
 
     /**
      * @static
@@ -57,6 +60,10 @@ export class DaemonizeProcess {
                 flagsProcess["no-daemon"] = true;
             }
 
+            if (this.setup.isGlobal()) {
+                flagsProcess["interpreter"] = "bash";
+            }
+
             flagsProcess.name = processName;
 
             const potato: boolean = totalmem() < 2 * 1024 ** 3;
@@ -64,6 +71,7 @@ export class DaemonizeProcess {
             this.processManager.start(
                 {
                     ...options,
+                    script: this.setup.isGlobal() ? "ark" : this.setup.getRootPath(),
                     ...{
                         env: {
                             NODE_ENV: "production",

--- a/packages/core-cli/src/actions/daemonize-process.ts
+++ b/packages/core-cli/src/actions/daemonize-process.ts
@@ -60,10 +60,6 @@ export class DaemonizeProcess {
                 flagsProcess["no-daemon"] = true;
             }
 
-            if (this.setup.isGlobal()) {
-                flagsProcess["interpreter"] = "bash";
-            }
-
             flagsProcess.name = processName;
 
             const potato: boolean = totalmem() < 2 * 1024 ** 3;
@@ -71,7 +67,7 @@ export class DaemonizeProcess {
             this.processManager.start(
                 {
                     ...options,
-                    script: this.setup.isGlobal() ? "ark" : this.setup.getRootPath(),
+                    script: this.setup.isGlobal() ? this.setup.getGlobalEntrypoint() : this.setup.getLocalEntrypoint(),
                     ...{
                         env: {
                             NODE_ENV: "production",

--- a/packages/core-cli/src/application-factory.ts
+++ b/packages/core-cli/src/application-factory.ts
@@ -46,7 +46,7 @@ import {
 import { Input, InputValidator } from "./input";
 import { Container, Identifiers, interfaces } from "./ioc";
 import { Output } from "./output";
-import { Config, Environment, Installer, Logger, PluginManager, ProcessManager, Updater } from "./services";
+import { Config, Environment, Installer, Logger, PluginManager, ProcessManager, Setup, Updater } from "./services";
 import { Process } from "./utils";
 
 export class ApplicationFactory {
@@ -88,6 +88,8 @@ export class ApplicationFactory {
         app.bind(Identifiers.PluginManager).to(PluginManager).inSingletonScope();
 
         app.bind(Identifiers.Installer).to(Installer).inSingletonScope();
+
+        app.bind(Identifiers.Setup).to(Setup).inSingletonScope();
 
         app.bind(Identifiers.Environment).to(Environment).inSingletonScope();
 

--- a/packages/core-cli/src/contracts.ts
+++ b/packages/core-cli/src/contracts.ts
@@ -85,7 +85,7 @@ export type ProcessIdentifier = string | number;
 
 export type ProcessDescription = Record<string, any>;
 
-export type ProcessOptions = Record<"name" | "script" | "args", string>;
+export type ProcessOptions = Record<"name" | "args", string>;
 
 // APPLICATION
 export interface Application {

--- a/packages/core-cli/src/ioc/identifiers.ts
+++ b/packages/core-cli/src/ioc/identifiers.ts
@@ -13,6 +13,7 @@ export const Identifiers = {
     ProcessManager: Symbol.for("ProcessManager"),
     PluginManager: Symbol.for("PluginManager"),
     Updater: Symbol.for("Updater"),
+    Setup: Symbol.for("Setup"),
     // Input
     InputValidator: Symbol.for("Input<Validator>"),
     // Factories

--- a/packages/core-cli/src/services/index.ts
+++ b/packages/core-cli/src/services/index.ts
@@ -4,4 +4,5 @@ export * from "./installer";
 export * from "./logger";
 export * from "./plugin-manager";
 export * from "./process-manager";
+export * from "./setup";
 export * from "./updater";

--- a/packages/core-cli/src/services/setup.ts
+++ b/packages/core-cli/src/services/setup.ts
@@ -26,7 +26,7 @@ export class Setup {
         const { stdout, exitCode } = sync(`pnpm root -g dir`, { shell: true });
 
         if (exitCode !== 0) {
-            throw new Error("Cannot determine global pNpm dir.");
+            throw new Error("Cannot determine global pNpm dir");
         }
 
         return stdout;

--- a/packages/core-cli/src/services/setup.ts
+++ b/packages/core-cli/src/services/setup.ts
@@ -1,0 +1,25 @@
+import { sync } from "execa";
+
+import { injectable } from "../ioc";
+
+@injectable()
+export class Setup {
+    public isGlobal(): boolean {
+        const globalDir = this.getGlobalDir();
+        return !!(globalDir && this.getRootPath().startsWith(globalDir));
+    }
+
+    public getRootPath(): string {
+        return require.main!.filename;
+    }
+
+    private getGlobalDir(): string | undefined {
+        const { stdout, exitCode } = sync(`pnpm root -g dir`, { shell: true });
+
+        if (exitCode === 0) {
+            return stdout;
+        }
+
+        return undefined;
+    }
+}

--- a/packages/core/__tests__/commands/core-start.test.ts
+++ b/packages/core/__tests__/commands/core-start.test.ts
@@ -1,9 +1,8 @@
+import { Command } from "@packages/core/src/commands/core-start";
 import { Container } from "@packages/core-cli";
 import { Console } from "@packages/core-test-framework";
-import { Command } from "@packages/core/src/commands/core-start";
 import { writeJSONSync } from "fs-extra";
 import os from "os";
-import { resolve } from "path";
 import { dirSync, setGracefulCleanup } from "tmp";
 
 let cli;
@@ -37,7 +36,7 @@ describe("StartCommand", () => {
                 },
                 name: "ark-core",
                 node_args: undefined,
-                script: resolve(__dirname, "../../../../packages/core/bin/run"),
+                script: __filename,
             },
             { "kill-timeout": 30000, "max-restarts": 5, name: "ark-core" },
         );

--- a/packages/core/__tests__/commands/forger-start.test.ts
+++ b/packages/core/__tests__/commands/forger-start.test.ts
@@ -1,9 +1,8 @@
+import { Command } from "@packages/core/src/commands/forger-start";
 import { Container } from "@packages/core-cli";
 import { Console } from "@packages/core-test-framework";
-import { Command } from "@packages/core/src/commands/forger-start";
 import { writeJSONSync } from "fs-extra";
 import os from "os";
-import { resolve } from "path";
 import { dirSync, setGracefulCleanup } from "tmp";
 
 let cli;
@@ -37,7 +36,7 @@ describe("StartCommand", () => {
                 },
                 name: "ark-forger",
                 node_args: undefined,
-                script: resolve(__dirname, "../../../../packages/core/bin/run"),
+                script: __filename,
             },
             { "kill-timeout": 30000, "max-restarts": 5, name: "ark-forger" },
         );

--- a/packages/core/__tests__/commands/relay-start.test.ts
+++ b/packages/core/__tests__/commands/relay-start.test.ts
@@ -1,8 +1,7 @@
+import { Command } from "@packages/core/src/commands/relay-start";
 import { Container } from "@packages/core-cli";
 import { Console } from "@packages/core-test-framework";
-import { Command } from "@packages/core/src/commands/relay-start";
 import os from "os";
-import { resolve } from "path";
 
 let cli;
 let processManager;
@@ -29,7 +28,7 @@ describe("StartCommand", () => {
                 },
                 name: "ark-relay",
                 node_args: undefined,
-                script: resolve(__dirname, "../../../../packages/core/bin/run"),
+                script: __filename,
             },
             { "kill-timeout": 30000, "max-restarts": 5, name: "ark-relay" },
         );

--- a/packages/core/src/commands/core-start.ts
+++ b/packages/core/src/commands/core-start.ts
@@ -1,7 +1,6 @@
 import { Commands, Container, Contracts, Utils } from "@arkecosystem/core-cli";
 import { Networks } from "@arkecosystem/crypto";
 import Joi from "joi";
-import { resolve } from "path";
 
 import { buildBIP38 } from "../internal/crypto";
 
@@ -68,7 +67,6 @@ export class Command extends Commands.Command {
         await this.actions.daemonizeProcess(
             {
                 name: `${flags.token}-core`,
-                script: resolve(__dirname, "../../bin/run"),
                 args: `core:run ${Utils.castFlagsToString(flags, ["daemon"])}`,
             },
             flags,

--- a/packages/core/src/commands/forger-start.ts
+++ b/packages/core/src/commands/forger-start.ts
@@ -1,7 +1,6 @@
 import { Commands, Container, Contracts, Utils } from "@arkecosystem/core-cli";
 import { Networks } from "@arkecosystem/crypto";
 import Joi from "joi";
-import { resolve } from "path";
 
 import { buildBIP38 } from "../internal/crypto";
 
@@ -66,7 +65,6 @@ export class Command extends Commands.Command {
         await this.actions.daemonizeProcess(
             {
                 name: `${flags.token}-forger`,
-                script: resolve(__dirname, "../../bin/run"),
                 args: `forger:run ${Utils.castFlagsToString(flags, ["daemon"])}`,
             },
             flags,

--- a/packages/core/src/commands/relay-start.ts
+++ b/packages/core/src/commands/relay-start.ts
@@ -1,7 +1,6 @@
 import { Commands, Container, Contracts, Utils } from "@arkecosystem/core-cli";
 import { Networks } from "@arkecosystem/crypto";
 import Joi from "joi";
-import { resolve } from "path";
 
 /**
  * @export
@@ -59,7 +58,6 @@ export class Command extends Commands.Command {
         await this.actions.daemonizeProcess(
             {
                 name: `${flags.token}-relay`,
-                script: resolve(__dirname, "../../bin/run"),
                 args: `relay:run ${Utils.castFlagsToString(flags, ["daemon"])}`,
             },
             flags,


### PR DESCRIPTION
## Summary

Check if core is installed globally using pnpm when daemonizing processes. If global setup is detected then create path to ark command from pnpm root dir. This prevents starting core from specific relese, but uses a [Capistrano like deployments](https://pm2.keymetrics.io/docs/tutorials/capistrano-like-deployments).

This fixes the issues with version lock. Now latest core version is selected on restart after updating. 

Notes: Running start:* commands is also possible when yarn is used. 

## Checklist

- [x] Tests
- [x] Ready to be merged