### PR TITLE
fix(core-cli): peerDependencies installation

### DIFF
--- a/packages/core-cli/__tests__/services/installer.test.ts
+++ b/packages/core-cli/__tests__/services/installer.test.ts
@@ -67,7 +67,7 @@ describe("Installer.installPeerDependencies", () => {
             .mockReturnValue(undefined);
 
         const spySync: jest.SpyInstance = jest.spyOn(execa, "sync").mockReturnValue({
-            stdout: JSON.stringify({ data: { pm2: "4.5.0", somepkg: "^1.0.0" } }),
+            stdout: JSON.stringify({ pm2: "4.5.0", somepkg: "^1.0.0" }),
             exitCode: 0,
         });
 
@@ -87,7 +87,7 @@ describe("Installer.installPeerDependencies", () => {
             .mockReturnValue(undefined);
 
         const spySync: jest.SpyInstance = jest.spyOn(execa, "sync").mockReturnValue({
-            stdout: JSON.stringify({}),
+            stdout: "",
             exitCode: 0,
         });
 
@@ -119,7 +119,7 @@ describe("Installer.installRangeLatest", () => {
         const spyInstall: jest.SpyInstance = jest.spyOn(installer, "install").mockReturnValue(undefined);
 
         const spySync: jest.SpyInstance = jest.spyOn(execa, "sync").mockReturnValue({
-            stdout: JSON.stringify({ data: ["3.0.0", "3.1.0", "3.0.0-next.9"] }),
+            stdout: JSON.stringify(["3.0.0", "3.1.0", "3.0.0-next.9"]),
             exitCode: 0,
         });
 
@@ -147,7 +147,22 @@ describe("Installer.installRangeLatest", () => {
 
     it("should throw error when there is no version matching requested range", () => {
         const spySync: jest.SpyInstance = jest.spyOn(execa, "sync").mockReturnValue({
-            stdout: JSON.stringify({ data: ["3.0.0", "3.0.0-next.9"] }),
+            stdout: JSON.stringify(["3.0.0", "3.0.0-next.9"]),
+            exitCode: 0,
+        });
+
+        expect(() => installer.installRangeLatest("@arkecosystem/core", "^4.0.0 <4.4.0")).toThrow(
+            "No @arkecosystem/core version to satisfy ^4.0.0 <4.4.0",
+        );
+
+        expect(spySync).toHaveBeenCalledWith("pnpm info @arkecosystem/core versions --json", {
+            shell: true,
+        });
+    });
+
+    it("should throw error when package doesn't exist", () => {
+        const spySync: jest.SpyInstance = jest.spyOn(execa, "sync").mockReturnValue({
+            stdout: "",
             exitCode: 0,
         });
 

--- a/packages/core-cli/__tests__/services/installer.test.ts
+++ b/packages/core-cli/__tests__/services/installer.test.ts
@@ -61,19 +61,70 @@ describe("Installer.install", () => {
 });
 
 describe("Installer.installPeerDependencies", () => {
-    it("should install each peer dependency", () => {
+    it("should install each peer dependency, when packages aren't installed", () => {
         const spyInstallRangeLatest: jest.SpyInstance = jest
             .spyOn(installer, "installRangeLatest")
             .mockReturnValue(undefined);
 
-        const spySync: jest.SpyInstance = jest.spyOn(execa, "sync").mockReturnValue({
-            stdout: JSON.stringify({ pm2: "4.5.0", somepkg: "^1.0.0" }),
-            exitCode: 0,
-        });
+        const spySync: jest.SpyInstance = jest
+            .spyOn(execa, "sync")
+            .mockReturnValueOnce({
+                stdout: JSON.stringify({ pm2: "4.5.0", somepkg: "^1.0.0" }),
+                exitCode: 0,
+            })
+            .mockReturnValueOnce({
+                stdout: "",
+                exitCode: 0,
+            });
 
         installer.installPeerDependencies("@arkecosystem/core", "3.0.0");
 
         expect(spySync).toHaveBeenCalledWith("pnpm info @arkecosystem/core@3.0.0 peerDependencies --json", {
+            shell: true,
+        });
+
+        expect(spySync).toHaveBeenCalledWith("pnpm list -g --json", {
+            shell: true,
+        });
+
+        expect(spyInstallRangeLatest).toHaveBeenCalledWith("pm2", "4.5.0");
+        expect(spyInstallRangeLatest).toHaveBeenCalledWith("somepkg", "^1.0.0");
+    });
+
+    it("should install each peer dependency, when installed packages doesn't pass semver validation", () => {
+        const spyInstallRangeLatest: jest.SpyInstance = jest
+            .spyOn(installer, "installRangeLatest")
+            .mockReturnValue(undefined);
+
+        const spySync: jest.SpyInstance = jest
+            .spyOn(execa, "sync")
+            .mockReturnValueOnce({
+                stdout: JSON.stringify({ pm2: "4.5.0", somepkg: "^1.0.0" }),
+                exitCode: 0,
+            })
+            .mockReturnValueOnce({
+                stdout: JSON.stringify([
+                    {
+                        dependencies: {
+                            pm2: {
+                                version: "4.0.0",
+                            },
+                            somepkg: {
+                                version: "0.0.1",
+                            },
+                        },
+                    },
+                ]),
+                exitCode: 0,
+            });
+
+        installer.installPeerDependencies("@arkecosystem/core", "3.0.0");
+
+        expect(spySync).toHaveBeenCalledWith("pnpm info @arkecosystem/core@3.0.0 peerDependencies --json", {
+            shell: true,
+        });
+
+        expect(spySync).toHaveBeenCalledWith("pnpm list -g --json", {
             shell: true,
         });
 
@@ -100,13 +151,80 @@ describe("Installer.installPeerDependencies", () => {
         expect(spyInstallRangeLatest).not.toHaveBeenCalled();
     });
 
-    it("should throw error when pnpm command fails", () => {
+    it("should not install each peer dependency, when installed packages pass semver validation", () => {
+        const spyInstallRangeLatest: jest.SpyInstance = jest
+            .spyOn(installer, "installRangeLatest")
+            .mockReturnValue(undefined);
+
+        const spySync: jest.SpyInstance = jest
+            .spyOn(execa, "sync")
+            .mockReturnValueOnce({
+                stdout: JSON.stringify({ pm2: "4.5.0", somepkg: "^1.0.0" }),
+                exitCode: 0,
+            })
+            .mockReturnValueOnce({
+                stdout: JSON.stringify([
+                    {
+                        dependencies: {
+                            pm2: {
+                                version: "4.5.0",
+                            },
+                            somepkg: {
+                                version: "1.2.1",
+                            },
+                        },
+                    },
+                ]),
+                exitCode: 0,
+            });
+
+        installer.installPeerDependencies("@arkecosystem/core", "3.0.0");
+
+        expect(spySync).toHaveBeenCalledWith("pnpm info @arkecosystem/core@3.0.0 peerDependencies --json", {
+            shell: true,
+        });
+
+        expect(spySync).toHaveBeenCalledWith("pnpm list -g --json", {
+            shell: true,
+        });
+
+        expect(spyInstallRangeLatest).not.toHaveBeenCalled();
+    });
+
+    it("should throw error when pnpm command fails on pnpm info", () => {
+        const spySync: jest.SpyInstance = jest
+            .spyOn(execa, "sync")
+            .mockReturnValueOnce({
+                stdout: JSON.stringify({ pm2: "4.5.0", somepkg: "^1.0.0" }),
+                exitCode: 0,
+            })
+            .mockReturnValue({
+                stderr: "stderr",
+                exitCode: 1,
+            });
+
+        expect(() => installer.installPeerDependencies("@arkecosystem/core")).toThrow(
+            `"pnpm list -g --json" exited with code 1\nstderr`,
+        );
+
+        expect(spySync).toHaveBeenCalledWith("pnpm info @arkecosystem/core@latest peerDependencies --json", {
+            shell: true,
+        });
+
+        expect(spySync).toHaveBeenCalledWith("pnpm list -g --json", {
+            shell: true,
+        });
+    });
+
+    it("should throw error when pnpm command fails on pnpm info", () => {
         const spySync: jest.SpyInstance = jest.spyOn(execa, "sync").mockReturnValue({
             stderr: "stderr",
             exitCode: 1,
         });
 
-        expect(() => installer.installPeerDependencies("@arkecosystem/core")).toThrow("stderr");
+        expect(() => installer.installPeerDependencies("@arkecosystem/core")).toThrow(
+            `"pnpm info @arkecosystem/core@latest peerDependencies --json" exited with code 1\nstderr`,
+        );
 
         expect(spySync).toHaveBeenCalledWith("pnpm info @arkecosystem/core@latest peerDependencies --json", {
             shell: true,

--- a/packages/core-cli/__tests__/services/updater.test.ts
+++ b/packages/core-cli/__tests__/services/updater.test.ts
@@ -92,13 +92,10 @@ describe("Updater", () => {
 
             nock(/.*/).get("/@arkecosystem%2Fcore").reply(200, response);
 
-            const spySync: jest.SpyInstance = jest.spyOn(execa, "sync").mockReturnValue({
-                stdout: '"null"',
-                stderr: undefined,
-                exitCode: 0,
-            });
             const spySpinner = jest.spyOn(cli.app.get(Container.Identifiers.Spinner), "render");
-            const spyInstaller = jest.spyOn(cli.app.get(Container.Identifiers.Installer), "install");
+            const spyInstaller = jest
+                .spyOn(cli.app.get(Container.Identifiers.Installer), "install")
+                .mockImplementation(async () => {});
             const spyProcessManager = jest.spyOn(cli.app.get(Container.Identifiers.ProcessManager), "update");
 
             // Act...
@@ -108,7 +105,6 @@ describe("Updater", () => {
 
             // Assert...
             expect(update).toBeTrue();
-            expect(spySync).toHaveBeenCalled();
             expect(spySpinner).toHaveBeenCalled();
             expect(spyInstaller).toHaveBeenCalled();
             expect(spyProcessManager).toHaveBeenCalled();
@@ -126,13 +122,10 @@ describe("Updater", () => {
 
             nock(/.*/).get("/@arkecosystem%2Fcore").reply(200, response);
 
-            const spySync: jest.SpyInstance = jest.spyOn(execa, "sync").mockReturnValue({
-                stdout: '"null"',
-                stderr: undefined,
-                exitCode: 0,
-            });
             const spySpinner = jest.spyOn(cli.app.get(Container.Identifiers.Spinner), "render");
-            const spyInstaller = jest.spyOn(cli.app.get(Container.Identifiers.Installer), "install");
+            const spyInstaller = jest
+                .spyOn(cli.app.get(Container.Identifiers.Installer), "install")
+                .mockImplementation(async () => {});
 
             prompts.inject([true]);
 
@@ -143,7 +136,6 @@ describe("Updater", () => {
 
             // Assert...
             expect(update).toBeTrue();
-            expect(spySync).toHaveBeenCalled();
             expect(spySpinner).toHaveBeenCalled();
             expect(spyInstaller).toHaveBeenCalled();
         });

--- a/packages/core-cli/src/services/installer.ts
+++ b/packages/core-cli/src/services/installer.ts
@@ -34,7 +34,7 @@ export class Installer {
             );
         }
 
-        for (const [peerPkg, peerPkgSemver] of Object.entries(JSON.parse(stdout).data ?? {})) {
+        for (const [peerPkg, peerPkgSemver] of Object.entries(stdout !== "" ? JSON.parse(stdout) : {})) {
             this.installRangeLatest(peerPkg, peerPkgSemver as string);
         }
     }
@@ -46,7 +46,7 @@ export class Installer {
             throw new Error(`"pnpm info ${pkg} versions --json" exited with code ${exitCode}\n${stderr}`);
         }
 
-        const versions = (JSON.parse(stdout).data as string[])
+        const versions = (stdout !== "" ? (JSON.parse(stdout) as string[]) : [])
             .filter((v) => semver.satisfies(v, range))
             .sort((a, b) => semver.rcompare(a, b));
 

--- a/packages/core-cli/src/services/installer.ts
+++ b/packages/core-cli/src/services/installer.ts
@@ -3,6 +3,11 @@ import * as semver from "semver";
 
 import { injectable } from "../ioc";
 
+type Package = {
+    pkg: string;
+    version: string;
+};
+
 /**
  * @export
  * @class Installer
@@ -34,8 +39,13 @@ export class Installer {
             );
         }
 
+        const installedPackages = this.getInstalled();
+
         for (const [peerPkg, peerPkgSemver] of Object.entries(stdout !== "" ? JSON.parse(stdout) : {})) {
-            this.installRangeLatest(peerPkg, peerPkgSemver as string);
+            const installedPkg = installedPackages.find((installed) => installed.pkg === peerPkg);
+            if (!installedPkg || !semver.satisfies(installedPkg.version, peerPkgSemver as string)) {
+                this.installRangeLatest(peerPkg, peerPkgSemver as string);
+            }
         }
     }
 
@@ -55,5 +65,24 @@ export class Installer {
         }
 
         this.install(pkg, versions[0]);
+    }
+
+    private getInstalled(): Package[] {
+        const { stdout, stderr, exitCode } = sync(`pnpm list -g --json`, { shell: true });
+
+        if (exitCode !== 0) {
+            throw new Error(`"pnpm list -g --json" exited with code ${exitCode}\n${stderr}`);
+        }
+
+        if (stdout === "") {
+            return [];
+        }
+
+        return Object.entries<{ version: string }>(JSON.parse(stdout)[0].dependencies).map(([pkg, meta]) => {
+            return {
+                pkg,
+                version: meta.version,
+            };
+        });
     }
 }


### PR DESCRIPTION
## Summary

Fix peerDependencies installation in Installer. Code is modified because, pnpm uses different command output than yarn. 

Install peer dependencies only if existing peer dependency doesn't satisfy defined version range. 
This prevents pm2 package installation every time new pm2 version is published. Pm2 causes issues with ProcessManager class when installed version is not the same as currently running version.  

## Checklist

- [x] Tests
- [x] Ready to be merged