### PR TITLE
fix(core-transaction-pool): pass buffer content as string to child processes

### DIFF
--- a/packages/core-kernel/src/contracts/transaction-pool/worker.ts
+++ b/packages/core-kernel/src/contracts/transaction-pool/worker.ts
@@ -12,7 +12,7 @@ export interface WorkerScriptHandler {
     loadCryptoPackage(packageName: string): void;
     setConfig(networkConfig: any): void;
     setHeight(height: number): void;
-    getTransactionFromData(transactionData: Interfaces.ITransactionData | string): Promise<SerializedTransaction>;
+    getTransactionFromData(transactionDataDTO: Interfaces.ITransactionData | string): Promise<SerializedTransaction>;
 }
 
 export type WorkerIpcSubprocess = IpcSubprocess<WorkerScriptHandler>;

--- a/packages/core-kernel/src/contracts/transaction-pool/worker.ts
+++ b/packages/core-kernel/src/contracts/transaction-pool/worker.ts
@@ -12,7 +12,7 @@ export interface WorkerScriptHandler {
     loadCryptoPackage(packageName: string): void;
     setConfig(networkConfig: any): void;
     setHeight(height: number): void;
-    getTransactionFromData(transactionData: Interfaces.ITransactionData | Buffer): Promise<SerializedTransaction>;
+    getTransactionFromData(transactionData: Interfaces.ITransactionData | string): Promise<SerializedTransaction>;
 }
 
 export type WorkerIpcSubprocess = IpcSubprocess<WorkerScriptHandler>;

--- a/packages/core-kernel/src/contracts/transaction-pool/worker.ts
+++ b/packages/core-kernel/src/contracts/transaction-pool/worker.ts
@@ -12,7 +12,7 @@ export interface WorkerScriptHandler {
     loadCryptoPackage(packageName: string): void;
     setConfig(networkConfig: any): void;
     setHeight(height: number): void;
-    getTransactionFromData(transactionDataDTO: Interfaces.ITransactionData | string): Promise<SerializedTransaction>;
+    getTransactionFromData(transactionData: Interfaces.ITransactionData | string): Promise<SerializedTransaction>;
 }
 
 export type WorkerIpcSubprocess = IpcSubprocess<WorkerScriptHandler>;

--- a/packages/core-transaction-pool/src/worker-script-handler.ts
+++ b/packages/core-transaction-pool/src/worker-script-handler.ts
@@ -18,12 +18,12 @@ export class WorkerScriptHandler implements Contracts.TransactionPool.WorkerScri
     }
 
     public async getTransactionFromData(
-        transactionData: Interfaces.ITransactionData | string,
+        transactionDataDTO: Interfaces.ITransactionData | string,
     ): Promise<Contracts.TransactionPool.SerializedTransaction> {
         const tx =
-            typeof transactionData === "string"
-                ? Transactions.TransactionFactory.fromBytes(Buffer.from(transactionData, "hex"))
-                : Transactions.TransactionFactory.fromData(transactionData);
+            typeof transactionDataDTO === "string"
+                ? Transactions.TransactionFactory.fromBytes(Buffer.from(transactionDataDTO, "hex"))
+                : Transactions.TransactionFactory.fromData(transactionDataDTO);
         return { id: tx.id!, serialized: tx.serialized.toString("hex"), isVerified: tx.isVerified };
     }
 }

--- a/packages/core-transaction-pool/src/worker-script-handler.ts
+++ b/packages/core-transaction-pool/src/worker-script-handler.ts
@@ -18,11 +18,11 @@ export class WorkerScriptHandler implements Contracts.TransactionPool.WorkerScri
     }
 
     public async getTransactionFromData(
-        transactionData: Interfaces.ITransactionData | Buffer,
+        transactionData: Interfaces.ITransactionData | string,
     ): Promise<Contracts.TransactionPool.SerializedTransaction> {
         const tx =
-            transactionData instanceof Buffer
-                ? Transactions.TransactionFactory.fromBytes(transactionData)
+            typeof transactionData === "string"
+                ? Transactions.TransactionFactory.fromBytes(Buffer.from(transactionData, "hex"))
                 : Transactions.TransactionFactory.fromData(transactionData);
         return { id: tx.id!, serialized: tx.serialized.toString("hex"), isVerified: tx.isVerified };
     }

--- a/packages/core-transaction-pool/src/worker-script-handler.ts
+++ b/packages/core-transaction-pool/src/worker-script-handler.ts
@@ -18,12 +18,12 @@ export class WorkerScriptHandler implements Contracts.TransactionPool.WorkerScri
     }
 
     public async getTransactionFromData(
-        transactionDataDTO: Interfaces.ITransactionData | string,
+        transactionData: Interfaces.ITransactionData | string,
     ): Promise<Contracts.TransactionPool.SerializedTransaction> {
         const tx =
-            typeof transactionDataDTO === "string"
-                ? Transactions.TransactionFactory.fromBytes(Buffer.from(transactionDataDTO, "hex"))
-                : Transactions.TransactionFactory.fromData(transactionDataDTO);
+            typeof transactionData === "string"
+                ? Transactions.TransactionFactory.fromBytes(Buffer.from(transactionData, "hex"))
+                : Transactions.TransactionFactory.fromData(transactionData);
         return { id: tx.id!, serialized: tx.serialized.toString("hex"), isVerified: tx.isVerified };
     }
 }

--- a/packages/core-transaction-pool/src/worker.ts
+++ b/packages/core-transaction-pool/src/worker.ts
@@ -32,12 +32,9 @@ export class Worker implements Contracts.TransactionPool.Worker {
             this.ipcSubprocess.sendAction("setHeight", currentHeight);
         }
 
-        const transactionDataDTO =
-            transactionData instanceof Buffer ? transactionData.toString("hex") : transactionData;
-
         const { id, serialized, isVerified } = await this.ipcSubprocess.sendRequest(
             "getTransactionFromData",
-            transactionDataDTO,
+            transactionData instanceof Buffer ? transactionData.toString("hex") : transactionData,
         );
         const transaction = Transactions.TransactionFactory.fromBytesUnsafe(Buffer.from(serialized, "hex"), id);
         transaction.isVerified = isVerified;

--- a/packages/core-transaction-pool/src/worker.ts
+++ b/packages/core-transaction-pool/src/worker.ts
@@ -32,7 +32,13 @@ export class Worker implements Contracts.TransactionPool.Worker {
             this.ipcSubprocess.sendAction("setHeight", currentHeight);
         }
 
-        const { id, serialized, isVerified } = await this.ipcSubprocess.sendRequest("getTransactionFromData", transactionData);
+        const transactionDataDTO =
+            transactionData instanceof Buffer ? transactionData.toString("hex") : transactionData;
+
+        const { id, serialized, isVerified } = await this.ipcSubprocess.sendRequest(
+            "getTransactionFromData",
+            transactionDataDTO,
+        );
         const transaction = Transactions.TransactionFactory.fromBytesUnsafe(Buffer.from(serialized, "hex"), id);
         transaction.isVerified = isVerified;
 


### PR DESCRIPTION
## Summary

Transform buffer to string before sending it to the child process. When worker receives string content it transform it back to buffer in order to deserialize it. 

This fixes exiting issue when broadcasting tranactions to other peers, where transactions are not processed. 

## Checklist

- [x] Tests
- [x] Ready to be merged
