### PR TITLE
merge: cherry pick from `develop`

### DIFF
--- a/__tests__/unit/core-p2p/network-monitor.test.ts
+++ b/__tests__/unit/core-p2p/network-monitor.test.ts
@@ -400,7 +400,7 @@ describe("NetworkMonitor", () => {
 
             expect(communicator.ping).toBeCalledTimes(peers.length);
             for (const peer of peers) {
-                expect(communicator.ping).toBeCalledWith(peer, config.verifyTimeout, expect.anything());
+                expect(communicator.ping).toBeCalledWith(peer, config.verifyTimeout, expect.anything(), false);
             }
         });
 
@@ -412,7 +412,7 @@ describe("NetworkMonitor", () => {
 
             expect(communicator.ping).toBeCalledTimes(peers.length);
             for (const peer of peers) {
-                expect(communicator.ping).toBeCalledWith(peer, config.verifyTimeout, expect.anything());
+                expect(communicator.ping).toBeCalledWith(peer, config.verifyTimeout, expect.anything(), false);
             }
         });
 

--- a/__tests__/unit/core-p2p/network-state.test.ts
+++ b/__tests__/unit/core-p2p/network-state.test.ts
@@ -2,7 +2,7 @@ import { Container, Utils as KernelUtils } from "@packages/core-kernel";
 import { NetworkStateStatus } from "@packages/core-p2p/src/enums";
 import { NetworkState } from "@packages/core-p2p/src/network-state";
 import { Peer } from "@packages/core-p2p/src/peer";
-import { PeerVerificationResult } from "@packages/core-p2p/src/peer-verifier";
+import { FastPeerVerificationResult } from "@packages/core-p2p/src/peer-verifier";
 import { Blocks, Crypto, Utils } from "@packages/crypto";
 
 describe("NetworkState", () => {
@@ -99,7 +99,7 @@ describe("NetworkState", () => {
                 peer3.state = { header: {}, height: 8, forgingAllowed: true, currentSlot: currentSlot }; // same height
                 const peer4 = new Peer("184.168.65.65", 4000);
                 peer4.state = { header: {}, height: 6, forgingAllowed: false, currentSlot: currentSlot - 2 }; // below height
-                peer4.verificationResult = new PeerVerificationResult(8, 6, 4); // forked
+                peer4.fastVerificationResult = new FastPeerVerificationResult(8, 6); // forked
                 const peer5 = new Peer("185.168.65.65", 4000);
                 peer5.state = { header: {}, height: 6, forgingAllowed: false, currentSlot: currentSlot - 2 }; // below height, not forked
                 peers = [peer1, peer2, peer3, peer4, peer5];

--- a/packages/core-kernel/src/contracts/p2p/peer-verifier.ts
+++ b/packages/core-kernel/src/contracts/p2p/peer-verifier.ts
@@ -1,7 +1,9 @@
-import { Peer, PeerState, PeerVerificationResult } from "./peer";
+import { FastPeerVerificationResult, Peer, PeerState, PeerVerificationResult } from "./peer";
 
 export interface PeerVerifier {
     initialize(peer: Peer);
 
     checkState(claimedState: PeerState, deadline: number): Promise<PeerVerificationResult | undefined>;
+
+    checkStateFast(claimedState: PeerState, deadline: number): Promise<FastPeerVerificationResult | undefined>;
 }

--- a/packages/core-kernel/src/contracts/p2p/peer.ts
+++ b/packages/core-kernel/src/contracts/p2p/peer.ts
@@ -23,6 +23,7 @@ export interface Peer {
     lastPinged: Dayjs | undefined;
     sequentialErrorCounter: number;
     verificationResult: PeerVerificationResult | undefined;
+    fastVerificationResult: FastPeerVerificationResult | undefined;
 
     isVerified(): boolean;
     isForked(): boolean;
@@ -72,5 +73,11 @@ export interface PeerVerificationResult {
     readonly myHeight: number;
     readonly hisHeight: number;
     readonly highestCommonHeight: number;
+    readonly forked: boolean;
+}
+
+export interface FastPeerVerificationResult {
+    readonly myHeight: number;
+    readonly hisHeight: number;
     readonly forked: boolean;
 }

--- a/packages/core-p2p/src/defaults.ts
+++ b/packages/core-p2p/src/defaults.ts
@@ -7,7 +7,7 @@ export const defaults = {
     /**
      * The minimum peer version we expect
      */
-    minimumVersions: ["^3.0", "^3.0.0-next.0", "^3.0.0-alpha.0"],
+    minimumVersions: ["^3.0", "^3.0.0-next.0", "^4.0.0-next.0"],
     /**
      * The number of peers we expect to be available to start a relay
      */

--- a/packages/core-p2p/src/network-monitor.ts
+++ b/packages/core-p2p/src/network-monitor.ts
@@ -144,7 +144,7 @@ export class NetworkMonitor implements Contracts.P2P.NetworkMonitor {
             Promise.all(
                 peers.map(async (peer) => {
                     try {
-                        await this.communicator.ping(peer, pingDelay, forcePing);
+                        await this.communicator.ping(peer, pingDelay, forcePing, fast);
                     } catch (error) {
                         unresponsivePeers++;
 
@@ -285,7 +285,7 @@ export class NetworkMonitor implements Contracts.P2P.NetworkMonitor {
         );
 
         const forkHeights: number[] = forkVerificationResults
-            .map((verificationResult: Contracts.P2P.PeerVerificationResult) => verificationResult.highestCommonHeight)
+            .map((verificationResult) => verificationResult.highestCommonHeight!)
             .filter((forkHeight, i, arr) => arr.indexOf(forkHeight) === i) // unique
             .sort()
             .reverse();

--- a/packages/core-p2p/src/network-state.ts
+++ b/packages/core-p2p/src/network-state.ts
@@ -173,7 +173,7 @@ export class NetworkState implements Contracts.P2P.NetworkState {
             this.quorumDetails.peersOverHeight++;
             this.quorumDetails.peersOverHeightBlockHeaders[peer.state.header.id] = peer.state.header;
         } else {
-            if (peer.isForked()) {
+            if (peer.fastVerificationResult?.forked) {
                 this.quorumDetails.peersNoQuorum++;
                 this.quorumDetails.peersForked++;
             } else {

--- a/packages/core-p2p/src/peer.ts
+++ b/packages/core-p2p/src/peer.ts
@@ -43,7 +43,13 @@ export class Peer implements Contracts.P2P.Peer {
      * @type {(PeerVerificationResult | undefined)}
      * @memberof Peer
      */
-    public verificationResult: PeerVerificationResult | undefined;
+    public verificationResult: Contracts.P2P.PeerVerificationResult | undefined;
+
+    /**
+     * @type {(PeerVerificationResult | undefined)}
+     * @memberof Peer
+     */
+    public fastVerificationResult: Contracts.P2P.FastPeerVerificationResult | undefined;
 
     /**
      * @type {Contracts.P2P.PeerState}

--- a/packages/core-p2p/src/utils/is-valid-version.ts
+++ b/packages/core-p2p/src/utils/is-valid-version.ts
@@ -12,25 +12,15 @@ export const isValidVersion = (app: Contracts.Kernel.Application, peer: Contract
         return false;
     }
 
-    let minimumVersions: string[];
-    const milestones: Record<string, any> = Managers.configManager.getMilestone();
-
-    const { p2p } = milestones;
-
-    if (p2p && Array.isArray(p2p.minimumVersions) && p2p.minimumVersions.length > 0) {
-        minimumVersions = p2p.minimumVersions;
-    } else {
-        const configuration = app.getTagged<Providers.PluginConfiguration>(
-            Container.Identifiers.PluginConfiguration,
-            "plugin",
-            "@arkecosystem/core-p2p",
-        );
-        minimumVersions = configuration.getOptional<string[]>("minimumVersions", []);
-    }
+    const configuration = app.getTagged<Providers.PluginConfiguration>(
+        Container.Identifiers.PluginConfiguration,
+        "plugin",
+        "@arkecosystem/core-p2p",
+    );
+    const minimumVersions = configuration.getOptional<string[]>("minimumVersions", []);
 
     const includePrerelease: boolean = Managers.configManager.get("network.name") !== "mainnet";
     return minimumVersions.some((minimumVersion: string) =>
-        // @ts-ignore - check why the peer.version errors even though we exit early
-        semver.satisfies(peer.version, minimumVersion, { includePrerelease }),
+        semver.satisfies(peer.version!, minimumVersion, { includePrerelease }),
     );
 };


### PR DESCRIPTION
## Summary

- refactor(core-p2p): get min peer version from `default.ts` instead of milestones (#4680)
- fix(core-p2p): skip highest common block search on fast validation  (#4681)

## Checklist

- [x] Ready to be merged
