### PR TITLE
feat(core-database): use second database connection for API

### DIFF
--- a/__tests__/integration/core-api/handlers/delegates.test.ts
+++ b/__tests__/integration/core-api/handlers/delegates.test.ts
@@ -60,7 +60,7 @@ describe("API 2.0 - Delegates", () => {
             const response = await api.request("GET", `delegates`, { address });
             expect(response).toBeSuccessfulResponse();
             expect(response.data.data).toBeArray();
-            expect(response.data.data.map(d => d.address).sort()).toEqual(address.sort());
+            expect(response.data.data.map((d) => d.address).sort()).toEqual(address.sort());
         });
     });
 
@@ -74,7 +74,11 @@ describe("API 2.0 - Delegates", () => {
 
             // save a new block so that we can make the request with generatorPublicKey
             await app
-                .get<Repositories.BlockRepository>(Container.Identifiers.DatabaseBlockRepository)
+                .getTagged<Repositories.BlockRepository>(
+                    Container.Identifiers.DatabaseBlockRepository,
+                    "connection",
+                    "api",
+                )
                 .saveBlocks([block2]);
 
             const response = await api.request("GET", `delegates/${block2.data.generatorPublicKey}/blocks`);
@@ -86,7 +90,11 @@ describe("API 2.0 - Delegates", () => {
             }
 
             await app
-                .get<Repositories.BlockRepository>(Container.Identifiers.DatabaseBlockRepository)
+                .getTagged<Repositories.BlockRepository>(
+                    Container.Identifiers.DatabaseBlockRepository,
+                    "connection",
+                    "api",
+                )
                 .deleteBlocks([block2.data]); // reset to genesis block
         });
 

--- a/__tests__/integration/core-api/handlers/locks.test.ts
+++ b/__tests__/integration/core-api/handlers/locks.test.ts
@@ -68,8 +68,10 @@ describe("API 2.0 - Locks", () => {
                 })
                 .build()[0];
 
-            const transactionRepository = app.get<Repositories.TransactionRepository>(
+            const transactionRepository = app.getTagged<Repositories.TransactionRepository>(
                 Container.Identifiers.DatabaseTransactionRepository,
+                "connection",
+                "api",
             );
 
             jest.spyOn(transactionRepository, "listByExpression").mockResolvedValueOnce({

--- a/__tests__/integration/core-state/block-state/lock-then-claim.test.ts
+++ b/__tests__/integration/core-state/block-state/lock-then-claim.test.ts
@@ -33,8 +33,10 @@ test("BlockState handling [lock], [claim] blocks", async () => {
         "blockchain",
     );
 
-    const transactionRepository = app.get<Repositories.TransactionRepository>(
+    const transactionRepository = app.getTagged<Repositories.TransactionRepository>(
         Container.Identifiers.DatabaseTransactionRepository,
+        "connection",
+        "default",
     );
 
     const lockSecret = Buffer.from("a".repeat(32), "utf-8");

--- a/__tests__/integration/core-state/block-state/lock-then-refund.test.ts
+++ b/__tests__/integration/core-state/block-state/lock-then-refund.test.ts
@@ -33,8 +33,10 @@ test("BlockState handling [lock], [claim] blocks", async () => {
         "blockchain",
     );
 
-    const transactionRepository = app.get<Repositories.TransactionRepository>(
+    const transactionRepository = app.getTagged<Repositories.TransactionRepository>(
         Container.Identifiers.DatabaseTransactionRepository,
+        "connection",
+        "default",
     );
 
     const lockSecret = Buffer.from("a".repeat(32), "utf-8");

--- a/__tests__/unit/core-database/service-provider.test.ts
+++ b/__tests__/unit/core-database/service-provider.test.ts
@@ -43,7 +43,7 @@ describe("ServiceProvider.register", () => {
         await serviceProvider.register();
 
         expect(createConnection).toBeCalled();
-        expect(getCustomRepository).toBeCalledTimes(3);
+        expect(getCustomRepository).toBeCalledTimes(6);
 
         expect(events.dispatch).toBeCalled();
 

--- a/__tests__/unit/core-database/service-provider.test.ts
+++ b/__tests__/unit/core-database/service-provider.test.ts
@@ -127,6 +127,7 @@ describe("ServiceProvider.configSchema", () => {
         expect(result.value.connection.entityPrefix).toBeString();
         expect(result.value.connection.synchronize).toBeFalse();
         expect(result.value.connection.logging).toBeFalse();
+        expect(result.value.apiConnectionTimeout).toEqual(3000);
     });
 
     it("should allow configuration extension", async () => {
@@ -348,6 +349,28 @@ describe("ServiceProvider.configSchema", () => {
             result = (serviceProvider.configSchema() as AnySchema).validate(defaults);
 
             expect(result.error!.message).toEqual('"connection.logging" is required');
+        });
+
+        it("apiConnectionTimeout is required && is integer && is >= 1", async () => {
+            defaults.apiConnectionTimeout = false;
+            let result = (serviceProvider.configSchema() as AnySchema).validate(defaults);
+
+            expect(result.error!.message).toEqual('"apiConnectionTimeout" must be a number');
+
+            defaults.apiConnectionTimeout = 1.12;
+            result = (serviceProvider.configSchema() as AnySchema).validate(defaults);
+
+            expect(result.error!.message).toEqual('"apiConnectionTimeout" must be an integer');
+
+            defaults.apiConnectionTimeout = 0;
+            result = (serviceProvider.configSchema() as AnySchema).validate(defaults);
+
+            expect(result.error!.message).toEqual('"apiConnectionTimeout" must be greater than or equal to 1');
+
+            delete defaults.apiConnectionTimeout;
+            result = (serviceProvider.configSchema() as AnySchema).validate(defaults);
+
+            expect(result.error!.message).toEqual('"apiConnectionTimeout" is required');
         });
     });
 });

--- a/packages/core-api/src/controllers/blocks.ts
+++ b/packages/core-api/src/controllers/blocks.ts
@@ -12,11 +12,11 @@ export class BlocksController extends Controller {
     private readonly blockchain!: Contracts.Blockchain.Blockchain;
 
     @Container.inject(Container.Identifiers.BlockHistoryService)
-    @Container.tagged("connection", "default")
+    @Container.tagged("connection", "api")
     private readonly blockHistoryService!: Contracts.Shared.BlockHistoryService;
 
     @Container.inject(Container.Identifiers.TransactionHistoryService)
-    @Container.tagged("connection", "default")
+    @Container.tagged("connection", "api")
     private readonly transactionHistoryService!: Contracts.Shared.TransactionHistoryService;
 
     @Container.inject(Container.Identifiers.StateStore)

--- a/packages/core-api/src/controllers/blocks.ts
+++ b/packages/core-api/src/controllers/blocks.ts
@@ -16,6 +16,7 @@ export class BlocksController extends Controller {
     private readonly blockHistoryService!: Contracts.Shared.BlockHistoryService;
 
     @Container.inject(Container.Identifiers.TransactionHistoryService)
+    @Container.tagged("connection", "default")
     private readonly transactionHistoryService!: Contracts.Shared.TransactionHistoryService;
 
     @Container.inject(Container.Identifiers.StateStore)

--- a/packages/core-api/src/controllers/blocks.ts
+++ b/packages/core-api/src/controllers/blocks.ts
@@ -12,6 +12,7 @@ export class BlocksController extends Controller {
     private readonly blockchain!: Contracts.Blockchain.Blockchain;
 
     @Container.inject(Container.Identifiers.BlockHistoryService)
+    @Container.tagged("connection", "default")
     private readonly blockHistoryService!: Contracts.Shared.BlockHistoryService;
 
     @Container.inject(Container.Identifiers.TransactionHistoryService)

--- a/packages/core-api/src/controllers/delegates.ts
+++ b/packages/core-api/src/controllers/delegates.ts
@@ -26,6 +26,7 @@ export class DelegatesController extends Controller {
     private readonly walletSearchService!: WalletSearchService;
 
     @Container.inject(Container.Identifiers.BlockHistoryService)
+    @Container.tagged("connection", "default")
     private readonly blockHistoryService!: Contracts.Shared.BlockHistoryService;
 
     public index(request: Hapi.Request): Contracts.Search.ResultsPage<DelegateResource> {

--- a/packages/core-api/src/controllers/delegates.ts
+++ b/packages/core-api/src/controllers/delegates.ts
@@ -26,7 +26,7 @@ export class DelegatesController extends Controller {
     private readonly walletSearchService!: WalletSearchService;
 
     @Container.inject(Container.Identifiers.BlockHistoryService)
-    @Container.tagged("connection", "default")
+    @Container.tagged("connection", "api")
     private readonly blockHistoryService!: Contracts.Shared.BlockHistoryService;
 
     public index(request: Hapi.Request): Contracts.Search.ResultsPage<DelegateResource> {

--- a/packages/core-api/src/controllers/locks.ts
+++ b/packages/core-api/src/controllers/locks.ts
@@ -15,6 +15,7 @@ export class LocksController extends Controller {
     private readonly lockSearchService!: LockSearchService;
 
     @Container.inject(Container.Identifiers.TransactionHistoryService)
+    @Container.tagged("connection", "api")
     private readonly transactionHistoryService!: Contracts.Shared.TransactionHistoryService;
 
     public index(request: Hapi.Request): Contracts.Search.ResultsPage<LockResource> {

--- a/packages/core-api/src/controllers/rounds.ts
+++ b/packages/core-api/src/controllers/rounds.ts
@@ -8,6 +8,7 @@ import { Controller } from "./controller";
 
 export class RoundsController extends Controller {
     @Container.inject(Container.Identifiers.DatabaseRoundRepository)
+    @Container.tagged("connection", "api")
     private readonly roundRepository!: Repositories.RoundRepository;
 
     public async delegates(request: Hapi.Request, h: Hapi.ResponseToolkit) {

--- a/packages/core-api/src/controllers/transactions.ts
+++ b/packages/core-api/src/controllers/transactions.ts
@@ -23,6 +23,7 @@ export class TransactionsController extends Controller {
     private readonly transactionHistoryService!: Contracts.Shared.TransactionHistoryService;
 
     @Container.inject(Container.Identifiers.BlockHistoryService)
+    @Container.tagged("connection", "default")
     private readonly blockHistoryService!: Contracts.Shared.BlockHistoryService;
 
     @Container.inject(Container.Identifiers.TransactionPoolProcessor)

--- a/packages/core-api/src/controllers/transactions.ts
+++ b/packages/core-api/src/controllers/transactions.ts
@@ -20,10 +20,11 @@ export class TransactionsController extends Controller {
     private readonly poolQuery!: Contracts.TransactionPool.Query;
 
     @Container.inject(Container.Identifiers.TransactionHistoryService)
+    @Container.tagged("connection", "api")
     private readonly transactionHistoryService!: Contracts.Shared.TransactionHistoryService;
 
     @Container.inject(Container.Identifiers.BlockHistoryService)
-    @Container.tagged("connection", "default")
+    @Container.tagged("connection", "api")
     private readonly blockHistoryService!: Contracts.Shared.BlockHistoryService;
 
     @Container.inject(Container.Identifiers.TransactionPoolProcessor)

--- a/packages/core-api/src/controllers/votes.ts
+++ b/packages/core-api/src/controllers/votes.ts
@@ -9,6 +9,7 @@ import { Controller } from "./controller";
 @Container.injectable()
 export class VotesController extends Controller {
     @Container.inject(Container.Identifiers.TransactionHistoryService)
+    @Container.tagged("connection", "api")
     private readonly transactionHistoryService!: Contracts.Shared.TransactionHistoryService;
 
     public async index(request: Hapi.Request, h: Hapi.ResponseToolkit) {

--- a/packages/core-api/src/controllers/wallets.ts
+++ b/packages/core-api/src/controllers/wallets.ts
@@ -28,6 +28,7 @@ export class WalletsController extends Controller {
     private readonly lockSearchService!: LockSearchService;
 
     @Container.inject(Container.Identifiers.TransactionHistoryService)
+    @Container.tagged("connection", "api")
     private readonly transactionHistoryService!: Contracts.Shared.TransactionHistoryService;
 
     public index(request: Hapi.Request): Contracts.Search.ResultsPage<WalletResource> {

--- a/packages/core-blockchain/src/blockchain.ts
+++ b/packages/core-blockchain/src/blockchain.ts
@@ -27,6 +27,7 @@ export class Blockchain implements Contracts.Blockchain.Blockchain {
     private readonly database!: DatabaseService;
 
     @Container.inject(Container.Identifiers.DatabaseBlockRepository)
+    @Container.tagged("connection", "default")
     private readonly blockRepository!: Repositories.BlockRepository;
 
     @Container.inject(Container.Identifiers.TransactionPoolService)

--- a/packages/core-blockchain/src/process-blocks-job.ts
+++ b/packages/core-blockchain/src/process-blocks-job.ts
@@ -25,6 +25,7 @@ export class ProcessBlocksJob implements Contracts.Kernel.QueueJob {
     private readonly database!: DatabaseService;
 
     @Container.inject(Container.Identifiers.DatabaseBlockRepository)
+    @Container.tagged("connection", "default")
     private readonly blockRepository!: Repositories.BlockRepository;
 
     @Container.inject(Container.Identifiers.DatabaseInteraction)

--- a/packages/core-blockchain/src/processor/block-processor.ts
+++ b/packages/core-blockchain/src/processor/block-processor.ts
@@ -35,6 +35,7 @@ export class BlockProcessor {
     private readonly blockchain!: Contracts.Blockchain.Blockchain;
 
     @Container.inject(Container.Identifiers.DatabaseTransactionRepository)
+    @Container.tagged("connection", "default")
     private readonly transactionRepository!: Repositories.TransactionRepository;
 
     @Container.inject(Container.Identifiers.WalletRepository)

--- a/packages/core-database/src/block-history-service.ts
+++ b/packages/core-database/src/block-history-service.ts
@@ -12,6 +12,7 @@ export class BlockHistoryService implements Contracts.Shared.BlockHistoryService
     private readonly blockRepository!: BlockRepository;
 
     @Container.inject(Container.Identifiers.DatabaseTransactionRepository)
+    @Container.tagged("connection", "default")
     private readonly transactionRepository!: TransactionRepository;
 
     @Container.inject(Container.Identifiers.DatabaseBlockFilter)

--- a/packages/core-database/src/block-history-service.ts
+++ b/packages/core-database/src/block-history-service.ts
@@ -8,11 +8,9 @@ import { TransactionRepository } from "./repositories/transaction-repository";
 @Container.injectable()
 export class BlockHistoryService implements Contracts.Shared.BlockHistoryService {
     @Container.inject(Container.Identifiers.DatabaseBlockRepository)
-    @Container.tagged("connection", "default")
     private readonly blockRepository!: BlockRepository;
 
     @Container.inject(Container.Identifiers.DatabaseTransactionRepository)
-    @Container.tagged("connection", "default")
     private readonly transactionRepository!: TransactionRepository;
 
     @Container.inject(Container.Identifiers.DatabaseBlockFilter)

--- a/packages/core-database/src/block-history-service.ts
+++ b/packages/core-database/src/block-history-service.ts
@@ -8,6 +8,7 @@ import { TransactionRepository } from "./repositories/transaction-repository";
 @Container.injectable()
 export class BlockHistoryService implements Contracts.Shared.BlockHistoryService {
     @Container.inject(Container.Identifiers.DatabaseBlockRepository)
+    @Container.tagged("connection", "default")
     private readonly blockRepository!: BlockRepository;
 
     @Container.inject(Container.Identifiers.DatabaseTransactionRepository)

--- a/packages/core-database/src/database-service.ts
+++ b/packages/core-database/src/database-service.ts
@@ -15,6 +15,7 @@ export class DatabaseService {
     private readonly app!: Contracts.Kernel.Application;
 
     @Container.inject(Container.Identifiers.DatabaseConnection)
+    @Container.tagged("connection", "default")
     private readonly connection!: Connection;
 
     @Container.inject(Container.Identifiers.DatabaseBlockRepository)

--- a/packages/core-database/src/database-service.ts
+++ b/packages/core-database/src/database-service.ts
@@ -19,6 +19,7 @@ export class DatabaseService {
     private readonly connection!: Connection;
 
     @Container.inject(Container.Identifiers.DatabaseBlockRepository)
+    @Container.tagged("connection", "default")
     private readonly blockRepository!: BlockRepository;
 
     @Container.inject(Container.Identifiers.DatabaseTransactionRepository)

--- a/packages/core-database/src/database-service.ts
+++ b/packages/core-database/src/database-service.ts
@@ -25,6 +25,7 @@ export class DatabaseService {
     private readonly transactionRepository!: TransactionRepository;
 
     @Container.inject(Container.Identifiers.DatabaseRoundRepository)
+    @Container.tagged("connection", "default")
     private readonly roundRepository!: RoundRepository;
 
     @Container.inject(Container.Identifiers.LogService)

--- a/packages/core-database/src/database-service.ts
+++ b/packages/core-database/src/database-service.ts
@@ -23,6 +23,7 @@ export class DatabaseService {
     private readonly blockRepository!: BlockRepository;
 
     @Container.inject(Container.Identifiers.DatabaseTransactionRepository)
+    @Container.tagged("connection", "default")
     private readonly transactionRepository!: TransactionRepository;
 
     @Container.inject(Container.Identifiers.DatabaseRoundRepository)

--- a/packages/core-database/src/defaults.ts
+++ b/packages/core-database/src/defaults.ts
@@ -10,4 +10,5 @@ export const defaults = {
         synchronize: false,
         logging: false,
     },
+    apiConnectionTimeout: 3000,
 };

--- a/packages/core-database/src/service-provider.ts
+++ b/packages/core-database/src/service-provider.ts
@@ -100,7 +100,7 @@ export class ServiceProvider extends Providers.ServiceProvider {
             name: connectionName,
             namingStrategy: new SnakeNamingStrategy(),
             migrations: [__dirname + "/migrations/*.js"],
-            migrationsRun: true,
+            migrationsRun: connectionName === "default",
             extra,
             // TODO: expose entities to allow extending the models by plugins
             entities: [__dirname + "/models/*.js"],

--- a/packages/core-database/src/service-provider.ts
+++ b/packages/core-database/src/service-provider.ts
@@ -23,17 +23,21 @@ export class ServiceProvider extends Providers.ServiceProvider {
             .bind(Container.Identifiers.DatabaseConnection)
             .toConstantValue(await this.connect())
             .when(Container.Selectors.anyAncestorOrTargetTaggedFirst("connection", "default"));
-
         this.app
             .bind(Container.Identifiers.DatabaseConnection)
             .toConstantValue(await this.connect("api"))
             .when(Container.Selectors.anyAncestorOrTargetTaggedFirst("connection", "api"));
 
-        // await this.connect("api_connection");
-
         logger.debug("Connection established.");
 
-        this.app.bind(Container.Identifiers.DatabaseRoundRepository).toConstantValue(this.getRoundRepository());
+        this.app
+            .bind(Container.Identifiers.DatabaseRoundRepository)
+            .toConstantValue(this.getRoundRepository())
+            .when(Container.Selectors.anyAncestorOrTargetTaggedFirst("connection", "default"));
+        this.app
+            .bind(Container.Identifiers.DatabaseRoundRepository)
+            .toConstantValue(this.getRoundRepository("api"))
+            .when(Container.Selectors.anyAncestorOrTargetTaggedFirst("connection", "api"));
 
         this.app.bind(Container.Identifiers.DatabaseBlockRepository).toConstantValue(this.getBlockRepository());
         this.app.bind(Container.Identifiers.DatabaseBlockFilter).to(BlockFilter);
@@ -84,8 +88,8 @@ export class ServiceProvider extends Providers.ServiceProvider {
         });
     }
 
-    public getRoundRepository(): RoundRepository {
-        return getCustomRepository(RoundRepository);
+    public getRoundRepository(connectionName = "default"): RoundRepository {
+        return getCustomRepository(RoundRepository, connectionName);
     }
 
     public getBlockRepository(): BlockRepository {

--- a/packages/core-database/src/service-provider.ts
+++ b/packages/core-database/src/service-provider.ts
@@ -39,7 +39,15 @@ export class ServiceProvider extends Providers.ServiceProvider {
             .toConstantValue(this.getRoundRepository("api"))
             .when(Container.Selectors.anyAncestorOrTargetTaggedFirst("connection", "api"));
 
-        this.app.bind(Container.Identifiers.DatabaseBlockRepository).toConstantValue(this.getBlockRepository());
+        this.app
+            .bind(Container.Identifiers.DatabaseBlockRepository)
+            .toConstantValue(this.getBlockRepository())
+            .when(Container.Selectors.anyAncestorOrTargetTaggedFirst("connection", "default"));
+        this.app
+            .bind(Container.Identifiers.DatabaseBlockRepository)
+            .toConstantValue(this.getBlockRepository("api"))
+            .when(Container.Selectors.anyAncestorOrTargetTaggedFirst("connection", "api"));
+
         this.app.bind(Container.Identifiers.DatabaseBlockFilter).to(BlockFilter);
         this.app.bind(Container.Identifiers.BlockHistoryService).to(BlockHistoryService);
 
@@ -92,8 +100,8 @@ export class ServiceProvider extends Providers.ServiceProvider {
         return getCustomRepository(RoundRepository, connectionName);
     }
 
-    public getBlockRepository(): BlockRepository {
-        return getCustomRepository(BlockRepository);
+    public getBlockRepository(connectionName = "default"): BlockRepository {
+        return getCustomRepository(BlockRepository, connectionName);
     }
 
     public getTransactionRepository(): TransactionRepository {

--- a/packages/core-database/src/service-provider.ts
+++ b/packages/core-database/src/service-provider.ts
@@ -101,6 +101,7 @@ export class ServiceProvider extends Providers.ServiceProvider {
             namingStrategy: new SnakeNamingStrategy(),
             migrations: [__dirname + "/migrations/*.js"],
             migrationsRun: true,
+            extra,
             // TODO: expose entities to allow extending the models by plugins
             entities: [__dirname + "/models/*.js"],
         });

--- a/packages/core-database/src/service-provider.ts
+++ b/packages/core-database/src/service-provider.ts
@@ -25,7 +25,11 @@ export class ServiceProvider extends Providers.ServiceProvider {
             .when(Container.Selectors.anyAncestorOrTargetTaggedFirst("connection", "default"));
         this.app
             .bind(Container.Identifiers.DatabaseConnection)
-            .toConstantValue(await this.connect("api"))
+            .toConstantValue(
+                await this.connect("api", {
+                    options: "-c statement_timeout=5000ms",
+                }),
+            )
             .when(Container.Selectors.anyAncestorOrTargetTaggedFirst("connection", "api"));
 
         logger.debug("Connection established.");
@@ -80,7 +84,7 @@ export class ServiceProvider extends Providers.ServiceProvider {
         return true;
     }
 
-    public async connect(connectionName = "default"): Promise<Connection> {
+    public async connect(connectionName = "default", extra = {}): Promise<Connection> {
         const connection: Record<string, any> = this.config().all().connection as any;
         this.app
             .get<Contracts.Kernel.EventDispatcher>(Container.Identifiers.EventDispatcherService)

--- a/packages/core-database/src/service-provider.ts
+++ b/packages/core-database/src/service-provider.ts
@@ -27,7 +27,7 @@ export class ServiceProvider extends Providers.ServiceProvider {
             .bind(Container.Identifiers.DatabaseConnection)
             .toConstantValue(
                 await this.connect("api", {
-                    options: "-c statement_timeout=5000ms",
+                    options: `-c statement_timeout=${this.config().getRequired("apiConnectionTimeout")}ms`,
                 }),
             )
             .when(Container.Selectors.anyAncestorOrTargetTaggedFirst("connection", "api"));
@@ -132,6 +132,7 @@ export class ServiceProvider extends Providers.ServiceProvider {
                 synchronize: Joi.bool().required(),
                 logging: Joi.bool().required(),
             }).required(),
+            apiConnectionTimeout: Joi.number().integer().min(1).required(),
         }).unknown(true);
     }
 }

--- a/packages/core-database/src/service-provider.ts
+++ b/packages/core-database/src/service-provider.ts
@@ -53,7 +53,13 @@ export class ServiceProvider extends Providers.ServiceProvider {
 
         this.app
             .bind(Container.Identifiers.DatabaseTransactionRepository)
-            .toConstantValue(this.getTransactionRepository());
+            .toConstantValue(this.getTransactionRepository())
+            .when(Container.Selectors.anyAncestorOrTargetTaggedFirst("connection", "default"));
+        this.app
+            .bind(Container.Identifiers.DatabaseTransactionRepository)
+            .toConstantValue(this.getTransactionRepository("api"))
+            .when(Container.Selectors.anyAncestorOrTargetTaggedFirst("connection", "api"));
+
         this.app.bind(Container.Identifiers.DatabaseTransactionFilter).to(TransactionFilter);
         this.app.bind(Container.Identifiers.TransactionHistoryService).to(TransactionHistoryService);
 
@@ -104,8 +110,8 @@ export class ServiceProvider extends Providers.ServiceProvider {
         return getCustomRepository(BlockRepository, connectionName);
     }
 
-    public getTransactionRepository(): TransactionRepository {
-        return getCustomRepository(TransactionRepository);
+    public getTransactionRepository(connectionName = "default"): TransactionRepository {
+        return getCustomRepository(TransactionRepository, connectionName);
     }
 
     public configSchema(): object {

--- a/packages/core-database/src/transaction-filter.ts
+++ b/packages/core-database/src/transaction-filter.ts
@@ -3,13 +3,8 @@ import { Enums } from "@arkecosystem/crypto";
 
 import { Transaction } from "./models/transaction";
 
-const {
-    handleAndCriteria,
-    handleOrCriteria,
-    handleNumericCriteria,
-    optimizeExpression,
-    hasOrCriteria,
-} = AppUtils.Search;
+const { handleAndCriteria, handleOrCriteria, handleNumericCriteria, optimizeExpression, hasOrCriteria } =
+    AppUtils.Search;
 
 @Container.injectable()
 export class TransactionFilter implements Contracts.Database.TransactionFilter {

--- a/packages/core-database/src/transaction-history-service.ts
+++ b/packages/core-database/src/transaction-history-service.ts
@@ -12,6 +12,7 @@ export class TransactionHistoryService implements Contracts.Shared.TransactionHi
     private readonly blockRepository!: BlockRepository;
 
     @Container.inject(Container.Identifiers.DatabaseTransactionRepository)
+    @Container.tagged("connection", "default")
     private readonly transactionRepository!: TransactionRepository;
 
     @Container.inject(Container.Identifiers.DatabaseTransactionFilter)

--- a/packages/core-database/src/transaction-history-service.ts
+++ b/packages/core-database/src/transaction-history-service.ts
@@ -8,11 +8,9 @@ import { TransactionRepository } from "./repositories/transaction-repository";
 @Container.injectable()
 export class TransactionHistoryService implements Contracts.Shared.TransactionHistoryService {
     @Container.inject(Container.Identifiers.DatabaseBlockRepository)
-    @Container.tagged("connection", "default")
     private readonly blockRepository!: BlockRepository;
 
     @Container.inject(Container.Identifiers.DatabaseTransactionRepository)
-    @Container.tagged("connection", "default")
     private readonly transactionRepository!: TransactionRepository;
 
     @Container.inject(Container.Identifiers.DatabaseTransactionFilter)

--- a/packages/core-database/src/transaction-history-service.ts
+++ b/packages/core-database/src/transaction-history-service.ts
@@ -8,6 +8,7 @@ import { TransactionRepository } from "./repositories/transaction-repository";
 @Container.injectable()
 export class TransactionHistoryService implements Contracts.Shared.TransactionHistoryService {
     @Container.inject(Container.Identifiers.DatabaseBlockRepository)
+    @Container.tagged("connection", "default")
     private readonly blockRepository!: BlockRepository;
 
     @Container.inject(Container.Identifiers.DatabaseTransactionRepository)

--- a/packages/core-database/src/wallets-table-service.ts
+++ b/packages/core-database/src/wallets-table-service.ts
@@ -4,6 +4,7 @@ import { Connection } from "typeorm";
 @Container.injectable()
 export class WalletsTableService implements Contracts.Database.WalletsTableService {
     @Container.inject(Container.Identifiers.DatabaseConnection)
+    @Container.tagged("connection", "default")
     private readonly connection!: Connection;
 
     public async flush(): Promise<void> {
@@ -38,7 +39,13 @@ export class WalletsTableService implements Contracts.Database.WalletsTableServi
                     const batchWallets = wallets.slice(i, i + batchSize);
 
                     const params = batchWallets
-                        .map((w) => [w.getAddress(), w.getPublicKey(), w.getBalance().toFixed(), w.getNonce().toFixed(), w.getAttributes()])
+                        .map((w) => [
+                            w.getAddress(),
+                            w.getPublicKey(),
+                            w.getBalance().toFixed(),
+                            w.getNonce().toFixed(),
+                            w.getAttributes(),
+                        ])
                         .flat();
 
                     const values = batchWallets

--- a/packages/core-magistrate-transactions/src/handlers/bridgechain-registration.ts
+++ b/packages/core-magistrate-transactions/src/handlers/bridgechain-registration.ts
@@ -22,6 +22,7 @@ import { packageNameRegex } from "./utils";
 @Container.injectable()
 export class BridgechainRegistrationTransactionHandler extends MagistrateTransactionHandler {
     @Container.inject(Container.Identifiers.TransactionHistoryService)
+    @Container.tagged("connection", "default")
     private readonly transactionHistoryService!: Contracts.Shared.TransactionHistoryService;
 
     public dependencies(): ReadonlyArray<Handlers.TransactionHandlerConstructor> {
@@ -49,9 +50,8 @@ export class BridgechainRegistrationTransactionHandler extends MagistrateTransac
             );
 
             const wallet: Contracts.State.Wallet = this.walletRepository.findByPublicKey(transaction.senderPublicKey);
-            const businessAttributes: IBusinessWalletAttributes = wallet.getAttribute<IBusinessWalletAttributes>(
-                "business",
-            );
+            const businessAttributes: IBusinessWalletAttributes =
+                wallet.getAttribute<IBusinessWalletAttributes>("business");
             if (!businessAttributes.bridgechains) {
                 businessAttributes.bridgechains = {};
             }
@@ -84,9 +84,8 @@ export class BridgechainRegistrationTransactionHandler extends MagistrateTransac
 
         const { data }: Interfaces.ITransaction = transaction;
         if (wallet.hasAttribute("business.bridgechains")) {
-            const bridgechains: Record<string, IBridgechainWalletAttributes> = wallet.getAttribute(
-                "business.bridgechains",
-            );
+            const bridgechains: Record<string, IBridgechainWalletAttributes> =
+                wallet.getAttribute("business.bridgechains");
 
             if (
                 Object.values(bridgechains).some(
@@ -126,9 +125,8 @@ export class BridgechainRegistrationTransactionHandler extends MagistrateTransac
 
         const sender: Contracts.State.Wallet = this.walletRepository.findByPublicKey(transaction.data.senderPublicKey);
 
-        const businessAttributes: IBusinessWalletAttributes = sender.getAttribute<IBusinessWalletAttributes>(
-            "business",
-        );
+        const businessAttributes: IBusinessWalletAttributes =
+            sender.getAttribute<IBusinessWalletAttributes>("business");
 
         if (!businessAttributes.bridgechains) {
             businessAttributes.bridgechains = {};
@@ -154,9 +152,8 @@ export class BridgechainRegistrationTransactionHandler extends MagistrateTransac
 
         const sender: Contracts.State.Wallet = this.walletRepository.findByPublicKey(transaction.data.senderPublicKey);
 
-        const businessAttributes: IBusinessWalletAttributes = sender.getAttribute<IBusinessWalletAttributes>(
-            "business",
-        );
+        const businessAttributes: IBusinessWalletAttributes =
+            sender.getAttribute<IBusinessWalletAttributes>("business");
 
         AppUtils.assert.defined<Record<string, IBridgechainWalletAttributes>>(businessAttributes.bridgechains);
 

--- a/packages/core-magistrate-transactions/src/handlers/bridgechain-resignation.ts
+++ b/packages/core-magistrate-transactions/src/handlers/bridgechain-resignation.ts
@@ -21,6 +21,7 @@ export class BridgechainResignationTransactionHandler extends MagistrateTransact
     private readonly poolQuery!: Contracts.TransactionPool.Query;
 
     @Container.inject(Container.Identifiers.TransactionHistoryService)
+    @Container.tagged("connection", "default")
     private readonly transactionHistoryService!: Contracts.Shared.TransactionHistoryService;
 
     public dependencies(): ReadonlyArray<Handlers.TransactionHandlerConstructor> {
@@ -48,13 +49,11 @@ export class BridgechainResignationTransactionHandler extends MagistrateTransact
             );
 
             const wallet: Contracts.State.Wallet = this.walletRepository.findByPublicKey(transaction.senderPublicKey);
-            const businessAttributes: IBusinessWalletAttributes = wallet.getAttribute<IBusinessWalletAttributes>(
-                "business",
-            );
+            const businessAttributes: IBusinessWalletAttributes =
+                wallet.getAttribute<IBusinessWalletAttributes>("business");
 
-            const bridgechainAsset = businessAttributes.bridgechains![
-                transaction.asset.bridgechainResignation.bridgechainId
-            ];
+            const bridgechainAsset =
+                businessAttributes.bridgechains![transaction.asset.bridgechainResignation.bridgechainId];
             bridgechainAsset.resigned = true;
 
             wallet.setAttribute<IBusinessWalletAttributes>("business", businessAttributes);
@@ -70,9 +69,8 @@ export class BridgechainResignationTransactionHandler extends MagistrateTransact
             throw new WalletIsNotBusinessError();
         }
 
-        const businessAttributes: IBusinessWalletAttributes = wallet.getAttribute<IBusinessWalletAttributes>(
-            "business",
-        );
+        const businessAttributes: IBusinessWalletAttributes =
+            wallet.getAttribute<IBusinessWalletAttributes>("business");
 
         if (businessAttributes.resigned) {
             throw new BusinessIsResignedError();
@@ -139,8 +137,8 @@ export class BridgechainResignationTransactionHandler extends MagistrateTransact
         //     transaction.data.asset?.bridgechainResignation,
         // );
 
-        const bridgechainResignation: MagistrateInterfaces.IBridgechainResignationAsset = transaction.data.asset!
-            .bridgechainResignation;
+        const bridgechainResignation: MagistrateInterfaces.IBridgechainResignationAsset =
+            transaction.data.asset!.bridgechainResignation;
 
         AppUtils.assert.defined<Record<string, IBridgechainWalletAttributes>>(businessAttributes.bridgechains);
 

--- a/packages/core-magistrate-transactions/src/handlers/bridgechain-update.ts
+++ b/packages/core-magistrate-transactions/src/handlers/bridgechain-update.ts
@@ -26,6 +26,7 @@ export class BridgechainUpdateTransactionHandler extends MagistrateTransactionHa
     private readonly poolQuery!: Contracts.TransactionPool.Query;
 
     @Container.inject(Container.Identifiers.TransactionHistoryService)
+    @Container.tagged("connection", "default")
     private readonly transactionHistoryService!: Contracts.Shared.TransactionHistoryService;
 
     public dependencies(): ReadonlyArray<Handlers.TransactionHandlerConstructor> {
@@ -51,9 +52,8 @@ export class BridgechainUpdateTransactionHandler extends MagistrateTransactionHa
             AppUtils.assert.defined<MagistrateInterfaces.IBridgechainUpdateAsset>(transaction.asset?.bridgechainUpdate);
 
             const wallet: Contracts.State.Wallet = this.walletRepository.findByPublicKey(transaction.senderPublicKey);
-            const businessAttributes: IBusinessWalletAttributes = wallet.getAttribute<IBusinessWalletAttributes>(
-                "business",
-            );
+            const businessAttributes: IBusinessWalletAttributes =
+                wallet.getAttribute<IBusinessWalletAttributes>("business");
 
             const shallowCloneBridgechainUpdate = { ...transaction.asset.bridgechainUpdate };
             const bridgechainId = shallowCloneBridgechainUpdate.bridgechainId;
@@ -84,9 +84,8 @@ export class BridgechainUpdateTransactionHandler extends MagistrateTransactionHa
             transaction.data.asset?.bridgechainUpdate,
         );
 
-        const businessAttributes: IBusinessWalletAttributes = wallet.getAttribute<IBusinessWalletAttributes>(
-            "business",
-        );
+        const businessAttributes: IBusinessWalletAttributes =
+            wallet.getAttribute<IBusinessWalletAttributes>("business");
 
         if (!businessAttributes.bridgechains) {
             throw new BridgechainIsNotRegisteredByWalletError();
@@ -146,12 +145,11 @@ export class BridgechainUpdateTransactionHandler extends MagistrateTransactionHa
 
         const wallet: Contracts.State.Wallet = this.walletRepository.findByPublicKey(transaction.data.senderPublicKey);
 
-        const businessAttributes: IBusinessWalletAttributes = wallet.getAttribute<IBusinessWalletAttributes>(
-            "business",
-        );
+        const businessAttributes: IBusinessWalletAttributes =
+            wallet.getAttribute<IBusinessWalletAttributes>("business");
 
-        const bridgechainUpdate: MagistrateInterfaces.IBridgechainUpdateAsset = transaction.data.asset! // Assertion check inside super.applyToSender
-            .bridgechainUpdate;
+        const bridgechainUpdate: MagistrateInterfaces.IBridgechainUpdateAsset =
+            transaction.data.asset!.bridgechainUpdate; // Assertion check inside super.applyToSender
 
         AppUtils.assert.defined<Record<string, IBridgechainWalletAttributes>>(businessAttributes.bridgechains);
 
@@ -180,9 +178,8 @@ export class BridgechainUpdateTransactionHandler extends MagistrateTransactionHa
         const sender: Contracts.State.Wallet = this.walletRepository.findByPublicKey(transaction.data.senderPublicKey);
         AppUtils.assert.defined<string>(sender.getPublicKey());
 
-        const businessAttributes: IBusinessWalletAttributes = sender.getAttribute<IBusinessWalletAttributes>(
-            "business",
-        );
+        const businessAttributes: IBusinessWalletAttributes =
+            sender.getAttribute<IBusinessWalletAttributes>("business");
         const bridgechainId: string = transaction.data.asset.bridgechainUpdate.bridgechainId;
 
         const bridgechainTransactions = await this.transactionHistoryService.findManyByCriteria([

--- a/packages/core-magistrate-transactions/src/handlers/business-registration.ts
+++ b/packages/core-magistrate-transactions/src/handlers/business-registration.ts
@@ -17,6 +17,7 @@ export class BusinessRegistrationTransactionHandler extends MagistrateTransactio
     private readonly poolQuery!: Contracts.TransactionPool.Query;
 
     @Container.inject(Container.Identifiers.TransactionHistoryService)
+    @Container.tagged("connection", "default")
     private readonly transactionHistoryService!: Contracts.Shared.TransactionHistoryService;
 
     public dependencies(): ReadonlyArray<Handlers.TransactionHandlerConstructor> {

--- a/packages/core-magistrate-transactions/src/handlers/business-resignation.ts
+++ b/packages/core-magistrate-transactions/src/handlers/business-resignation.ts
@@ -15,6 +15,7 @@ export class BusinessResignationTransactionHandler extends MagistrateTransaction
     private readonly poolQuery!: Contracts.TransactionPool.Query;
 
     @Container.inject(Container.Identifiers.TransactionHistoryService)
+    @Container.tagged("connection", "default")
     private readonly transactionHistoryService!: Contracts.Shared.TransactionHistoryService;
 
     public dependencies(): ReadonlyArray<Handlers.TransactionHandlerConstructor> {

--- a/packages/core-magistrate-transactions/src/handlers/business-update.ts
+++ b/packages/core-magistrate-transactions/src/handlers/business-update.ts
@@ -19,6 +19,7 @@ export class BusinessUpdateTransactionHandler extends MagistrateTransactionHandl
     private readonly poolQuery!: Contracts.TransactionPool.Query;
 
     @Container.inject(Container.Identifiers.TransactionHistoryService)
+    @Container.tagged("connection", "default")
     private readonly transactionHistoryService!: Contracts.Shared.TransactionHistoryService;
 
     public dependencies(): ReadonlyArray<Handlers.TransactionHandlerConstructor> {
@@ -45,9 +46,8 @@ export class BusinessUpdateTransactionHandler extends MagistrateTransactionHandl
 
             const wallet: Contracts.State.Wallet = this.walletRepository.findByPublicKey(transaction.senderPublicKey);
 
-            const businessWalletAsset: MagistrateInterfaces.IBusinessRegistrationAsset = wallet.getAttribute<
-                IBusinessWalletAttributes
-            >("business").businessAsset;
+            const businessWalletAsset: MagistrateInterfaces.IBusinessRegistrationAsset =
+                wallet.getAttribute<IBusinessWalletAttributes>("business").businessAsset;
             const businessUpdate: MagistrateInterfaces.IBusinessUpdateAsset = transaction.asset.businessUpdate;
 
             wallet.setAttribute("business.businessAsset", {
@@ -96,9 +96,8 @@ export class BusinessUpdateTransactionHandler extends MagistrateTransactionHandl
 
         const sender: Contracts.State.Wallet = this.walletRepository.findByPublicKey(transaction.data.senderPublicKey);
 
-        const businessWalletAsset: MagistrateInterfaces.IBusinessRegistrationAsset = sender.getAttribute<
-            IBusinessWalletAttributes
-        >("business").businessAsset;
+        const businessWalletAsset: MagistrateInterfaces.IBusinessRegistrationAsset =
+            sender.getAttribute<IBusinessWalletAttributes>("business").businessAsset;
 
         AppUtils.assert.defined<MagistrateInterfaces.IBusinessUpdateAsset>(transaction.data.asset?.businessUpdate);
 

--- a/packages/core-magistrate-transactions/src/handlers/entity.ts
+++ b/packages/core-magistrate-transactions/src/handlers/entity.ts
@@ -28,6 +28,7 @@ export class EntityTransactionHandler extends Handlers.TransactionHandler {
     private readonly mempoolIndexRegistry!: Contracts.TransactionPool.MempoolIndexRegistry;
 
     @Container.inject(Container.Identifiers.TransactionHistoryService)
+    @Container.tagged("connection", "default")
     private readonly transactionHistoryService!: Contracts.Shared.TransactionHistoryService;
 
     public dependencies(): ReadonlyArray<Handlers.TransactionHandlerConstructor> {

--- a/packages/core-state/src/state-builder.ts
+++ b/packages/core-state/src/state-builder.ts
@@ -14,6 +14,7 @@ export class StateBuilder {
     private blockRepository!: Repositories.BlockRepository;
 
     @Container.inject(Container.Identifiers.DatabaseTransactionRepository)
+    @Container.tagged("connection", "default")
     private transactionRepository!: Repositories.TransactionRepository;
 
     @Container.inject(Container.Identifiers.WalletRepository)

--- a/packages/core-state/src/state-builder.ts
+++ b/packages/core-state/src/state-builder.ts
@@ -10,6 +10,7 @@ export class StateBuilder {
     private readonly app!: Application;
 
     @Container.inject(Container.Identifiers.DatabaseBlockRepository)
+    @Container.tagged("connection", "default")
     private blockRepository!: Repositories.BlockRepository;
 
     @Container.inject(Container.Identifiers.DatabaseTransactionRepository)

--- a/packages/core-transactions/src/handlers/one/multi-signature-registration.ts
+++ b/packages/core-transactions/src/handlers/one/multi-signature-registration.ts
@@ -9,6 +9,7 @@ import { TransactionHandler, TransactionHandlerConstructor } from "../transactio
 @Container.injectable()
 export class MultiSignatureRegistrationTransactionHandler extends TransactionHandler {
     @Container.inject(Container.Identifiers.TransactionHistoryService)
+    @Container.tagged("connection", "default")
     private readonly transactionHistoryService!: Contracts.Shared.TransactionHistoryService;
 
     public dependencies(): ReadonlyArray<TransactionHandlerConstructor> {

--- a/packages/core-transactions/src/handlers/transaction.ts
+++ b/packages/core-transactions/src/handlers/transaction.ts
@@ -25,6 +25,7 @@ export abstract class TransactionHandler {
     protected readonly app!: Contracts.Kernel.Application;
 
     @Container.inject(Container.Identifiers.DatabaseBlockRepository)
+    @Container.tagged("connection", "default")
     protected readonly blockRepository!: Repositories.BlockRepository;
 
     @Container.inject(Container.Identifiers.DatabaseTransactionRepository)

--- a/packages/core-transactions/src/handlers/transaction.ts
+++ b/packages/core-transactions/src/handlers/transaction.ts
@@ -29,6 +29,7 @@ export abstract class TransactionHandler {
     protected readonly blockRepository!: Repositories.BlockRepository;
 
     @Container.inject(Container.Identifiers.DatabaseTransactionRepository)
+    @Container.tagged("connection", "default")
     protected readonly transactionRepository!: Repositories.TransactionRepository;
 
     @Container.inject(Container.Identifiers.WalletRepository)

--- a/packages/core-transactions/src/handlers/two/delegate-registration.ts
+++ b/packages/core-transactions/src/handlers/two/delegate-registration.ts
@@ -7,6 +7,7 @@ import { One } from "../index";
 @Container.injectable()
 export class DelegateRegistrationTransactionHandler extends One.DelegateRegistrationTransactionHandler {
     @Container.inject(Container.Identifiers.TransactionHistoryService)
+    @Container.tagged("connection", "default")
     private readonly transactionHistoryService!: Contracts.Shared.TransactionHistoryService;
 
     public getConstructor(): Transactions.TransactionConstructor {

--- a/packages/core-transactions/src/handlers/two/delegate-resignation.ts
+++ b/packages/core-transactions/src/handlers/two/delegate-resignation.ts
@@ -13,6 +13,7 @@ export class DelegateResignationTransactionHandler extends TransactionHandler {
     private readonly poolQuery!: Contracts.TransactionPool.Query;
 
     @Container.inject(Container.Identifiers.TransactionHistoryService)
+    @Container.tagged("connection", "default")
     private readonly transactionHistoryService!: Contracts.Shared.TransactionHistoryService;
 
     public dependencies(): ReadonlyArray<TransactionHandlerConstructor> {

--- a/packages/core-transactions/src/handlers/two/ipfs.ts
+++ b/packages/core-transactions/src/handlers/two/ipfs.ts
@@ -13,6 +13,7 @@ export class IpfsTransactionHandler extends TransactionHandler {
     private readonly mempoolIndexRegistry!: Contracts.TransactionPool.MempoolIndexRegistry;
 
     @Container.inject(Container.Identifiers.TransactionHistoryService)
+    @Container.tagged("connection", "default")
     private readonly transactionHistoryService!: Contracts.Shared.TransactionHistoryService;
 
     public dependencies(): ReadonlyArray<TransactionHandlerConstructor> {

--- a/packages/core-transactions/src/handlers/two/multi-payment.ts
+++ b/packages/core-transactions/src/handlers/two/multi-payment.ts
@@ -7,6 +7,7 @@ import { TransactionHandler, TransactionHandlerConstructor } from "../transactio
 @Container.injectable()
 export class MultiPaymentTransactionHandler extends TransactionHandler {
     @Container.inject(Container.Identifiers.TransactionHistoryService)
+    @Container.tagged("connection", "default")
     private readonly transactionHistoryService!: Contracts.Shared.TransactionHistoryService;
 
     public dependencies(): ReadonlyArray<TransactionHandlerConstructor> {

--- a/packages/core-transactions/src/handlers/two/multi-signature-registration.ts
+++ b/packages/core-transactions/src/handlers/two/multi-signature-registration.ts
@@ -19,6 +19,7 @@ export class MultiSignatureRegistrationTransactionHandler extends TransactionHan
     private readonly mempoolIndexRegistry!: Contracts.TransactionPool.MempoolIndexRegistry;
 
     @Container.inject(Container.Identifiers.TransactionHistoryService)
+    @Container.tagged("connection", "default")
     private readonly transactionHistoryService!: Contracts.Shared.TransactionHistoryService;
 
     public dependencies(): ReadonlyArray<TransactionHandlerConstructor> {

--- a/packages/core-transactions/src/handlers/two/second-signature-registration.ts
+++ b/packages/core-transactions/src/handlers/two/second-signature-registration.ts
@@ -6,6 +6,7 @@ import { One } from "../index";
 @Container.injectable()
 export class SecondSignatureRegistrationTransactionHandler extends One.SecondSignatureRegistrationTransactionHandler {
     @Container.inject(Container.Identifiers.TransactionHistoryService)
+    @Container.tagged("connection", "default")
     private readonly transactionHistoryService!: Contracts.Shared.TransactionHistoryService;
 
     public getConstructor(): Transactions.TransactionConstructor {

--- a/packages/core-transactions/src/handlers/two/vote.ts
+++ b/packages/core-transactions/src/handlers/two/vote.ts
@@ -8,6 +8,7 @@ import { DelegateRegistrationTransactionHandler } from "./delegate-registration"
 @Container.injectable()
 export class VoteTransactionHandler extends One.VoteTransactionHandler {
     @Container.inject(Container.Identifiers.TransactionHistoryService)
+    @Container.tagged("connection", "default")
     private readonly transactionHistoryService!: Contracts.Shared.TransactionHistoryService;
 
     public dependencies(): ReadonlyArray<TransactionHandlerConstructor> {


### PR DESCRIPTION
## Summary

Create second database connection for core-api API calls. This allow additional connection settings like statement timeout.  By default timeout is 3000 ms. 

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged
