### PR TITLE
feat(core-transaction-pool): implements `readdTransactionsFromMempool`

### DIFF
--- a/packages/core-blockchain/__tests__/blockchain.test.ts
+++ b/packages/core-blockchain/__tests__/blockchain.test.ts
@@ -59,11 +59,11 @@ describe("Blockchain", () => {
             .get<Services.Triggers.Triggers>(Container.Identifiers.TriggerService)
             .bind("getActiveDelegates", new GetActiveDelegatesAction(sandbox.app));
 
-        sandbox.app
-            .bind(Identifiers.QueueFactory)
-            .toFactory((context: interfaces.Context) => async <K, T>(name?: string): Promise<Queue> =>
-                sandbox.app.resolve<Queue>(MemoryQueue).make(),
-            );
+        sandbox.app.bind(Identifiers.QueueFactory).toFactory(
+            (context: interfaces.Context) =>
+                async <K, T>(name?: string): Promise<Queue> =>
+                    sandbox.app.resolve<Queue>(MemoryQueue).make(),
+        );
 
         Managers.configManager.setFromPreset("testnet");
     });
@@ -125,7 +125,7 @@ describe("Blockchain", () => {
 
         blockProcessor.process = jest.fn();
 
-        transactionPoolService.readdTransactions = jest.fn();
+        transactionPoolService.readdTransactionsFromStore = jest.fn();
     });
 
     describe("initialize", () => {

--- a/packages/core-blockchain/__tests__/processor/handlers/accept-block-handler.test.ts
+++ b/packages/core-blockchain/__tests__/processor/handlers/accept-block-handler.test.ts
@@ -21,6 +21,7 @@ describe("AcceptBlockHandler", () => {
     const transactionPool = {
         removeForgedTransaction: jest.fn(),
         readdTransactionsFromMempool: jest.fn(),
+        cleanUp: jest.fn(),
     };
     const databaseInteractions = {
         walletRepository: {
@@ -77,6 +78,7 @@ describe("AcceptBlockHandler", () => {
             expect(transactionPool.removeForgedTransaction).toHaveBeenCalledWith(block.transactions[1]);
 
             expect(transactionPool.readdTransactionsFromMempool).toBeCalledTimes(1);
+            expect(transactionPool.cleanUp).toBeCalledTimes(1);
         });
 
         it("should clear forkedBlock if incoming block has same height", async () => {

--- a/packages/core-blockchain/__tests__/processor/handlers/accept-block-handler.test.ts
+++ b/packages/core-blockchain/__tests__/processor/handlers/accept-block-handler.test.ts
@@ -20,8 +20,6 @@ describe("AcceptBlockHandler", () => {
     };
     const transactionPool = {
         removeForgedTransaction: jest.fn(),
-        readdTransactionsFromMempool: jest.fn(),
-        cleanUp: jest.fn(),
     };
     const databaseInteractions = {
         walletRepository: {
@@ -76,9 +74,6 @@ describe("AcceptBlockHandler", () => {
             expect(transactionPool.removeForgedTransaction).toBeCalledTimes(2);
             expect(transactionPool.removeForgedTransaction).toHaveBeenCalledWith(block.transactions[0]);
             expect(transactionPool.removeForgedTransaction).toHaveBeenCalledWith(block.transactions[1]);
-
-            expect(transactionPool.readdTransactionsFromMempool).toBeCalledTimes(1);
-            expect(transactionPool.cleanUp).toBeCalledTimes(1);
         });
 
         it("should clear forkedBlock if incoming block has same height", async () => {

--- a/packages/core-blockchain/__tests__/processor/handlers/accept-block-handler.test.ts
+++ b/packages/core-blockchain/__tests__/processor/handlers/accept-block-handler.test.ts
@@ -18,7 +18,10 @@ describe("AcceptBlockHandler", () => {
         setForkedBlock: jest.fn(),
         clearForkedBlock: jest.fn(),
     };
-    const transactionPool = { removeForgedTransaction: jest.fn() };
+    const transactionPool = {
+        removeForgedTransaction: jest.fn(),
+        readdTransactionsFromMempool: jest.fn(),
+    };
     const databaseInteractions = {
         walletRepository: {
             getNonce: jest.fn(),
@@ -72,6 +75,8 @@ describe("AcceptBlockHandler", () => {
             expect(transactionPool.removeForgedTransaction).toBeCalledTimes(2);
             expect(transactionPool.removeForgedTransaction).toHaveBeenCalledWith(block.transactions[0]);
             expect(transactionPool.removeForgedTransaction).toHaveBeenCalledWith(block.transactions[1]);
+
+            expect(transactionPool.readdTransactionsFromMempool).toBeCalledTimes(1);
         });
 
         it("should clear forkedBlock if incoming block has same height", async () => {

--- a/packages/core-blockchain/__tests__/state-machine/actions/initialize.test.ts
+++ b/packages/core-blockchain/__tests__/state-machine/actions/initialize.test.ts
@@ -13,7 +13,7 @@ describe("Initialize", () => {
         getNetworkStart: jest.fn().mockReturnValue(false),
         getRestoredDatabaseIntegrity: jest.fn().mockReturnValue(false),
     };
-    const transactionPool = { readdTransactions: jest.fn() };
+    const transactionPool = { readdTransactionsFromStore: jest.fn() };
     const databaseService = {
         verifyBlockchain: jest.fn(),
         deleteRound: jest.fn(),
@@ -74,7 +74,7 @@ describe("Initialize", () => {
 
                 expect(databaseService.deleteRound).toHaveBeenCalledTimes(1);
                 expect(databaseInteractions.restoreCurrentRound).toHaveBeenCalledTimes(1);
-                expect(transactionPool.readdTransactions).toHaveBeenCalledTimes(1);
+                expect(transactionPool.readdTransactionsFromStore).toHaveBeenCalledTimes(1);
                 expect(peerNetworkMonitor.boot).toHaveBeenCalledTimes(1);
                 expect(stateBuilder.run).toHaveBeenCalledTimes(1);
                 expect(blockchain.dispatch).toHaveBeenCalledTimes(1);
@@ -197,7 +197,7 @@ describe("Initialize", () => {
 
                 expect(databaseService.deleteRound).toHaveBeenCalledTimes(1);
                 expect(databaseInteractions.restoreCurrentRound).toHaveBeenCalledTimes(1);
-                expect(transactionPool.readdTransactions).toHaveBeenCalledTimes(0);
+                expect(transactionPool.readdTransactionsFromStore).toHaveBeenCalledTimes(0);
                 expect(peerNetworkMonitor.boot).toHaveBeenCalledTimes(1);
                 expect(stateBuilder.run).toHaveBeenCalledTimes(1);
                 expect(blockchain.dispatch).toHaveBeenCalledTimes(1);

--- a/packages/core-blockchain/src/blockchain.ts
+++ b/packages/core-blockchain/src/blockchain.ts
@@ -362,7 +362,7 @@ export class Blockchain implements Contracts.Blockchain.Blockchain {
             await this.blockRepository.deleteBlocks(removedBlocks.reverse());
             this.stateStore.setLastStoredBlockHeight(lastBlock.data.height - nblocks);
 
-            await this.transactionPool.readdTransactions(removedTransactions.reverse());
+            await this.transactionPool.readdTransactionsFromStore(removedTransactions.reverse());
 
             // Validate last block
             const lastStoredBlock = await this.database.getLastBlock();

--- a/packages/core-blockchain/src/process-blocks-job.ts
+++ b/packages/core-blockchain/src/process-blocks-job.ts
@@ -27,6 +27,9 @@ export class ProcessBlocksJob implements Contracts.Kernel.QueueJob {
     @Container.inject(Container.Identifiers.DatabaseInteraction)
     private readonly databaseInteraction!: DatabaseInteraction;
 
+    @Container.inject(Container.Identifiers.TransactionPoolService)
+    private readonly transactionPool!: Contracts.TransactionPool.Service;
+
     @Container.inject(Container.Identifiers.PeerNetworkMonitor)
     private readonly networkMonitor!: Contracts.P2P.NetworkMonitor;
 
@@ -154,6 +157,9 @@ export class ProcessBlocksJob implements Contracts.Kernel.QueueJob {
 
                 return;
             }
+
+            await this.transactionPool.readdTransactionsFromMempool();
+            await this.transactionPool.cleanUp();
         }
 
         if (

--- a/packages/core-blockchain/src/processor/handlers/accept-block-handler.ts
+++ b/packages/core-blockchain/src/processor/handlers/accept-block-handler.ts
@@ -41,6 +41,8 @@ export class AcceptBlockHandler implements BlockHandler {
                 await this.transactionPool.removeForgedTransaction(transaction);
             }
 
+            await this.transactionPool.readdTransactionsFromMempool();
+
             // Reset wake-up timer after chaining a block, since there's no need to
             // wake up at all if blocks arrive periodically. Only wake up when there are
             // no new blocks.

--- a/packages/core-blockchain/src/processor/handlers/accept-block-handler.ts
+++ b/packages/core-blockchain/src/processor/handlers/accept-block-handler.ts
@@ -42,6 +42,7 @@ export class AcceptBlockHandler implements BlockHandler {
             }
 
             await this.transactionPool.readdTransactionsFromMempool();
+            await this.transactionPool.cleanUp();
 
             // Reset wake-up timer after chaining a block, since there's no need to
             // wake up at all if blocks arrive periodically. Only wake up when there are

--- a/packages/core-blockchain/src/processor/handlers/accept-block-handler.ts
+++ b/packages/core-blockchain/src/processor/handlers/accept-block-handler.ts
@@ -41,9 +41,6 @@ export class AcceptBlockHandler implements BlockHandler {
                 await this.transactionPool.removeForgedTransaction(transaction);
             }
 
-            await this.transactionPool.readdTransactionsFromMempool();
-            await this.transactionPool.cleanUp();
-
             // Reset wake-up timer after chaining a block, since there's no need to
             // wake up at all if blocks arrive periodically. Only wake up when there are
             // no new blocks.

--- a/packages/core-blockchain/src/state-machine/actions/initialize.ts
+++ b/packages/core-blockchain/src/state-machine/actions/initialize.ts
@@ -68,7 +68,7 @@ export class Initialize implements Action {
             if (this.stateStore.getNetworkStart()) {
                 await this.app.get<Contracts.State.StateBuilder>(Container.Identifiers.StateBuilder).run();
                 await this.databaseInteraction.restoreCurrentRound();
-                await this.transactionPool.readdTransactions();
+                await this.transactionPool.readdTransactionsFromStore();
                 await this.networkMonitor.boot();
 
                 return this.blockchain.dispatch("STARTED");
@@ -94,7 +94,7 @@ export class Initialize implements Action {
             await this.app.get<Contracts.State.StateBuilder>(Container.Identifiers.StateBuilder).run();
 
             await this.databaseInteraction.restoreCurrentRound();
-            await this.transactionPool.readdTransactions();
+            await this.transactionPool.readdTransactionsFromStore();
 
             await this.networkMonitor.boot();
 

--- a/packages/core-kernel/src/contracts/transaction-pool/service.ts
+++ b/packages/core-kernel/src/contracts/transaction-pool/service.ts
@@ -4,7 +4,8 @@ export interface Service {
     getPoolSize(): number;
 
     addTransaction(transaction: Interfaces.ITransaction): Promise<void>;
-    readdTransactions(previouslyForgedTransactions?: Interfaces.ITransaction[]): Promise<void>;
+    readdTransactionsFromStore(previouslyForgedTransactions?: Interfaces.ITransaction[]): Promise<void>;
+    readdTransactionsFromMempool(): Promise<void>;
     removeTransaction(transaction: Interfaces.ITransaction): Promise<void>;
     removeForgedTransaction(transaction: Interfaces.ITransaction): Promise<void>;
     cleanUp(): Promise<void>;

--- a/packages/core-transaction-pool/__tests__/service.test.ts
+++ b/packages/core-transaction-pool/__tests__/service.test.ts
@@ -126,20 +126,20 @@ describe("Service.dispose", () => {
 describe("Service.handle", () => {
     it("should re-add transactions after state builder had finished", async () => {
         const service = container.resolve(Service);
-        jest.spyOn(service, "readdTransactions").mockImplementation(() => Promise.resolve());
+        jest.spyOn(service, "readdTransactionsFromStore").mockImplementation(() => Promise.resolve());
 
         await service.handle({ name: Enums.StateEvent.BuilderFinished });
 
-        expect(service.readdTransactions).toBeCalled();
+        expect(service.readdTransactionsFromStore).toBeCalled();
     });
 
     it("should re-add transactions after milestone had changed", async () => {
         const service = container.resolve(Service);
-        jest.spyOn(service, "readdTransactions").mockImplementation(() => Promise.resolve());
+        jest.spyOn(service, "readdTransactionsFromStore").mockImplementation(() => Promise.resolve());
 
         await service.handle({ name: Enums.CryptoEvent.MilestoneChanged });
 
-        expect(service.readdTransactions).toBeCalled();
+        expect(service.readdTransactionsFromStore).toBeCalled();
     });
 
     it("should cleanup transactions after block is applied", async () => {
@@ -410,12 +410,12 @@ describe("Service.removeForgedTransaction", () => {
     });
 });
 
-describe("Service.readdTransactions", () => {
+describe("Service.readdTransactionsFromStore", () => {
     it("should flush mempool", async () => {
         storage.getAllTransactions.mockReturnValueOnce([]);
 
         const service = container.resolve(Service);
-        await service.readdTransactions();
+        await service.readdTransactionsFromStore();
 
         expect(mempool.flush).toBeCalled();
     });
@@ -437,7 +437,7 @@ describe("Service.readdTransactions", () => {
         ]);
 
         const service = container.resolve(Service);
-        await service.readdTransactions();
+        await service.readdTransactionsFromStore();
 
         expect(mempool.addTransaction).toBeCalledTimes(3);
         expect(mempool.addTransaction).toBeCalledWith(transaction1);
@@ -463,7 +463,7 @@ describe("Service.readdTransactions", () => {
         mempool.addTransaction.mockRejectedValueOnce(new Error("Something wrong"));
 
         const service = container.resolve(Service);
-        await service.readdTransactions();
+        await service.readdTransactionsFromStore();
 
         expect(mempool.addTransaction).toBeCalledTimes(1);
         expect(mempool.addTransaction).toBeCalledWith(transaction1);
@@ -491,7 +491,7 @@ describe("Service.readdTransactions", () => {
         mempool.addTransaction.mockRejectedValueOnce(new Error("Something wrong"));
 
         const service = container.resolve(Service);
-        await service.readdTransactions();
+        await service.readdTransactionsFromStore();
 
         expect(mempool.addTransaction).toBeCalledTimes(2);
         expect(mempool.addTransaction).toBeCalledWith(transaction1);
@@ -517,7 +517,7 @@ describe("Service.readdTransactions", () => {
         ]);
 
         const service = container.resolve(Service);
-        await service.readdTransactions([transaction1, transaction2]);
+        await service.readdTransactionsFromStore([transaction1, transaction2]);
 
         expect(mempool.addTransaction).toBeCalledTimes(3);
         expect(mempool.addTransaction).toBeCalledWith(transaction1);
@@ -557,7 +557,7 @@ describe("Service.readdTransactions", () => {
         mempool.addTransaction.mockRejectedValueOnce(new Error("Something wrong"));
 
         const service = container.resolve(Service);
-        await service.readdTransactions([transaction1, transaction2]);
+        await service.readdTransactionsFromStore([transaction1, transaction2]);
 
         expect(mempool.addTransaction).toBeCalledTimes(3);
         expect(mempool.addTransaction).toBeCalledWith(transaction1);
@@ -592,7 +592,7 @@ describe("Service.readdTransactions", () => {
         mempool.addTransaction.mockRejectedValueOnce(new Error("Something wrong"));
 
         const service = container.resolve(Service);
-        await service.readdTransactions([transaction1, transaction2]);
+        await service.readdTransactionsFromStore([transaction1, transaction2]);
 
         expect(mempool.addTransaction).toBeCalledTimes(3);
         expect(mempool.addTransaction).toBeCalledWith(transaction1);

--- a/packages/core-transaction-pool/__tests__/service.test.ts
+++ b/packages/core-transaction-pool/__tests__/service.test.ts
@@ -109,7 +109,6 @@ describe("Service.boot", () => {
 
         expect(events.listen).toBeCalledWith(Enums.StateEvent.BuilderFinished, service);
         expect(events.listen).toBeCalledWith(Enums.CryptoEvent.MilestoneChanged, service);
-        expect(events.listen).toBeCalledWith(Enums.BlockEvent.Applied, service);
     });
 });
 
@@ -120,7 +119,6 @@ describe("Service.dispose", () => {
 
         expect(events.forget).toBeCalledWith(Enums.StateEvent.BuilderFinished, service);
         expect(events.forget).toBeCalledWith(Enums.CryptoEvent.MilestoneChanged, service);
-        expect(events.forget).toBeCalledWith(Enums.BlockEvent.Applied, service);
     });
 });
 
@@ -141,15 +139,6 @@ describe("Service.handle", () => {
         await service.handle({ name: Enums.CryptoEvent.MilestoneChanged });
 
         expect(service.readdTransactionsFromStore).toBeCalled();
-    });
-
-    it("should cleanup transactions after block is applied", async () => {
-        const service = container.resolve(Service);
-        jest.spyOn(service, "cleanUp").mockImplementation(() => Promise.resolve());
-
-        await service.handle({ name: Enums.BlockEvent.Applied });
-
-        expect(service.cleanUp).toBeCalled();
     });
 });
 

--- a/packages/core-transaction-pool/__tests__/service.test.ts
+++ b/packages/core-transaction-pool/__tests__/service.test.ts
@@ -685,6 +685,9 @@ describe("Service.readdTransactionsFromMempool", () => {
 
         expect(storage.removeTransaction).toBeCalledTimes(1);
         expect(storage.removeTransaction).toBeCalledWith(transaction1.id);
+
+        expect(events.dispatch).toHaveBeenCalledTimes(1);
+        expect(events.dispatch).toHaveBeenCalledWith(Enums.TransactionEvent.RemovedFromPool, transaction1.data);
     });
 
     it("should remove all transactions from storage that cannot be added to mempool", async () => {
@@ -721,6 +724,9 @@ describe("Service.readdTransactionsFromMempool", () => {
         expect(storage.removeTransaction).toBeCalledTimes(2);
         expect(storage.removeTransaction).toBeCalledWith(transaction1.id);
         expect(storage.removeTransaction).toBeCalledWith(transaction2.id);
+
+        expect(events.dispatch).toHaveBeenCalledTimes(2);
+        expect(events.dispatch).toHaveBeenCalledWith(Enums.TransactionEvent.RemovedFromPool, expect.anything());
     });
 
     it("should remove expired transaction from storage", async () => {
@@ -750,6 +756,9 @@ describe("Service.readdTransactionsFromMempool", () => {
 
         expect(storage.removeTransaction).toBeCalledTimes(1);
         expect(storage.removeTransaction).toBeCalledWith(transaction1.id);
+
+        expect(events.dispatch).toHaveBeenCalledTimes(1);
+        expect(events.dispatch).toHaveBeenCalledWith(Enums.TransactionEvent.Expired, transaction1.data);
     });
 });
 

--- a/packages/core-transaction-pool/src/service.ts
+++ b/packages/core-transaction-pool/src/service.ts
@@ -40,7 +40,6 @@ export class Service implements Contracts.TransactionPool.Service {
     public async boot(): Promise<void> {
         this.events.listen(Enums.StateEvent.BuilderFinished, this);
         this.events.listen(Enums.CryptoEvent.MilestoneChanged, this);
-        this.events.listen(Enums.BlockEvent.Applied, this);
 
         if (process.env.CORE_RESET_DATABASE || process.env.CORE_RESET_POOL) {
             await this.flush();
@@ -50,7 +49,6 @@ export class Service implements Contracts.TransactionPool.Service {
     public dispose(): void {
         this.events.forget(Enums.CryptoEvent.MilestoneChanged, this);
         this.events.forget(Enums.StateEvent.BuilderFinished, this);
-        this.events.forget(Enums.BlockEvent.Applied, this);
 
         this.disposed = true;
     }
@@ -63,9 +61,6 @@ export class Service implements Contracts.TransactionPool.Service {
                     break;
                 case Enums.CryptoEvent.MilestoneChanged:
                     await this.readdTransactionsFromStore();
-                    break;
-                case Enums.BlockEvent.Applied:
-                    await this.cleanUp();
                     break;
             }
         } catch (error) {


### PR DESCRIPTION
## Summary

Implements new readdTransactionsFromMempool method on transaction pool Service. Previous readdTransaction is renamed to readdTransactionsFromStore. Re-adding transactions from mempool is way faster than from store, because transaction is already deserialized. 

Transactions are re-added from mempool on evey block chunk processed. Than means transactions are re-added on every block, when node is synced and on every chunk when downloading blocks. 

Mempool cleanup is called after re-add. Block.Applied event listener is replaced with direct call. 

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged
