### PR TITLE
fix(core-state): create new wallet instance in `WalletRepositoryCopyOnWrite` 

### DIFF
--- a/packages/core-state/__tests__/wallets/wallet-repository-copy-on-write.test.ts
+++ b/packages/core-state/__tests__/wallets/wallet-repository-copy-on-write.test.ts
@@ -49,7 +49,7 @@ describe("Wallet Repository Copy On Write", () => {
     it("should find wallets by address", () => {
         const spyFindByAddress = jest.spyOn(walletRepo, "findByAddress");
         const clonedWallet = walletRepoCopyOnWrite.findByAddress("notexisting");
-        expect(spyFindByAddress).toHaveBeenCalledWith("notexisting");
+        expect(spyFindByAddress).not.toBeCalled();
         const originalWallet = walletRepo.findByAddress(clonedWallet.getAddress());
         expect(originalWallet).not.toBe(clonedWallet);
     });

--- a/packages/core-state/src/wallets/wallet-repository-copy-on-write.ts
+++ b/packages/core-state/src/wallets/wallet-repository-copy-on-write.ts
@@ -14,7 +14,14 @@ export class WalletRepositoryCopyOnWrite extends WalletRepository {
 
     public findByAddress(address: string): Contracts.State.Wallet {
         if (address && !this.hasByAddress(address)) {
-            this.cloneWallet(this.blockchainWalletRepository, this.blockchainWalletRepository.findByAddress(address));
+            if (this.blockchainWalletRepository.hasByAddress(address)) {
+                this.cloneWallet(
+                    this.blockchainWalletRepository,
+                    this.blockchainWalletRepository.findByAddress(address),
+                );
+            } else {
+                super.findByAddress(address);
+            }
         }
         return this.findByIndex(Contracts.State.WalletIndexes.Addresses, address)!;
     }


### PR DESCRIPTION
## Summary

Create new wallet in WalletRepositoryCopyOnWrite instead main WalletRepository. This prevents WalletRepository pollution in transaction pools sender state. When address does not exists in WalletRepository neither in WalletRepositoryCopyOnWrite, then new wallet is created only in WalletRepositoryCopyOnWrite. WalletRepository is not aware of the new wallet until block is processed. 


## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged
