### PR TITLE
deps(crypto): update `@arkecosystem/crypto-networks` to 1.2.2

### DIFF
--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -32,7 +32,7 @@
     },
     "dependencies": {
         "@arkecosystem/crypto-identities": "1.2.0",
-        "@arkecosystem/crypto-networks": "1.2.1",
+        "@arkecosystem/crypto-networks": "1.2.2",
         "@arkecosystem/utils": "1.3.1",
         "ajv": "6.12.6",
         "ajv-keywords": "3.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -20,10 +20,10 @@
     fast-memoize "^2.5.1"
     wif "^2.0.6"
 
-"@arkecosystem/crypto-networks@1.2.1":
-  version "1.2.1"
-  resolved "https://registry.npmjs.org/@arkecosystem/crypto-networks/-/crypto-networks-1.2.1.tgz#0715507bd0d04042ec710e09e2f51de4521de63e"
-  integrity sha512-Dyk9LZKzV4lS7uddjYQpeN1tS0r40i4tyWGFEipvlFEgqAECKQhH6MBnR+tWMC3c6Q+DV1EVA7F+n8KIjW4fmw==
+"@arkecosystem/crypto-networks@1.2.2":
+  version "1.2.2"
+  resolved "https://registry.npmjs.org/@arkecosystem/crypto-networks/-/crypto-networks-1.2.2.tgz#5efb52c161af5a05ee805e2327d58673024b4b5a"
+  integrity sha512-2iVeiYNnqtV9oZxWt/q9LFb/7zEMN2u/3pwTwIvBonrqtJwazorCBP+zbBwxeXivwnM4SxrCQweoTlujjvA+8w==
 
 "@arkecosystem/utils@1.3.1":
   version "1.3.1"


### PR DESCRIPTION
## Summary
Update @arkecosystem/typescript-crypto-networks to 1.2.2. New version sets p2p.minimumVersions [milestone](https://github.com/ArkEcosystem/typescript-crypto-networks/commit/863e0f607898defd20d2e8e23c351df08cfb4057) on mainnet. 

## Checklist

- [x] Ready to be merged
