### PR TITLE
fix(core-kernel): fix item ordering for `undefined` and `null` values

### DIFF
--- a/packages/core-kernel/__tests__/services/search/pagination-service.test.ts
+++ b/packages/core-kernel/__tests__/services/search/pagination-service.test.ts
@@ -32,6 +32,20 @@ describe("PaginationService.getPage", () => {
         });
     });
 
+    it("should leave items order intact when sorting by undefined property", () => {
+        const paginationService = container.resolve(PaginationService);
+        const pagination = { offset: 0, limit: 100 };
+        const items = [{ v: 1 }, { v: 3 }, {}, { v: 2 }];
+        const sorting = [{ property: "dummy", direction: "asc" as const }];
+        const resultsPage = paginationService.getPage(pagination, sorting, items);
+
+        expect(resultsPage).toEqual({
+            results: [{ v: 1 }, { v: 3 }, {}, { v: 2 }],
+            totalCount: 4,
+            meta: { totalCountIsEstimate: false },
+        });
+    });
+
     it("should return items with undefined properties at the end", () => {
         const paginationService = container.resolve(PaginationService);
         const pagination = { offset: 0, limit: 100 };
@@ -207,6 +221,56 @@ describe("PaginationService.getPage", () => {
                 { a: Utils.BigNumber.make("1"), b: 101 },
                 { a: Utils.BigNumber.make("1"), b: 200 },
                 { a: Utils.BigNumber.make("2"), b: 100 },
+            ],
+            totalCount: 3,
+            meta: { totalCountIsEstimate: false },
+        });
+    });
+
+    it("should sort using second sorting instruction when first properties are null", () => {
+        const paginationService = container.resolve(PaginationService);
+        const pagination = { offset: 0, limit: 100 };
+        const items = [
+            { a: null, b: 101 },
+            { a: true, b: 100 },
+            { a: null, b: 200 },
+        ];
+        const sorting = [
+            { property: "a", direction: "asc" as const },
+            { property: "b", direction: "asc" as const },
+        ];
+        const resultsPage = paginationService.getPage(pagination, sorting, items);
+
+        expect(resultsPage).toEqual({
+            results: [
+                { a: true, b: 100 },
+                { a: null, b: 101 },
+                { a: null, b: 200 },
+            ],
+            totalCount: 3,
+            meta: { totalCountIsEstimate: false },
+        });
+    });
+
+    it("should sort using second sorting instruction when first properties are undefined", () => {
+        const paginationService = container.resolve(PaginationService);
+        const pagination = { offset: 0, limit: 100 };
+        const items = [
+            { a: undefined, b: 200 },
+            { a: undefined, b: 101 },
+            { a: true, b: 100 },
+        ];
+        const sorting = [
+            { property: "a", direction: "asc" as const },
+            { property: "b", direction: "asc" as const },
+        ];
+        const resultsPage = paginationService.getPage(pagination, sorting, items);
+
+        expect(resultsPage).toEqual({
+            results: [
+                { a: true, b: 100 },
+                { a: undefined, b: 101 },
+                { a: undefined, b: 200 },
             ],
             totalCount: 3,
             meta: { totalCountIsEstimate: false },

--- a/packages/core-kernel/src/services/search/pagination-service.ts
+++ b/packages/core-kernel/src/services/search/pagination-service.ts
@@ -63,10 +63,10 @@ export class PaginationService {
             let valueB = get(b.item, property);
 
             // undefined and null are always at the end regardless of direction
-            if (typeof valueA === "undefined" && typeof valueB === "undefined") return 0;
+            if (typeof valueA === "undefined" && typeof valueB === "undefined") continue;
             if (typeof valueA === "undefined" && typeof valueB !== "undefined") return 1;
             if (typeof valueA !== "undefined" && typeof valueB === "undefined") return -1;
-            if (valueA === null && valueB === null) return 0;
+            if (valueA === null && valueB === null) continue;
             if (valueA === null && valueB !== null) return 1;
             if (valueA !== null && valueB === null) return -1;
 
@@ -98,9 +98,6 @@ export class PaginationService {
             }
         }
 
-        if (a.index < b.index) return -1;
-        if (a.index > b.index) return 1;
-
-        return 0;
+        return a.index < b.index ? -1 : 1;
     }
 }


### PR DESCRIPTION
## Summary

Fixes: #4690

Red back tree requires comparison method that returns either -1 or 1 to preserve fixed items order. Items that have equal property values are sorted by index. Now two same **undefined** or same **null** values are considered as equal so item order is defined based on index value. 

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged


