### PR TITLE
refactor(core): set --updateProcessManager to false by default in `update` command

### DIFF
--- a/packages/core/src/commands/update.ts
+++ b/packages/core/src/commands/update.ts
@@ -43,7 +43,7 @@ export class Command extends Commands.Command {
         this.definition
             .setFlag("token", "The name of the token.", Joi.string().default("ark"))
             .setFlag("force", "Force an update.", Joi.boolean().default(false))
-            .setFlag("updateProcessManager", "Update process manager.", Joi.boolean())
+            .setFlag("updateProcessManager", "Update process manager.", Joi.boolean().default(false))
             .setFlag("restart", "Restart all running processes.", Joi.boolean())
             .setFlag("restartCore", "Restart the Core process.", Joi.boolean())
             .setFlag("restartRelay", "Restart the Relay process.", Joi.boolean())


### PR DESCRIPTION
## Summary

Set --updateProcessManager to false by default in update command.

Mock installer in tests.

## Checklist

- [x] Tests
- [x] Ready to be merged