### PR TITLE
chore: enable `declarationMap` typescript option

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
         "assumeChangesOnlyAffectDirectDependencies": true,
         "baseUrl": "./",
         "declaration": true,
+        "declarationMap": true,
         "emitDecoratorMetadata": true,
         "esModuleInterop": true,
         "experimentalDecorators": true,


### PR DESCRIPTION
## Summary

Enable [declarationMap](https://www.typescriptlang.org/tsconfig#declarationMap) for TS.

_Generates a source map for .d.ts files which map back to the original .ts source file. This will allow editors such as VS Code to go to the original .ts file when using features like Go to Definition._

## Checklist

- [x] Ready to be merged

