### PR TITLE
fix(core): skip prompts if --force is used in `reinstall` command

### DIFF
--- a/packages/core/__tests__/commands/reinstall.test.ts
+++ b/packages/core/__tests__/commands/reinstall.test.ts
@@ -1,89 +1,63 @@
-import "jest-extended";
-
 import { Command } from "@packages/core/src/commands/reinstall";
-import { Container } from "@packages/core-cli";
+import { ActionFactory, Container } from "@packages/core-cli";
+import { Installer, ProcessManager } from "@packages/core-cli/src/services";
 import { Console } from "@packages/core-test-framework";
-import execa from "execa";
 import prompts from "prompts";
 
 let cli;
-let processManager;
+let processManager: Partial<ProcessManager>;
+let installer: Partial<Installer>;
+let actionFactory: Partial<ActionFactory>;
+
 beforeEach(() => {
+    installer = {
+        install: jest.fn(),
+    };
+
+    processManager = {
+        update: jest.fn(),
+    };
+
+    actionFactory = {
+        restartRunningProcess: jest.fn(),
+        restartRunningProcessWithPrompt: jest.fn(),
+    };
+
     cli = new Console();
-    processManager = cli.app.get(Container.Identifiers.ProcessManager);
+    cli.app.rebind(Container.Identifiers.Installer).toConstantValue(installer);
+    cli.app.rebind(Container.Identifiers.ProcessManager).toConstantValue(processManager);
+    cli.app.rebind(Container.Identifiers.ActionFactory).toConstantValue(actionFactory);
 });
 
 describe("ReinstallCommand", () => {
     it("should reinstall without a prompt if the [--force] flag is used", async () => {
-        const sync: jest.SpyInstance = jest.spyOn(execa, "sync").mockReturnValue({
-            stdout: '"null"',
-            stderr: undefined,
-            exitCode: 0,
-        } as any);
-
         await cli.withFlags({ force: true }).execute(Command);
 
-        // pnpm info peerDependencies > pnpm install -g > pm2 update > check core > check relay > check forger
-        expect(sync).toHaveBeenCalledTimes(6);
-
-        sync.mockReset();
+        expect(installer.install).toHaveBeenCalled();
+        expect(processManager.update).toHaveBeenCalled();
+        expect(actionFactory.restartRunningProcess).toHaveBeenCalledTimes(3);
+        expect(actionFactory.restartRunningProcessWithPrompt).not.toHaveBeenCalled();
     });
 
     it("should reinstall with a prompt confirmation", async () => {
-        const sync: jest.SpyInstance = jest.spyOn(execa, "sync").mockReturnValue({
-            stdout: '"null"',
-            stderr: undefined,
-            exitCode: 0,
-        } as any);
-
         prompts.inject([true]);
 
         await cli.execute(Command);
 
-        // pnpm info peerDependencies > pnpm install -g > pm2 update > check core > check relay > check forger
-        expect(sync).toHaveBeenCalledTimes(6);
-
-        sync.mockReset();
+        expect(installer.install).toHaveBeenCalled();
+        expect(processManager.update).toHaveBeenCalled();
+        expect(actionFactory.restartRunningProcess).not.toHaveBeenCalled();
+        expect(actionFactory.restartRunningProcessWithPrompt).toHaveBeenCalledTimes(3);
     });
 
     it("should not reinstall without a prompt confirmation", async () => {
-        const sync: jest.SpyInstance = jest.spyOn(execa, "sync").mockReturnValue({
-            stdout: '"null"',
-            stderr: undefined,
-            exitCode: 0,
-        } as any);
-
         prompts.inject([false]);
 
         await expect(cli.execute(Command)).rejects.toThrow("You'll need to confirm the reinstall to continue.");
 
-        expect(sync).not.toHaveBeenCalled();
-
-        sync.mockReset();
-    });
-
-    it("should should ask to restart processes if they are online", async () => {
-        const sync: jest.SpyInstance = jest.spyOn(execa, "sync").mockReturnValue({
-            stdout: '"null"',
-            stderr: undefined,
-            exitCode: 0,
-        } as any);
-
-        const isOnline = jest.spyOn(processManager, "isOnline").mockReturnValue(true);
-        const restart = jest.spyOn(processManager, "restart").mockImplementation(undefined);
-
-        prompts.inject([true]); // restart core
-        prompts.inject([true]); // restart relay
-        prompts.inject([true]); // restart forger
-
-        await cli.withFlags({ force: true }).execute(Command);
-
-        expect(sync).toHaveBeenCalled();
-        expect(isOnline).toHaveBeenCalled();
-        expect(restart).toHaveBeenCalledTimes(3);
-
-        sync.mockReset();
-        isOnline.mockClear();
-        restart.mockClear();
+        expect(installer.install).not.toHaveBeenCalled();
+        expect(processManager.update).not.toHaveBeenCalled();
+        expect(actionFactory.restartRunningProcess).not.toHaveBeenCalled();
+        expect(actionFactory.restartRunningProcessWithPrompt).not.toHaveBeenCalled();
     });
 });

--- a/packages/core/src/commands/reinstall.ts
+++ b/packages/core/src/commands/reinstall.ts
@@ -88,8 +88,14 @@ export class Command extends Commands.Command {
 
         spinner.succeed();
 
-        await this.actions.restartRunningProcessWithPrompt(`${this.getFlag("token")}-core`);
-        await this.actions.restartRunningProcessWithPrompt(`${this.getFlag("token")}-relay`);
-        await this.actions.restartRunningProcessWithPrompt(`${this.getFlag("token")}-forger`);
+        if (this.getFlag("force")) {
+            await this.actions.restartRunningProcess(`${this.getFlag("token")}-core`);
+            await this.actions.restartRunningProcess(`${this.getFlag("token")}-relay`);
+            await this.actions.restartRunningProcess(`${this.getFlag("token")}-forger`);
+        } else {
+            await this.actions.restartRunningProcessWithPrompt(`${this.getFlag("token")}-core`);
+            await this.actions.restartRunningProcessWithPrompt(`${this.getFlag("token")}-relay`);
+            await this.actions.restartRunningProcessWithPrompt(`${this.getFlag("token")}-forger`);
+        }
     }
 }


### PR DESCRIPTION
## Summary

Skip prompts if --force is used in reinstall command.

Mock installer in tests.

## Checklist

- [x] Tests
- [x] Ready to be merged