### PR TITLE
fix(core): remove all sqlite files with `pool:clear` command

### DIFF
--- a/packages/core/__tests__/commands/pool-clear.test.ts
+++ b/packages/core/__tests__/commands/pool-clear.test.ts
@@ -19,7 +19,7 @@ describe("PoolClearCommand", () => {
         prompts.inject([true]);
         jest.spyOn(cli.app, "getCorePath").mockResolvedValueOnce(null);
         await expect(cli.execute(Command)).toResolve();
-        expect(removeSync).toHaveBeenCalled();
+        expect(removeSync).toHaveBeenCalledTimes(3);
     });
 
     it("should throw any errors", async () => {
@@ -48,6 +48,6 @@ describe("PoolClearCommand", () => {
         prompts.inject([true]);
         jest.spyOn(cli.app, "getCorePath").mockResolvedValueOnce(null);
         await expect(cli.withFlags({ false: true }).execute(Command)).toResolve();
-        expect(removeSync).toHaveBeenCalled();
+        expect(removeSync).toHaveBeenCalledTimes(3);
     });
 });

--- a/packages/core/src/commands/pool-clear.ts
+++ b/packages/core/src/commands/pool-clear.ts
@@ -71,6 +71,8 @@ export class Command extends Commands.Command {
      * @memberof Command
      */
     private removeFiles() {
-        removeSync(this.app.getCorePath("data", "transaction-pool"));
+        removeSync(this.app.getCorePath("data", "transaction-pool.sqlite"));
+        removeSync(this.app.getCorePath("data", "transaction-pool.sqlite-shm"));
+        removeSync(this.app.getCorePath("data", "transaction-pool.sqlite-wal"));
     }
 }


### PR DESCRIPTION
## Summary

Fixes invalid path defined in pool:clear command. Now all 3 files created by sqlite are removed:
- transaction-pool.sqlite
- transaction-pool.sqlite-shm
- transaction-pool.sqlite-wal

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged

