### PR TITLE
fix(crypto): Reduce allocated buffer size for transaction serialization

### DIFF
--- a/packages/crypto/__tests__/blocks/block.test.ts
+++ b/packages/crypto/__tests__/blocks/block.test.ts
@@ -16,7 +16,7 @@ const { outlookTable } = configManager.getPreset("mainnet").exceptions;
 
 beforeEach(() => configManager.setFromPreset("devnet"));
 
-afterEach(() => jest.resetAllMocks());
+afterEach(() => jest.clearAllMocks());
 
 describe("Block", () => {
     const data = {
@@ -135,7 +135,7 @@ describe("Block", () => {
             jest.spyOn(configManager, "getMilestone").mockImplementation((height) => ({
                 block: {
                     version: 0,
-                    maxTransactions: 200,
+                    maxTransactions: dummyBlock.numberOfTransactions,
                     maxPayload: dummyBlockSize - 1,
                 },
                 reward: 200000000,
@@ -150,7 +150,7 @@ describe("Block", () => {
             jest.spyOn(configManager, "getMilestone").mockImplementation((height) => ({
                 block: {
                     version: 0,
-                    maxTransactions: 200,
+                    maxTransactions: dummyBlock.numberOfTransactions,
                     maxPayload: dummyBlockSize,
                 },
                 reward: 200000000,

--- a/packages/crypto/src/transactions/serializer.ts
+++ b/packages/crypto/src/transactions/serializer.ts
@@ -28,8 +28,16 @@ export class Serializer {
      * Serializes the given transaction according to AIP11.
      */
     public static serialize(transaction: ITransaction, options: ISerializeOptions = {}): Buffer {
+        let size = 83886;
+        const maxPayload = configManager.getMilestone(configManager.getHeight()).block?.maxPayload;
+        const maxTransactions = configManager.getMilestone(configManager.getHeight()).block?.maxTransactions;
+
+        if( maxPayload && maxTransactions) {
+            size = Math.floor(maxPayload / maxTransactions) * 2
+        }
+
         const buff: ByteBuffer = new ByteBuffer(
-            Buffer.alloc(configManager.getMilestone(configManager.getHeight()).block?.maxPayload ?? 8192),
+            Buffer.alloc(size),
         );
 
         this.serializeCommon(transaction.data, buff);

--- a/packages/crypto/src/transactions/serializer.ts
+++ b/packages/crypto/src/transactions/serializer.ts
@@ -32,13 +32,11 @@ export class Serializer {
         const maxPayload = configManager.getMilestone(configManager.getHeight()).block?.maxPayload;
         const maxTransactions = configManager.getMilestone(configManager.getHeight()).block?.maxTransactions;
 
-        if( maxPayload && maxTransactions) {
-            size = Math.floor(maxPayload / maxTransactions) * 2
+        if (maxPayload && maxTransactions) {
+            size = Math.floor(maxPayload / maxTransactions) * 2;
         }
 
-        const buff: ByteBuffer = new ByteBuffer(
-            Buffer.alloc(size),
-        );
+        const buff: ByteBuffer = new ByteBuffer(Buffer.alloc(size));
 
         this.serializeCommon(transaction.data, buff);
         this.serializeVendorField(transaction, buff);


### PR DESCRIPTION
## Summary

Reduce buffer allocated for transaction to maxBlockPaylod / maxTransaction. Fix drasticaly improves serialization performance (4 - 8 times faster, depending on system configuration and network setting). 

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged

