### PR TITLE
fix(core-blockchain): apply block on transaction-pool after block broadcast

### DIFF
--- a/packages/core-blockchain/__tests__/process-blocks-job.test.ts
+++ b/packages/core-blockchain/__tests__/process-blocks-job.test.ts
@@ -18,6 +18,7 @@ describe("Blockchain", () => {
     const blockProcessor: any = {};
     const transactionPool: any = {
         applyBlock: jest.fn(),
+        cleanUp: jest.fn(),
     };
     const stateStore: any = {};
     const databaseService: any = {};
@@ -97,6 +98,7 @@ describe("Blockchain", () => {
             expect(stateStore.setLastStoredBlockHeight).toHaveBeenCalledTimes(1);
             expect(stateStore.setLastStoredBlockHeight).toHaveBeenCalledWith(currentBlock.height);
             expect(transactionPool.applyBlock).toHaveBeenCalledTimes(1);
+            expect(transactionPool.cleanUp).toHaveBeenCalledTimes(1);
         });
 
         it("should process a valid block already known", async () => {
@@ -110,6 +112,7 @@ describe("Blockchain", () => {
             expect(blockchainService.clearQueue).toBeCalledTimes(1);
             expect(blockchainService.resetLastDownloadedBlock).toBeCalledTimes(1);
             expect(transactionPool.applyBlock).not.toBeCalled();
+            expect(transactionPool.cleanUp).not.toBeCalled();
         });
 
         it("should not process the remaining blocks if one is not accepted (BlockProcessorResult.Rollback)", async () => {
@@ -124,6 +127,7 @@ describe("Blockchain", () => {
             expect(blockProcessor.process).toBeCalledTimes(1); // only 1 out of the 2 blocks
             expect(blockchainService.forkBlock).toBeCalledTimes(1); // because Rollback
             expect(transactionPool.applyBlock).not.toBeCalled();
+            expect(transactionPool.cleanUp).not.toBeCalled();
         });
 
         it("should not process the remaining blocks if one is not accepted (BlockProcessorResult.Rejected)", async () => {
@@ -144,6 +148,7 @@ describe("Blockchain", () => {
             expect(blockchainService.clearQueue).toBeCalledTimes(1);
             expect(blockchainService.resetLastDownloadedBlock).toBeCalledTimes(1);
             expect(transactionPool.applyBlock).not.toBeCalled();
+            expect(transactionPool.cleanUp).not.toBeCalled();
         });
 
         it("should not process the remaining blocks if second is not accepted (BlockProcessorResult.Rejected)", async () => {
@@ -177,6 +182,7 @@ describe("Blockchain", () => {
             expect(stateStore.setLastStoredBlockHeight).toBeCalledTimes(1);
             expect(stateStore.setLastStoredBlockHeight).toHaveBeenCalledWith(lastBlock.height);
             expect(transactionPool.applyBlock).toBeCalledTimes(1);
+            expect(transactionPool.cleanUp).toBeCalledTimes(1);
         });
 
         it("should not process the remaining blocks if one is not accepted (BlockProcessorResult.Corrupted)", async () => {
@@ -200,6 +206,7 @@ describe("Blockchain", () => {
             expect(blockchainService.clearQueue).not.toBeCalled();
             expect(blockchainService.resetLastDownloadedBlock).not.toBeCalled();
             expect(transactionPool.applyBlock).not.toBeCalled();
+            expect(transactionPool.cleanUp).not.toBeCalled();
 
             expect(process.exit).toHaveBeenCalled();
         });
@@ -229,6 +236,7 @@ describe("Blockchain", () => {
             expect(databaseInteraction.restoreCurrentRound).toBeCalledTimes(1);
             expect(stateStore.setLastStoredBlockHeight).not.toBeCalled();
             expect(transactionPool.applyBlock).not.toBeCalled();
+            expect(transactionPool.cleanUp).not.toBeCalled();
         });
 
         it("should stop app when revertBlockHandler return Corrupted", async () => {
@@ -259,6 +267,7 @@ describe("Blockchain", () => {
             expect(databaseInteraction.restoreCurrentRound).toBeCalledTimes(1);
             expect(stateStore.setLastStoredBlockHeight).not.toHaveBeenCalled();
             expect(transactionPool.applyBlock).not.toBeCalled();
+            expect(transactionPool.cleanUp).not.toBeCalled();
 
             expect(process.exit).toHaveBeenCalled();
         });
@@ -305,6 +314,7 @@ describe("Blockchain", () => {
 
             expect(peerNetworkMonitor.broadcastBlock).toBeCalledTimes(1);
             expect(transactionPool.applyBlock).toBeCalledTimes(1);
+            expect(transactionPool.cleanUp).toBeCalledTimes(1);
         });
 
         it("should skip broadcasting if state is downloadFinished", async () => {
@@ -347,6 +357,7 @@ describe("Blockchain", () => {
             expect(stateStore.setLastStoredBlockHeight).toBeCalledTimes(1);
             expect(stateStore.setLastStoredBlockHeight).toBeCalledWith(block.height);
             expect(transactionPool.applyBlock).toBeCalledTimes(1);
+            expect(transactionPool.cleanUp).toBeCalledTimes(1);
 
             expect(peerNetworkMonitor.broadcastBlock).toBeCalledTimes(0);
         });

--- a/packages/core-blockchain/__tests__/process-blocks-job.test.ts
+++ b/packages/core-blockchain/__tests__/process-blocks-job.test.ts
@@ -16,6 +16,9 @@ describe("Blockchain", () => {
         getState: jest.fn(),
     };
     const blockProcessor: any = {};
+    const transactionPool: any = {
+        applyBlock: jest.fn(),
+    };
     const stateStore: any = {};
     const databaseService: any = {};
     const databaseBlockRepository: any = {};
@@ -40,6 +43,7 @@ describe("Blockchain", () => {
         sandbox.app.bind(Container.Identifiers.DatabaseInteraction).toConstantValue(databaseInteraction);
         sandbox.app.bind(Container.Identifiers.PeerNetworkMonitor).toConstantValue(peerNetworkMonitor);
         sandbox.app.bind(Container.Identifiers.LogService).toConstantValue(logService);
+        sandbox.app.bind(Container.Identifiers.TransactionPoolService).toConstantValue(transactionPool);
 
         sandbox.app.bind(Container.Identifiers.TriggerService).to(Services.Triggers.Triggers).inSingletonScope();
         sandbox.app
@@ -92,6 +96,7 @@ describe("Blockchain", () => {
             expect(databaseBlockRepository.saveBlocks).toHaveBeenCalledTimes(1);
             expect(stateStore.setLastStoredBlockHeight).toHaveBeenCalledTimes(1);
             expect(stateStore.setLastStoredBlockHeight).toHaveBeenCalledWith(currentBlock.height);
+            expect(transactionPool.applyBlock).toHaveBeenCalledTimes(1);
         });
 
         it("should process a valid block already known", async () => {
@@ -104,6 +109,7 @@ describe("Blockchain", () => {
 
             expect(blockchainService.clearQueue).toBeCalledTimes(1);
             expect(blockchainService.resetLastDownloadedBlock).toBeCalledTimes(1);
+            expect(transactionPool.applyBlock).not.toBeCalled();
         });
 
         it("should not process the remaining blocks if one is not accepted (BlockProcessorResult.Rollback)", async () => {
@@ -117,6 +123,7 @@ describe("Blockchain", () => {
 
             expect(blockProcessor.process).toBeCalledTimes(1); // only 1 out of the 2 blocks
             expect(blockchainService.forkBlock).toBeCalledTimes(1); // because Rollback
+            expect(transactionPool.applyBlock).not.toBeCalled();
         });
 
         it("should not process the remaining blocks if one is not accepted (BlockProcessorResult.Rejected)", async () => {
@@ -136,6 +143,7 @@ describe("Blockchain", () => {
             expect(blockProcessor.process).toBeCalledTimes(1);
             expect(blockchainService.clearQueue).toBeCalledTimes(1);
             expect(blockchainService.resetLastDownloadedBlock).toBeCalledTimes(1);
+            expect(transactionPool.applyBlock).not.toBeCalled();
         });
 
         it("should not process the remaining blocks if second is not accepted (BlockProcessorResult.Rejected)", async () => {
@@ -168,6 +176,7 @@ describe("Blockchain", () => {
             expect(blockchainService.resetLastDownloadedBlock).toBeCalledTimes(1);
             expect(stateStore.setLastStoredBlockHeight).toBeCalledTimes(1);
             expect(stateStore.setLastStoredBlockHeight).toHaveBeenCalledWith(lastBlock.height);
+            expect(transactionPool.applyBlock).toBeCalledTimes(1);
         });
 
         it("should not process the remaining blocks if one is not accepted (BlockProcessorResult.Corrupted)", async () => {
@@ -190,6 +199,7 @@ describe("Blockchain", () => {
             expect(blockProcessor.process).toBeCalledTimes(1);
             expect(blockchainService.clearQueue).not.toBeCalled();
             expect(blockchainService.resetLastDownloadedBlock).not.toBeCalled();
+            expect(transactionPool.applyBlock).not.toBeCalled();
 
             expect(process.exit).toHaveBeenCalled();
         });
@@ -218,6 +228,7 @@ describe("Blockchain", () => {
             expect(blockchainService.resetLastDownloadedBlock).toBeCalledTimes(1);
             expect(databaseInteraction.restoreCurrentRound).toBeCalledTimes(1);
             expect(stateStore.setLastStoredBlockHeight).not.toBeCalled();
+            expect(transactionPool.applyBlock).not.toBeCalled();
         });
 
         it("should stop app when revertBlockHandler return Corrupted", async () => {
@@ -247,6 +258,7 @@ describe("Blockchain", () => {
             expect(blockchainService.resetLastDownloadedBlock).toBeCalledTimes(1);
             expect(databaseInteraction.restoreCurrentRound).toBeCalledTimes(1);
             expect(stateStore.setLastStoredBlockHeight).not.toHaveBeenCalled();
+            expect(transactionPool.applyBlock).not.toBeCalled();
 
             expect(process.exit).toHaveBeenCalled();
         });
@@ -292,6 +304,7 @@ describe("Blockchain", () => {
             expect(stateStore.setLastStoredBlockHeight).toBeCalledWith(block.height);
 
             expect(peerNetworkMonitor.broadcastBlock).toBeCalledTimes(1);
+            expect(transactionPool.applyBlock).toBeCalledTimes(1);
         });
 
         it("should skip broadcasting if state is downloadFinished", async () => {
@@ -333,6 +346,7 @@ describe("Blockchain", () => {
             expect(databaseBlockRepository.saveBlocks).toBeCalledTimes(1);
             expect(stateStore.setLastStoredBlockHeight).toBeCalledTimes(1);
             expect(stateStore.setLastStoredBlockHeight).toBeCalledWith(block.height);
+            expect(transactionPool.applyBlock).toBeCalledTimes(1);
 
             expect(peerNetworkMonitor.broadcastBlock).toBeCalledTimes(0);
         });

--- a/packages/core-blockchain/__tests__/processor/handlers/accept-block-handler.test.ts
+++ b/packages/core-blockchain/__tests__/processor/handlers/accept-block-handler.test.ts
@@ -18,7 +18,6 @@ describe("AcceptBlockHandler", () => {
         setForkedBlock: jest.fn(),
         clearForkedBlock: jest.fn(),
     };
-    const transactionPool = { applyBlock: jest.fn() };
     const databaseInteractions = {
         walletRepository: {
             getNonce: jest.fn(),
@@ -43,7 +42,6 @@ describe("AcceptBlockHandler", () => {
         container.bind(Container.Identifiers.BlockchainService).toConstantValue(blockchain);
         container.bind(Container.Identifiers.StateStore).toConstantValue(state);
         container.bind(Container.Identifiers.DatabaseInteraction).toConstantValue(databaseInteractions);
-        container.bind(Container.Identifiers.TransactionPoolService).toConstantValue(transactionPool);
     });
 
     beforeEach(() => {
@@ -68,8 +66,6 @@ describe("AcceptBlockHandler", () => {
             expect(databaseInteractions.applyBlock).toHaveBeenCalledWith(block);
 
             expect(blockchain.resetWakeUp).toBeCalledTimes(1);
-
-            expect(transactionPool.applyBlock).toBeCalledTimes(1);
         });
 
         it("should clear forkedBlock if incoming block has same height", async () => {

--- a/packages/core-blockchain/__tests__/processor/handlers/revert-block-handler.test.ts
+++ b/packages/core-blockchain/__tests__/processor/handlers/revert-block-handler.test.ts
@@ -11,7 +11,6 @@ describe("AcceptBlockHandler", () => {
         getLastBlocks: jest.fn(),
         setLastBlock: jest.fn(),
     };
-    const transactionPool = { addTransaction: jest.fn() };
     const databaseInteractions = {
         revertBlock: jest.fn(),
     };
@@ -25,7 +24,6 @@ describe("AcceptBlockHandler", () => {
         container.bind(Container.Identifiers.StateStore).toConstantValue(state);
         container.bind(Container.Identifiers.DatabaseInteraction).toConstantValue(databaseInteractions);
         container.bind(Container.Identifiers.DatabaseService).toConstantValue(databaseService);
-        container.bind(Container.Identifiers.TransactionPoolService).toConstantValue(transactionPool);
     });
 
     beforeEach(() => {
@@ -59,10 +57,6 @@ describe("AcceptBlockHandler", () => {
             expect(databaseInteractions.revertBlock).toBeCalledTimes(1);
             expect(databaseInteractions.revertBlock).toHaveBeenCalledWith(block);
 
-            expect(transactionPool.addTransaction).toBeCalledTimes(2);
-            expect(transactionPool.addTransaction).toHaveBeenCalledWith(block.transactions[0]);
-            expect(transactionPool.addTransaction).toHaveBeenCalledWith(block.transactions[1]);
-
             expect(databaseService.getLastBlock).not.toHaveBeenCalled();
             expect(state.setLastBlock).toHaveBeenCalledWith(previousBlock);
         });
@@ -79,10 +73,6 @@ describe("AcceptBlockHandler", () => {
 
             expect(databaseInteractions.revertBlock).toBeCalledTimes(1);
             expect(databaseInteractions.revertBlock).toHaveBeenCalledWith(block);
-
-            expect(transactionPool.addTransaction).toBeCalledTimes(2);
-            expect(transactionPool.addTransaction).toHaveBeenCalledWith(block.transactions[0]);
-            expect(transactionPool.addTransaction).toHaveBeenCalledWith(block.transactions[1]);
 
             expect(databaseService.getLastBlock).toHaveBeenCalledTimes(1);
             expect(state.setLastBlock).toHaveBeenCalledWith(previousBlock);
@@ -113,10 +103,6 @@ describe("AcceptBlockHandler", () => {
 
             expect(databaseInteractions.revertBlock).toBeCalledTimes(1);
             expect(databaseInteractions.revertBlock).toHaveBeenCalledWith(block);
-
-            expect(transactionPool.addTransaction).toBeCalledTimes(2);
-            expect(transactionPool.addTransaction).toHaveBeenCalledWith(block.transactions[0]);
-            expect(transactionPool.addTransaction).toHaveBeenCalledWith(block.transactions[1]);
 
             expect(databaseService.getLastBlock).toHaveBeenCalledTimes(1);
             expect(state.setLastBlock).not.toHaveBeenCalled();

--- a/packages/core-blockchain/src/process-blocks-job.ts
+++ b/packages/core-blockchain/src/process-blocks-job.ts
@@ -177,6 +177,9 @@ export class ProcessBlocksJob implements Contracts.Kernel.QueueJob {
         for (const block of acceptedBlocks) {
             await this.transactionPool.applyBlock(block);
         }
+        if (acceptedBlocks.length) {
+            await this.transactionPool.cleanUp();
+        }
 
         return;
     }

--- a/packages/core-blockchain/src/process-blocks-job.ts
+++ b/packages/core-blockchain/src/process-blocks-job.ts
@@ -30,6 +30,9 @@ export class ProcessBlocksJob implements Contracts.Kernel.QueueJob {
     @Container.inject(Container.Identifiers.PeerNetworkMonitor)
     private readonly networkMonitor!: Contracts.P2P.NetworkMonitor;
 
+    @Container.inject(Container.Identifiers.TransactionPoolService)
+    private readonly transactionPool!: Contracts.TransactionPool.Service;
+
     @Container.inject(Container.Identifiers.TriggerService)
     private readonly triggers!: Services.Triggers.Triggers;
 
@@ -169,6 +172,10 @@ export class ProcessBlocksJob implements Contracts.Kernel.QueueJob {
         } else {
             this.blockchain.clearQueue();
             this.blockchain.resetLastDownloadedBlock();
+        }
+
+        for (const block of acceptedBlocks) {
+            await this.transactionPool.applyBlock(block);
         }
 
         return;

--- a/packages/core-blockchain/src/processor/handlers/accept-block-handler.ts
+++ b/packages/core-blockchain/src/processor/handlers/accept-block-handler.ts
@@ -23,9 +23,6 @@ export class AcceptBlockHandler implements BlockHandler {
     @Container.inject(Container.Identifiers.DatabaseInteraction)
     private readonly databaseInteraction!: DatabaseInteraction;
 
-    @Container.inject(Container.Identifiers.TransactionPoolService)
-    private readonly transactionPool!: Contracts.TransactionPool.Service;
-
     public async execute(block: Interfaces.IBlock): Promise<BlockProcessorResult> {
         try {
             await this.databaseInteraction.applyBlock(block);
@@ -50,8 +47,6 @@ export class AcceptBlockHandler implements BlockHandler {
             if (lastDownloadedBock && lastDownloadedBock.height < block.data.height) {
                 this.state.setLastDownloadedBlock(block.data);
             }
-
-            await this.transactionPool.applyBlock(block);
 
             return BlockProcessorResult.Accepted;
         } catch (error) {

--- a/packages/core-blockchain/src/processor/handlers/revert-block-handler.ts
+++ b/packages/core-blockchain/src/processor/handlers/revert-block-handler.ts
@@ -20,17 +20,9 @@ export class RevertBlockHandler implements BlockHandler {
     @Container.inject(Container.Identifiers.DatabaseService)
     private readonly database!: DatabaseService;
 
-    @Container.inject(Container.Identifiers.TransactionPoolService)
-    private readonly transactionPool!: Contracts.TransactionPool.Service;
-
     public async execute(block: Interfaces.IBlock): Promise<BlockProcessorResult> {
         try {
             await this.databaseInteraction.revertBlock(block);
-
-            // TODO: Check if same situation applies to fork revert
-            for (const transaction of block.transactions) {
-                await this.transactionPool.addTransaction(transaction);
-            }
 
             // Remove last block, take from DB if list is empty
             let previousBlock: Interfaces.IBlock | undefined = this.state

--- a/packages/core-transaction-pool/__tests__/service.test.ts
+++ b/packages/core-transaction-pool/__tests__/service.test.ts
@@ -119,7 +119,6 @@ describe("Service.boot", () => {
         await service.boot();
 
         expect(events.listen).toBeCalledWith(Enums.CryptoEvent.MilestoneChanged, service);
-        expect(events.listen).toBeCalledWith(Enums.BlockEvent.Applied, service);
     });
 });
 
@@ -129,7 +128,6 @@ describe("Service.dispose", () => {
         service.dispose();
 
         expect(events.forget).toBeCalledWith(Enums.CryptoEvent.MilestoneChanged, service);
-        expect(events.forget).toBeCalledWith(Enums.BlockEvent.Applied, service);
     });
 });
 
@@ -141,15 +139,6 @@ describe("Service.handle", () => {
         await service.handle({ name: Enums.CryptoEvent.MilestoneChanged });
 
         expect(service.readdTransactions).toBeCalled();
-    });
-
-    it("should cleanup transactions after block is applied", async () => {
-        const service = container.resolve(Service);
-        jest.spyOn(service, "cleanUp").mockImplementation(() => Promise.resolve());
-
-        await service.handle({ name: Enums.BlockEvent.Applied });
-
-        expect(service.cleanUp).toBeCalled();
     });
 });
 

--- a/packages/core-transaction-pool/__tests__/service.test.ts
+++ b/packages/core-transaction-pool/__tests__/service.test.ts
@@ -118,7 +118,6 @@ describe("Service.boot", () => {
         const service = container.resolve(Service);
         await service.boot();
 
-        expect(events.listen).toBeCalledWith(Enums.StateEvent.BuilderFinished, service);
         expect(events.listen).toBeCalledWith(Enums.CryptoEvent.MilestoneChanged, service);
         expect(events.listen).toBeCalledWith(Enums.BlockEvent.Applied, service);
     });
@@ -129,22 +128,12 @@ describe("Service.dispose", () => {
         const service = container.resolve(Service);
         service.dispose();
 
-        expect(events.forget).toBeCalledWith(Enums.StateEvent.BuilderFinished, service);
         expect(events.forget).toBeCalledWith(Enums.CryptoEvent.MilestoneChanged, service);
         expect(events.forget).toBeCalledWith(Enums.BlockEvent.Applied, service);
     });
 });
 
 describe("Service.handle", () => {
-    it("should re-add transactions after state builder had finished", async () => {
-        const service = container.resolve(Service);
-        jest.spyOn(service, "readdTransactions").mockImplementation(() => Promise.resolve());
-
-        await service.handle({ name: Enums.StateEvent.BuilderFinished });
-
-        expect(service.readdTransactions).toBeCalled();
-    });
-
     it("should re-add transactions after milestone had changed", async () => {
         const service = container.resolve(Service);
         jest.spyOn(service, "readdTransactions").mockImplementation(() => Promise.resolve());

--- a/packages/core-transaction-pool/src/service.ts
+++ b/packages/core-transaction-pool/src/service.ts
@@ -235,7 +235,7 @@ export class Service implements Contracts.TransactionPool.Service {
     }
 
     public async applyBlock(block: Interfaces.IBlock): Promise<void> {
-        await this.lock.runNonExclusive(async () => {
+        await this.lock.runExclusive(async () => {
             const removedTransactions = await this.mempool.applyBlock(block);
 
             if (removedTransactions.length >= 1) {

--- a/packages/core-transaction-pool/src/service.ts
+++ b/packages/core-transaction-pool/src/service.ts
@@ -46,7 +46,6 @@ export class Service implements Contracts.TransactionPool.Service {
     private disposed = false;
 
     public async boot(): Promise<void> {
-        this.events.listen(Enums.StateEvent.BuilderFinished, this);
         this.events.listen(Enums.CryptoEvent.MilestoneChanged, this);
         this.events.listen(Enums.BlockEvent.Applied, this);
 
@@ -57,7 +56,6 @@ export class Service implements Contracts.TransactionPool.Service {
 
     public dispose(): void {
         this.events.forget(Enums.CryptoEvent.MilestoneChanged, this);
-        this.events.forget(Enums.StateEvent.BuilderFinished, this);
         this.events.forget(Enums.BlockEvent.Applied, this);
 
         this.disposed = true;
@@ -66,9 +64,6 @@ export class Service implements Contracts.TransactionPool.Service {
     public async handle({ name }): Promise<void> {
         try {
             switch (name) {
-                case Enums.StateEvent.BuilderFinished:
-                    await this.readdTransactions();
-                    break;
                 case Enums.CryptoEvent.MilestoneChanged:
                     await this.readdTransactions();
                     break;

--- a/packages/core-transaction-pool/src/service.ts
+++ b/packages/core-transaction-pool/src/service.ts
@@ -47,7 +47,6 @@ export class Service implements Contracts.TransactionPool.Service {
 
     public async boot(): Promise<void> {
         this.events.listen(Enums.CryptoEvent.MilestoneChanged, this);
-        this.events.listen(Enums.BlockEvent.Applied, this);
 
         if (process.env.CORE_RESET_DATABASE || process.env.CORE_RESET_POOL) {
             await this.flush();
@@ -56,21 +55,13 @@ export class Service implements Contracts.TransactionPool.Service {
 
     public dispose(): void {
         this.events.forget(Enums.CryptoEvent.MilestoneChanged, this);
-        this.events.forget(Enums.BlockEvent.Applied, this);
 
         this.disposed = true;
     }
 
     public async handle({ name }): Promise<void> {
         try {
-            switch (name) {
-                case Enums.CryptoEvent.MilestoneChanged:
-                    await this.readdTransactions();
-                    break;
-                case Enums.BlockEvent.Applied:
-                    await this.cleanUp();
-                    break;
-            }
+            await this.readdTransactions();
         } catch (error) {
             this.logger.critical(error.stack);
             throw error;


### PR DESCRIPTION
## Summary

Apply block on transaction-pool after block broadcast. 

Use direct transaction-pool service calls instead handler. 

applyBlock is run exclusively. 

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged


