### PR TITLE
fix(core-cli): delete better_sqlite3.node before installing

### DIFF
--- a/__tests__/unit/core-cli/services/installer.test.ts
+++ b/__tests__/unit/core-cli/services/installer.test.ts
@@ -31,7 +31,7 @@ describe("Installer.install", () => {
 
         installer.install("@arkecosystem/core");
 
-        expect(spySync).toHaveBeenCalledWith("yarn global add @arkecosystem/core@latest --force", { shell: true });
+        expect(spySync).toHaveBeenCalledWith("rm -f `yarn global dir`/node_modules/better-sqlite3/build/Release/better_sqlite3.node && yarn global add @arkecosystem/core@latest --force", { shell: true });
     });
 
     it("should install specific package when tag is provided", () => {
@@ -44,7 +44,7 @@ describe("Installer.install", () => {
 
         installer.install("@arkecosystem/core", "3.0.0");
 
-        expect(spySync).toHaveBeenCalledWith("yarn global add @arkecosystem/core@3.0.0 --force", { shell: true });
+        expect(spySync).toHaveBeenCalledWith("rm -f `yarn global dir`/node_modules/better-sqlite3/build/Release/better_sqlite3.node && yarn global add @arkecosystem/core@3.0.0 --force", { shell: true });
     });
 
     it("should throw when exit code isn't 0", () => {
@@ -57,7 +57,7 @@ describe("Installer.install", () => {
 
         expect(() => installer.install("@arkecosystem/core")).toThrow("stderr");
 
-        expect(spySync).toHaveBeenCalledWith("yarn global add @arkecosystem/core@latest --force", { shell: true });
+        expect(spySync).toHaveBeenCalledWith("rm -f `yarn global dir`/node_modules/better-sqlite3/build/Release/better_sqlite3.node && yarn global add @arkecosystem/core@latest --force", { shell: true });
     });
 });
 

--- a/__tests__/unit/core-cli/services/installer.test.ts
+++ b/__tests__/unit/core-cli/services/installer.test.ts
@@ -31,7 +31,7 @@ describe("Installer.install", () => {
 
         installer.install("@arkecosystem/core");
 
-        expect(spySync).toHaveBeenCalledWith("rm -f `yarn global dir`/node_modules/better-sqlite3/build/Release/better_sqlite3.node && yarn global add @arkecosystem/core@latest --force", { shell: true });
+        expect(spySync).toHaveBeenCalledWith("rm -f \"`yarn global dir`\"/node_modules/better-sqlite3/build/Release/better_sqlite3.node && yarn global add @arkecosystem/core@latest --force", { shell: true });
     });
 
     it("should install specific package when tag is provided", () => {
@@ -44,7 +44,7 @@ describe("Installer.install", () => {
 
         installer.install("@arkecosystem/core", "3.0.0");
 
-        expect(spySync).toHaveBeenCalledWith("rm -f `yarn global dir`/node_modules/better-sqlite3/build/Release/better_sqlite3.node && yarn global add @arkecosystem/core@3.0.0 --force", { shell: true });
+        expect(spySync).toHaveBeenCalledWith("rm -f \"`yarn global dir`\"/node_modules/better-sqlite3/build/Release/better_sqlite3.node && yarn global add @arkecosystem/core@3.0.0 --force", { shell: true });
     });
 
     it("should throw when exit code isn't 0", () => {
@@ -57,7 +57,7 @@ describe("Installer.install", () => {
 
         expect(() => installer.install("@arkecosystem/core")).toThrow("stderr");
 
-        expect(spySync).toHaveBeenCalledWith("rm -f `yarn global dir`/node_modules/better-sqlite3/build/Release/better_sqlite3.node && yarn global add @arkecosystem/core@latest --force", { shell: true });
+        expect(spySync).toHaveBeenCalledWith("rm -f \"`yarn global dir`\"/node_modules/better-sqlite3/build/Release/better_sqlite3.node && yarn global add @arkecosystem/core@latest --force", { shell: true });
     });
 });
 

--- a/packages/core-cli/src/services/installer.ts
+++ b/packages/core-cli/src/services/installer.ts
@@ -16,7 +16,7 @@ export class Installer {
     public install(pkg: string, tag: string = "latest"): void {
         this.installPeerDependencies(pkg, tag);
 
-        const { stdout, stderr, exitCode } = sync(`rm -f \`yarn global dir\`/node_modules/better-sqlite3/build/Release/better_sqlite3.node && yarn global add ${pkg}@${tag} --force`, { shell: true });
+        const { stdout, stderr, exitCode } = sync(`rm -f "\`yarn global dir\`"/node_modules/better-sqlite3/build/Release/better_sqlite3.node && yarn global add ${pkg}@${tag} --force`, { shell: true });
 
         if (exitCode !== 0) {
             throw new Error(`"yarn global add ${pkg}@${tag} --force" exited with code ${exitCode}\n${stderr}`);

--- a/packages/core-cli/src/services/installer.ts
+++ b/packages/core-cli/src/services/installer.ts
@@ -16,7 +16,7 @@ export class Installer {
     public install(pkg: string, tag: string = "latest"): void {
         this.installPeerDependencies(pkg, tag);
 
-        const { stdout, stderr, exitCode } = sync(`yarn global add ${pkg}@${tag} --force`, { shell: true });
+        const { stdout, stderr, exitCode } = sync(`rm -f \`yarn global dir\`/node_modules/better-sqlite3/build/Release/better_sqlite3.node && yarn global add ${pkg}@${tag} --force`, { shell: true });
 
         if (exitCode !== 0) {
             throw new Error(`"yarn global add ${pkg}@${tag} --force" exited with code ${exitCode}\n${stderr}`);


### PR DESCRIPTION
## Summary

Fixes #4601.

Two things worth mentioning:

1. This could be refactored to use `fs.existsSync` and `fs.unlinkSync` if desired rather than `rm -f` via the shell, but I thought the latter would be easier since we're already executing a command via the shell anyway when running `yarn global add`.

2. This PR is aimed at the `master` branch since it is specific to `yarn` rather than `pnpm` as used in `develop` and I think the issue is important enough to warrant being fixed in Core 3.1 rather than being deferred to 4.0.

## Checklist

- [x] Ready to be merged