### PR TITLE
fix(core-api): replace deprecated `querystring` with `qs` and use dot notation

### DIFF
--- a/packages/core-api/package.json
+++ b/packages/core-api/package.json
@@ -34,6 +34,7 @@
         "joi": "17.4.2",
         "nanomatch": "1.2.13",
         "node-cache": "5.1.2",
+        "qs": "6.10.3",
         "rate-limiter-flexible": "1.3.2",
         "semver": "6.3.0"
     },

--- a/packages/core-api/src/plugins/pagination/ext.ts
+++ b/packages/core-api/src/plugins/pagination/ext.ts
@@ -2,7 +2,7 @@
 
 import { Utils } from "@arkecosystem/core-kernel";
 import Hoek from "@hapi/hoek";
-import Qs from "querystring";
+import qs from "qs";
 
 export class Ext {
     private readonly routePathPrefix = "/api";
@@ -69,8 +69,12 @@ export class Ext {
 
         const getUri = (page: number | null): string | null =>
             /* istanbul ignore next */
-            // tslint:disable-next-line: no-null-keyword
-            page ? baseUri + Qs.stringify(Hoek.applyToDefaults({ ...query, ...request.orig.query }, { page })) : null;
+            page
+                ? baseUri +
+                  qs.stringify(Hoek.applyToDefaults({ ...query, ...request.orig.query }, { page }), {
+                      allowDots: true,
+                  })
+                : null;
 
         const newSource = {
             meta: {
@@ -79,14 +83,10 @@ export class Ext {
                     count: results.length,
                     pageCount: pageCount,
                     totalCount: totalCount ? totalCount : 0,
-
-                    // tslint:disable-next-line: no-null-keyword
                     /* istanbul ignore next */
                     next: totalCount && currentPage < pageCount ? getUri(currentPage + 1) : null,
                     previous:
-                        // tslint:disable-next-line: no-null-keyword
                         totalCount && currentPage > 1 && currentPage <= pageCount + 1 ? getUri(currentPage - 1) : null,
-
                     self: getUri(currentPage),
                     first: getUri(1),
                     last: getUri(pageCount),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -227,6 +227,7 @@ importers:
       lodash.clonedeep: 4.5.0
       nanomatch: 1.2.13
       node-cache: 5.1.2
+      qs: 6.10.3
       rate-limiter-flexible: 1.3.2
       semver: 6.3.0
     dependencies:
@@ -240,6 +241,7 @@ importers:
       joi: 17.4.2
       nanomatch: 1.2.13
       node-cache: 5.1.2
+      qs: 6.10.3
       rate-limiter-flexible: 1.3.2
       semver: 6.3.0
     devDependencies:
@@ -5091,11 +5093,10 @@ packages:
     dev: false
 
   /call-bind/1.0.2:
-    resolution: {integrity: sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.com/call-bind/-/call-bind-1.0.2.tgz}
+    resolution: {integrity: sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==}
     dependencies:
       function-bind: 1.1.1
       get-intrinsic: 1.1.1
-    dev: true
 
   /call-me-maybe/1.0.1:
     resolution: {integrity: sha1-JtII6onje1y95gJQoV8DHBak1ms=, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.com/call-me-maybe/-/call-me-maybe-1.0.1.tgz}
@@ -7239,7 +7240,7 @@ packages:
     dev: false
 
   /function-bind/1.1.1:
-    resolution: {integrity: sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.com/function-bind/-/function-bind-1.1.1.tgz}
+    resolution: {integrity: sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==}
 
   /functional-red-black-tree/1.0.1:
     resolution: {integrity: sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz}
@@ -7289,12 +7290,11 @@ packages:
     engines: {node: 6.* || 8.* || >= 10.*}
 
   /get-intrinsic/1.1.1:
-    resolution: {integrity: sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.com/get-intrinsic/-/get-intrinsic-1.1.1.tgz}
+    resolution: {integrity: sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==}
     dependencies:
       function-bind: 1.1.1
       has: 1.0.3
       has-symbols: 1.0.2
-    dev: true
 
   /get-own-enumerable-property-symbols/3.0.2:
     resolution: {integrity: sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.com/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz}
@@ -7590,9 +7590,8 @@ packages:
     dev: true
 
   /has-symbols/1.0.2:
-    resolution: {integrity: sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.com/has-symbols/-/has-symbols-1.0.2.tgz}
+    resolution: {integrity: sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==}
     engines: {node: '>= 0.4'}
-    dev: true
 
   /has-tostringtag/1.0.0:
     resolution: {integrity: sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.com/has-tostringtag/-/has-tostringtag-1.0.0.tgz}
@@ -7637,7 +7636,7 @@ packages:
     dev: true
 
   /has/1.0.3:
-    resolution: {integrity: sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.com/has/-/has-1.0.3.tgz}
+    resolution: {integrity: sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==}
     engines: {node: '>= 0.4.0'}
     dependencies:
       function-bind: 1.1.1
@@ -10424,8 +10423,7 @@ packages:
       kind-of: 3.2.2
 
   /object-inspect/1.11.0:
-    resolution: {integrity: sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.com/object-inspect/-/object-inspect-1.11.0.tgz}
-    dev: true
+    resolution: {integrity: sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==}
 
   /object-keys/1.1.1:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.com/object-keys/-/object-keys-1.1.1.tgz}
@@ -11317,6 +11315,13 @@ packages:
       - supports-color
     dev: true
 
+  /qs/6.10.3:
+    resolution: {integrity: sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==}
+    engines: {node: '>=0.6'}
+    dependencies:
+      side-channel: 1.0.4
+    dev: false
+
   /qs/6.5.2:
     resolution: {integrity: sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.com/qs/-/qs-6.5.2.tgz}
     engines: {node: '>=0.6'}
@@ -12072,12 +12077,11 @@ packages:
     dev: false
 
   /side-channel/1.0.4:
-    resolution: {integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.com/side-channel/-/side-channel-1.0.4.tgz}
+    resolution: {integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==}
     dependencies:
       call-bind: 1.0.2
       get-intrinsic: 1.1.1
       object-inspect: 1.11.0
-    dev: true
 
   /signal-exit/3.0.6:
     resolution: {integrity: sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.com/signal-exit/-/signal-exit-3.0.6.tgz}


### PR DESCRIPTION
## Summary

Replace **querystring** with [qs](https://www.npmjs.com/package/qs). 
Use **allowDots** option for nesting. 

Fixes: #4647

## Checklist

- [x] Ready to be merged