### PR TITLE
fix(core-webhooks): use timeout form defaults.ts for broadcast

### DIFF
--- a/packages/core-webhooks/__tests__/listener.test.ts
+++ b/packages/core-webhooks/__tests__/listener.test.ts
@@ -27,6 +27,10 @@ const mockEventDispatcher = {
     dispatch: jest.fn(),
 };
 
+const webhooksConfiguration = {
+    getRequired: jest.fn().mockReturnValue(2000),
+};
+
 let spyOnPost: jest.SpyInstance;
 
 const expectFinishedEventData = () => {
@@ -54,6 +58,7 @@ beforeEach(() => {
     sandbox.app.bind<Database>(Identifiers.Database).to(Database).inSingletonScope();
 
     sandbox.app.bind(Container.Identifiers.LogService).toConstantValue(logger);
+    sandbox.app.bind(Container.Identifiers.PluginConfiguration).toConstantValue(webhooksConfiguration);
 
     database = sandbox.app.get<Database>(Identifiers.Database);
     database.boot();

--- a/packages/core-webhooks/src/listener.ts
+++ b/packages/core-webhooks/src/listener.ts
@@ -1,4 +1,4 @@
-import { Container, Contracts, Utils } from "@arkecosystem/core-kernel";
+import { Container, Contracts, Providers, Utils } from "@arkecosystem/core-kernel";
 import { performance } from "perf_hooks";
 
 import * as conditions from "./conditions";
@@ -38,6 +38,15 @@ export class Listener {
     private readonly logger!: Contracts.Kernel.Logger;
 
     /**
+     * @private
+     * @type {Providers.PluginConfiguration}
+     * @memberof Listener
+     */
+    @Container.inject(Container.Identifiers.PluginConfiguration)
+    @Container.tagged("plugin", "@arkecosystem/core-webhooks")
+    private readonly webhooksConfiguration!: Providers.PluginConfiguration;
+
+    /**
      * @param {string} event
      * @memberof Listener
      */
@@ -64,7 +73,7 @@ export class Listener {
      * @returns {Promise<void>}
      * @memberof Broadcaster
      */
-    public async broadcast(webhook: Webhook, payload: object, timeout: number = 1500): Promise<void> {
+    public async broadcast(webhook: Webhook, payload: object): Promise<void> {
         const start = performance.now();
 
         try {
@@ -77,7 +86,7 @@ export class Listener {
                 headers: {
                     Authorization: webhook.token,
                 },
-                timeout,
+                timeout: this.webhooksConfiguration.getRequired("timeout"),
             });
 
             this.logger.debug(


### PR DESCRIPTION
## Summary

Use timeout form defaults.ts for broadcast timeout value. 

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged
