### PR TITLE
fix(core-p2p): skip highest common block search on fast validation 

### DIFF
--- a/packages/core-kernel/src/contracts/p2p/peer-verifier.ts
+++ b/packages/core-kernel/src/contracts/p2p/peer-verifier.ts
@@ -1,7 +1,9 @@
-import { Peer, PeerState, PeerVerificationResult } from "./peer";
+import { FastPeerVerificationResult, Peer, PeerState, PeerVerificationResult } from "./peer";
 
 export interface PeerVerifier {
     initialize(peer: Peer);
 
-    checkState(claimedState: PeerState, deadline: number, fast: boolean): Promise<PeerVerificationResult | undefined>;
+    checkState(claimedState: PeerState, deadline: number): Promise<PeerVerificationResult | undefined>;
+
+    checkStateFast(claimedState: PeerState, deadline: number): Promise<FastPeerVerificationResult | undefined>;
 }

--- a/packages/core-kernel/src/contracts/p2p/peer-verifier.ts
+++ b/packages/core-kernel/src/contracts/p2p/peer-verifier.ts
@@ -3,5 +3,5 @@ import { Peer, PeerState, PeerVerificationResult } from "./peer";
 export interface PeerVerifier {
     initialize(peer: Peer);
 
-    checkState(claimedState: PeerState, deadline: number): Promise<PeerVerificationResult | undefined>;
+    checkState(claimedState: PeerState, deadline: number, fast: boolean): Promise<PeerVerificationResult | undefined>;
 }

--- a/packages/core-kernel/src/contracts/p2p/peer.ts
+++ b/packages/core-kernel/src/contracts/p2p/peer.ts
@@ -23,6 +23,7 @@ export interface Peer {
     lastPinged: Dayjs | undefined;
     sequentialErrorCounter: number;
     verificationResult: PeerVerificationResult | undefined;
+    fastVerificationResult: FastPeerVerificationResult | undefined;
 
     isVerified(): boolean;
     isForked(): boolean;
@@ -71,6 +72,12 @@ export interface PeerPingResponse {
 export interface PeerVerificationResult {
     readonly myHeight: number;
     readonly hisHeight: number;
-    readonly highestCommonHeight?: number;
+    readonly highestCommonHeight: number;
+    readonly forked: boolean;
+}
+
+export interface FastPeerVerificationResult {
+    readonly myHeight: number;
+    readonly hisHeight: number;
     readonly forked: boolean;
 }

--- a/packages/core-kernel/src/contracts/p2p/peer.ts
+++ b/packages/core-kernel/src/contracts/p2p/peer.ts
@@ -71,6 +71,6 @@ export interface PeerPingResponse {
 export interface PeerVerificationResult {
     readonly myHeight: number;
     readonly hisHeight: number;
-    readonly highestCommonHeight: number;
+    readonly highestCommonHeight?: number;
     readonly forked: boolean;
 }

--- a/packages/core-p2p/__tests__/network-monitor.test.ts
+++ b/packages/core-p2p/__tests__/network-monitor.test.ts
@@ -420,7 +420,7 @@ describe("NetworkMonitor", () => {
 
             expect(communicator.ping).toBeCalledTimes(peers.length);
             for (const peer of peers) {
-                expect(communicator.ping).toBeCalledWith(peer, config.verifyTimeout, expect.anything());
+                expect(communicator.ping).toBeCalledWith(peer, config.verifyTimeout, expect.anything(), false);
             }
         });
 
@@ -432,7 +432,7 @@ describe("NetworkMonitor", () => {
 
             expect(communicator.ping).toBeCalledTimes(peers.length);
             for (const peer of peers) {
-                expect(communicator.ping).toBeCalledWith(peer, config.verifyTimeout, expect.anything());
+                expect(communicator.ping).toBeCalledWith(peer, config.verifyTimeout, expect.anything(), false);
             }
         });
 

--- a/packages/core-p2p/__tests__/network-state.test.ts
+++ b/packages/core-p2p/__tests__/network-state.test.ts
@@ -2,7 +2,7 @@ import { Container, Utils as KernelUtils } from "@packages/core-kernel";
 import { NetworkStateStatus } from "@packages/core-p2p/src/enums";
 import { NetworkState } from "@packages/core-p2p/src/network-state";
 import { Peer } from "@packages/core-p2p/src/peer";
-import { PeerVerificationResult } from "@packages/core-p2p/src/peer-verifier";
+import { FastPeerVerificationResult } from "@packages/core-p2p/src/peer-verifier";
 import { Blocks, Crypto, Utils } from "@packages/crypto";
 
 describe("NetworkState", () => {
@@ -99,7 +99,7 @@ describe("NetworkState", () => {
                 peer3.state = { header: {}, height: 8, forgingAllowed: true, currentSlot: currentSlot }; // same height
                 const peer4 = new Peer("184.168.65.65", 4000);
                 peer4.state = { header: {}, height: 6, forgingAllowed: false, currentSlot: currentSlot - 2 }; // below height
-                peer4.verificationResult = new PeerVerificationResult(8, 6, 4); // forked
+                peer4.fastVerificationResult = new FastPeerVerificationResult(8, 6); // forked
                 const peer5 = new Peer("185.168.65.65", 4000);
                 peer5.state = { header: {}, height: 6, forgingAllowed: false, currentSlot: currentSlot - 2 }; // below height, not forked
                 peers = [peer1, peer2, peer3, peer4, peer5];

--- a/packages/core-p2p/__tests__/peer-verifier.test.ts
+++ b/packages/core-p2p/__tests__/peer-verifier.test.ts
@@ -1,6 +1,6 @@
 import { Application, Container, Contracts } from "@packages/core-kernel";
 import { Peer } from "@packages/core-p2p/src/peer";
-import { PeerVerificationResult, PeerVerifier } from "@packages/core-p2p/src/peer-verifier";
+import { PeerVerificationResult, FastPeerVerificationResult, PeerVerifier } from "@packages/core-p2p/src/peer-verifier";
 import { Blocks } from "@packages/crypto";
 
 describe("PeerVerifier", () => {
@@ -91,7 +91,7 @@ describe("PeerVerifier", () => {
                     },
                 };
 
-                expect(await peerVerifier.checkState(claimedState, Date.now() + 2000, false)).toBeUndefined();
+                expect(await peerVerifier.checkState(claimedState, Date.now() + 2000)).toBeUndefined();
             });
         });
 
@@ -145,12 +145,12 @@ describe("PeerVerifier", () => {
                     .spyOn(Blocks.BlockFactory, "fromData")
                     .mockImplementation(blockWithIdFromDataMock);
 
-                const result = await peerVerifier.checkState(claimedState, Date.now() + 2000, false);
+                const result = await peerVerifier.checkState(claimedState, Date.now() + 2000);
 
                 expect(result).toBeInstanceOf(PeerVerificationResult);
                 expect(result.forked).toBeFalse();
 
-                const resultAlreadyVerified = await peerVerifier.checkState(claimedState, Date.now() + 2000, false);
+                const resultAlreadyVerified = await peerVerifier.checkState(claimedState, Date.now() + 2000);
 
                 expect(resultAlreadyVerified).toBeInstanceOf(PeerVerificationResult);
                 expect(resultAlreadyVerified.forked).toBeFalse();
@@ -206,9 +206,9 @@ describe("PeerVerifier", () => {
                     .spyOn(Blocks.BlockFactory, "fromData")
                     .mockImplementation(blockWithIdFromDataMock);
 
-                const result = await peerVerifier.checkState(claimedState, Date.now() + 2000, true);
+                const result = await peerVerifier.checkStateFast(claimedState, Date.now() + 2000);
 
-                expect(result).toBeInstanceOf(PeerVerificationResult);
+                expect(result).toBeInstanceOf(FastPeerVerificationResult);
                 expect(result.forked).toBeTrue();
                 expect(result.myHeight).toEqual(15);
                 expect(result.hisHeight).toEqual(18);
@@ -273,7 +273,7 @@ describe("PeerVerifier", () => {
                 });
                 const spyFromData = jest.spyOn(Blocks.BlockFactory, "fromData").mockImplementation(blockFromDataMock);
 
-                const result = await peerVerifier.checkState(claimedState, Date.now() + 2000, false);
+                const result = await peerVerifier.checkState(claimedState, Date.now() + 2000);
 
                 expect(result).toBeInstanceOf(PeerVerificationResult);
                 expect(result.forked).toBeTrue();
@@ -308,9 +308,9 @@ describe("PeerVerifier", () => {
                 ]); // getActiveDelegates mock
                 const spyFromData = jest.spyOn(Blocks.BlockFactory, "fromData").mockImplementation(blockFromDataMock);
 
-                const result = await peerVerifier.checkState(claimedState, Date.now() + 2000, true);
+                const result = await peerVerifier.checkStateFast(claimedState, Date.now() + 2000);
 
-                expect(result).toBeInstanceOf(PeerVerificationResult);
+                expect(result).toBeInstanceOf(FastPeerVerificationResult);
                 expect(result.forked).toBeTrue();
                 expect(result.myHeight).toEqual(15);
                 expect(result.hisHeight).toEqual(18);
@@ -343,7 +343,7 @@ describe("PeerVerifier", () => {
                     ]);
                 databaseInterceptor.getBlocksByHeight = jest.fn().mockReturnValueOnce([{ id: claimedState.header.id }]);
 
-                const result = await peerVerifier.checkState(claimedState, Date.now() + 2000, false);
+                const result = await peerVerifier.checkState(claimedState, Date.now() + 2000);
 
                 expect(result).toBeInstanceOf(PeerVerificationResult);
                 expect(result.forked).toBeFalse();
@@ -358,9 +358,9 @@ describe("PeerVerifier", () => {
                     ]);
                 databaseInterceptor.getBlocksByHeight = jest.fn().mockReturnValueOnce([{ id: claimedState.header.id }]);
 
-                const result = await peerVerifier.checkState(claimedState, Date.now() + 2000, true);
+                const result = await peerVerifier.checkStateFast(claimedState, Date.now() + 2000);
 
-                expect(result).toBeInstanceOf(PeerVerificationResult);
+                expect(result).toBeInstanceOf(FastPeerVerificationResult);
                 expect(result.forked).toBeFalse();
                 expect(result.myHeight).toEqual(15);
                 expect(result.hisHeight).toEqual(15);
@@ -455,7 +455,7 @@ describe("PeerVerifier", () => {
                         .spyOn(Blocks.BlockFactory, "fromData")
                         .mockImplementation(blockFromDataMock);
 
-                    const result = await peerVerifier.checkState(claimedState, Date.now() + 2000, false);
+                    const result = await peerVerifier.checkState(claimedState, Date.now() + 2000);
 
                     expect(result).toBeInstanceOf(PeerVerificationResult);
                     expect(result.forked).toBeTrue();
@@ -525,9 +525,9 @@ describe("PeerVerifier", () => {
                         .spyOn(Blocks.BlockFactory, "fromData")
                         .mockImplementation(blockFromDataMock);
 
-                    const result = await peerVerifier.checkState(claimedState, Date.now() + 2000, true);
+                    const result = await peerVerifier.checkStateFast(claimedState, Date.now() + 2000);
 
-                    expect(result).toBeInstanceOf(PeerVerificationResult);
+                    expect(result).toBeInstanceOf(FastPeerVerificationResult);
                     expect(result.forked).toBeTrue();
                     expect(result.myHeight).toEqual(15);
                     expect(result.hisHeight).toEqual(15);
@@ -553,7 +553,7 @@ describe("PeerVerifier", () => {
                 trigger.call = jest.fn().mockReturnValue([{ publicKey: generatorPublicKey }]); // getActiveDelegates mock
                 stateStore.getLastBlocks = jest.fn();
 
-                const result = await peerVerifier.checkState(claimedState, Date.now() + 2000, false);
+                const result = await peerVerifier.checkState(claimedState, Date.now() + 2000);
 
                 expect(result).toBeUndefined();
             });
@@ -574,7 +574,7 @@ describe("PeerVerifier", () => {
                     );
                 peerCommunicator.hasCommonBlocks = jest.fn();
 
-                const result = await peerVerifier.checkState(claimedState, Date.now() + 2000, false);
+                const result = await peerVerifier.checkState(claimedState, Date.now() + 2000);
 
                 expect(result).toBeUndefined();
             });
@@ -599,7 +599,7 @@ describe("PeerVerifier", () => {
                 peerCommunicator.hasCommonBlocks = jest.fn();
                 jest.spyOn(Blocks.BlockFactory, "fromData").mockImplementation(blockFromDataMock);
 
-                await expect(peerVerifier.checkState(claimedState, Date.now() + 2000, false)).toReject();
+                await expect(peerVerifier.checkState(claimedState, Date.now() + 2000)).toReject();
             });
 
             it("should return undefined when peer returns no common block", async () => {
@@ -622,7 +622,7 @@ describe("PeerVerifier", () => {
                 peerCommunicator.hasCommonBlocks = jest.fn().mockResolvedValueOnce(undefined);
                 jest.spyOn(Blocks.BlockFactory, "fromData").mockImplementation(blockFromDataMock);
 
-                const result = await peerVerifier.checkState(claimedState, Date.now() + 2000, false);
+                const result = await peerVerifier.checkState(claimedState, Date.now() + 2000);
 
                 expect(result).toBeUndefined();
             });
@@ -649,7 +649,7 @@ describe("PeerVerifier", () => {
                     .mockImplementation((_, ids) => ({ id: "unexpectedId", height: parseInt(ids[0].slice(0, 2)) }));
                 jest.spyOn(Blocks.BlockFactory, "fromData").mockImplementation(blockFromDataMock);
 
-                const result = await peerVerifier.checkState(claimedState, Date.now() + 2000, false);
+                const result = await peerVerifier.checkState(claimedState, Date.now() + 2000);
 
                 expect(result).toBeUndefined();
             });
@@ -676,7 +676,7 @@ describe("PeerVerifier", () => {
                     .mockImplementation((_, ids) => ({ id: ids[0], height: 1000 + parseInt(ids[0].slice(0, 2)) }));
                 jest.spyOn(Blocks.BlockFactory, "fromData").mockImplementation(blockFromDataMock);
 
-                const result = await peerVerifier.checkState(claimedState, Date.now() + 2000, false);
+                const result = await peerVerifier.checkState(claimedState, Date.now() + 2000);
 
                 expect(result).toBeUndefined();
             });
@@ -719,7 +719,7 @@ describe("PeerVerifier", () => {
                         peerCommunicator.getPeerBlocks = jest.fn().mockRejectedValueOnce(new Error("timeout"));
                     }
 
-                    const result = await peerVerifier.checkState(claimedState, Date.now() + 2000, false);
+                    const result = await peerVerifier.checkState(claimedState, Date.now() + 2000);
 
                     expect(result).toBeUndefined();
                 },
@@ -765,7 +765,7 @@ describe("PeerVerifier", () => {
                     .mockImplementationOnce(blockFromDataMock)
                     .mockImplementation(notVerifiedBlockFromDataMock);
 
-                const result = await peerVerifier.checkState(claimedState, Date.now() + 2000, false);
+                const result = await peerVerifier.checkState(claimedState, Date.now() + 2000);
 
                 expect(result).toBeUndefined();
             });
@@ -808,7 +808,7 @@ describe("PeerVerifier", () => {
                 });
                 jest.spyOn(Blocks.BlockFactory, "fromData").mockImplementation(blockFromDataMock);
 
-                const result = await peerVerifier.checkState(claimedState, Date.now() + 2000, false);
+                const result = await peerVerifier.checkState(claimedState, Date.now() + 2000);
 
                 expect(result).toBeUndefined();
             });
@@ -852,7 +852,7 @@ describe("PeerVerifier", () => {
                 });
                 jest.spyOn(Blocks.BlockFactory, "fromData").mockImplementation(blockFromDataMock);
 
-                const result = await peerVerifier.checkState(claimedState, Date.now() + 2000, false);
+                const result = await peerVerifier.checkState(claimedState, Date.now() + 2000);
 
                 expect(result).toBeUndefined();
             });
@@ -888,7 +888,7 @@ describe("PeerVerifier", () => {
                 });
                 const spyFromData = jest.spyOn(Blocks.BlockFactory, "fromData").mockImplementation(blockFromDataMock);
 
-                await expect(peerVerifier.checkState(claimedState, Date.now() - 1, false)).rejects.toEqual(
+                await expect(peerVerifier.checkState(claimedState, Date.now() - 1)).rejects.toEqual(
                     new Error("timeout elapsed before successful completion of the verification"),
                 );
 
@@ -923,7 +923,7 @@ describe("PeerVerifier", () => {
                 ]);
                 databaseInterceptor.getBlocksByHeight = jest.fn().mockReturnValueOnce([{ id: claimedState.header.id }]);
 
-                const result = await peerVerifier.checkState(claimedState, Date.now() + 2000, false);
+                const result = await peerVerifier.checkState(claimedState, Date.now() + 2000);
 
                 expect(result).toBeInstanceOf(PeerVerificationResult);
                 expect(result.forked).toBeFalse();
@@ -937,9 +937,9 @@ describe("PeerVerifier", () => {
                 ]);
                 databaseInterceptor.getBlocksByHeight = jest.fn().mockReturnValueOnce([{ id: claimedState.header.id }]);
 
-                const result = await peerVerifier.checkState(claimedState, Date.now() + 2000, true);
+                const result = await peerVerifier.checkStateFast(claimedState, Date.now() + 2000);
 
-                expect(result).toBeInstanceOf(PeerVerificationResult);
+                expect(result).toBeInstanceOf(FastPeerVerificationResult);
                 expect(result.forked).toBeFalse();
                 expect(result.myHeight).toEqual(17);
                 expect(result.hisHeight).toEqual(15);
@@ -1000,7 +1000,7 @@ describe("PeerVerifier", () => {
                 });
                 const spyFromData = jest.spyOn(Blocks.BlockFactory, "fromData").mockImplementation(blockFromDataMock);
 
-                const result = await peerVerifier.checkState(claimedState, Date.now() + 2000, false);
+                const result = await peerVerifier.checkState(claimedState, Date.now() + 2000);
 
                 expect(result).toBeInstanceOf(PeerVerificationResult);
                 expect(result.forked).toBeTrue();
@@ -1038,9 +1038,9 @@ describe("PeerVerifier", () => {
 
                 const spyFromData = jest.spyOn(Blocks.BlockFactory, "fromData").mockImplementation(blockFromDataMock);
 
-                const result = await peerVerifier.checkState(claimedState, Date.now() + 2000, true);
+                const result = await peerVerifier.checkStateFast(claimedState, Date.now() + 2000);
 
-                expect(result).toBeInstanceOf(PeerVerificationResult);
+                expect(result).toBeInstanceOf(FastPeerVerificationResult);
                 expect(result.forked).toBeTrue();
                 expect(result.myHeight).toEqual(15);
                 expect(result.hisHeight).toEqual(12);

--- a/packages/core-p2p/__tests__/peer-verifier.test.ts
+++ b/packages/core-p2p/__tests__/peer-verifier.test.ts
@@ -163,65 +163,6 @@ describe("PeerVerifier", () => {
                 trigger.call = jest.fn();
                 stateStore.getLastBlocks = jest.fn();
             });
-
-            it("should return PeerVerificationResult forked - using fast option", async () => {
-                const generatorPublicKey = "03c5282b639d0e8f94cfac6c0ed242d1634d8a2c93cbd76c6ed2856a9f19cf6a13";
-                const claimedState: Contracts.P2P.PeerState = {
-                    height: 18,
-                    forgingAllowed: false,
-                    currentSlot: 18,
-                    header: {
-                        height: 18,
-                        id: "13965046748333390338",
-                        generatorPublicKey,
-                    },
-                };
-                const ourHeader = {
-                    height: 15,
-                    id: "11165046748333390338",
-                };
-
-                stateStore.getLastHeight = jest.fn().mockReturnValue(ourHeader.height);
-                stateStore.getLastBlocks = jest
-                    .fn()
-                    .mockReturnValue([{ data: { height: ourHeader.height }, getHeader: () => ourHeader }]);
-                databaseInterceptor.getBlocksByHeight = jest.fn().mockImplementation((blockHeights) =>
-                    blockHeights.map((height: number) => ({
-                        height,
-                        id: height.toString().padStart(2, "0").repeat(20), // just using height to mock the id
-                    })),
-                );
-                peerCommunicator.hasCommonBlocks = jest.fn().mockImplementation((_, ids) => ({
-                    id: ids[ids.length - 1],
-                    height: parseInt(ids[ids.length - 1].slice(0, 2)),
-                }));
-                trigger.call = jest.fn().mockReturnValue([
-                    {
-                        getPublicKey: () => {
-                            return generatorPublicKey;
-                        },
-                    },
-                ]);
-                const spyFromData = jest
-                    .spyOn(Blocks.BlockFactory, "fromData")
-                    .mockImplementation(blockWithIdFromDataMock);
-
-                const result = await peerVerifier.checkStateFast(claimedState, Date.now() + 2000);
-
-                expect(result).toBeInstanceOf(FastPeerVerificationResult);
-                expect(result.forked).toBeTrue();
-                expect(result.myHeight).toEqual(15);
-                expect(result.hisHeight).toEqual(18);
-                expect(result.highestCommonHeight).toBeUndefined();
-
-                spyFromData.mockRestore();
-                peerCommunicator.getPeerBlocks = jest.fn();
-                databaseInterceptor.getBlocksByHeight = jest.fn();
-                peerCommunicator.hasCommonBlocks = jest.fn();
-                stateStore.getLastHeight = jest.fn();
-                trigger.call = jest.fn();
-                stateStore.getLastBlocks = jest.fn();
-            });
         });
 
         describe("when Case2. Peer height > our height and our highest block is not part of the peer's chain", () => {
@@ -283,44 +224,6 @@ describe("PeerVerifier", () => {
                 databaseInterceptor.getBlocksByHeight = jest.fn();
                 peerCommunicator.hasCommonBlocks = jest.fn();
             });
-
-            it("should return PeerVerificationResult forked - using fast option", async () => {
-                const generatorPublicKey = "03c5282b639d0e8f94cfac6c0ed242d1634d8a2c93cbd76c6ed2856a9f19cf6a13";
-                stateStore.getLastHeight = jest
-                    .fn()
-                    .mockReturnValueOnce(ourHeader.height)
-                    .mockReturnValueOnce(ourHeader.height);
-                stateStore.getLastBlocks = jest
-                    .fn()
-                    .mockReturnValueOnce([{ data: { height: ourHeader.height }, getHeader: () => ourHeader }]);
-                databaseInterceptor.getBlocksByHeight = jest.fn().mockImplementation((blockHeights) =>
-                    blockHeights.map((height: number) => ({
-                        height,
-                        id: height.toString().padStart(2, "0").repeat(20), // just using height to mock the id
-                    })),
-                );
-                trigger.call = jest.fn().mockReturnValue([
-                    {
-                        getPublicKey: () => {
-                            return generatorPublicKey;
-                        },
-                    },
-                ]); // getActiveDelegates mock
-                const spyFromData = jest.spyOn(Blocks.BlockFactory, "fromData").mockImplementation(blockFromDataMock);
-
-                const result = await peerVerifier.checkStateFast(claimedState, Date.now() + 2000);
-
-                expect(result).toBeInstanceOf(FastPeerVerificationResult);
-                expect(result.forked).toBeTrue();
-                expect(result.myHeight).toEqual(15);
-                expect(result.hisHeight).toEqual(18);
-                expect(result.highestCommonHeight).toBeUndefined();
-
-                spyFromData.mockRestore();
-                peerCommunicator.getPeerBlocks = jest.fn();
-                databaseInterceptor.getBlocksByHeight = jest.fn();
-                peerCommunicator.hasCommonBlocks = jest.fn();
-            });
         });
 
         describe("when Case3. Peer height == our height and our latest blocks are the same", () => {
@@ -347,24 +250,6 @@ describe("PeerVerifier", () => {
 
                 expect(result).toBeInstanceOf(PeerVerificationResult);
                 expect(result.forked).toBeFalse();
-            });
-
-            it("should return PeerVerificationResult not forked - suing fast option", async () => {
-                stateStore.getLastHeight = jest.fn().mockReturnValueOnce(claimedState.height);
-                stateStore.getLastBlocks = jest
-                    .fn()
-                    .mockReturnValueOnce([
-                        { data: { height: claimedState.height }, getHeader: () => claimedState.header },
-                    ]);
-                databaseInterceptor.getBlocksByHeight = jest.fn().mockReturnValueOnce([{ id: claimedState.header.id }]);
-
-                const result = await peerVerifier.checkStateFast(claimedState, Date.now() + 2000);
-
-                expect(result).toBeInstanceOf(FastPeerVerificationResult);
-                expect(result.forked).toBeFalse();
-                expect(result.myHeight).toEqual(15);
-                expect(result.hisHeight).toEqual(15);
-                expect(result.highestCommonHeight).toEqual(15);
             });
         });
 
@@ -459,79 +344,6 @@ describe("PeerVerifier", () => {
 
                     expect(result).toBeInstanceOf(PeerVerificationResult);
                     expect(result.forked).toBeTrue();
-
-                    spyFromData.mockRestore();
-                    peerCommunicator.getPeerBlocks = jest.fn();
-                    databaseInterceptor.getBlocksByHeight = jest.fn();
-                    peerCommunicator.hasCommonBlocks = jest.fn();
-                },
-            );
-
-            it.each([[true], [false]])(
-                "should return PeerVerificationResult forked when claimed state block header is valid, using fast option",
-                async (delegatesEmpty) => {
-                    const generatorPublicKey = "03c5282b639d0e8f94cfac6c0ed242d1634d8a2c93cbd76c6ed2856a9f19cf6a13";
-                    stateStore.getLastHeight = jest
-                        .fn()
-                        .mockReturnValueOnce(claimedState.height)
-                        .mockReturnValueOnce(claimedState.height);
-                    stateStore.getLastBlocks = jest
-                        .fn()
-                        .mockReturnValueOnce([{ data: { height: claimedState.height }, getHeader: () => ourHeader }]);
-                    databaseInterceptor.getBlocksByHeight = jest
-                        .fn()
-                        .mockReturnValueOnce([{ id: ourHeader.id }])
-                        .mockImplementation((blockHeights) =>
-                            blockHeights.map((height: number) => ({
-                                height,
-                                id: height.toString().padStart(2, "0").repeat(20), // just using height to mock the id
-                            })),
-                        );
-
-                    if (delegatesEmpty) {
-                        // getActiveDelegates return empty array, should still work using dpos state
-                        trigger.call = jest.fn().mockReturnValue([]); // getActiveDelegates mock
-                        dposState.getRoundInfo = jest
-                            .fn()
-                            .mockReturnValueOnce({ round: 1, maxDelegates: 51 })
-                            .mockReturnValueOnce({ round: 1, maxDelegates: 51 });
-                        dposState.getRoundDelegates = jest
-                            .fn()
-                            .mockReturnValueOnce([
-                                {
-                                    getPublicKey: () => {
-                                        return generatorPublicKey;
-                                    },
-                                },
-                            ])
-                            .mockReturnValueOnce([
-                                {
-                                    getPublicKey: () => {
-                                        return generatorPublicKey;
-                                    },
-                                },
-                            ]);
-                    } else {
-                        trigger.call = jest.fn().mockReturnValue([
-                            {
-                                getPublicKey: () => {
-                                    return generatorPublicKey;
-                                },
-                            },
-                        ]); // getActiveDelegates mock
-                    }
-
-                    const spyFromData = jest
-                        .spyOn(Blocks.BlockFactory, "fromData")
-                        .mockImplementation(blockFromDataMock);
-
-                    const result = await peerVerifier.checkStateFast(claimedState, Date.now() + 2000);
-
-                    expect(result).toBeInstanceOf(FastPeerVerificationResult);
-                    expect(result.forked).toBeTrue();
-                    expect(result.myHeight).toEqual(15);
-                    expect(result.hisHeight).toEqual(15);
-                    expect(result.highestCommonHeight).toBeUndefined();
 
                     spyFromData.mockRestore();
                     peerCommunicator.getPeerBlocks = jest.fn();
@@ -928,23 +740,6 @@ describe("PeerVerifier", () => {
                 expect(result).toBeInstanceOf(PeerVerificationResult);
                 expect(result.forked).toBeFalse();
             });
-
-            it("should return PeerVerificationResult not forked, using fast option", async () => {
-                stateStore.getLastHeight = jest.fn().mockReturnValueOnce(ourHeight);
-                stateStore.getLastBlocks = jest.fn().mockReturnValueOnce([
-                    { data: { height: ourHeight }, getHeader: () => ourHeader },
-                    { data: { height: claimedState.height }, getHeader: () => claimedState.header },
-                ]);
-                databaseInterceptor.getBlocksByHeight = jest.fn().mockReturnValueOnce([{ id: claimedState.header.id }]);
-
-                const result = await peerVerifier.checkStateFast(claimedState, Date.now() + 2000);
-
-                expect(result).toBeInstanceOf(FastPeerVerificationResult);
-                expect(result.forked).toBeFalse();
-                expect(result.myHeight).toEqual(17);
-                expect(result.hisHeight).toEqual(15);
-                expect(result.highestCommonHeight).toEqual(15);
-            });
         });
 
         describe("when Case6. Peer height < our height and peer's latest block is not part of our chain", () => {
@@ -1010,8 +805,312 @@ describe("PeerVerifier", () => {
                 databaseInterceptor.getBlocksByHeight = jest.fn();
                 peerCommunicator.hasCommonBlocks = jest.fn();
             });
+        });
+    });
 
-            it("should return PeerVerificationResult forked, using fast option", async () => {
+    describe("checkStateFast", () => {
+        describe("when claimed state block header does not match claimed state height", () => {
+            it("should return undefined", async () => {
+                const claimedState: Contracts.P2P.PeerState = {
+                    height: 18,
+                    forgingAllowed: false,
+                    currentSlot: 18,
+                    header: {
+                        height: 19,
+                        id: "13965046748333390338",
+                    },
+                };
+
+                expect(await peerVerifier.checkState(claimedState, Date.now() + 2000)).toBeUndefined();
+            });
+        });
+
+        describe("when Case1. Peer height > our height and our highest block is part of the peer's chain", () => {
+            it("should return PeerVerificationResult forked", async () => {
+                const generatorPublicKey = "03c5282b639d0e8f94cfac6c0ed242d1634d8a2c93cbd76c6ed2856a9f19cf6a13";
+                const claimedState: Contracts.P2P.PeerState = {
+                    height: 18,
+                    forgingAllowed: false,
+                    currentSlot: 18,
+                    header: {
+                        height: 18,
+                        id: "13965046748333390338",
+                        generatorPublicKey,
+                    },
+                };
+                const ourHeader = {
+                    height: 15,
+                    id: "11165046748333390338",
+                };
+
+                stateStore.getLastHeight = jest.fn().mockReturnValue(ourHeader.height);
+                stateStore.getLastBlocks = jest
+                    .fn()
+                    .mockReturnValue([{ data: { height: ourHeader.height }, getHeader: () => ourHeader }]);
+                databaseInterceptor.getBlocksByHeight = jest.fn().mockImplementation((blockHeights) =>
+                    blockHeights.map((height: number) => ({
+                        height,
+                        id: height.toString().padStart(2, "0").repeat(20), // just using height to mock the id
+                    })),
+                );
+                peerCommunicator.hasCommonBlocks = jest.fn().mockImplementation((_, ids) => ({
+                    id: ids[ids.length - 1],
+                    height: parseInt(ids[ids.length - 1].slice(0, 2)),
+                }));
+                trigger.call = jest.fn().mockReturnValue([
+                    {
+                        getPublicKey: () => {
+                            return generatorPublicKey;
+                        },
+                    },
+                ]);
+                const spyFromData = jest
+                    .spyOn(Blocks.BlockFactory, "fromData")
+                    .mockImplementation(blockWithIdFromDataMock);
+
+                const result = await peerVerifier.checkStateFast(claimedState, Date.now() + 2000);
+
+                expect(result).toBeInstanceOf(FastPeerVerificationResult);
+                expect(result.forked).toBeTrue();
+                expect(result.myHeight).toEqual(15);
+                expect(result.hisHeight).toEqual(18);
+                expect(result.highestCommonHeight).toBeUndefined();
+
+                spyFromData.mockRestore();
+                peerCommunicator.getPeerBlocks = jest.fn();
+                databaseInterceptor.getBlocksByHeight = jest.fn();
+                peerCommunicator.hasCommonBlocks = jest.fn();
+                stateStore.getLastHeight = jest.fn();
+                trigger.call = jest.fn();
+                stateStore.getLastBlocks = jest.fn();
+            });
+        });
+
+        describe("when Case2. Peer height > our height and our highest block is not part of the peer's chain", () => {
+            const claimedState: Contracts.P2P.PeerState = {
+                height: 18,
+                forgingAllowed: false,
+                currentSlot: 18,
+                header: {
+                    height: 18,
+                    id: "13965046748333390338",
+                },
+            };
+            const ourHeader = {
+                height: 15,
+                id: "11165046748333390338",
+            };
+
+            it("should return PeerVerificationResult forked", async () => {
+                const generatorPublicKey = "03c5282b639d0e8f94cfac6c0ed242d1634d8a2c93cbd76c6ed2856a9f19cf6a13";
+                stateStore.getLastHeight = jest
+                    .fn()
+                    .mockReturnValueOnce(ourHeader.height)
+                    .mockReturnValueOnce(ourHeader.height);
+                stateStore.getLastBlocks = jest
+                    .fn()
+                    .mockReturnValueOnce([{ data: { height: ourHeader.height }, getHeader: () => ourHeader }]);
+                databaseInterceptor.getBlocksByHeight = jest.fn().mockImplementation((blockHeights) =>
+                    blockHeights.map((height: number) => ({
+                        height,
+                        id: height.toString().padStart(2, "0").repeat(20), // just using height to mock the id
+                    })),
+                );
+                trigger.call = jest.fn().mockReturnValue([
+                    {
+                        getPublicKey: () => {
+                            return generatorPublicKey;
+                        },
+                    },
+                ]); // getActiveDelegates mock
+                const spyFromData = jest.spyOn(Blocks.BlockFactory, "fromData").mockImplementation(blockFromDataMock);
+
+                const result = await peerVerifier.checkStateFast(claimedState, Date.now() + 2000);
+
+                expect(result).toBeInstanceOf(FastPeerVerificationResult);
+                expect(result.forked).toBeTrue();
+                expect(result.myHeight).toEqual(15);
+                expect(result.hisHeight).toEqual(18);
+                expect(result.highestCommonHeight).toBeUndefined();
+
+                spyFromData.mockRestore();
+                peerCommunicator.getPeerBlocks = jest.fn();
+                databaseInterceptor.getBlocksByHeight = jest.fn();
+                peerCommunicator.hasCommonBlocks = jest.fn();
+            });
+        });
+
+        describe("when Case3. Peer height == our height and our latest blocks are the same", () => {
+            const claimedState: Contracts.P2P.PeerState = {
+                height: 15,
+                forgingAllowed: false,
+                currentSlot: 15,
+                header: {
+                    height: 15,
+                    id: "13965046748333390338",
+                },
+            };
+
+            it("should return PeerVerificationResult not forked", async () => {
+                stateStore.getLastHeight = jest.fn().mockReturnValueOnce(claimedState.height);
+                stateStore.getLastBlocks = jest
+                    .fn()
+                    .mockReturnValueOnce([
+                        { data: { height: claimedState.height }, getHeader: () => claimedState.header },
+                    ]);
+                databaseInterceptor.getBlocksByHeight = jest.fn().mockReturnValueOnce([{ id: claimedState.header.id }]);
+
+                const result = await peerVerifier.checkStateFast(claimedState, Date.now() + 2000);
+
+                expect(result).toBeInstanceOf(FastPeerVerificationResult);
+                expect(result.forked).toBeFalse();
+                expect(result.myHeight).toEqual(15);
+                expect(result.hisHeight).toEqual(15);
+                expect(result.highestCommonHeight).toEqual(15);
+            });
+        });
+
+        describe("when Case4. Peer height == our height and our latest blocks differ", () => {
+            const claimedState: Contracts.P2P.PeerState = {
+                height: 15,
+                forgingAllowed: false,
+                currentSlot: 15,
+                header: {
+                    height: 15,
+                    id: "13965046748333390338",
+                },
+            };
+            const ourHeader = {
+                height: 15,
+                id: "11165046748333390338",
+            };
+
+            it.each([[true], [false]])(
+                "should return PeerVerificationResult forked when claimed state block header is valid",
+                async (delegatesEmpty) => {
+                    const generatorPublicKey = "03c5282b639d0e8f94cfac6c0ed242d1634d8a2c93cbd76c6ed2856a9f19cf6a13";
+                    stateStore.getLastHeight = jest
+                        .fn()
+                        .mockReturnValueOnce(claimedState.height)
+                        .mockReturnValueOnce(claimedState.height);
+                    stateStore.getLastBlocks = jest
+                        .fn()
+                        .mockReturnValueOnce([{ data: { height: claimedState.height }, getHeader: () => ourHeader }]);
+                    databaseInterceptor.getBlocksByHeight = jest
+                        .fn()
+                        .mockReturnValueOnce([{ id: ourHeader.id }])
+                        .mockImplementation((blockHeights) =>
+                            blockHeights.map((height: number) => ({
+                                height,
+                                id: height.toString().padStart(2, "0").repeat(20), // just using height to mock the id
+                            })),
+                        );
+
+                    if (delegatesEmpty) {
+                        // getActiveDelegates return empty array, should still work using dpos state
+                        trigger.call = jest.fn().mockReturnValue([]); // getActiveDelegates mock
+                        dposState.getRoundInfo = jest
+                            .fn()
+                            .mockReturnValueOnce({ round: 1, maxDelegates: 51 })
+                            .mockReturnValueOnce({ round: 1, maxDelegates: 51 });
+                        dposState.getRoundDelegates = jest
+                            .fn()
+                            .mockReturnValueOnce([
+                                {
+                                    getPublicKey: () => {
+                                        return generatorPublicKey;
+                                    },
+                                },
+                            ])
+                            .mockReturnValueOnce([
+                                {
+                                    getPublicKey: () => {
+                                        return generatorPublicKey;
+                                    },
+                                },
+                            ]);
+                    } else {
+                        trigger.call = jest.fn().mockReturnValue([
+                            {
+                                getPublicKey: () => {
+                                    return generatorPublicKey;
+                                },
+                            },
+                        ]); // getActiveDelegates mock
+                    }
+
+                    const spyFromData = jest
+                        .spyOn(Blocks.BlockFactory, "fromData")
+                        .mockImplementation(blockFromDataMock);
+
+                    const result = await peerVerifier.checkStateFast(claimedState, Date.now() + 2000);
+
+                    expect(result).toBeInstanceOf(FastPeerVerificationResult);
+                    expect(result.forked).toBeTrue();
+                    expect(result.myHeight).toEqual(15);
+                    expect(result.hisHeight).toEqual(15);
+                    expect(result.highestCommonHeight).toBeUndefined();
+
+                    spyFromData.mockRestore();
+                    peerCommunicator.getPeerBlocks = jest.fn();
+                    databaseInterceptor.getBlocksByHeight = jest.fn();
+                    peerCommunicator.hasCommonBlocks = jest.fn();
+                },
+            );
+        });
+
+        describe("when Case5. Peer height < our height and peer's latest block is part of our chain", () => {
+            const claimedState: Contracts.P2P.PeerState = {
+                height: 15,
+                forgingAllowed: false,
+                currentSlot: 15,
+                header: {
+                    height: 15,
+                    id: "13965046748333390338",
+                },
+            };
+            const ourHeight = claimedState.height + 2;
+            const ourHeader = {
+                height: ourHeight,
+                id: "6857401089891373446",
+            };
+
+            it("should return PeerVerificationResult not forked", async () => {
+                stateStore.getLastHeight = jest.fn().mockReturnValueOnce(ourHeight);
+                stateStore.getLastBlocks = jest.fn().mockReturnValueOnce([
+                    { data: { height: ourHeight }, getHeader: () => ourHeader },
+                    { data: { height: claimedState.height }, getHeader: () => claimedState.header },
+                ]);
+                databaseInterceptor.getBlocksByHeight = jest.fn().mockReturnValueOnce([{ id: claimedState.header.id }]);
+
+                const result = await peerVerifier.checkStateFast(claimedState, Date.now() + 2000);
+
+                expect(result).toBeInstanceOf(FastPeerVerificationResult);
+                expect(result.forked).toBeFalse();
+                expect(result.myHeight).toEqual(17);
+                expect(result.hisHeight).toEqual(15);
+                expect(result.highestCommonHeight).toEqual(15);
+            });
+        });
+
+        describe("when Case6. Peer height < our height and peer's latest block is not part of our chain", () => {
+            const generatorPublicKey = "03c5282b639d0e8f94cfac6c0ed242d1634d8a2c93cbd76c6ed2856a9f19cf6a13";
+            const claimedState: Contracts.P2P.PeerState = {
+                height: 12,
+                forgingAllowed: false,
+                currentSlot: 12,
+                header: {
+                    height: 12,
+                    id: "13965046748333390338",
+                    generatorPublicKey,
+                },
+            };
+            const ourHeader = {
+                height: 15,
+                id: "11165046748333390338",
+            };
+
+            it("should return PeerVerificationResult forked", async () => {
                 stateStore.getLastHeight = jest
                     .fn()
                     .mockReturnValueOnce(ourHeader.height)

--- a/packages/core-p2p/__tests__/peer-verifier.test.ts
+++ b/packages/core-p2p/__tests__/peer-verifier.test.ts
@@ -395,7 +395,7 @@ describe("PeerVerifier", () => {
                 stateStore.getLastHeight = jest
                     .fn()
                     .mockReturnValueOnce(claimedState.height)
-                    .mockRejectedValueOnce(undefined);
+                    .mockReturnValueOnce(undefined);
                 stateStore.getLastBlocks = jest
                     .fn()
                     .mockReturnValueOnce([{ data: { height: claimedState.height }, getHeader: () => ourHeader }]);

--- a/packages/core-p2p/__tests__/peer-verifier.test.ts
+++ b/packages/core-p2p/__tests__/peer-verifier.test.ts
@@ -91,7 +91,7 @@ describe("PeerVerifier", () => {
                     },
                 };
 
-                expect(await peerVerifier.checkState(claimedState, Date.now() + 2000)).toBeUndefined();
+                expect(await peerVerifier.checkState(claimedState, Date.now() + 2000, false)).toBeUndefined();
             });
         });
 
@@ -145,12 +145,12 @@ describe("PeerVerifier", () => {
                     .spyOn(Blocks.BlockFactory, "fromData")
                     .mockImplementation(blockWithIdFromDataMock);
 
-                const result = await peerVerifier.checkState(claimedState, Date.now() + 2000);
+                const result = await peerVerifier.checkState(claimedState, Date.now() + 2000, false);
 
                 expect(result).toBeInstanceOf(PeerVerificationResult);
                 expect(result.forked).toBeFalse();
 
-                const resultAlreadyVerified = await peerVerifier.checkState(claimedState, Date.now() + 2000);
+                const resultAlreadyVerified = await peerVerifier.checkState(claimedState, Date.now() + 2000, false);
 
                 expect(resultAlreadyVerified).toBeInstanceOf(PeerVerificationResult);
                 expect(resultAlreadyVerified.forked).toBeFalse();
@@ -214,7 +214,7 @@ describe("PeerVerifier", () => {
                 });
                 const spyFromData = jest.spyOn(Blocks.BlockFactory, "fromData").mockImplementation(blockFromDataMock);
 
-                const result = await peerVerifier.checkState(claimedState, Date.now() + 2000);
+                const result = await peerVerifier.checkState(claimedState, Date.now() + 2000, false);
 
                 expect(result).toBeInstanceOf(PeerVerificationResult);
                 expect(result.forked).toBeTrue();
@@ -246,7 +246,7 @@ describe("PeerVerifier", () => {
                     ]);
                 databaseInterceptor.getBlocksByHeight = jest.fn().mockReturnValueOnce([{ id: claimedState.header.id }]);
 
-                const result = await peerVerifier.checkState(claimedState, Date.now() + 2000);
+                const result = await peerVerifier.checkState(claimedState, Date.now() + 2000, false);
 
                 expect(result).toBeInstanceOf(PeerVerificationResult);
                 expect(result.forked).toBeFalse();
@@ -340,7 +340,7 @@ describe("PeerVerifier", () => {
                         .spyOn(Blocks.BlockFactory, "fromData")
                         .mockImplementation(blockFromDataMock);
 
-                    const result = await peerVerifier.checkState(claimedState, Date.now() + 2000);
+                    const result = await peerVerifier.checkState(claimedState, Date.now() + 2000, false);
 
                     expect(result).toBeInstanceOf(PeerVerificationResult);
                     expect(result.forked).toBeTrue();
@@ -365,7 +365,7 @@ describe("PeerVerifier", () => {
                 trigger.call = jest.fn().mockReturnValue([{ publicKey: generatorPublicKey }]); // getActiveDelegates mock
                 stateStore.getLastBlocks = jest.fn();
 
-                const result = await peerVerifier.checkState(claimedState, Date.now() + 2000);
+                const result = await peerVerifier.checkState(claimedState, Date.now() + 2000, false);
 
                 expect(result).toBeUndefined();
             });
@@ -386,7 +386,7 @@ describe("PeerVerifier", () => {
                     );
                 peerCommunicator.hasCommonBlocks = jest.fn();
 
-                const result = await peerVerifier.checkState(claimedState, Date.now() + 2000);
+                const result = await peerVerifier.checkState(claimedState, Date.now() + 2000, false);
 
                 expect(result).toBeUndefined();
             });
@@ -411,7 +411,7 @@ describe("PeerVerifier", () => {
                 peerCommunicator.hasCommonBlocks = jest.fn();
                 jest.spyOn(Blocks.BlockFactory, "fromData").mockImplementation(blockFromDataMock);
 
-                await expect(peerVerifier.checkState(claimedState, Date.now() + 2000)).toReject();
+                await expect(peerVerifier.checkState(claimedState, Date.now() + 2000, false)).toReject();
             });
 
             it("should return undefined when peer returns no common block", async () => {
@@ -434,7 +434,7 @@ describe("PeerVerifier", () => {
                 peerCommunicator.hasCommonBlocks = jest.fn().mockResolvedValueOnce(undefined);
                 jest.spyOn(Blocks.BlockFactory, "fromData").mockImplementation(blockFromDataMock);
 
-                const result = await peerVerifier.checkState(claimedState, Date.now() + 2000);
+                const result = await peerVerifier.checkState(claimedState, Date.now() + 2000, false);
 
                 expect(result).toBeUndefined();
             });
@@ -461,7 +461,7 @@ describe("PeerVerifier", () => {
                     .mockImplementation((_, ids) => ({ id: "unexpectedId", height: parseInt(ids[0].slice(0, 2)) }));
                 jest.spyOn(Blocks.BlockFactory, "fromData").mockImplementation(blockFromDataMock);
 
-                const result = await peerVerifier.checkState(claimedState, Date.now() + 2000);
+                const result = await peerVerifier.checkState(claimedState, Date.now() + 2000, false);
 
                 expect(result).toBeUndefined();
             });
@@ -488,7 +488,7 @@ describe("PeerVerifier", () => {
                     .mockImplementation((_, ids) => ({ id: ids[0], height: 1000 + parseInt(ids[0].slice(0, 2)) }));
                 jest.spyOn(Blocks.BlockFactory, "fromData").mockImplementation(blockFromDataMock);
 
-                const result = await peerVerifier.checkState(claimedState, Date.now() + 2000);
+                const result = await peerVerifier.checkState(claimedState, Date.now() + 2000, false);
 
                 expect(result).toBeUndefined();
             });
@@ -531,7 +531,7 @@ describe("PeerVerifier", () => {
                         peerCommunicator.getPeerBlocks = jest.fn().mockRejectedValueOnce(new Error("timeout"));
                     }
 
-                    const result = await peerVerifier.checkState(claimedState, Date.now() + 2000);
+                    const result = await peerVerifier.checkState(claimedState, Date.now() + 2000, false);
 
                     expect(result).toBeUndefined();
                 },
@@ -577,7 +577,7 @@ describe("PeerVerifier", () => {
                     .mockImplementationOnce(blockFromDataMock)
                     .mockImplementation(notVerifiedBlockFromDataMock);
 
-                const result = await peerVerifier.checkState(claimedState, Date.now() + 2000);
+                const result = await peerVerifier.checkState(claimedState, Date.now() + 2000, false);
 
                 expect(result).toBeUndefined();
             });
@@ -620,7 +620,7 @@ describe("PeerVerifier", () => {
                 });
                 jest.spyOn(Blocks.BlockFactory, "fromData").mockImplementation(blockFromDataMock);
 
-                const result = await peerVerifier.checkState(claimedState, Date.now() + 2000);
+                const result = await peerVerifier.checkState(claimedState, Date.now() + 2000, false);
 
                 expect(result).toBeUndefined();
             });
@@ -664,7 +664,7 @@ describe("PeerVerifier", () => {
                 });
                 jest.spyOn(Blocks.BlockFactory, "fromData").mockImplementation(blockFromDataMock);
 
-                const result = await peerVerifier.checkState(claimedState, Date.now() + 2000);
+                const result = await peerVerifier.checkState(claimedState, Date.now() + 2000, false);
 
                 expect(result).toBeUndefined();
             });
@@ -700,7 +700,7 @@ describe("PeerVerifier", () => {
                 });
                 const spyFromData = jest.spyOn(Blocks.BlockFactory, "fromData").mockImplementation(blockFromDataMock);
 
-                await expect(peerVerifier.checkState(claimedState, Date.now() - 1)).rejects.toEqual(
+                await expect(peerVerifier.checkState(claimedState, Date.now() - 1, false)).rejects.toEqual(
                     new Error("timeout elapsed before successful completion of the verification"),
                 );
 
@@ -735,7 +735,7 @@ describe("PeerVerifier", () => {
                 ]);
                 databaseInterceptor.getBlocksByHeight = jest.fn().mockReturnValueOnce([{ id: claimedState.header.id }]);
 
-                const result = await peerVerifier.checkState(claimedState, Date.now() + 2000);
+                const result = await peerVerifier.checkState(claimedState, Date.now() + 2000, false);
 
                 expect(result).toBeInstanceOf(PeerVerificationResult);
                 expect(result.forked).toBeFalse();
@@ -795,7 +795,7 @@ describe("PeerVerifier", () => {
                 });
                 const spyFromData = jest.spyOn(Blocks.BlockFactory, "fromData").mockImplementation(blockFromDataMock);
 
-                const result = await peerVerifier.checkState(claimedState, Date.now() + 2000);
+                const result = await peerVerifier.checkState(claimedState, Date.now() + 2000, false);
 
                 expect(result).toBeInstanceOf(PeerVerificationResult);
                 expect(result.forked).toBeTrue();

--- a/packages/core-p2p/src/network-monitor.ts
+++ b/packages/core-p2p/src/network-monitor.ts
@@ -291,8 +291,8 @@ export class NetworkMonitor implements Contracts.P2P.NetworkMonitor {
             .reverse();
 
         for (const forkHeight of forkHeights) {
-            const forkPeerCount = forkVerificationResults.filter((vr) => vr.highestCommonHeight! === forkHeight).length;
-            const ourPeerCount = verificationResults.filter((vr) => vr.highestCommonHeight! > forkHeight).length + 1;
+            const forkPeerCount = forkVerificationResults.filter((vr) => vr.highestCommonHeight === forkHeight).length;
+            const ourPeerCount = verificationResults.filter((vr) => vr.highestCommonHeight > forkHeight).length + 1;
 
             if (forkPeerCount > ourPeerCount) {
                 const blocksToRollback = lastBlock.data.height - forkHeight;

--- a/packages/core-p2p/src/network-monitor.ts
+++ b/packages/core-p2p/src/network-monitor.ts
@@ -144,7 +144,7 @@ export class NetworkMonitor implements Contracts.P2P.NetworkMonitor {
             Promise.all(
                 peers.map(async (peer) => {
                     try {
-                        await this.communicator.ping(peer, pingDelay, forcePing);
+                        await this.communicator.ping(peer, pingDelay, forcePing, fast);
                     } catch (error) {
                         unresponsivePeers++;
 
@@ -285,14 +285,14 @@ export class NetworkMonitor implements Contracts.P2P.NetworkMonitor {
         );
 
         const forkHeights: number[] = forkVerificationResults
-            .map((verificationResult: Contracts.P2P.PeerVerificationResult) => verificationResult.highestCommonHeight)
+            .map((verificationResult) => verificationResult.highestCommonHeight!)
             .filter((forkHeight, i, arr) => arr.indexOf(forkHeight) === i) // unique
             .sort()
             .reverse();
 
         for (const forkHeight of forkHeights) {
-            const forkPeerCount = forkVerificationResults.filter((vr) => vr.highestCommonHeight === forkHeight).length;
-            const ourPeerCount = verificationResults.filter((vr) => vr.highestCommonHeight > forkHeight).length + 1;
+            const forkPeerCount = forkVerificationResults.filter((vr) => vr.highestCommonHeight! === forkHeight).length;
+            const ourPeerCount = verificationResults.filter((vr) => vr.highestCommonHeight! > forkHeight).length + 1;
 
             if (forkPeerCount > ourPeerCount) {
                 const blocksToRollback = lastBlock.data.height - forkHeight;

--- a/packages/core-p2p/src/network-state.ts
+++ b/packages/core-p2p/src/network-state.ts
@@ -173,7 +173,7 @@ export class NetworkState implements Contracts.P2P.NetworkState {
             this.quorumDetails.peersOverHeight++;
             this.quorumDetails.peersOverHeightBlockHeaders[peer.state.header.id] = peer.state.header;
         } else {
-            if (peer.isForked()) {
+            if (peer.fastVerificationResult?.forked) {
                 this.quorumDetails.peersNoQuorum++;
                 this.quorumDetails.peersForked++;
             } else {

--- a/packages/core-p2p/src/peer-communicator.ts
+++ b/packages/core-p2p/src/peer-communicator.ts
@@ -97,7 +97,7 @@ export class PeerCommunicator implements Contracts.P2P.PeerCommunicator {
     // ! do not rely on parameter timeoutMsec as guarantee that ping method will resolve within it !
     // ! peerVerifier.checkState can take more time !
     // TODO refactor ?
-    public async ping(peer: Contracts.P2P.Peer, timeoutMsec: number, force = false): Promise<any> {
+    public async ping(peer: Contracts.P2P.Peer, timeoutMsec: number, force = false, fast = false): Promise<any> {
         const deadline = new Date().getTime() + timeoutMsec;
 
         if (peer.recentlyPinged() && !force) {
@@ -127,7 +127,7 @@ export class PeerCommunicator implements Contracts.P2P.PeerCommunicator {
                 throw new PeerPingTimeoutError(timeoutMsec);
             }
 
-            peer.verificationResult = await peerVerifier.checkState(pingResponse.state, deadline);
+            peer.verificationResult = await peerVerifier.checkState(pingResponse.state, deadline, fast);
 
             if (!peer.isVerified()) {
                 throw new PeerVerificationFailedError();

--- a/packages/core-p2p/src/peer-communicator.ts
+++ b/packages/core-p2p/src/peer-communicator.ts
@@ -127,10 +127,18 @@ export class PeerCommunicator implements Contracts.P2P.PeerCommunicator {
                 throw new PeerPingTimeoutError(timeoutMsec);
             }
 
-            peer.verificationResult = await peerVerifier.checkState(pingResponse.state, deadline, fast);
+            if (fast) {
+                peer.fastVerificationResult = await peerVerifier.checkStateFast(pingResponse.state, deadline);
 
-            if (!peer.isVerified()) {
-                throw new PeerVerificationFailedError();
+                if (!peer.fastVerificationResult) {
+                    throw new PeerVerificationFailedError();
+                }
+            } else {
+                peer.verificationResult = await peerVerifier.checkState(pingResponse.state, deadline);
+
+                if (!peer.isVerified()) {
+                    throw new PeerVerificationFailedError();
+                }
             }
         }
 

--- a/packages/core-p2p/src/peer-verifier.ts
+++ b/packages/core-p2p/src/peer-verifier.ts
@@ -19,7 +19,7 @@ export class PeerVerificationResult {
             return this.highestCommonHeight !== this.myHeight && this.highestCommonHeight !== this.hisHeight;
         }
 
-        return this.myHeight > this.hisHeight;
+        return true;
     }
 }
 
@@ -110,11 +110,18 @@ export class PeerVerifier implements Contracts.P2P.PeerVerifier {
         const claimedHeight = Number(claimedState.header.height);
         const ourHeight: number = this.ourHeight();
         if (await this.weHavePeersHighestBlock(claimedState, ourHeight)) {
-            // Case3 and Case5
+            // Case3 and Case5 -> peersQuorum++;
             return new PeerVerificationResult(ourHeight, claimedHeight, claimedHeight);
         }
 
         if (fast) {
+            /* Case 1 -> peersNoQuorum++
+             * Case 2 -> peersNoQuorum++
+             * Case 4 -> peersNoQuorum++; peersForked++;
+             * Case 6 -> peersNoQuorum++; peersForked++;
+             *
+             * All those cases will report PeerVerificationResult.forked === true. That is ok, because we use fast check only for quorum validation.
+             */
             return new PeerVerificationResult(ourHeight, claimedHeight);
         }
 

--- a/packages/core-p2p/src/peer-verifier.ts
+++ b/packages/core-p2p/src/peer-verifier.ts
@@ -104,7 +104,6 @@ export class PeerVerifier implements Contracts.P2P.PeerVerifier {
      * The caller should ensure that it is a valid state: must have .header.height and .header.id
      * properties.
      * @param {Number} deadline operation deadline, in milliseconds since Epoch
-     * @param {Boolean} fast skip commonBlockHeight check, because we need only data for quorum
      * @return {PeerVerificationResut|undefined} PeerVerificationResut object if the peer's blockchain
      * is verified to be legit (albeit it may be different than our blockchain), or undefined if
      * the peer's state could not be verified.
@@ -121,7 +120,7 @@ export class PeerVerifier implements Contracts.P2P.PeerVerifier {
         const claimedHeight = Number(claimedState.header.height);
         const ourHeight: number = this.ourHeight();
         if (await this.weHavePeersHighestBlock(claimedState, ourHeight)) {
-            // Case3 and Case5 -> peersQuorum++;
+            // Case3 and Case5
             return new PeerVerificationResult(ourHeight, claimedHeight, claimedHeight);
         }
 

--- a/packages/core-p2p/src/peer.ts
+++ b/packages/core-p2p/src/peer.ts
@@ -43,7 +43,13 @@ export class Peer implements Contracts.P2P.Peer {
      * @type {(PeerVerificationResult | undefined)}
      * @memberof Peer
      */
-    public verificationResult: PeerVerificationResult | undefined;
+    public verificationResult: Contracts.P2P.PeerVerificationResult | undefined;
+
+    /**
+     * @type {(PeerVerificationResult | undefined)}
+     * @memberof Peer
+     */
+    public fastVerificationResult: Contracts.P2P.FastPeerVerificationResult | undefined;
 
     /**
      * @type {Contracts.P2P.PeerState}


### PR DESCRIPTION
## Summary

Add fast option to the peer verification. Fast option is only used to calculate quorum before forging. It skips the calculation of the highest common block. Result is saved in separate property to prevent collision with the normal check.  

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged
