### PR TITLE
fix(core-api): use comma separator for query array

### DIFF
--- a/packages/core-api/src/plugins/pagination/ext.ts
+++ b/packages/core-api/src/plugins/pagination/ext.ts
@@ -73,6 +73,7 @@ export class Ext {
                 ? baseUri +
                   qs.stringify(Hoek.applyToDefaults({ ...query, ...request.orig.query }, { page }), {
                       allowDots: true,
+                      arrayFormat: "comma",
                   })
                 : null;
 


### PR DESCRIPTION
## Summary

Use comma separator for query array.

## Checklist

- [X] Ready to be merged
