### PR TITLE
fix(core-database): convert vendorField query parameter to buffer

### DIFF
--- a/packages/core-database/__tests__/transaction-filter.test.ts
+++ b/packages/core-database/__tests__/transaction-filter.test.ts
@@ -374,7 +374,7 @@ describe("TransactionFilter.getExpression", () => {
             expect(expression).toEqual({
                 property: "vendorField",
                 op: "like",
-                pattern: "%pattern%",
+                pattern: Buffer.from("%pattern%", "utf-8"),
             });
         });
     });

--- a/packages/core-database/src/transaction-filter.ts
+++ b/packages/core-database/src/transaction-filter.ts
@@ -77,7 +77,7 @@ export class TransactionFilter implements Contracts.Database.TransactionFilter {
                     });
                 case "vendorField":
                     return handleOrCriteria(criteria.vendorField!, async (c) => {
-                        return { property: "vendorField", op: "like", pattern: c };
+                        return { property: "vendorField", op: "like", pattern: Buffer.from(c, "utf-8") };
                     });
                 case "amount":
                     return handleOrCriteria(criteria.amount!, async (c) => {


### PR DESCRIPTION
## Summary

Convert vendorField query parameter to buffer. Solves issues with queries like:

https://api.ark.io/api/transactions?vendorField=%00
https://api.ark.io/api/transactions?vendorField=\

The credit for the reported issue goes to: @alessiodf 

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged
