### PR TITLE
fix(core-cli): exclude `node_modules` folder from global path check

### DIFF
--- a/packages/core-cli/src/services/setup.ts
+++ b/packages/core-cli/src/services/setup.ts
@@ -8,7 +8,7 @@ export class Setup {
     public isGlobal(): boolean {
         try {
             const globalDir = this.getGlobalRootDir();
-            return !!(globalDir && this.getLocalEntrypoint().startsWith(globalDir));
+            return !!(globalDir && this.getLocalEntrypoint().startsWith(globalDir.replace("node_modules", "")));
         } catch {
             return false;
         }


### PR DESCRIPTION
## Summary

Exclude node_modules from global path check. 

New pnpm version stores files differently under: 
`/home/ark/.pnpm/5/.pnpm/`
compared to previous version:
`/home/ark/.pnpm/5/node_modules/.pnpm/`

When `node_modules` is excluded from isGlobal check satisfies both structures.  This PR fixes the issue when `ark <relay|core|forge>:start` is run with direct path instead relative path and causes problem with `ark update` command. 

## Checklist

- [x] Ready to be merged

