### PR TITLE
fix(core-database): query optimizer workaround

### DIFF
--- a/packages/core-database/src/repositories/abstract-repository.ts
+++ b/packages/core-database/src/repositories/abstract-repository.ts
@@ -143,7 +143,7 @@ export abstract class AbstractRepository<TEntity extends ObjectLiteral> extends 
     private addOrderBy(queryBuilder: SelectQueryBuilder<TEntity>, sorting: Contracts.Search.Sorting): void {
         if (sorting.length) {
             const column = this.queryHelper.getColumnName(this.metadata, sorting[0].property);
-            queryBuilder.orderBy(column, sorting[0].direction === "desc" ? "DESC" : "ASC");
+            queryBuilder.orderBy(`${column}+0`, sorting[0].direction === "desc" ? "DESC" : "ASC");
 
             for (const item of sorting.slice(1)) {
                 const column = this.queryHelper.getColumnName(this.metadata, item.property);

--- a/packages/core-database/src/repositories/abstract-repository.ts
+++ b/packages/core-database/src/repositories/abstract-repository.ts
@@ -142,8 +142,14 @@ export abstract class AbstractRepository<TEntity extends ObjectLiteral> extends 
 
     private addOrderBy(queryBuilder: SelectQueryBuilder<TEntity>, sorting: Contracts.Search.Sorting): void {
         if (sorting.length) {
-            const column = this.queryHelper.getColumnName(this.metadata, sorting[0].property);
-            queryBuilder.orderBy(`${column}+0`, sorting[0].direction === "desc" ? "DESC" : "ASC");
+            let column = this.queryHelper.getColumnName(this.metadata, sorting[0].property);
+
+            // Forces PostgreSQL query optimizer to take faster route
+            if (this.metadata.name === "Transaction" && column === "timestamp") {
+                column = `${column}+0`;
+            }
+
+            queryBuilder.orderBy(column, sorting[0].direction === "desc" ? "DESC" : "ASC");
 
             for (const item of sorting.slice(1)) {
                 const column = this.queryHelper.getColumnName(this.metadata, item.property);


### PR DESCRIPTION
## Summary

Change order by on first column to force PostgreSQL query optimizer to take faster query procedure when transactions are ordered by timestamp:asc only and limit is less than 6. 

## Checklist

- [x] Ready to be merged
