### PR TITLE
fix(core-api): use current supply to calculate delegates approval

### DIFF
--- a/__tests__/integration/core-api/services/__support__/setup.ts
+++ b/__tests__/integration/core-api/services/__support__/setup.ts
@@ -29,7 +29,13 @@ export const setUp = async (): Promise<Application> => {
     await transactionsServiceProvider.register();
     await apiServiceProvider.register();
 
-    app.rebind(Container.Identifiers.StateStore).toConstantValue(null);
+    app.rebind(Container.Identifiers.StateStore).toConstantValue({
+        getLastBlock: jest.fn().mockReturnValue({
+            data: {
+                height: 1,
+            },
+        }),
+    });
 
     const walletAttributes = app.get<Services.Attributes.AttributeSet>(Container.Identifiers.WalletAttributes);
     walletAttributes.set("delegate.username");

--- a/packages/core-api/src/services/delegate-search-service.ts
+++ b/packages/core-api/src/services/delegate-search-service.ts
@@ -8,6 +8,9 @@ export class DelegateSearchService {
     @Container.tagged("state", "blockchain")
     private readonly walletRepository!: Contracts.State.WalletRepository;
 
+    @Container.inject(Container.Identifiers.StateStore)
+    private readonly stateStore!: Contracts.State.StateStore;
+
     @Container.inject(Container.Identifiers.StandardCriteriaService)
     private readonly standardCriteriaService!: Services.Search.StandardCriteriaService;
 
@@ -61,7 +64,10 @@ export class DelegateSearchService {
                 last: delegateLastBlock,
             },
             production: {
-                approval: AppUtils.delegateCalculator.calculateApproval(wallet),
+                approval: AppUtils.delegateCalculator.calculateApproval(
+                    wallet,
+                    this.stateStore.getLastBlock().data.height,
+                ),
             },
             forged: {
                 fees: delegateAttribute.forgedFees,


### PR DESCRIPTION
## Summary

Fix #4614.

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged
