### PR TITLE
feat(core-transaction-pool): calculate workers count from `cpus` and add `CORE_TRANSACTION_POOL_WORKERS` env variable

### DIFF
--- a/__tests__/unit/core-transaction-pool/service-provider.test.ts
+++ b/__tests__/unit/core-transaction-pool/service-provider.test.ts
@@ -234,6 +234,32 @@ describe("ServiceProvider", () => {
             });
         });
 
+        describe("process.env.CORE_TRANSACTION_POOL_WORKERS", () => {
+            it("should parse process.env.CORE_TRANSACTION_POOL_WORKERS", async () => {
+                process.env.CORE_TRANSACTION_POOL_WORKERS = "20";
+
+                jest.resetModules();
+                const result = (serviceProvider.configSchema() as AnySchema).validate(
+                    (await import("@packages/core-transaction-pool/src/defaults")).defaults,
+                );
+
+                expect(result.error).toBeUndefined();
+                expect(result.value.workerPool.workerCount).toEqual(20);
+            });
+
+            it("should throw if process.env.CORE_TRANSACTION_POOL_WORKERS is not number", async () => {
+                process.env.CORE_TRANSACTION_POOL_WORKERS = "false";
+
+                jest.resetModules();
+                const result = (serviceProvider.configSchema() as AnySchema).validate(
+                    (await import("@packages/core-transaction-pool/src/defaults")).defaults,
+                );
+
+                expect(result.error).toBeDefined();
+                expect(result.error!.message).toEqual('"workerPool.workerCount" must be a number');
+            });
+        });
+
         describe("schema restrictions", () => {
             let defaults;
 

--- a/packages/core-transaction-pool/src/defaults.ts
+++ b/packages/core-transaction-pool/src/defaults.ts
@@ -1,3 +1,5 @@
+import { cpus } from "os";
+
 export const defaults = {
     enabled: !process.env.CORE_TRANSACTION_POOL_DISABLED,
     storage: `${process.env.CORE_PATH_DATA}/transaction-pool.sqlite`,
@@ -33,7 +35,7 @@ export const defaults = {
         },
     },
     workerPool: {
-        workerCount: 3,
+        workerCount: process.env.CORE_TRANSACTION_POOL_WORKERS || Math.max(1, Math.floor(cpus().length / 2)),
         cryptoPackages: [{ typeGroup: 2, packageName: "@arkecosystem/core-magistrate-crypto" }],
     },
 };


### PR DESCRIPTION
## Summary

Calculate workers count from cpus(). 
Allow setting workers count via CORE_TRANSACTION_POOL_WORKERS env variable. 

Feature is based on: 
https://github.com/Solar-network/core/commit/2843746de33481c9c0f7adc3131fee100a00a782 by @alessiodf 


## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged

