### PR TITLE
fix(core-kernel): make pagination service non blocking

### DIFF
--- a/__tests__/integration/core-api/services/delegate-search-service.test.ts
+++ b/__tests__/integration/core-api/services/delegate-search-service.test.ts
@@ -94,7 +94,7 @@ describe("DelegateSearchService.getDelegate", () => {
 });
 
 describe("DelegateSearchService.getDelegatesPage", () => {
-    it("should get all delegates when criteria is empty", () => {
+    it("should get all delegates when criteria is empty", async () => {
         const wallet1 = walletRepository.findByPublicKey(Identities.PublicKey.fromPassphrase("secret1"));
         wallet1.setAttribute("delegate", delegateAttribute1);
         walletRepository.index(wallet1);
@@ -103,7 +103,7 @@ describe("DelegateSearchService.getDelegatesPage", () => {
         wallet2.setAttribute("delegate", delegateAttribute2);
         walletRepository.index(wallet2);
 
-        const delegatesPage = delegateSearchService.getDelegatesPage({ offset: 0, limit: 100 }, [
+        const delegatesPage = await delegateSearchService.getDelegatesPage({ offset: 0, limit: 100 }, [
             { property: "username", direction: "asc" },
         ]);
 
@@ -112,7 +112,7 @@ describe("DelegateSearchService.getDelegatesPage", () => {
         expect(delegatesPage.results[1].username).toBe("cryptology");
     });
 
-    it("should get delegates that match criteria", () => {
+    it("should get delegates that match criteria", async () => {
         const wallet1 = walletRepository.findByPublicKey(Identities.PublicKey.fromPassphrase("secret1"));
         wallet1.setAttribute("delegate", delegateAttribute1);
         walletRepository.index(wallet1);
@@ -121,7 +121,7 @@ describe("DelegateSearchService.getDelegatesPage", () => {
         wallet2.setAttribute("delegate", delegateAttribute2);
         walletRepository.index(wallet2);
 
-        const delegatesPage = delegateSearchService.getDelegatesPage(
+        const delegatesPage = await delegateSearchService.getDelegatesPage(
             { offset: 0, limit: 100 },
             [{ property: "username", direction: "asc" }],
             { username: "binance_staking" },

--- a/__tests__/integration/core-api/services/lock-search-service.test.ts
+++ b/__tests__/integration/core-api/services/lock-search-service.test.ts
@@ -59,13 +59,13 @@ beforeEach(async () => {
 });
 
 describe("LockSearchService.getLock", () => {
-    it("should return lock resource by id", () => {
+    it("should return lock resource by id", async () => {
         const wallet1 = walletRepository.findByPublicKey(Identities.PublicKey.fromPassphrase("wallet1"));
         wallet1.setAttribute("htlc.locks", { [lockId1]: lockAttribute1 });
         walletRepository.index(wallet1);
 
         stateStore.getLastBlock.mockReturnValue({ data: { height: 1000 } } as any);
-        const lockResource1 = lockSearchService.getLock(lockId1);
+        const lockResource1 = await lockSearchService.getLock(lockId1);
 
         expect(lockResource1.lockId).toEqual(lockId1);
     });
@@ -77,7 +77,7 @@ describe("LockSearchService.getLock", () => {
 });
 
 describe("LockSearchService.getLocksPage", () => {
-    it("should return all locks", () => {
+    it("should return all locks", async () => {
         const wallet1 = walletRepository.findByPublicKey(Identities.PublicKey.fromPassphrase("wallet1"));
         wallet1.setAttribute("htlc.locks", { [lockId1]: lockAttribute1 });
         walletRepository.index(wallet1);
@@ -87,7 +87,7 @@ describe("LockSearchService.getLocksPage", () => {
         walletRepository.index(wallet2);
 
         stateStore.getLastBlock.mockReturnValue({ data: { height: 1000 } } as any);
-        const locksPage = lockSearchService.getLocksPage({ offset: 0, limit: 100 }, [
+        const locksPage = await lockSearchService.getLocksPage({ offset: 0, limit: 100 }, [
             { property: "amount", direction: "asc" },
         ]);
 
@@ -96,7 +96,7 @@ describe("LockSearchService.getLocksPage", () => {
         expect(locksPage.results[1].lockId).toBe(lockId2);
     });
 
-    it("should return locks that match criteria", () => {
+    it("should return locks that match criteria", async () => {
         const wallet1 = walletRepository.findByPublicKey(Identities.PublicKey.fromPassphrase("wallet1"));
         wallet1.setAttribute("htlc.locks", { [lockId1]: lockAttribute1 });
         walletRepository.index(wallet1);
@@ -106,7 +106,7 @@ describe("LockSearchService.getLocksPage", () => {
         walletRepository.index(wallet2);
 
         stateStore.getLastBlock.mockReturnValue({ data: { height: 1000 } } as any);
-        const locksPage = lockSearchService.getLocksPage(
+        const locksPage = await lockSearchService.getLocksPage(
             { offset: 0, limit: 100 },
             [{ property: "amount", direction: "asc" }],
             { amount: "1000" },
@@ -118,13 +118,13 @@ describe("LockSearchService.getLocksPage", () => {
 });
 
 describe("LockSearchService.getWalletLocksPage", () => {
-    it("should return all wallet locks", () => {
+    it("should return all wallet locks", async () => {
         const wallet1 = walletRepository.findByPublicKey(Identities.PublicKey.fromPassphrase("wallet1"));
         wallet1.setAttribute("htlc.locks", { [lockId1]: lockAttribute1, [lockId2]: lockAttribute2 });
         walletRepository.index(wallet1);
 
         stateStore.getLastBlock.mockReturnValue({ data: { height: 1000 } } as any);
-        const locksPage = lockSearchService.getWalletLocksPage(
+        const locksPage = await lockSearchService.getWalletLocksPage(
             { offset: 0, limit: 100 },
             [{ property: "amount", direction: "asc" }],
             wallet1.getAddress(),
@@ -135,13 +135,13 @@ describe("LockSearchService.getWalletLocksPage", () => {
         expect(locksPage.results[1].lockId).toBe(lockId2);
     });
 
-    it("should return all wallet locks that match criteria", () => {
+    it("should return all wallet locks that match criteria", async () => {
         const wallet1 = walletRepository.findByPublicKey(Identities.PublicKey.fromPassphrase("wallet1"));
         wallet1.setAttribute("htlc.locks", { [lockId1]: lockAttribute1, [lockId2]: lockAttribute2 });
         walletRepository.index(wallet1);
 
         stateStore.getLastBlock.mockReturnValue({ data: { height: 1000 } } as any);
-        const locksPage = lockSearchService.getWalletLocksPage(
+        const locksPage = await lockSearchService.getWalletLocksPage(
             { offset: 0, limit: 100 },
             [{ property: "amount", direction: "asc" }],
             wallet1.getAddress(),
@@ -152,7 +152,7 @@ describe("LockSearchService.getWalletLocksPage", () => {
         expect(locksPage.results[0].lockId).toBe(lockId1);
     });
 
-    it("should return only wallet locks", () => {
+    it("should return only wallet locks", async () => {
         const wallet1 = walletRepository.findByPublicKey(Identities.PublicKey.fromPassphrase("wallet1"));
         wallet1.setAttribute("htlc.locks", { [lockId1]: lockAttribute1 });
         walletRepository.index(wallet1);
@@ -162,7 +162,7 @@ describe("LockSearchService.getWalletLocksPage", () => {
         walletRepository.index(wallet2);
 
         stateStore.getLastBlock.mockReturnValue({ data: { height: 1000 } } as any);
-        const locksPage = lockSearchService.getWalletLocksPage(
+        const locksPage = await lockSearchService.getWalletLocksPage(
             { offset: 0, limit: 100 },
             [{ property: "amount", direction: "asc" }],
             wallet1.getAddress(),

--- a/__tests__/integration/core-api/services/wallet-search-service.test.ts
+++ b/__tests__/integration/core-api/services/wallet-search-service.test.ts
@@ -68,7 +68,7 @@ describe("WalletSearchService.getWallet", () => {
 });
 
 describe("WalletSearchService.getWalletsPage", () => {
-    it("should get first three wallets sorted by balance:desc", () => {
+    it("should get first three wallets sorted by balance:desc", async () => {
         const wallet1 = walletRepository.findByPublicKey(Identities.PublicKey.fromPassphrase("secret1"));
         const wallet2 = walletRepository.findByPublicKey(Identities.PublicKey.fromPassphrase("secret2"));
         const wallet3 = walletRepository.findByPublicKey(Identities.PublicKey.fromPassphrase("secret3"));
@@ -81,7 +81,7 @@ describe("WalletSearchService.getWalletsPage", () => {
         wallet4.setBalance(Utils.BigNumber.make("40"));
         wallet5.setBalance(Utils.BigNumber.make("50"));
 
-        const page = walletSearchService.getWalletsPage({ limit: 3, offset: 0 }, []);
+        const page = await walletSearchService.getWalletsPage({ limit: 3, offset: 0 }, []);
 
         expect(page.results.length).toBe(3);
         expect(page.results[0].address).toBe(wallet3.getAddress());
@@ -90,7 +90,7 @@ describe("WalletSearchService.getWalletsPage", () => {
         expect(page.totalCount).toBe(5);
     });
 
-    it("should get last two wallets sorted by balance:desc", () => {
+    it("should get last two wallets sorted by balance:desc", async () => {
         const wallet1 = walletRepository.findByPublicKey(Identities.PublicKey.fromPassphrase("secret1"));
         const wallet2 = walletRepository.findByPublicKey(Identities.PublicKey.fromPassphrase("secret2"));
         const wallet3 = walletRepository.findByPublicKey(Identities.PublicKey.fromPassphrase("secret3"));
@@ -103,7 +103,7 @@ describe("WalletSearchService.getWalletsPage", () => {
         wallet4.setBalance(Utils.BigNumber.make("40"));
         wallet5.setBalance(Utils.BigNumber.make("50"));
 
-        const page = walletSearchService.getWalletsPage({ limit: 3, offset: 3 }, []);
+        const page = await walletSearchService.getWalletsPage({ limit: 3, offset: 3 }, []);
 
         expect(page.results.length).toBe(2);
         expect(page.results[0].address).toBe(wallet5.getAddress());
@@ -111,7 +111,7 @@ describe("WalletSearchService.getWalletsPage", () => {
         expect(page.totalCount).toBe(5);
     });
 
-    it("should get only three wallets sorted by balance:desc", () => {
+    it("should get only three wallets sorted by balance:desc", async () => {
         const wallet1 = walletRepository.findByPublicKey(Identities.PublicKey.fromPassphrase("secret1"));
         const wallet2 = walletRepository.findByPublicKey(Identities.PublicKey.fromPassphrase("secret2"));
         const wallet3 = walletRepository.findByPublicKey(Identities.PublicKey.fromPassphrase("secret3"));
@@ -124,7 +124,9 @@ describe("WalletSearchService.getWalletsPage", () => {
         wallet4.setBalance(Utils.BigNumber.make("40"));
         wallet5.setBalance(Utils.BigNumber.make("50"));
 
-        const page = walletSearchService.getWalletsPage({ limit: 5, offset: 0 }, [], { balance: { from: "100" } });
+        const page = await walletSearchService.getWalletsPage({ limit: 5, offset: 0 }, [], {
+            balance: { from: "100" },
+        });
 
         expect(page.results.length).toBe(3);
         expect(page.results[0].address).toBe(wallet3.getAddress());
@@ -135,7 +137,7 @@ describe("WalletSearchService.getWalletsPage", () => {
 });
 
 describe("WalletSearchService.getActiveWalletsPage", () => {
-    it("should only get wallets with public keys", () => {
+    it("should only get wallets with public keys", async () => {
         const wallet1 = walletRepository.findByPublicKey(Identities.PublicKey.fromPassphrase("secret1"));
         const wallet2 = walletRepository.findByPublicKey(Identities.PublicKey.fromPassphrase("secret2"));
         const wallet3 = walletRepository.findByAddress(Identities.Address.fromPassphrase("secret3"));
@@ -148,7 +150,7 @@ describe("WalletSearchService.getActiveWalletsPage", () => {
         wallet4.setBalance(Utils.BigNumber.make("400"));
         wallet5.setBalance(Utils.BigNumber.make("500"));
 
-        const page = walletSearchService.getActiveWalletsPage({ offset: 0, limit: 100 }, [
+        const page = await walletSearchService.getActiveWalletsPage({ offset: 0, limit: 100 }, [
             { property: "balance", direction: "asc" },
         ]);
 

--- a/__tests__/integration/core-magistrate-api/services/entity-search-service.test.ts
+++ b/__tests__/integration/core-magistrate-api/services/entity-search-service.test.ts
@@ -1,10 +1,10 @@
-import { EntitySearchService, Identifiers as MagistrateApiIdentifiers } from "@arkecosystem/core-magistrate-api/src";
 import { Container, Contracts } from "@arkecosystem/core-kernel";
-
-import { setUp } from "./__support__/setup";
-import { setIndexes } from "../__support__/set-indexes";
+import { EntitySearchService, Identifiers as MagistrateApiIdentifiers } from "@arkecosystem/core-magistrate-api/src";
 import { Enums } from "@arkecosystem/core-magistrate-crypto";
 import { Identities } from "@arkecosystem/crypto";
+
+import { setIndexes } from "../__support__/set-indexes";
+import { setUp } from "./__support__/setup";
 
 const entityId1 = "2a2498072a798318f5e321b312dfc7dcb87f33e10a251baf07ed8f950bd499ec";
 const entityAttribute1 = {
@@ -56,7 +56,7 @@ describe("EntitySearchService.getEntity", () => {
 });
 
 describe("EntitySearchService.getEntitiesPage", () => {
-    it("should return all entities", () => {
+    it("should return all entities", async () => {
         const wallet1 = walletRepository.findByPublicKey(Identities.PublicKey.fromPassphrase("wallet1"));
         wallet1.setAttribute("entities", { [entityId1]: entityAttribute1 });
         setIndexes(walletRepository, wallet1);
@@ -65,14 +65,14 @@ describe("EntitySearchService.getEntitiesPage", () => {
         wallet2.setAttribute("entities", { [entityId2]: entityAttribute2 });
         setIndexes(walletRepository, wallet2);
 
-        const entitiesPage = entitySearchService.getEntitiesPage({ offset: 0, limit: 100 }, []);
+        const entitiesPage = await entitySearchService.getEntitiesPage({ offset: 0, limit: 100 }, []);
 
         expect(entitiesPage.totalCount).toBe(2);
         expect(entitiesPage.results[0].data.name).toBe("entity 1");
         expect(entitiesPage.results[1].data.name).toBe("entity 2");
     });
 
-    it("should entities that match criteria", () => {
+    it("should entities that match criteria", async () => {
         const wallet1 = walletRepository.findByPublicKey(Identities.PublicKey.fromPassphrase("wallet1"));
         wallet1.setAttribute("entities", { [entityId1]: entityAttribute1 });
         setIndexes(walletRepository, wallet1);
@@ -81,7 +81,7 @@ describe("EntitySearchService.getEntitiesPage", () => {
         wallet2.setAttribute("entities", { [entityId2]: entityAttribute2 });
         setIndexes(walletRepository, wallet2);
 
-        const entitiesPage = entitySearchService.getEntitiesPage({ offset: 0, limit: 100 }, [], {
+        const entitiesPage = await entitySearchService.getEntitiesPage({ offset: 0, limit: 100 }, [], {
             data: { name: "entity 1" },
         });
 

--- a/__tests__/unit/core-api/controllers/delegates.test.ts
+++ b/__tests__/unit/core-api/controllers/delegates.test.ts
@@ -97,7 +97,7 @@ const voterWalletResource: Resources.WalletResource = {
 
 describe("DelegatesController", () => {
     describe("Index", () => {
-        it("should get criteria from query and return delegates page from DelegateSearchService", () => {
+        it("should get criteria from query and return delegates page from DelegateSearchService", async () => {
             const delegatesPage: Contracts.Search.ResultsPage<Resources.DelegateResource> = {
                 results: [delegateResource],
                 totalCount: 1,
@@ -106,7 +106,7 @@ describe("DelegatesController", () => {
             delegateSearchService.getDelegatesPage.mockReturnValueOnce(delegatesPage);
 
             const delegatesController = container.resolve(DelegatesController);
-            const result = delegatesController.index({
+            const result = await delegatesController.index({
                 query: {
                     page: 1,
                     limit: 100,
@@ -174,7 +174,7 @@ describe("DelegatesController", () => {
     });
 
     describe("Voters", () => {
-        it("should get delegate id from pathname and criteria from query and return voter wallets from WalletSearchService", () => {
+        it("should get delegate id from pathname and criteria from query and return voter wallets from WalletSearchService", async () => {
             walletSearchService.getWallet.mockReturnValueOnce(delegateWalletResource);
             delegateSearchService.getDelegate.mockReturnValueOnce(delegateResource);
 
@@ -186,7 +186,7 @@ describe("DelegatesController", () => {
             walletSearchService.getActiveWalletsPage.mockReturnValueOnce(voterWalletsPage);
 
             const delegatesController = container.resolve(DelegatesController);
-            const result = delegatesController.voters({
+            const result = await delegatesController.voters({
                 params: {
                     id: "biz_classic",
                 },
@@ -211,11 +211,11 @@ describe("DelegatesController", () => {
             expect(result).toBe(voterWalletsPage);
         });
 
-        it("should return 404 when wallet wasn't found", () => {
+        it("should return 404 when wallet wasn't found", async () => {
             walletSearchService.getWallet.mockReturnValueOnce(undefined);
 
             const delegatesController = container.resolve(DelegatesController);
-            const result = delegatesController.voters({
+            const result = await delegatesController.voters({
                 params: {
                     id: "non-existing-wallet-id",
                 },
@@ -231,12 +231,12 @@ describe("DelegatesController", () => {
             expect(result).toBeInstanceOf(Boom);
         });
 
-        it("should return 404 when wallet isn't delegate", () => {
+        it("should return 404 when wallet isn't delegate", async () => {
             walletSearchService.getWallet.mockReturnValueOnce(voterWalletResource);
             delegateSearchService.getDelegate.mockReturnValueOnce(undefined);
 
             const delegatesController = container.resolve(DelegatesController);
-            const result = delegatesController.voters({
+            const result = await delegatesController.voters({
                 params: {
                     id: "ATL9kyo71wjPPXqvGMUD89t5RazmQfQMc6",
                 },

--- a/__tests__/unit/core-api/controllers/delegates.test.ts
+++ b/__tests__/unit/core-api/controllers/delegates.test.ts
@@ -103,7 +103,7 @@ describe("DelegatesController", () => {
                 totalCount: 1,
                 meta: { totalCountIsEstimate: false },
             };
-            delegateSearchService.getDelegatesPage.mockReturnValueOnce(delegatesPage);
+            delegateSearchService.getDelegatesPage.mockResolvedValueOnce(delegatesPage);
 
             const delegatesController = container.resolve(DelegatesController);
             const result = await delegatesController.index({
@@ -183,7 +183,7 @@ describe("DelegatesController", () => {
                 totalCount: 1,
                 meta: { totalCountIsEstimate: false },
             };
-            walletSearchService.getActiveWalletsPage.mockReturnValueOnce(voterWalletsPage);
+            walletSearchService.getActiveWalletsPage.mockResolvedValueOnce(voterWalletsPage);
 
             const delegatesController = container.resolve(DelegatesController);
             const result = await delegatesController.voters({

--- a/__tests__/unit/core-api/controllers/locks.test.ts
+++ b/__tests__/unit/core-api/controllers/locks.test.ts
@@ -63,7 +63,7 @@ describe("LocksController", () => {
                 totalCount: 1,
                 meta: { totalCountIsEstimate: false },
             };
-            lockSearchService.getLocksPage.mockReturnValueOnce(locksPage);
+            lockSearchService.getLocksPage.mockResolvedValueOnce(locksPage);
 
             const locksController = container.resolve(LocksController);
             const result = await locksController.index({

--- a/__tests__/unit/core-api/controllers/locks.test.ts
+++ b/__tests__/unit/core-api/controllers/locks.test.ts
@@ -57,7 +57,7 @@ const lockResource1: Resources.LockResource = {
 
 describe("LocksController", () => {
     describe("Index", () => {
-        it("should get criteria from query and return locks page from LockSearchService", () => {
+        it("should get criteria from query and return locks page from LockSearchService", async () => {
             const locksPage: Contracts.Search.ResultsPage<Resources.LockResource> = {
                 results: [lockResource1],
                 totalCount: 1,
@@ -66,7 +66,7 @@ describe("LocksController", () => {
             lockSearchService.getLocksPage.mockReturnValueOnce(locksPage);
 
             const locksController = container.resolve(LocksController);
-            const result = locksController.index({
+            const result = await locksController.index({
                 query: {
                     page: 1,
                     limit: 100,

--- a/__tests__/unit/core-api/controllers/wallets.test.ts
+++ b/__tests__/unit/core-api/controllers/wallets.test.ts
@@ -83,7 +83,7 @@ const wallet1LockResource1: Resources.LockResource = {
 
 describe("WalletsController", () => {
     describe("Index", () => {
-        it("should get criteria from query and return wallets page from WalletSearchService", () => {
+        it("should get criteria from query and return wallets page from WalletSearchService", async () => {
             const walletsPage: Contracts.Search.ResultsPage<Resources.WalletResource> = {
                 results: [walletResource1],
                 totalCount: 1,
@@ -92,7 +92,7 @@ describe("WalletsController", () => {
             walletSearchService.getWalletsPage.mockReturnValueOnce(walletsPage);
 
             const walletsController = container.resolve(WalletsController);
-            const result = walletsController.index({
+            const result = await walletsController.index({
                 query: {
                     page: 1,
                     limit: 100,
@@ -114,7 +114,7 @@ describe("WalletsController", () => {
     describe("Top", () => {
         // it is exact duplicate of WalletsController.index
 
-        it("should get criteria from query and return wallets page from WalletSearchService", () => {
+        it("should get criteria from query and return wallets page from WalletSearchService", async () => {
             const walletsPage: Contracts.Search.ResultsPage<Resources.WalletResource> = {
                 results: [walletResource1],
                 totalCount: 1,
@@ -123,7 +123,7 @@ describe("WalletsController", () => {
             walletSearchService.getWalletsPage.mockReturnValueOnce(walletsPage);
 
             const walletsController = container.resolve(WalletsController);
-            const result = walletsController.top({
+            const result = await walletsController.top({
                 query: {
                     page: 1,
                     limit: 100,
@@ -173,7 +173,7 @@ describe("WalletsController", () => {
     });
 
     describe("Locks", () => {
-        it("should get wallet id from pathname and criteria from query and return locks page from LockSearchService", () => {
+        it("should get wallet id from pathname and criteria from query and return locks page from LockSearchService", async () => {
             walletSearchService.getWallet.mockReturnValueOnce(walletResource1);
 
             const locksPage: Contracts.Search.ResultsPage<Resources.LockResource> = {
@@ -184,7 +184,7 @@ describe("WalletsController", () => {
             lockSearchService.getWalletLocksPage.mockReturnValueOnce(locksPage);
 
             const walletsController = container.resolve(WalletsController);
-            const result = walletsController.locks({
+            const result = await walletsController.locks({
                 params: {
                     id: walletResource1.publicKey,
                 },
@@ -208,11 +208,11 @@ describe("WalletsController", () => {
             expect(result).toBe(locksPage);
         });
 
-        it("should return 404 when wallet wasn't found", () => {
+        it("should return 404 when wallet wasn't found", async () => {
             walletSearchService.getWallet.mockReturnValueOnce(undefined);
 
             const walletsController = container.resolve(WalletsController);
-            const result = walletsController.locks({
+            const result = await walletsController.locks({
                 params: {
                     id: "non-existing-wallet-id",
                 },

--- a/__tests__/unit/core-api/controllers/wallets.test.ts
+++ b/__tests__/unit/core-api/controllers/wallets.test.ts
@@ -89,7 +89,7 @@ describe("WalletsController", () => {
                 totalCount: 1,
                 meta: { totalCountIsEstimate: false },
             };
-            walletSearchService.getWalletsPage.mockReturnValueOnce(walletsPage);
+            walletSearchService.getWalletsPage.mockResolvedValueOnce(walletsPage);
 
             const walletsController = container.resolve(WalletsController);
             const result = await walletsController.index({
@@ -120,7 +120,7 @@ describe("WalletsController", () => {
                 totalCount: 1,
                 meta: { totalCountIsEstimate: false },
             };
-            walletSearchService.getWalletsPage.mockReturnValueOnce(walletsPage);
+            walletSearchService.getWalletsPage.mockResolvedValueOnce(walletsPage);
 
             const walletsController = container.resolve(WalletsController);
             const result = await walletsController.top({
@@ -181,7 +181,7 @@ describe("WalletsController", () => {
                 totalCount: 1,
                 meta: { totalCountIsEstimate: false },
             };
-            lockSearchService.getWalletLocksPage.mockReturnValueOnce(locksPage);
+            lockSearchService.getWalletLocksPage.mockResolvedValueOnce(locksPage);
 
             const walletsController = container.resolve(WalletsController);
             const result = await walletsController.locks({

--- a/__tests__/unit/core-api/services/delegate-search-service.test.ts
+++ b/__tests__/unit/core-api/services/delegate-search-service.test.ts
@@ -122,7 +122,7 @@ describe("DelegateSearchService", () => {
     });
 
     describe("getDelegatesPage", () => {
-        it("should return results with delegate", () => {
+        it("should return results with delegate", async () => {
             const delegate = new Wallets.Wallet("ANBkoGqWeTSiaEVgVzSKZd3jS7UWzv9PSo", attributeMap);
             delegate.setPublicKey("03287bfebba4c7881a0509717e71b34b63f31e40021c321f89ae04f84be6d6ac37");
 
@@ -138,7 +138,7 @@ describe("DelegateSearchService", () => {
             walletRepository.allByUsername.mockReturnValue([delegate]);
             standardCriteriaService.testStandardCriterias.mockReturnValue(true);
 
-            const result = delegateSearchService.getDelegatesPage(
+            const result = await delegateSearchService.getDelegatesPage(
                 {
                     offset: 0,
                     limit: 100,
@@ -154,7 +154,7 @@ describe("DelegateSearchService", () => {
             expect(spyOnCalculateApproval).toHaveBeenCalledWith(delegate, AppUtils.BigNumber.ZERO, 100);
         });
 
-        it("should return empty array if all tested criterias are false", () => {
+        it("should return empty array if all tested criterias are false", async () => {
             const delegate = new Wallets.Wallet("ANBkoGqWeTSiaEVgVzSKZd3jS7UWzv9PSo", attributeMap);
             delegate.setPublicKey("03287bfebba4c7881a0509717e71b34b63f31e40021c321f89ae04f84be6d6ac37");
 
@@ -170,7 +170,7 @@ describe("DelegateSearchService", () => {
             walletRepository.allByUsername.mockReturnValue([delegate]);
             standardCriteriaService.testStandardCriterias.mockReturnValue(false);
 
-            const result = delegateSearchService.getDelegatesPage(
+            const result = await delegateSearchService.getDelegatesPage(
                 {
                     offset: 0,
                     limit: 100,

--- a/__tests__/unit/core-api/services/lock-search-service.test.ts
+++ b/__tests__/unit/core-api/services/lock-search-service.test.ts
@@ -94,11 +94,11 @@ describe("LockSearchService", () => {
             });
         });
 
-        it("should check all locks in locks index", () => {
+        it("should check all locks in locks index", async () => {
             standardCriteriaService.testStandardCriterias.mockReturnValue(true);
             AppUtils.expirationCalculator.calculateLockExpirationStatus = jest.fn().mockReturnValue(false);
 
-            const result = lockSearchService.getLocksPage(
+            const result = await lockSearchService.getLocksPage(
                 {
                     offset: 0,
                     limit: 100,
@@ -110,11 +110,11 @@ describe("LockSearchService", () => {
             expect(result.results).toEqual([Locks.lockResource]);
         });
 
-        it("should return empty array if all tested criterias are false", () => {
+        it("should return empty array if all tested criterias are false", async () => {
             standardCriteriaService.testStandardCriterias.mockReturnValue(false);
             AppUtils.expirationCalculator.calculateLockExpirationStatus = jest.fn().mockReturnValue(false);
 
-            const result = lockSearchService.getLocksPage(
+            const result = await lockSearchService.getLocksPage(
                 {
                     offset: 0,
                     limit: 100,
@@ -140,11 +140,11 @@ describe("LockSearchService", () => {
             walletRepository.findByAddress.mockReturnValue(walletWithLock);
         });
 
-        it("should check and return all wallet locks", () => {
+        it("should check and return all wallet locks", async () => {
             standardCriteriaService.testStandardCriterias.mockReturnValue(true);
             AppUtils.expirationCalculator.calculateLockExpirationStatus = jest.fn().mockReturnValue(false);
 
-            const result = lockSearchService.getWalletLocksPage(
+            const result = await lockSearchService.getWalletLocksPage(
                 {
                     offset: 0,
                     limit: 100,
@@ -157,11 +157,11 @@ describe("LockSearchService", () => {
             expect(result.results).toEqual([Locks.lockResource]);
         });
 
-        it("should return empty array if all tested criterias are false", () => {
+        it("should return empty array if all tested criterias are false", async () => {
             standardCriteriaService.testStandardCriterias.mockReturnValue(false);
             AppUtils.expirationCalculator.calculateLockExpirationStatus = jest.fn().mockReturnValue(false);
 
-            const result = lockSearchService.getWalletLocksPage(
+            const result = await lockSearchService.getWalletLocksPage(
                 {
                     offset: 0,
                     limit: 100,

--- a/__tests__/unit/core-api/services/wallet-search-service.test.ts
+++ b/__tests__/unit/core-api/services/wallet-search-service.test.ts
@@ -135,11 +135,11 @@ describe("WalletSearchService", () => {
     });
 
     describe("getWalletsPage", () => {
-        it("should return wallets page with wallet on positive criteria tests", () => {
+        it("should return wallets page with wallet on positive criteria tests", async () => {
             walletRepository.allByAddress.mockReturnValue([wallet]);
             standardCriteriaService.testStandardCriterias.mockReturnValue(true);
 
-            const result = walletSearchService.getWalletsPage(
+            const result = await walletSearchService.getWalletsPage(
                 {
                     offset: 0,
                     limit: 100,
@@ -151,11 +151,11 @@ describe("WalletSearchService", () => {
             expect(result.results).toEqual([walletResource]);
         });
 
-        it("should return wallets page with empty array on negative criteria tests", () => {
+        it("should return wallets page with empty array on negative criteria tests", async () => {
             walletRepository.allByAddress.mockReturnValue([wallet]);
             standardCriteriaService.testStandardCriterias.mockReturnValue(false);
 
-            const result = walletSearchService.getWalletsPage(
+            const result = await walletSearchService.getWalletsPage(
                 {
                     offset: 0,
                     limit: 100,
@@ -169,11 +169,11 @@ describe("WalletSearchService", () => {
     });
 
     describe("getActiveWalletsPage", () => {
-        it("should return wallets page with wallet on positive criteria tests", () => {
+        it("should return wallets page with wallet on positive criteria tests", async () => {
             walletRepository.allByPublicKey.mockReturnValue([wallet]);
             standardCriteriaService.testStandardCriterias.mockReturnValue(true);
 
-            const result = walletSearchService.getActiveWalletsPage(
+            const result = await walletSearchService.getActiveWalletsPage(
                 {
                     offset: 0,
                     limit: 100,
@@ -185,11 +185,11 @@ describe("WalletSearchService", () => {
             expect(result.results).toEqual([walletResource]);
         });
 
-        it("should return wallets page with empty array on negative criteria tests", () => {
+        it("should return wallets page with empty array on negative criteria tests", async () => {
             walletRepository.allByPublicKey.mockReturnValue([wallet]);
             standardCriteriaService.testStandardCriterias.mockReturnValue(false);
 
-            const result = walletSearchService.getActiveWalletsPage(
+            const result = await walletSearchService.getActiveWalletsPage(
                 {
                     offset: 0,
                     limit: 100,

--- a/__tests__/unit/core-kernel/services/search/pagination-service.test.ts
+++ b/__tests__/unit/core-kernel/services/search/pagination-service.test.ts
@@ -18,12 +18,12 @@ describe("PaginationService.getEmptyPage", () => {
 });
 
 describe("PaginationService.getPage", () => {
-    it("should leave items order intact when sorting isn't provided", () => {
+    it("should leave items order intact when sorting isn't provided", async () => {
         const paginationService = container.resolve(PaginationService);
         const pagination = { offset: 0, limit: 100 };
         const items = [{ v: 1 }, { v: 3 }, {}, { v: 2 }];
         const sorting = [];
-        const resultsPage = paginationService.getPage(pagination, sorting, items);
+        const resultsPage = await paginationService.getPage(pagination, sorting, items);
 
         expect(resultsPage).toEqual({
             results: [{ v: 1 }, { v: 3 }, {}, { v: 2 }],
@@ -32,12 +32,12 @@ describe("PaginationService.getPage", () => {
         });
     });
 
-    it("should leave items order intact when sorting by undefined property", () => {
+    it("should leave items order intact when sorting by undefined property", async () => {
         const paginationService = container.resolve(PaginationService);
         const pagination = { offset: 0, limit: 100 };
         const items = [{ v: 1 }, { v: 3 }, {}, { v: 2 }];
         const sorting = [{ property: "dummy", direction: "asc" as const }];
-        const resultsPage = paginationService.getPage(pagination, sorting, items);
+        const resultsPage = await paginationService.getPage(pagination, sorting, items);
 
         expect(resultsPage).toEqual({
             results: [{ v: 1 }, { v: 3 }, {}, { v: 2 }],
@@ -46,12 +46,12 @@ describe("PaginationService.getPage", () => {
         });
     });
 
-    it("should return items with undefined properties at the end", () => {
+    it("should return items with undefined properties at the end", async () => {
         const paginationService = container.resolve(PaginationService);
         const pagination = { offset: 0, limit: 100 };
         const items = [{ v: 1 }, {}, { v: 3 }, {}, { v: 2 }];
         const sorting = [{ property: "v", direction: "asc" as const }];
-        const resultsPage = paginationService.getPage(pagination, sorting, items);
+        const resultsPage = await paginationService.getPage(pagination, sorting, items);
 
         expect(resultsPage).toEqual({
             results: [{ v: 1 }, { v: 2 }, { v: 3 }, {}, {}],
@@ -60,12 +60,12 @@ describe("PaginationService.getPage", () => {
         });
     });
 
-    it("should return items with undefined properties at the end regardless of direction", () => {
+    it("should return items with undefined properties at the end regardless of direction", async () => {
         const paginationService = container.resolve(PaginationService);
         const pagination = { offset: 0, limit: 100 };
         const items = [{ v: 1 }, { v: 3 }, {}, { v: 2 }];
         const sorting = [{ property: "v", direction: "desc" as const }];
-        const resultsPage = paginationService.getPage(pagination, sorting, items);
+        const resultsPage = await paginationService.getPage(pagination, sorting, items);
 
         expect(resultsPage).toEqual({
             results: [{ v: 3 }, { v: 2 }, { v: 1 }, {}],
@@ -74,12 +74,12 @@ describe("PaginationService.getPage", () => {
         });
     });
 
-    it("should return items with null properties at the end before items with undefined properties", () => {
+    it("should return items with null properties at the end before items with undefined properties", async () => {
         const paginationService = container.resolve(PaginationService);
         const pagination = { offset: 0, limit: 100 };
         const items = [{ v: 1 }, { v: 3 }, {}, { v: null }, { v: 2 }, { v: null }];
         const sorting = [{ property: "v", direction: "asc" as const }];
-        const resultsPage = paginationService.getPage(pagination, sorting, items);
+        const resultsPage = await paginationService.getPage(pagination, sorting, items);
 
         expect(resultsPage).toEqual({
             results: [{ v: 1 }, { v: 2 }, { v: 3 }, { v: null }, { v: null }, {}],
@@ -88,12 +88,12 @@ describe("PaginationService.getPage", () => {
         });
     });
 
-    it("should return items with null properties at the end before items with undefined properties regardless of direction", () => {
+    it("should return items with null properties at the end before items with undefined properties regardless of direction", async () => {
         const paginationService = container.resolve(PaginationService);
         const pagination = { offset: 0, limit: 100 };
         const items = [{ v: 1 }, { v: null }, { v: 3 }, {}, { v: 2 }];
         const sorting = [{ property: "v", direction: "desc" as const }];
-        const resultsPage = paginationService.getPage(pagination, sorting, items);
+        const resultsPage = await paginationService.getPage(pagination, sorting, items);
 
         expect(resultsPage).toEqual({
             results: [{ v: 3 }, { v: 2 }, { v: 1 }, { v: null }, {}],
@@ -102,7 +102,7 @@ describe("PaginationService.getPage", () => {
         });
     });
 
-    it("should sort using second sorting instruction when first properties are equal booleans", () => {
+    it("should sort using second sorting instruction when first properties are equal booleans", async () => {
         const paginationService = container.resolve(PaginationService);
         const pagination = { offset: 0, limit: 100 };
         const items = [
@@ -114,7 +114,7 @@ describe("PaginationService.getPage", () => {
             { property: "a", direction: "asc" as const },
             { property: "b", direction: "asc" as const },
         ];
-        const resultsPage = paginationService.getPage(pagination, sorting, items);
+        const resultsPage = await paginationService.getPage(pagination, sorting, items);
 
         expect(resultsPage).toEqual({
             results: [
@@ -127,7 +127,7 @@ describe("PaginationService.getPage", () => {
         });
     });
 
-    it("should sort using second sorting instruction when first properties are equal strings", () => {
+    it("should sort using second sorting instruction when first properties are equal strings", async () => {
         const paginationService = container.resolve(PaginationService);
         const pagination = { offset: 0, limit: 100 };
         const items = [
@@ -139,7 +139,7 @@ describe("PaginationService.getPage", () => {
             { property: "a", direction: "asc" as const },
             { property: "b", direction: "asc" as const },
         ];
-        const resultsPage = paginationService.getPage(pagination, sorting, items);
+        const resultsPage = await paginationService.getPage(pagination, sorting, items);
 
         expect(resultsPage).toEqual({
             results: [
@@ -152,7 +152,7 @@ describe("PaginationService.getPage", () => {
         });
     });
 
-    it("should sort using second sorting instruction when first properties are equal numbers", () => {
+    it("should sort using second sorting instruction when first properties are equal numbers", async () => {
         const paginationService = container.resolve(PaginationService);
         const pagination = { offset: 0, limit: 100 };
         const items = [
@@ -164,7 +164,7 @@ describe("PaginationService.getPage", () => {
             { property: "a", direction: "asc" as const },
             { property: "b", direction: "asc" as const },
         ];
-        const resultsPage = paginationService.getPage(pagination, sorting, items);
+        const resultsPage = await paginationService.getPage(pagination, sorting, items);
 
         expect(resultsPage).toEqual({
             results: [
@@ -177,7 +177,7 @@ describe("PaginationService.getPage", () => {
         });
     });
 
-    it("should sort using second sorting instruction when first properties are equal bigints", () => {
+    it("should sort using second sorting instruction when first properties are equal bigints", async () => {
         const paginationService = container.resolve(PaginationService);
         const pagination = { offset: 0, limit: 100 };
         const items = [
@@ -189,7 +189,7 @@ describe("PaginationService.getPage", () => {
             { property: "a", direction: "asc" as const },
             { property: "b", direction: "asc" as const },
         ];
-        const resultsPage = paginationService.getPage(pagination, sorting, items);
+        const resultsPage = await paginationService.getPage(pagination, sorting, items);
 
         expect(resultsPage).toEqual({
             results: [
@@ -202,7 +202,7 @@ describe("PaginationService.getPage", () => {
         });
     });
 
-    it("should sort using second sorting instruction when first properties are equal Utils.BigNumber instances", () => {
+    it("should sort using second sorting instruction when first properties are equal Utils.BigNumber instances", async () => {
         const paginationService = container.resolve(PaginationService);
         const pagination = { offset: 0, limit: 100 };
         const items = [
@@ -214,7 +214,7 @@ describe("PaginationService.getPage", () => {
             { property: "a", direction: "asc" as const },
             { property: "b", direction: "asc" as const },
         ];
-        const resultsPage = paginationService.getPage(pagination, sorting, items);
+        const resultsPage = await paginationService.getPage(pagination, sorting, items);
 
         expect(resultsPage).toEqual({
             results: [
@@ -227,7 +227,7 @@ describe("PaginationService.getPage", () => {
         });
     });
 
-    it("should sort using second sorting instruction when first properties are null", () => {
+    it("should sort using second sorting instruction when first properties are null", async () => {
         const paginationService = container.resolve(PaginationService);
         const pagination = { offset: 0, limit: 100 };
         const items = [
@@ -239,7 +239,7 @@ describe("PaginationService.getPage", () => {
             { property: "a", direction: "asc" as const },
             { property: "b", direction: "asc" as const },
         ];
-        const resultsPage = paginationService.getPage(pagination, sorting, items);
+        const resultsPage = await paginationService.getPage(pagination, sorting, items);
 
         expect(resultsPage).toEqual({
             results: [
@@ -252,7 +252,7 @@ describe("PaginationService.getPage", () => {
         });
     });
 
-    it("should sort using second sorting instruction when first properties are undefined", () => {
+    it("should sort using second sorting instruction when first properties are undefined", async () => {
         const paginationService = container.resolve(PaginationService);
         const pagination = { offset: 0, limit: 100 };
         const items = [
@@ -264,7 +264,7 @@ describe("PaginationService.getPage", () => {
             { property: "a", direction: "asc" as const },
             { property: "b", direction: "asc" as const },
         ];
-        const resultsPage = paginationService.getPage(pagination, sorting, items);
+        const resultsPage = await paginationService.getPage(pagination, sorting, items);
 
         expect(resultsPage).toEqual({
             results: [
@@ -277,12 +277,12 @@ describe("PaginationService.getPage", () => {
         });
     });
 
-    it("should sort by Utils.BigNumber property", () => {
+    it("should sort by Utils.BigNumber property", async () => {
         const paginationService = container.resolve(PaginationService);
         const pagination = { offset: 0, limit: 100 };
         const items = [{ v: Utils.BigNumber.make(1) }, { v: Utils.BigNumber.make(3) }, { v: Utils.BigNumber.make(2) }];
         const sorting = [{ property: "v", direction: "asc" as const }];
-        const resultsPage = paginationService.getPage(pagination, sorting, items);
+        const resultsPage = await paginationService.getPage(pagination, sorting, items);
 
         expect(resultsPage).toEqual({
             results: [{ v: Utils.BigNumber.make(1) }, { v: Utils.BigNumber.make(2) }, { v: Utils.BigNumber.make(3) }],
@@ -291,23 +291,25 @@ describe("PaginationService.getPage", () => {
         });
     });
 
-    it("should throw when sorting over property with union type", () => {
+    it("should throw when sorting over property with union type", async () => {
         const paginationService = container.resolve(PaginationService);
         const pagination = { offset: 0, limit: 100 };
         const items: { v: number | string }[] = [{ v: 1 }, { v: "2" }];
         const sorting = [{ property: "v", direction: "asc" as const }];
 
-        expect(() => paginationService.getPage(pagination, sorting, items)).toThrowError(
+        await expect(() => paginationService.getPage(pagination, sorting, items)).rejects.toThrowError(
             "Mismatched types 'string' and 'number' at 'v'",
         );
     });
 
-    it("should throw when sorting over property with invalid type", () => {
+    it("should throw when sorting over property with invalid type", async () => {
         const paginationService = container.resolve(PaginationService);
         const pagination = { offset: 0, limit: 100 };
         const items = [{ v: Symbol() }, { v: Symbol() }];
         const sorting = [{ property: "v", direction: "asc" as const }];
 
-        expect(() => paginationService.getPage(pagination, sorting, items)).toThrowError("Unexpected type at 'v'");
+        await expect(() => paginationService.getPage(pagination, sorting, items)).rejects.toThrowError(
+            "Unexpected type at 'v'",
+        );
     });
 });

--- a/__tests__/unit/core-magistrate-api/controllers/entities.test.ts
+++ b/__tests__/unit/core-magistrate-api/controllers/entities.test.ts
@@ -46,7 +46,7 @@ describe("EntityController.index", () => {
             meta: { totalCountIsEstimate: false },
         };
 
-        entitySearchService.getEntitiesPage.mockReturnValueOnce(entitiesPage);
+        entitySearchService.getEntitiesPage.mockResolvedValueOnce(entitiesPage);
 
         const entityController = container.resolve(EntityController);
         const result = await entityController.index({

--- a/__tests__/unit/core-magistrate-api/controllers/entities.test.ts
+++ b/__tests__/unit/core-magistrate-api/controllers/entities.test.ts
@@ -39,7 +39,7 @@ const entityResource1 = {
 };
 
 describe("EntityController.index", () => {
-    it("should get criteria from query and return page from EntitySearchService", () => {
+    it("should get criteria from query and return page from EntitySearchService", async () => {
         const entitiesPage: Contracts.Search.ResultsPage<Resources.EntityResource> = {
             results: [entityResource1],
             totalCount: 1,
@@ -49,7 +49,7 @@ describe("EntityController.index", () => {
         entitySearchService.getEntitiesPage.mockReturnValueOnce(entitiesPage);
 
         const entityController = container.resolve(EntityController);
-        const result = entityController.index({
+        const result = await entityController.index({
             query: {
                 type: Enums.EntityType.Business,
                 page: 1,

--- a/packages/core-api/src/controllers/delegates.ts
+++ b/packages/core-api/src/controllers/delegates.ts
@@ -28,7 +28,7 @@ export class DelegatesController extends Controller {
     @Container.inject(Container.Identifiers.BlockHistoryService)
     private readonly blockHistoryService!: Contracts.Shared.BlockHistoryService;
 
-    public index(request: Hapi.Request): Contracts.Search.ResultsPage<DelegateResource> {
+    public async index(request: Hapi.Request): Promise<Contracts.Search.ResultsPage<DelegateResource>> {
         const pagination = this.getQueryPagination(request.query);
         const sorting = request.query.orderBy as Contracts.Search.Sorting;
         const criteria = this.getQueryCriteria(request.query, delegateCriteriaSchemaObject) as DelegateCriteria;
@@ -52,7 +52,7 @@ export class DelegatesController extends Controller {
         return { data: delegateResource };
     }
 
-    public voters(request: Hapi.Request): Contracts.Search.ResultsPage<WalletResource> | Boom {
+    public async voters(request: Hapi.Request): Promise<Contracts.Search.ResultsPage<WalletResource> | Boom> {
         const walletId = request.params.id as string;
 
         const walletResource = this.walletSearchService.getWallet(walletId);

--- a/packages/core-api/src/controllers/locks.ts
+++ b/packages/core-api/src/controllers/locks.ts
@@ -17,7 +17,7 @@ export class LocksController extends Controller {
     @Container.inject(Container.Identifiers.TransactionHistoryService)
     private readonly transactionHistoryService!: Contracts.Shared.TransactionHistoryService;
 
-    public index(request: Hapi.Request): Contracts.Search.ResultsPage<LockResource> {
+    public async index(request: Hapi.Request): Promise<Contracts.Search.ResultsPage<LockResource>> {
         const pagination = this.getQueryPagination(request.query);
         const sorting = request.query.orderBy as Contracts.Search.Sorting;
         const criteria = this.getQueryCriteria(request.query, lockCriteriaSchemaObject) as LockCriteria;

--- a/packages/core-api/src/controllers/wallets.ts
+++ b/packages/core-api/src/controllers/wallets.ts
@@ -30,7 +30,7 @@ export class WalletsController extends Controller {
     @Container.inject(Container.Identifiers.TransactionHistoryService)
     private readonly transactionHistoryService!: Contracts.Shared.TransactionHistoryService;
 
-    public index(request: Hapi.Request): Contracts.Search.ResultsPage<WalletResource> {
+    public async index(request: Hapi.Request): Promise<Contracts.Search.ResultsPage<WalletResource>> {
         const pagination = this.getQueryPagination(request.query);
         const sorting = request.query.orderBy as Contracts.Search.Sorting;
         const criteria = this.getQueryCriteria(request.query, walletCriteriaSchemaObject) as WalletCriteria;
@@ -38,7 +38,7 @@ export class WalletsController extends Controller {
         return this.walletSearchService.getWalletsPage(pagination, sorting, criteria);
     }
 
-    public top(request: Hapi.Request): Contracts.Search.ResultsPage<WalletResource> {
+    public async top(request: Hapi.Request): Promise<Contracts.Search.ResultsPage<WalletResource>> {
         const pagination = this.getQueryPagination(request.query);
         const sorting = request.query.orderBy as Contracts.Search.Sorting;
         const criteria = this.getQueryCriteria(request.query, walletCriteriaSchemaObject) as WalletCriteria;
@@ -57,7 +57,7 @@ export class WalletsController extends Controller {
         return { data: walletResource };
     }
 
-    public locks(request: Hapi.Request): Contracts.Search.ResultsPage<LockResource> | Boom {
+    public async locks(request: Hapi.Request): Promise<Contracts.Search.ResultsPage<LockResource> | Boom> {
         const walletId = request.params.id as string;
         const walletResource = this.walletSearchService.getWallet(walletId);
 

--- a/packages/core-api/src/services/delegate-search-service.ts
+++ b/packages/core-api/src/services/delegate-search-service.ts
@@ -27,11 +27,11 @@ export class DelegateSearchService {
         }
     }
 
-    public getDelegatesPage(
+    public async getDelegatesPage(
         pagination: Contracts.Search.Pagination,
         sorting: Contracts.Search.Sorting,
         ...criterias: DelegateCriteria[]
-    ): Contracts.Search.ResultsPage<DelegateResource> {
+    ): Promise<Contracts.Search.ResultsPage<DelegateResource>> {
         sorting = [...sorting, { property: "rank", direction: "asc" }, { property: "publicKey", direction: "asc" }];
 
         return this.paginationService.getPage(pagination, sorting, this.getDelegates(...criterias));

--- a/packages/core-api/src/services/lock-search-service.ts
+++ b/packages/core-api/src/services/lock-search-service.ts
@@ -27,22 +27,22 @@ export class LockSearchService {
         }
     }
 
-    public getLocksPage(
+    public async getLocksPage(
         pagination: Contracts.Search.Pagination,
         sorting: Contracts.Search.Sorting,
         ...criterias: LockCriteria[]
-    ): Contracts.Search.ResultsPage<LockResource> {
+    ): Promise<Contracts.Search.ResultsPage<LockResource>> {
         sorting = [...sorting, { property: "timestamp.unix", direction: "desc" }];
 
         return this.paginationService.getPage(pagination, sorting, this.getLocks(...criterias));
     }
 
-    public getWalletLocksPage(
+    public async getWalletLocksPage(
         pagination: Contracts.Search.Pagination,
         sorting: Contracts.Search.Sorting,
         walletAddress: string,
         ...criterias: LockCriteria[]
-    ): Contracts.Search.ResultsPage<LockResource> {
+    ): Promise<Contracts.Search.ResultsPage<LockResource>> {
         sorting = [...sorting, { property: "timestamp.unix", direction: "desc" }];
 
         return this.paginationService.getPage(pagination, sorting, this.getWalletLocks(walletAddress, ...criterias));

--- a/packages/core-api/src/services/wallet-search-service.ts
+++ b/packages/core-api/src/services/wallet-search-service.ts
@@ -36,21 +36,21 @@ export class WalletSearchService {
         }
     }
 
-    public getWalletsPage(
+    public async getWalletsPage(
         pagination: Contracts.Search.Pagination,
         sorting: Contracts.Search.Sorting,
         ...criterias: WalletCriteria[]
-    ): Contracts.Search.ResultsPage<WalletResource> {
+    ): Promise<Contracts.Search.ResultsPage<WalletResource>> {
         sorting = [...sorting, { property: "balance", direction: "desc" }];
 
         return this.paginationService.getPage(pagination, sorting, this.getWallets(...criterias));
     }
 
-    public getActiveWalletsPage(
+    public async getActiveWalletsPage(
         pagination: Contracts.Search.Pagination,
         sorting: Contracts.Search.Sorting,
         ...criterias: WalletCriteria[]
-    ): Contracts.Search.ResultsPage<WalletResource> {
+    ): Promise<Contracts.Search.ResultsPage<WalletResource>> {
         sorting = [...sorting, { property: "balance", direction: "desc" }];
 
         return this.paginationService.getPage(pagination, sorting, this.getActiveWallets(...criterias));

--- a/packages/core-magistrate-api/src/controllers/entities.ts
+++ b/packages/core-magistrate-api/src/controllers/entities.ts
@@ -12,7 +12,7 @@ export class EntityController extends Controller {
     @Container.inject(Identifiers.EntitySearchService)
     private readonly entitySearchService!: EntitySearchService;
 
-    public index(request: Hapi.Request): Contracts.Search.ResultsPage<EntityResource> {
+    public async index(request: Hapi.Request): Promise<Contracts.Search.ResultsPage<EntityResource>> {
         const pagination = this.getQueryPagination(request.query);
         const sorting = request.query.orderBy as Contracts.Search.Sorting;
         const criteria = this.getQueryCriteria(request.query, entityCriteriaSchemaObject) as EntityCriteria;

--- a/packages/core-magistrate-api/src/services/entity-search-service.ts
+++ b/packages/core-magistrate-api/src/services/entity-search-service.ts
@@ -24,11 +24,11 @@ export class EntitySearchService {
         }
     }
 
-    public getEntitiesPage(
+    public async getEntitiesPage(
         pagination: Contracts.Search.Pagination,
         sorting: Contracts.Search.Sorting,
         ...criterias: EntityCriteria[]
-    ): Contracts.Search.ResultsPage<EntityResource> {
+    ): Promise<Contracts.Search.ResultsPage<EntityResource>> {
         sorting = [...sorting, { property: "data.name", direction: "asc" }];
 
         return this.paginationService.getPage(pagination, sorting, this.getEntities(...criterias));


### PR DESCRIPTION
## Summary

Make pagination service non blocking, by using setImmediate callback every 1000 items. 

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged

