### PR TITLE
chore: use `python3` in docker

### DIFF
--- a/docker/production/Dockerfile
+++ b/docker/production/Dockerfile
@@ -6,7 +6,7 @@ ADD docker/production/entrypoint.sh /entrypoint.sh
 
 ARG core_channel=latest
 
-RUN apk add --no-cache --virtual .build-deps make gcc g++ python git \
+RUN apk add --no-cache --virtual .build-deps make gcc g++ python3 git \
     && apk add --no-cache bash sudo git openntpd openssl \
     && echo "servers pool.ntp.org" > /etc/ntpd.conf \
     && echo "servers time.google.com" >> /etc/ntpd.conf \


### PR DESCRIPTION
## Summary
Fixes Docker builds.

## Checklist
- [x] Ready to be merged

