### PR TITLE
adjust  `maxBlockPayload` to fit next maxTx size

### DIFF
--- a/__tests__/unit/core-test-framework/app/generators/__fixtures__/assets.ts
+++ b/__tests__/unit/core-test-framework/app/generators/__fixtures__/assets.ts
@@ -14,7 +14,7 @@ export const sandboxOptions: SandboxOptions = {
             delegates: 51,
             blocktime: 8,
             maxTxPerBlock: 150,
-            maxBlockPayload: 2097152,
+            maxBlockPayload: 6291456,
             rewardHeight: 75600,
             rewardAmount: 200000000,
             pubKeyHash: 23,

--- a/__tests__/unit/core-test-framework/app/sandbox.test.ts
+++ b/__tests__/unit/core-test-framework/app/sandbox.test.ts
@@ -49,7 +49,7 @@ describe("Sandbox", () => {
                 delegates: 51,
                 blocktime: 8,
                 maxTxPerBlock: 150,
-                maxBlockPayload: 2097152,
+                maxBlockPayload: 6291456,
                 rewardHeight: 75600,
                 rewardAmount: 200000000,
                 pubKeyHash: 23,

--- a/packages/core-test-framework/src/app/generators/generator.ts
+++ b/packages/core-test-framework/src/app/generators/generator.ts
@@ -23,7 +23,7 @@ export abstract class Generator {
                 delegates: 51,
                 blocktime: 8,
                 maxTxPerBlock: 150,
-                maxBlockPayload: 2097152,
+                maxBlockPayload: 6291456,
                 rewardHeight: 75600,
                 rewardAmount: 200000000,
                 pubKeyHash: 23,

--- a/packages/core-test-framework/src/app/sandbox.ts
+++ b/packages/core-test-framework/src/app/sandbox.ts
@@ -52,7 +52,7 @@ export class Sandbox {
                 delegates: 51,
                 blocktime: 8,
                 maxTxPerBlock: 150,
-                maxBlockPayload: 2097152,
+                maxBlockPayload: 6291456,
                 rewardHeight: 75600,
                 rewardAmount: 200000000,
                 pubKeyHash: 23,

--- a/packages/core/src/commands/network-generate.ts
+++ b/packages/core/src/commands/network-generate.ts
@@ -180,7 +180,7 @@ export class Command extends Commands.Command {
             description: "The maximum payload length by block.",
             schema: Joi.number(),
             promptType: "number",
-            default: 2097152,
+            default: 6291456,
         },
         {
             name: "rewardHeight",


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

This considering next `maxTxPerBlock` value to 150.
This considering the value will be updated with network when approriate
This has also to be changed in modules `typescript-crypto-networks` when time will come

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ x ] Tests _(if necessary)_
- [ x ] Ready to be merged

<!-- Feel free to add additional comments. -->
