### PR TITLE
fix(core-api): use `ITransactionData` in argument with `BlockWithTransactionsResource`

### DIFF
--- a/packages/core-api/src/controllers/blocks.ts
+++ b/packages/core-api/src/controllers/blocks.ts
@@ -47,7 +47,7 @@ export class BlocksController extends Controller {
 
         if (request.query.transform) {
             return this.respondWithResource(
-                { data: block.data, transactions: block.data.transactions || [] },
+                { data: block.data, transactions: block.transactions.map((t) => t.data) },
                 BlockWithTransactionsResource,
                 true,
             );
@@ -61,7 +61,7 @@ export class BlocksController extends Controller {
 
         if (request.query.transform) {
             return this.respondWithResource(
-                { data: block.data, transactions: block.data.transactions || [] },
+                { data: block.data, transactions: block.transactions.map((t) => t.data) },
                 BlockWithTransactionsResource,
                 true,
             );

--- a/packages/core-api/src/controllers/blocks.ts
+++ b/packages/core-api/src/controllers/blocks.ts
@@ -46,7 +46,11 @@ export class BlocksController extends Controller {
         const block = this.stateStore.getGenesisBlock();
 
         if (request.query.transform) {
-            return this.respondWithResource(block, BlockWithTransactionsResource, true);
+            return this.respondWithResource(
+                { data: block.data, transactions: block.data.transactions || [] },
+                BlockWithTransactionsResource,
+                true,
+            );
         } else {
             return this.respondWithResource(block.data, BlockResource, false);
         }
@@ -56,7 +60,11 @@ export class BlocksController extends Controller {
         const block = this.blockchain.getLastBlock();
 
         if (request.query.transform) {
-            return this.respondWithResource(block, BlockWithTransactionsResource, true);
+            return this.respondWithResource(
+                { data: block.data, transactions: block.data.transactions || [] },
+                BlockWithTransactionsResource,
+                true,
+            );
         } else {
             return this.respondWithResource(block.data, BlockResource, false);
         }


### PR DESCRIPTION
## Summary

Use ITransactionData insted ITransaction data type as part of resource attribute when using BlockWithTransactionsResource. 

This fixes the issue caused by missing asset property on transaction object when MultiPayment total transfer ammount is calculated, that caused internal server errors.

Issue is described in details on: https://github.com/Solar-network/core/pull/63 by @alessiodf 

## Checklist

- [x] Ready to be merged

