### PR TITLE
fix(core-cli): allow `rc` channel in config

### DIFF
--- a/packages/core-cli/src/services/config.ts
+++ b/packages/core-cli/src/services/config.ts
@@ -148,7 +148,7 @@ export class Config {
      * @memberof Config
      */
     private getRegistryChannel(version: string): string {
-        const channels: string[] = ["next"];
+        const channels: string[] = ["next", "rc"];
 
         let channel = "latest";
         for (const item of channels) {


### PR DESCRIPTION
## Summary

Allow `rc` channel in config. This fixes problem while using `ark update` command. Before fix, it defaults to **latest** channel when `rc` channel was actually used. 

## Checklist

- [x] Ready to be merged

