### PR TITLE
fix(core-api): empty orderBy in pagination result 

### DIFF
--- a/packages/core-api/src/plugins/pagination/ext.ts
+++ b/packages/core-api/src/plugins/pagination/ext.ts
@@ -54,7 +54,8 @@ export class Ext {
 
         // strip prefix in baseUri, we want a "clean" relative path
         const baseUri = request.url.pathname.slice(this.routePathPrefix.length) + "?";
-        const { query } = request;
+        const query = { ...request.query };
+        delete query.orderBy;
         const currentPage = query.page;
         const currentLimit = query.limit;
 


### PR DESCRIPTION
## Summary

Take orderBy from original query to generate pagination. This fixes issue when orderBy is set by default and it produces invalid pagination value. 

## Checklist

- [x] Ready to be merged

