### PR TITLE
feat: support burn address

### DIFF
--- a/__tests__/unit/core-api/controllers/blockchain.test.ts
+++ b/__tests__/unit/core-api/controllers/blockchain.test.ts
@@ -1,39 +1,44 @@
 import "jest-extended";
 
 import { BlockchainController } from "@packages/core-api/src/controllers/blockchain";
-import { Application } from "@packages/core-kernel";
-import { Mocks } from "@packages/core-test-framework";
+import { Container, Utils } from "@packages/core-kernel";
+
 import { Interfaces } from "@packages/crypto";
 
-import { initApp, ItemResponse } from "../__support__";
+import { ItemResponse } from "../__support__";
 
-let app: Application;
+const mockBlockData: Partial<Interfaces.IBlockData> = {
+    id: "1",
+    height: 1,
+};
+
+const burnWallet = {
+    getBalance: jest.fn().mockReturnValue(Utils.BigNumber.ZERO),
+};
+
+const walletRepo = {
+    getBurnWallet: jest.fn().mockReturnValue(burnWallet),
+};
+
+const stateStore = {
+    getLastBlock: jest.fn().mockReturnValue({ data: mockBlockData }),
+};
+
 let controller: BlockchainController;
 
 beforeEach(() => {
-    app = initApp();
+    const container = new Container.Container();
+    container.bind(Container.Identifiers.WalletRepository).toConstantValue(walletRepo);
+    container.bind(Container.Identifiers.StateStore).toConstantValue(stateStore);
+    container.bind(Container.Identifiers.Application).toConstantValue({});
+    container.bind(Container.Identifiers.PluginConfiguration).toConstantValue({});
 
-    controller = app.resolve<BlockchainController>(BlockchainController);
-});
-
-afterEach(() => {
-    Mocks.StateStore.setBlock(undefined);
+    controller = container.resolve<BlockchainController>(BlockchainController);
 });
 
 describe("BlockchainController", () => {
     describe("index", () => {
         it("should return last block from store", async () => {
-            const mockBlockData: Partial<Interfaces.IBlockData> = {
-                id: "1",
-                height: 1,
-            };
-
-            const mockBlock = {
-                data: mockBlockData,
-            };
-
-            Mocks.StateStore.setBlock(mockBlock as Partial<Interfaces.IBlock>);
-
             type BlockItemResponse = ItemResponse & {
                 data: {
                     block: {
@@ -41,12 +46,16 @@ describe("BlockchainController", () => {
                         height: number;
                     };
                     supply: string;
+                    generated: string;
+                    burned: string;
                 };
             };
 
             const response = (await controller.index()) as BlockItemResponse;
 
-            expect(response.data.supply).toBeDefined();
+            expect(response.data.supply).toBeString();
+            expect(response.data.generated).toBeString();
+            expect(response.data.burned).toBeString();
             expect(response.data.block).toEqual(mockBlockData);
         });
     });

--- a/__tests__/unit/core-api/services/delegate-search-service.test.ts
+++ b/__tests__/unit/core-api/services/delegate-search-service.test.ts
@@ -4,9 +4,14 @@ import { Wallets } from "@packages/core-state";
 
 import { Delegates } from "./__fixtures__";
 
+const burnWallet = {
+    getBalance: jest.fn().mockReturnValue(AppUtils.BigNumber.ZERO),
+};
+
 const walletRepository = {
     findByAddress: jest.fn(),
     allByUsername: jest.fn(),
+    getBurnWallet: jest.fn().mockReturnValue(burnWallet),
 };
 
 const standardCriteriaService = {
@@ -77,7 +82,7 @@ describe("DelegateSearchService", () => {
                 Delegates.delegateResource,
             );
 
-            expect(spyOnCalculateApproval).toHaveBeenCalledWith(delegate, 100);
+            expect(spyOnCalculateApproval).toHaveBeenCalledWith(delegate, AppUtils.BigNumber.ZERO, 100);
         });
 
         it("should return delegate by wallet address with produced blocks", () => {
@@ -103,7 +108,7 @@ describe("DelegateSearchService", () => {
             expect(delegateSearchService.getDelegate("ANBkoGqWeTSiaEVgVzSKZd3jS7UWzv9PSo")).toEqual(
                 Delegates.delegateResourceWithLastBlock,
             );
-            expect(spyOnCalculateApproval).toHaveBeenCalledWith(delegate, 100);
+            expect(spyOnCalculateApproval).toHaveBeenCalledWith(delegate, AppUtils.BigNumber.ZERO, 100);
         });
 
         it("should return undefined if walled is not delegate", () => {
@@ -146,7 +151,7 @@ describe("DelegateSearchService", () => {
 
             expect(walletRepository.allByUsername).toHaveBeenCalled();
             expect(standardCriteriaService.testStandardCriterias).toHaveBeenCalled();
-            expect(spyOnCalculateApproval).toHaveBeenCalledWith(delegate, 100);
+            expect(spyOnCalculateApproval).toHaveBeenCalledWith(delegate, AppUtils.BigNumber.ZERO, 100);
         });
 
         it("should return empty array if all tested criterias are false", () => {

--- a/__tests__/unit/core-kernel/utils/delegate-calculator.test.ts
+++ b/__tests__/unit/core-kernel/utils/delegate-calculator.test.ts
@@ -42,7 +42,7 @@ describe("Delegate Calculator", () => {
                 voteBalance: Utils.BigNumber.make(10000 * 1e8),
             });
 
-            expect(calculateApproval(delegate, 1)).toBe(1);
+            expect(calculateApproval(delegate, Utils.BigNumber.ZERO, 1)).toBe(1);
         });
 
         it("should calculate correctly with default height 1", () => {
@@ -53,7 +53,7 @@ describe("Delegate Calculator", () => {
                 voteBalance: Utils.BigNumber.make(10000 * 1e8),
             });
 
-            expect(calculateApproval(delegate)).toBe(1);
+            expect(calculateApproval(delegate, Utils.BigNumber.ZERO)).toBe(1);
         });
 
         it("should calculate correctly with 2 decimals", () => {
@@ -64,7 +64,7 @@ describe("Delegate Calculator", () => {
                 voteBalance: Utils.BigNumber.make(16500 * 1e8),
             });
 
-            expect(calculateApproval(delegate, 1)).toBe(1.65);
+            expect(calculateApproval(delegate, Utils.BigNumber.ZERO, 1)).toBe(1.65);
         });
     });
 

--- a/__tests__/unit/core-kernel/utils/supply-calculator.test.ts
+++ b/__tests__/unit/core-kernel/utils/supply-calculator.test.ts
@@ -18,14 +18,16 @@ beforeEach(() => {
 describe("Supply calculator", () => {
     it("should calculate supply with milestone at height 2", () => {
         mockConfig.milestones[0].height = 2;
-        expect(calculate(1)).toBe(toString(mockConfig.genesisBlock.totalAmount));
+        expect(calculate(1).toString()).toBe(toString(mockConfig.genesisBlock.totalAmount));
         mockConfig.milestones[0].height = 1;
     });
 
     describe.each([0, 5, 100, 2000, 4000, 8000])("at height %s", (height) => {
         it("should calculate the genesis supply without milestone", () => {
             const genesisSupply = mockConfig.genesisBlock.totalAmount;
-            expect(calculate(height)).toBe(toString(genesisSupply + height * mockConfig.milestones[0].reward));
+            expect(calculate(height).toString()).toBe(
+                toString(genesisSupply + height * mockConfig.milestones[0].reward),
+            );
         });
     });
 
@@ -42,7 +44,7 @@ describe("Supply calculator", () => {
             };
 
             const genesisSupply = mockConfig.genesisBlock.totalAmount;
-            expect(calculate(height)).toBe(toString(genesisSupply + reward(height)));
+            expect(calculate(height).toString()).toBe(toString(genesisSupply + reward(height)));
 
             mockConfig.milestones = [{ height: 1, reward: 2 }];
         });
@@ -76,7 +78,7 @@ describe("Supply calculator", () => {
             };
 
             const genesisSupply = mockConfig.genesisBlock.totalAmount;
-            expect(calculate(height)).toBe(toString(genesisSupply + reward(height)));
+            expect(calculate(height).toString()).toBe(toString(genesisSupply + reward(height)));
 
             mockConfig.milestones = [{ height: 1, reward: 2 }];
         });

--- a/__tests__/unit/core-transactions/handlers/__support__/app.ts
+++ b/__tests__/unit/core-transactions/handlers/__support__/app.ts
@@ -208,7 +208,7 @@ export const buildSenderWallet = (
     const wallet: Wallets.Wallet = factoryBuilder
         .get("Wallet")
         .withOptions({
-            passphrase: passphrases[0],
+            passphrase: passphrase,
             nonce: 0,
         })
         .make();

--- a/__tests__/unit/core-transactions/handlers/two/multi-payment.test.ts
+++ b/__tests__/unit/core-transactions/handlers/two/multi-payment.test.ts
@@ -199,6 +199,25 @@ describe("MultiPaymentTransaction", () => {
                 SentToBurnWalletError,
             );
         });
+
+        it.each([false, undefined])(
+            "should not throw if recipient is burn wallet and blockBurnAddress is not set",
+            async (blockBurnAddress) => {
+                Managers.configManager.getMilestone().blockBurnAddress = blockBurnAddress;
+
+                const burnWallet = buildSenderWallet(factoryBuilder, "burn");
+
+                const multiPaymentTransaction = BuilderFactory.multiPayment()
+                    .addPayment("ARYJmeYHSUTgbxaiqsgoPwf6M3CYukqdKN", "10")
+                    .addPayment("AFyjB5jULQiYNsp37wwipCm9c7V1xEzTJD", "20")
+                    .addPayment(burnWallet.getAddress(), "20")
+                    .nonce("1")
+                    .sign(passphrases[0])
+                    .build();
+
+                await expect(handler.throwIfCannotBeApplied(multiPaymentTransaction, senderWallet)).toResolve();
+            },
+        );
     });
 
     describe("apply", () => {

--- a/__tests__/unit/core/commands/network-generate.test.ts
+++ b/__tests__/unit/core/commands/network-generate.test.ts
@@ -83,6 +83,7 @@ describe("GenerateCommand", () => {
                     },
                     vendorFieldLength: 255,
                     multiPaymentLimit: 256,
+                    blockBurnAddress: true,
                     aip11: true,
                 },
                 {
@@ -386,6 +387,7 @@ describe("GenerateCommand", () => {
                     },
                     vendorFieldLength: 64,
                     multiPaymentLimit: 256,
+                    blockBurnAddress: true,
                     htlcEnabled: true,
                     aip11: true,
                 },

--- a/packages/core-api/src/controllers/blockchain.ts
+++ b/packages/core-api/src/controllers/blockchain.ts
@@ -22,7 +22,7 @@ export class BlockchainController extends Controller {
                     height: data.height,
                     id: data.id,
                 },
-                supply: supply,
+                supply: supply.toFixed(),
                 burned: burnWallet.getBalance(),
             },
         };

--- a/packages/core-api/src/controllers/blockchain.ts
+++ b/packages/core-api/src/controllers/blockchain.ts
@@ -22,7 +22,8 @@ export class BlockchainController extends Controller {
                     height: data.height,
                     id: data.id,
                 },
-                supply: supply.toFixed(),
+                supply: supply.minus(burnWallet.getBalance()).toFixed(),
+                generated: supply.toFixed(),
                 burned: burnWallet.getBalance(),
             },
         };

--- a/packages/core-api/src/controllers/blockchain.ts
+++ b/packages/core-api/src/controllers/blockchain.ts
@@ -24,7 +24,7 @@ export class BlockchainController extends Controller {
                 },
                 supply: supply.minus(burnWallet.getBalance()).toFixed(),
                 generated: supply.toFixed(),
-                burned: burnWallet.getBalance(),
+                burned: burnWallet.getBalance().toFixed(),
             },
         };
     }

--- a/packages/core-api/src/controllers/blockchain.ts
+++ b/packages/core-api/src/controllers/blockchain.ts
@@ -3,11 +3,18 @@ import { Container, Contracts, Utils } from "@arkecosystem/core-kernel";
 import { Controller } from "./controller";
 
 export class BlockchainController extends Controller {
+    @Container.inject(Container.Identifiers.WalletRepository)
+    @Container.tagged("state", "blockchain")
+    private walletRepository!: Contracts.State.WalletRepository;
+
     @Container.inject(Container.Identifiers.StateStore)
     private readonly stateStore!: Contracts.State.StateStore;
 
     public async index() {
         const { data } = this.stateStore.getLastBlock();
+
+        const burnWallet = this.walletRepository.getBurnWallet();
+        const supply = Utils.supplyCalculator.calculate(data.height);
 
         return {
             data: {
@@ -15,7 +22,8 @@ export class BlockchainController extends Controller {
                     height: data.height,
                     id: data.id,
                 },
-                supply: Utils.supplyCalculator.calculate(data.height),
+                supply: supply,
+                burned: burnWallet.getBalance(),
             },
         };
     }

--- a/packages/core-api/src/services/delegate-search-service.ts
+++ b/packages/core-api/src/services/delegate-search-service.ts
@@ -66,6 +66,7 @@ export class DelegateSearchService {
             production: {
                 approval: AppUtils.delegateCalculator.calculateApproval(
                     wallet,
+                    this.walletRepository.getBurnWallet().getBalance(),
                     this.stateStore.getLastBlock().data.height,
                 ),
             },

--- a/packages/core-kernel/src/contracts/state/wallets.ts
+++ b/packages/core-kernel/src/contracts/state/wallets.ts
@@ -163,6 +163,8 @@ export interface WalletRepository {
 
     getIndex(name: string): WalletIndex;
 
+    getBurnWallet(): Wallet;
+
     allByAddress(): ReadonlyArray<Wallet>;
 
     allByPublicKey(): ReadonlyArray<Wallet>;

--- a/packages/core-kernel/src/utils/delegate-calculator.ts
+++ b/packages/core-kernel/src/utils/delegate-calculator.ts
@@ -12,8 +12,8 @@ const toDecimal = (voteBalance: BigNumber, totalSupply: BigNumber): number => {
     return +Number(div).toFixed(2);
 };
 
-export const calculateApproval = (delegate: Wallet, height: number = 1): number => {
-    const totalSupply: BigNumber = calculateSupply(height);
+export const calculateApproval = (delegate: Wallet, burnedSupply: BigNumber, height: number = 1): number => {
+    const totalSupply: BigNumber = calculateSupply(height).minus(burnedSupply);
     const voteBalance: BigNumber = delegate.getAttribute("delegate.voteBalance");
 
     return toDecimal(voteBalance, totalSupply);

--- a/packages/core-kernel/src/utils/delegate-calculator.ts
+++ b/packages/core-kernel/src/utils/delegate-calculator.ts
@@ -13,7 +13,7 @@ const toDecimal = (voteBalance: BigNumber, totalSupply: BigNumber): number => {
 };
 
 export const calculateApproval = (delegate: Wallet, height: number = 1): number => {
-    const totalSupply: BigNumber = BigNumber.make(calculateSupply(height));
+    const totalSupply: BigNumber = calculateSupply(height);
     const voteBalance: BigNumber = delegate.getAttribute("delegate.voteBalance");
 
     return toDecimal(voteBalance, totalSupply);

--- a/packages/core-kernel/src/utils/supply-calculator.ts
+++ b/packages/core-kernel/src/utils/supply-calculator.ts
@@ -3,7 +3,7 @@ import { Interfaces, Managers, Utils } from "@arkecosystem/crypto";
 import { assert } from "./assert";
 
 // todo: review the implementation
-export const calculate = (height: number): string => {
+export const calculate = (height: number): Utils.BigNumber => {
     const config: Interfaces.NetworkConfig | undefined = Managers.configManager.all();
 
     assert.defined<Interfaces.NetworkConfig>(config);
@@ -13,7 +13,7 @@ export const calculate = (height: number): string => {
     const totalAmount: Utils.BigNumber = Utils.BigNumber.make(genesisBlock.totalAmount);
 
     if (height === 0 || milestones.length === 0) {
-        return totalAmount.toFixed();
+        return totalAmount;
     }
 
     let rewards: Utils.BigNumber = Utils.BigNumber.ZERO;
@@ -38,5 +38,5 @@ export const calculate = (height: number): string => {
         }
     }
 
-    return totalAmount.plus(rewards).toFixed();
+    return totalAmount.plus(rewards);
 };

--- a/packages/core-state/src/wallets/wallet-repository.ts
+++ b/packages/core-state/src/wallets/wallet-repository.ts
@@ -1,5 +1,5 @@
 import { Container, Contracts, Utils as AppUtils } from "@arkecosystem/core-kernel";
-import { Identities, Utils } from "@arkecosystem/crypto";
+import { Identities, Managers, Utils } from "@arkecosystem/crypto";
 
 import { WalletIndexAlreadyRegisteredError, WalletIndexNotFoundError } from "./errors";
 import { WalletIndex } from "./wallet-index";
@@ -34,6 +34,13 @@ export class WalletRepository implements Contracts.State.WalletRepository {
             throw new WalletIndexNotFoundError(name);
         }
         return this.indexes[name];
+    }
+
+    public getBurnWallet(): Contracts.State.Wallet {
+        const burnAddress = Managers.configManager.get<string>("network.burnAddress");
+        AppUtils.assert.defined(burnAddress);
+
+        return this.findByAddress(burnAddress);
     }
 
     public getIndexNames(): string[] {

--- a/packages/core-test-framework/src/app/generators/crypto.ts
+++ b/packages/core-test-framework/src/app/generators/crypto.ts
@@ -77,6 +77,7 @@ export class CryptoGenerator extends Generator {
             wif,
             slip44: 1,
             aip20: 0,
+            burnAddress: this.createWallet(pubKeyHash, "burn").address,
             client: {
                 token,
                 symbol,

--- a/packages/core-test-framework/src/app/generators/crypto.ts
+++ b/packages/core-test-framework/src/app/generators/crypto.ts
@@ -126,6 +126,7 @@ export class CryptoGenerator extends Generator {
                 aip11: true,
                 aip37: true,
                 htlcEnabled: true,
+                blockBurnAddress: true,
             },
             {
                 height: rewardHeight,

--- a/packages/core-transactions/src/errors.ts
+++ b/packages/core-transactions/src/errors.ts
@@ -247,3 +247,9 @@ export class HtlcLockExpiredError extends TransactionError {
         super(`Failed to apply transaction, because the associated HTLC lock transaction expired.`);
     }
 }
+
+export class SentFromBurnWalletError extends TransactionError {
+    public constructor() {
+        super(`Failed to apply transaction, because the transaction is sent by burn wallet.`);
+    }
+}

--- a/packages/core-transactions/src/errors.ts
+++ b/packages/core-transactions/src/errors.ts
@@ -250,6 +250,12 @@ export class HtlcLockExpiredError extends TransactionError {
 
 export class SentFromBurnWalletError extends TransactionError {
     public constructor() {
-        super(`Failed to apply transaction, because the transaction is sent by burn wallet.`);
+        super(`Failed to apply transaction, because the transaction is sent from burn wallet.`);
+    }
+}
+
+export class SentToBurnWalletError extends TransactionError {
+    public constructor() {
+        super(`Failed to apply transaction, because the transaction is sent to burn wallet.`);
     }
 }

--- a/packages/core-transactions/src/handlers/transaction.ts
+++ b/packages/core-transactions/src/handlers/transaction.ts
@@ -12,6 +12,7 @@ import {
     LegacyMultiSignatureRegistrationError,
     MissingMultiSignatureOnSenderError,
     SenderWalletMismatchError,
+    SentFromBurnWalletError,
     UnexpectedNonceError,
     UnexpectedSecondSignatureError,
     UnsupportedMultiSignatureTransactionError,
@@ -74,6 +75,13 @@ export abstract class TransactionHandler {
         transaction: Interfaces.ITransaction,
         sender: Contracts.State.Wallet,
     ): Promise<void> {
+        const burnAddress = Managers.configManager.get("network.burnAddress");
+        AppUtils.assert.defined(burnAddress);
+
+        if (sender.getAddress() === burnAddress) {
+            throw new SentFromBurnWalletError();
+        }
+
         const senderWallet: Contracts.State.Wallet = this.walletRepository.findByAddress(sender.getAddress());
 
         AppUtils.assert.defined<string>(sender.getPublicKey());

--- a/packages/core-transactions/src/handlers/two/htlc-lock.ts
+++ b/packages/core-transactions/src/handlers/two/htlc-lock.ts
@@ -69,14 +69,16 @@ export class HtlcLockTransactionHandler extends TransactionHandler {
 
         const burnAddress = Managers.configManager.get("network.burnAddress");
         AppUtils.assert.defined(burnAddress);
-        if (transaction.data.recipientId === burnAddress) {
+
+        let { activeDelegates, blockBurnAddress } = Managers.configManager.getMilestone();
+
+        if (blockBurnAddress && transaction.data.recipientId === burnAddress) {
             throw new SentToBurnWalletError();
         }
 
         const lock: Interfaces.IHtlcLockAsset = transaction.data.asset.lock;
         const lastBlock: Interfaces.IBlock = this.app.get<any>(Container.Identifiers.StateStore).getLastBlock();
 
-        let { activeDelegates } = Managers.configManager.getMilestone();
         let blocktime = Utils.calculateBlockTime(lastBlock.data.height);
         const expiration: Interfaces.IHtlcExpiration = lock.expiration;
 

--- a/packages/core-transactions/src/handlers/two/multi-payment.ts
+++ b/packages/core-transactions/src/handlers/two/multi-payment.ts
@@ -60,7 +60,12 @@ export class MultiPaymentTransactionHandler extends TransactionHandler {
         const burnAddress = Managers.configManager.get("network.burnAddress");
         AppUtils.assert.defined(burnAddress);
 
-        if (transaction.data.asset.payments.some((payment) => payment.recipientId === burnAddress)) {
+        const { blockBurnAddress } = Managers.configManager.getMilestone();
+
+        if (
+            blockBurnAddress &&
+            transaction.data.asset.payments.some((payment) => payment.recipientId === burnAddress)
+        ) {
             throw new SentToBurnWalletError();
         }
 

--- a/packages/core-transactions/src/handlers/two/multi-payment.ts
+++ b/packages/core-transactions/src/handlers/two/multi-payment.ts
@@ -1,7 +1,7 @@
 import { Container, Contracts, Utils as AppUtils } from "@arkecosystem/core-kernel";
 import { Interfaces, Managers, Transactions, Utils } from "@arkecosystem/crypto";
 
-import { InsufficientBalanceError } from "../../errors";
+import { InsufficientBalanceError, SentToBurnWalletError } from "../../errors";
 import { TransactionHandler, TransactionHandlerConstructor } from "../transaction";
 
 @Container.injectable()
@@ -55,6 +55,13 @@ export class MultiPaymentTransactionHandler extends TransactionHandler {
 
         if (wallet.getBalance().minus(totalPaymentsAmount).minus(transaction.data.fee).isNegative()) {
             throw new InsufficientBalanceError();
+        }
+
+        const burnAddress = Managers.configManager.get("network.burnAddress");
+        AppUtils.assert.defined(burnAddress);
+
+        if (transaction.data.asset.payments.some((payment) => payment.recipientId === burnAddress)) {
+            throw new SentToBurnWalletError();
         }
 
         return super.throwIfCannotBeApplied(transaction, wallet);

--- a/packages/core/src/commands/network-generate.ts
+++ b/packages/core/src/commands/network-generate.ts
@@ -632,6 +632,7 @@ export class Command extends Commands.Command {
                 vendorFieldLength: options.vendorFieldLength,
                 multiPaymentLimit: 256,
                 htlcEnabled: options.htlcEnabled,
+                blockBurnAddress: true,
                 aip11: true,
             },
             {

--- a/packages/core/src/commands/network-generate.ts
+++ b/packages/core/src/commands/network-generate.ts
@@ -589,6 +589,7 @@ export class Command extends Commands.Command {
             wif: options.wif,
             slip44: 1,
             aip20: 0,
+            burnAddress: this.createWallet(options.pubKeyHash).address,
             client: {
                 token: options.token,
                 symbol: options.symbol,

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -32,7 +32,7 @@
     },
     "dependencies": {
         "@arkecosystem/crypto-identities": "1.2.0",
-        "@arkecosystem/crypto-networks": "1.4.0",
+        "@arkecosystem/crypto-networks": "git+https://github.com/sebastijankuzner/crypto-networks-burn.git#burn",
         "@arkecosystem/utils": "1.3.1",
         "ajv": "6.12.6",
         "ajv-keywords": "3.4.1",

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -32,7 +32,7 @@
     },
     "dependencies": {
         "@arkecosystem/crypto-identities": "1.2.0",
-        "@arkecosystem/crypto-networks": "1.6.0",
+        "@arkecosystem/crypto-networks": "1.6.1",
         "@arkecosystem/utils": "1.3.1",
         "ajv": "6.12.6",
         "ajv-keywords": "3.4.1",

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -32,7 +32,7 @@
     },
     "dependencies": {
         "@arkecosystem/crypto-identities": "1.2.0",
-        "@arkecosystem/crypto-networks": "git+https://github.com/sebastijankuzner/crypto-networks-burn.git#burn",
+        "@arkecosystem/crypto-networks": "1.5.0",
         "@arkecosystem/utils": "1.3.1",
         "ajv": "6.12.6",
         "ajv-keywords": "3.4.1",

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -32,7 +32,7 @@
     },
     "dependencies": {
         "@arkecosystem/crypto-identities": "1.2.0",
-        "@arkecosystem/crypto-networks": "1.5.0",
+        "@arkecosystem/crypto-networks": "1.6.0",
         "@arkecosystem/utils": "1.3.1",
         "ajv": "6.12.6",
         "ajv-keywords": "3.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -20,10 +20,10 @@
     fast-memoize "^2.5.1"
     wif "^2.0.6"
 
-"@arkecosystem/crypto-networks@1.6.0":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@arkecosystem/crypto-networks/-/crypto-networks-1.6.0.tgz#77ca435e851bd94e12ebbcf5b22920b62ab8fcff"
-  integrity sha512-U2ZPkpXoOHuHF2yGDuF8IhTA5k8LtskACxFpyP5B4tW03XHP/+HqgIA/DB2hVt8aiGPhrFsncUOeKmgvI/XoAw==
+"@arkecosystem/crypto-networks@1.6.1":
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/@arkecosystem/crypto-networks/-/crypto-networks-1.6.1.tgz#1de657ae58aa9b5b35b1a757f14f36ace96cd59e"
+  integrity sha512-/2I0Z8sb6yggmxcujkNPA853VGyEiwUjKyKdA/Y9hltN74iTkghMiceTLbiT0JMwlUnAWX309f4SYwg4pSzzLQ==
 
 "@arkecosystem/utils@1.3.1":
   version "1.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,7 +22,7 @@
 
 "@arkecosystem/crypto-networks@git+https://github.com/sebastijankuzner/crypto-networks-burn.git#burn":
   version "1.4.0"
-  resolved "git+https://github.com/sebastijankuzner/crypto-networks-burn.git#51b2f6ba08eb6268dc2e36640e2bc22e4e392b0b"
+  resolved "git+https://github.com/sebastijankuzner/crypto-networks-burn.git#e536fad8968598464b06d99688ffe12ab670eaf3"
 
 "@arkecosystem/utils@1.3.1":
   version "1.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -20,9 +20,10 @@
     fast-memoize "^2.5.1"
     wif "^2.0.6"
 
-"@arkecosystem/crypto-networks@git+https://github.com/sebastijankuzner/crypto-networks-burn.git#burn":
-  version "1.4.0"
-  resolved "git+https://github.com/sebastijankuzner/crypto-networks-burn.git#e536fad8968598464b06d99688ffe12ab670eaf3"
+"@arkecosystem/crypto-networks@1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@arkecosystem/crypto-networks/-/crypto-networks-1.5.0.tgz#a63841e6e59653487b198e77d3a2ad151a12db8e"
+  integrity sha512-nxYnM3+Cc8lyZ0kv8u4eObX6ZXqYGMVafmJp/22BLGjXc+8URyUS/ac9wQGZ+dbNQkdu06/l2DEHqK0c8KJhjQ==
 
 "@arkecosystem/utils@1.3.1":
   version "1.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -20,10 +20,9 @@
     fast-memoize "^2.5.1"
     wif "^2.0.6"
 
-"@arkecosystem/crypto-networks@1.4.0":
+"@arkecosystem/crypto-networks@git+https://github.com/sebastijankuzner/crypto-networks-burn.git#burn":
   version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@arkecosystem/crypto-networks/-/crypto-networks-1.4.0.tgz#fc19e1f2059554e335ef2400dc7b1de1f2d80f2d"
-  integrity sha512-I7F6ByIh9uk8WbHSr8kcAJUU1GwzKPnVfZrUR7QGEwU0DknZyp89enaMbfWRg6KKXGOuxtXWrgKEe4ucDjb65g==
+  resolved "git+https://github.com/sebastijankuzner/crypto-networks-burn.git#51b2f6ba08eb6268dc2e36640e2bc22e4e392b0b"
 
 "@arkecosystem/utils@1.3.1":
   version "1.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -20,10 +20,10 @@
     fast-memoize "^2.5.1"
     wif "^2.0.6"
 
-"@arkecosystem/crypto-networks@1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@arkecosystem/crypto-networks/-/crypto-networks-1.5.0.tgz#a63841e6e59653487b198e77d3a2ad151a12db8e"
-  integrity sha512-nxYnM3+Cc8lyZ0kv8u4eObX6ZXqYGMVafmJp/22BLGjXc+8URyUS/ac9wQGZ+dbNQkdu06/l2DEHqK0c8KJhjQ==
+"@arkecosystem/crypto-networks@1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@arkecosystem/crypto-networks/-/crypto-networks-1.6.0.tgz#77ca435e851bd94e12ebbcf5b22920b62ab8fcff"
+  integrity sha512-U2ZPkpXoOHuHF2yGDuF8IhTA5k8LtskACxFpyP5B4tW03XHP/+HqgIA/DB2hVt8aiGPhrFsncUOeKmgvI/XoAw==
 
 "@arkecosystem/utils@1.3.1":
   version "1.3.1"


### PR DESCRIPTION
## Summary

Add support for burn address.

- prevents sending transactions from burn address
- prevent sending multi payments to burn address
- prevent sending HTLC Lock to burn address
- changes in supply calculator (returns BigNumber)
- changes in delegate calculator (requires burned supply)
- generate burn address with **network:generate** command
- /api/blockchain return **supply**, **generated**, **burned** fields
- add **blockBurnAddress** milestone used in HTLCLock and MultiPayment transactions

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged

