### PR TITLE
fix(core-database): disable fastupdate option on GIN indexes

### DIFF
--- a/packages/core-database/src/migrations/20220606000000-disable-fastupdate-on-gin-indexes.ts
+++ b/packages/core-database/src/migrations/20220606000000-disable-fastupdate-on-gin-indexes.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class DisableFastupdateOnGinIndexes20220606000000 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query(`
+        DROP INDEX IF EXISTS transactions_asset;
+        DROP INDEX IF EXISTS transactions_asset_payments;
+        CREATE INDEX transactions_asset ON transactions USING GIN(asset) WITH (fastupdate = off);
+        CREATE INDEX transactions_asset_payments ON transactions USING GIN ((asset->'payments')) WITH (fastupdate = off);
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query(`
+        DROP INDEX IF EXISTS transactions_asset;
+        DROP INDEX IF EXISTS transactions_asset_payments;
+        CREATE INDEX transactions_asset ON transactions USING GIN(asset);
+        CREATE INDEX transactions_asset_payments ON transactions USING GIN ((asset->'payments'));
+        `);
+    }
+}


### PR DESCRIPTION
## Summary

Disable fastupdate option on GIN indexes to achieve constant insert time. It fixes random delays when processing blocks due cleanup cycle. 

The credit for the reported issue and suggesting various solutions goes to: @alessiodf 

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged

