### PR TITLE
refactor(core-p2p): get min peer version from `default.ts` instead of milestones

### DIFF
--- a/packages/core-p2p/src/defaults.ts
+++ b/packages/core-p2p/src/defaults.ts
@@ -7,7 +7,7 @@ export const defaults = {
     /**
      * The minimum peer version we expect
      */
-    minimumVersions: ["^3.0", "^3.0.0-next.0", "^3.0.0-alpha.0", "^4.0.0-next.0"],
+    minimumVersions: ["^3.0", "^3.0.0-next.0", "^4.0.0-next.0"],
     /**
      * The number of peers we expect to be available to start a relay
      */

--- a/packages/core-p2p/src/defaults.ts
+++ b/packages/core-p2p/src/defaults.ts
@@ -7,7 +7,7 @@ export const defaults = {
     /**
      * The minimum peer version we expect
      */
-    minimumVersions: ["^3.0", "^3.0.0-next.0", "^3.0.0-alpha.0"],
+    minimumVersions: ["^3.0", "^3.0.0-next.0", "^3.0.0-alpha.0", "^4.0.0-next.0"],
     /**
      * The number of peers we expect to be available to start a relay
      */

--- a/packages/core-p2p/src/utils/is-valid-version.ts
+++ b/packages/core-p2p/src/utils/is-valid-version.ts
@@ -12,25 +12,15 @@ export const isValidVersion = (app: Contracts.Kernel.Application, peer: Contract
         return false;
     }
 
-    let minimumVersions: string[];
-    const milestones: Record<string, any> = Managers.configManager.getMilestone();
-
-    const { p2p } = milestones;
-
-    if (p2p && Array.isArray(p2p.minimumVersions) && p2p.minimumVersions.length > 0) {
-        minimumVersions = p2p.minimumVersions;
-    } else {
-        const configuration = app.getTagged<Providers.PluginConfiguration>(
-            Container.Identifiers.PluginConfiguration,
-            "plugin",
-            "@arkecosystem/core-p2p",
-        );
-        minimumVersions = configuration.getOptional<string[]>("minimumVersions", []);
-    }
+    const configuration = app.getTagged<Providers.PluginConfiguration>(
+        Container.Identifiers.PluginConfiguration,
+        "plugin",
+        "@arkecosystem/core-p2p",
+    );
+    const minimumVersions = configuration.getOptional<string[]>("minimumVersions", []);
 
     const includePrerelease: boolean = Managers.configManager.get("network.name") !== "mainnet";
     return minimumVersions.some((minimumVersion: string) =>
-        // @ts-ignore - check why the peer.version errors even though we exit early
-        semver.satisfies(peer.version, minimumVersion, { includePrerelease }),
+        semver.satisfies(peer.version!, minimumVersion, { includePrerelease }),
     );
 };


### PR DESCRIPTION
## Summary

- don't use min versions defined in milestones
- use versions defined in default.ts
- add 4.0.0-next in version checks

## Checklist

- [x] Ready to be merged
