### PR TITLE
refactor(core-api): order resigned delegates by publicKey

### DIFF
--- a/packages/core-api/src/services/delegate-search-service.ts
+++ b/packages/core-api/src/services/delegate-search-service.ts
@@ -32,7 +32,7 @@ export class DelegateSearchService {
         sorting: Contracts.Search.Sorting,
         ...criterias: DelegateCriteria[]
     ): Contracts.Search.ResultsPage<DelegateResource> {
-        sorting = [...sorting, { property: "rank", direction: "asc" }];
+        sorting = [...sorting, { property: "rank", direction: "asc" }, { property: "publicKey", direction: "asc" }];
 
         return this.paginationService.getPage(pagination, sorting, this.getDelegates(...criterias));
     }


### PR DESCRIPTION
## Summary

Order resigned delegates by publicKey. Non resigned delegates are ordered by rank by default. 

## Checklist

- [x] Ready to be merged

