### PR TITLE
merge: cherry-pick `core-api` changes from develop

### DIFF
--- a/packages/core-api/package.json
+++ b/packages/core-api/package.json
@@ -32,6 +32,7 @@
         "joi": "17.4.2",
         "nanomatch": "1.2.13",
         "node-cache": "5.1.2",
+        "qs": "6.10.3",
         "rate-limiter-flexible": "1.3.2",
         "semver": "6.3.0"
     },

--- a/packages/core-api/src/plugins/pagination/ext.ts
+++ b/packages/core-api/src/plugins/pagination/ext.ts
@@ -73,6 +73,7 @@ export class Ext {
                 ? baseUri +
                   qs.stringify(Hoek.applyToDefaults({ ...query, ...request.orig.query }, { page }), {
                       allowDots: true,
+                      arrayFormat: "comma",
                   })
                 : null;
 

--- a/packages/core-api/src/plugins/pagination/ext.ts
+++ b/packages/core-api/src/plugins/pagination/ext.ts
@@ -74,6 +74,7 @@ export class Ext {
                   qs.stringify(Hoek.applyToDefaults({ ...query, ...request.orig.query }, { page }), {
                       allowDots: true,
                       arrayFormat: "comma",
+                      encode: false,
                   })
                 : null;
 

--- a/packages/core-api/src/plugins/pagination/ext.ts
+++ b/packages/core-api/src/plugins/pagination/ext.ts
@@ -2,7 +2,7 @@
 
 import { Utils } from "@arkecosystem/core-kernel";
 import Hoek from "@hapi/hoek";
-import Qs from "querystring";
+import qs from "qs";
 
 export class Ext {
     private readonly routePathPrefix = "/api";
@@ -69,8 +69,12 @@ export class Ext {
 
         const getUri = (page: number | null): string | null =>
             /* istanbul ignore next */
-            // tslint:disable-next-line: no-null-keyword
-            page ? baseUri + Qs.stringify(Hoek.applyToDefaults({ ...query, ...request.orig.query }, { page })) : null;
+            page
+                ? baseUri +
+                  qs.stringify(Hoek.applyToDefaults({ ...query, ...request.orig.query }, { page }), {
+                      allowDots: true,
+                  })
+                : null;
 
         const newSource = {
             meta: {
@@ -79,14 +83,10 @@ export class Ext {
                     count: results.length,
                     pageCount: pageCount,
                     totalCount: totalCount ? totalCount : 0,
-
-                    // tslint:disable-next-line: no-null-keyword
                     /* istanbul ignore next */
                     next: totalCount && currentPage < pageCount ? getUri(currentPage + 1) : null,
                     previous:
-                        // tslint:disable-next-line: no-null-keyword
                         totalCount && currentPage > 1 && currentPage <= pageCount + 1 ? getUri(currentPage - 1) : null,
-
                     self: getUri(currentPage),
                     first: getUri(1),
                     last: getUri(pageCount),

--- a/yarn.lock
+++ b/yarn.lock
@@ -12238,6 +12238,13 @@ qqjs@^0.3.10:
     tmp "^0.1.0"
     write-json-file "^4.1.1"
 
+qs@6.10.3:
+  version "6.10.3"
+  resolved "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz#d6cde1b2ffca87b5aa57889816c5f81535e22e8e"
+  integrity sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==
+  dependencies:
+    side-channel "^1.0.4"
+
 qs@^6.9.4:
   version "6.10.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.2.tgz#c1431bea37fc5b24c5bdbafa20f16bdf2a4b9ffe"


### PR DESCRIPTION
## Summary

Cherry pick:
- fix(core-api): replace deprecated `querystring` with `qs` and use dot notation (#4648)
- fix(core-api): use comma separator for query array (#4650)
- fix(core-api): undencoded query (#4652)

Changes:
- Yarn lock

## Checklist

- [x] Ready to be merged
