### PR TITLE
fix(core-p2p): node version should pass min version defined in configuration and milestones

### DIFF
--- a/packages/core-p2p/__tests__/utils/is-valid-version.test.ts
+++ b/packages/core-p2p/__tests__/utils/is-valid-version.test.ts
@@ -5,53 +5,104 @@ import { Peer } from "@packages/core-p2p/src/peer";
 import { Managers } from "@packages/crypto";
 
 let peerMock: Peer;
+const getOptional = jest.fn().mockReturnValue([]);
 const app = {
     getTagged: jest.fn().mockReturnValue({
-        getOptional: jest.fn().mockReturnValue(["^2.6.0"]),
+        getOptional,
     }),
+    get: jest.fn().mockReturnValue("mainnet"),
 } as any;
 beforeEach(async () => {
     peerMock = new Peer("1.0.0.99", 4002);
 });
 
-describe.each([[true], [false]])("isValidVersion", (withMilestones) => {
-    let spyGetMilestone = jest.spyOn(Managers.configManager, "getMilestone");
-    beforeEach(() => {
-        if (withMilestones) {
-            spyGetMilestone = jest.spyOn(Managers.configManager, "getMilestone").mockReturnValue({
-                p2p: {
-                    minimumVersions: ["^2.6.0"]
-                }
-            });
-        }
-    })
-    afterEach(() => {
-        spyGetMilestone.mockRestore();
-    })
+describe("isValidVersion", () => {
+    it("should return false if version is not defined", () => {
+        expect(isValidVersion(app, peerMock)).toBeFalse();
+    });
 
-    it.each([["2.6.0"], ["2.6.666"], ["2.7.0"], ["2.8.0"], ["2.9.0"], ["2.9.934"]])(
-        "should be a valid version",
-        (version) => {
-            peerMock.version = version;
-            expect(isValidVersion(app, peerMock)).toBeTrue();
-        },
-    );
-
-    it.each([
-        [undefined]
-        ["2.4.0"],
-        ["2.5.0"],
-        ["1.0.0"],
-        ["---aaa"],
-        ["2490"],
-        [2],
-        [-10.2],
-        [{}],
-        [true],
-        [() => 1],
-        ["2.0.0.0"],
-    ])("should be an invalid version", (version: any) => {
+    it.each(["a", "3", "3.6", "-3.4.0", "3.0.0.next.1"])("should return false if version is not valid", (version) => {
         peerMock.version = version;
         expect(isValidVersion(app, peerMock)).toBeFalse();
+    });
+
+    it.each(["3.0.0", "3.0.0-next.1"])("should return true if minVersion is not set", (version) => {
+        peerMock.version = version;
+        expect(isValidVersion(app, peerMock)).toBeTrue();
+    });
+
+    const tests = [
+        { network: "mainnet", version: "3.0.0", minVersion: ["3.0.0"], result: true },
+        { network: "mainnet", version: "3.0.0", minVersion: ["3.0.0", "2.0.0"], result: true },
+        { network: "mainnet", version: "4.0.0", minVersion: [">=3.0.0 || <=5.0.0"], result: true },
+        { network: "mainnet", version: "3.0.1", minVersion: ["3.0.0"], result: false },
+        { network: "mainnet", version: "3.0.13", minVersion: [">=3.0.0"], result: true },
+        { network: "mainnet", version: "4.0.0", minVersion: [">=3.0.0"], result: true },
+        { network: "mainnet", version: "3.3.3", minVersion: ["^3.0.0"], result: true },
+        { network: "mainnet", version: "4.0.0", minVersion: ["^3.0.0"], result: false },
+        { network: "mainnet", version: "4.0.0-next.1", minVersion: [">=3.0.0"], result: false },
+        { network: "devnet", version: "4.0.0-next.1", minVersion: [">=3.0.0"], result: true },
+        { network: "mainnet", version: "3.0.0", minVersion: [], result: true },
+    ];
+    it.each(tests)("minVersion in milestones", (test) => {
+        const spyGet = jest.spyOn(Managers.configManager, "get").mockReturnValue(test.network);
+        const spyGetMilestone = jest.spyOn(Managers.configManager, "getMilestone").mockReturnValue({
+            p2p: {
+                minimumVersions: test.minVersion,
+            },
+        });
+
+        peerMock.version = test.version;
+        expect(isValidVersion(app, peerMock)).toEqual(test.result);
+        expect(spyGet).toBeCalled();
+        expect(spyGetMilestone).toBeCalled();
+    });
+
+    it.each(tests)("minVersion in config", (test) => {
+        const spyGet = jest.spyOn(Managers.configManager, "get").mockReturnValue(test.network);
+        getOptional.mockReturnValue(test.minVersion);
+
+        peerMock.version = test.version;
+        expect(isValidVersion(app, peerMock)).toEqual(test.result);
+        expect(spyGet).toBeCalled();
+        expect(getOptional).toBeCalled();
+    });
+
+    it.each([
+        {
+            network: "mainnet",
+            version: "3.0.0",
+            minConfigVersion: ["3.0.0"],
+            minMilestonesVersion: ["3.0.0"],
+            result: true,
+        },
+        {
+            network: "mainnet",
+            version: "3.0.0",
+            minConfigVersion: ["4.0.0"],
+            minMilestonesVersion: ["3.0.0"],
+            result: false,
+        },
+        {
+            network: "mainnet",
+            version: "3.0.0",
+            minConfigVersion: ["3.0.0"],
+            minMilestonesVersion: ["4.0.0"],
+            result: false,
+        },
+    ])("should pass configuration and milestone minVersion", (test) => {
+        const spyGet = jest.spyOn(Managers.configManager, "get").mockReturnValue(test.network);
+        const spyGetMilestone = jest.spyOn(Managers.configManager, "getMilestone").mockReturnValue({
+            p2p: {
+                minimumVersions: test.minMilestonesVersion,
+            },
+        });
+        getOptional.mockReturnValue(test.minConfigVersion);
+
+        peerMock.version = test.version;
+        expect(isValidVersion(app, peerMock)).toEqual(test.result);
+        expect(spyGet).toBeCalled();
+        expect(spyGetMilestone).toBeCalled();
+        expect(getOptional).toBeCalled();
     });
 });

--- a/packages/core-p2p/src/utils/is-valid-version.ts
+++ b/packages/core-p2p/src/utils/is-valid-version.ts
@@ -2,7 +2,6 @@ import { Container, Contracts, Providers } from "@arkecosystem/core-kernel";
 import { Managers } from "@arkecosystem/crypto";
 import semver from "semver";
 
-// todo: review the implementation
 export const isValidVersion = (app: Contracts.Kernel.Application, peer: Contracts.P2P.Peer): boolean => {
     if (!peer.version) {
         return false;
@@ -12,15 +11,44 @@ export const isValidVersion = (app: Contracts.Kernel.Application, peer: Contract
         return false;
     }
 
+    const includePrerelease: boolean = Managers.configManager.get("network.name") !== "mainnet";
+
+    return (
+        isValidConfigVersion(app, peer.version, includePrerelease) &&
+        isValidMilestoneVersion(peer.version, includePrerelease)
+    );
+};
+
+const isValidConfigVersion = (
+    app: Contracts.Kernel.Application,
+    version: string,
+    includePrerelease: boolean,
+): boolean => {
     const configuration = app.getTagged<Providers.PluginConfiguration>(
         Container.Identifiers.PluginConfiguration,
         "plugin",
         "@arkecosystem/core-p2p",
     );
+
     const minimumVersions = configuration.getOptional<string[]>("minimumVersions", []);
 
-    const includePrerelease: boolean = Managers.configManager.get("network.name") !== "mainnet";
-    return minimumVersions.some((minimumVersion: string) =>
-        semver.satisfies(peer.version!, minimumVersion, { includePrerelease }),
-    );
+    if (minimumVersions.length > 0) {
+        return minimumVersions.some((minimumVersion: string) =>
+            semver.satisfies(version, minimumVersion, { includePrerelease }),
+        );
+    }
+
+    return true;
+};
+
+const isValidMilestoneVersion = (version: string, includePrerelease: boolean): boolean => {
+    const { p2p } = Managers.configManager.getMilestone();
+
+    if (p2p && Array.isArray(p2p.minimumVersions) && p2p.minimumVersions.length > 0) {
+        return p2p.minimumVersions.some((minimumVersion: string) =>
+            semver.satisfies(version, minimumVersion, { includePrerelease }),
+        );
+    }
+
+    return true;
 };

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -34,7 +34,7 @@
     },
     "dependencies": {
         "@arkecosystem/crypto-identities": "1.2.0",
-        "@arkecosystem/crypto-networks": "1.2.0",
+        "@arkecosystem/crypto-networks": "1.2.1",
         "@arkecosystem/utils": "1.3.1",
         "ajv": "6.12.6",
         "ajv-keywords": "3.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -788,7 +788,7 @@ importers:
   packages/crypto:
     specifiers:
       '@arkecosystem/crypto-identities': 1.2.0
-      '@arkecosystem/crypto-networks': 1.2.0
+      '@arkecosystem/crypto-networks': 1.2.1
       '@arkecosystem/utils': 1.3.1
       '@rollup/plugin-babel': 5.3.0
       '@rollup/plugin-commonjs': 13.0.2
@@ -826,7 +826,7 @@ importers:
       util: 0.12.4
     dependencies:
       '@arkecosystem/crypto-identities': 1.2.0
-      '@arkecosystem/crypto-networks': 1.2.0
+      '@arkecosystem/crypto-networks': 1.2.1
       '@arkecosystem/utils': 1.3.1
       ajv: 6.12.6
       ajv-keywords: 3.4.1_ajv@6.12.6
@@ -875,8 +875,8 @@ packages:
       wif: 2.0.6
     dev: false
 
-  /@arkecosystem/crypto-networks/1.2.0:
-    resolution: {integrity: sha512-ZytgxSgP4lfOUdQLvY6PyWkhvx6//V24MKv/faom9preIiamEfwEHLobFRs0cr5F1wSD7brMrLN/KcCkUw2Itw==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.com/@arkecosystem/crypto-networks/-/crypto-networks-1.2.0.tgz}
+  /@arkecosystem/crypto-networks/1.2.1:
+    resolution: {integrity: sha512-Dyk9LZKzV4lS7uddjYQpeN1tS0r40i4tyWGFEipvlFEgqAECKQhH6MBnR+tWMC3c6Q+DV1EVA7F+n8KIjW4fmw==}
     dev: false
 
   /@arkecosystem/utils/1.3.1:
@@ -5533,8 +5533,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
-      is-text-path: 1.0.1
       JSONStream: 1.3.5
+      is-text-path: 1.0.1
       lodash: 4.17.21
       meow: 8.1.2
       split2: 3.2.2


### PR DESCRIPTION
## Summary

Node version should pass both version setting in configuration and in milestones. If value is not defined, then check is skipped. 

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged
