### PR TITLE
chore(core-api): adjust semaphore plugin defaults & allow 0 concurrency

### DIFF
--- a/__tests__/unit/core-api/service-provider.test.ts
+++ b/__tests__/unit/core-api/service-provider.test.ts
@@ -880,7 +880,7 @@ describe("ServiceProvider", () => {
                 expect(result.error!.message).toEqual('"plugins.semaphore.database.levelOne" is required');
             });
 
-            it("plugins.semaphore.database.levelOne.concurrency is required && is integer && >= 1", async () => {
+            it("plugins.semaphore.database.levelOne.concurrency is required && is integer && >= 0", async () => {
                 defaults.plugins.semaphore.database.levelOne.concurrency = false;
                 let result = (coreApiServiceProvider.configSchema() as AnySchema).validate(defaults);
 
@@ -899,7 +899,7 @@ describe("ServiceProvider", () => {
                 result = (coreApiServiceProvider.configSchema() as AnySchema).validate(defaults);
 
                 expect(result.error!.message).toEqual(
-                    '"plugins.semaphore.database.levelOne.concurrency" must be greater than or equal to 1',
+                    '"plugins.semaphore.database.levelOne.concurrency" must be greater than or equal to 0',
                 );
 
                 delete defaults.plugins.semaphore.database.levelOne.concurrency;
@@ -976,7 +976,7 @@ describe("ServiceProvider", () => {
                 expect(result.error!.message).toEqual('"plugins.semaphore.database.levelTwo" is required');
             });
 
-            it("plugins.semaphore.database.levelTwo.concurrency is required && is integer && >= 1", async () => {
+            it("plugins.semaphore.database.levelTwo.concurrency is required && is integer && >= 0", async () => {
                 defaults.plugins.semaphore.database.levelTwo.concurrency = false;
                 let result = (coreApiServiceProvider.configSchema() as AnySchema).validate(defaults);
 
@@ -995,7 +995,7 @@ describe("ServiceProvider", () => {
                 result = (coreApiServiceProvider.configSchema() as AnySchema).validate(defaults);
 
                 expect(result.error!.message).toEqual(
-                    '"plugins.semaphore.database.levelTwo.concurrency" must be greater than or equal to 1',
+                    '"plugins.semaphore.database.levelTwo.concurrency" must be greater than or equal to 0',
                 );
 
                 delete defaults.plugins.semaphore.database.levelTwo.concurrency;
@@ -1056,7 +1056,7 @@ describe("ServiceProvider", () => {
                 expect(result.error!.message).toEqual('"plugins.semaphore.memory.levelOne" is required');
             });
 
-            it("plugins.semaphore.memory.levelOne.concurrency is required && is integer && >= 1", async () => {
+            it("plugins.semaphore.memory.levelOne.concurrency is required && is integer && >= 0", async () => {
                 defaults.plugins.semaphore.memory.levelOne.concurrency = false;
                 let result = (coreApiServiceProvider.configSchema() as AnySchema).validate(defaults);
 
@@ -1075,7 +1075,7 @@ describe("ServiceProvider", () => {
                 result = (coreApiServiceProvider.configSchema() as AnySchema).validate(defaults);
 
                 expect(result.error!.message).toEqual(
-                    '"plugins.semaphore.memory.levelOne.concurrency" must be greater than or equal to 1',
+                    '"plugins.semaphore.memory.levelOne.concurrency" must be greater than or equal to 0',
                 );
 
                 delete defaults.plugins.semaphore.memory.levelOne.concurrency;
@@ -1150,7 +1150,7 @@ describe("ServiceProvider", () => {
                 expect(result.error!.message).toEqual('"plugins.semaphore.memory.levelTwo" is required');
             });
 
-            it("plugins.semaphore.memory.levelTwo.concurrency is required && is integer && >= 1", async () => {
+            it("plugins.semaphore.memory.levelTwo.concurrency is required && is integer && >= 0", async () => {
                 defaults.plugins.semaphore.memory.levelTwo.concurrency = false;
                 let result = (coreApiServiceProvider.configSchema() as AnySchema).validate(defaults);
 
@@ -1169,7 +1169,7 @@ describe("ServiceProvider", () => {
                 result = (coreApiServiceProvider.configSchema() as AnySchema).validate(defaults);
 
                 expect(result.error!.message).toEqual(
-                    '"plugins.semaphore.memory.levelTwo.concurrency" must be greater than or equal to 1',
+                    '"plugins.semaphore.memory.levelTwo.concurrency" must be greater than or equal to 0',
                 );
 
                 delete defaults.plugins.semaphore.memory.levelTwo.concurrency;

--- a/packages/core-api/src/defaults.ts
+++ b/packages/core-api/src/defaults.ts
@@ -35,7 +35,7 @@ export const defaults = {
                 },
                 levelTwo: {
                     concurrency: 1,
-                    queueLimit: 10,
+                    queueLimit: 5,
                 },
             },
             memory: {

--- a/packages/core-api/src/service-provider.ts
+++ b/packages/core-api/src/service-provider.ts
@@ -73,23 +73,23 @@ export class ServiceProvider extends Providers.ServiceProvider {
                     enabled: Joi.bool().required(),
                     database: Joi.object({
                         levelOne: Joi.object({
-                            concurrency: Joi.number().integer().min(1).required(),
+                            concurrency: Joi.number().integer().min(0).required(),
                             queueLimit: Joi.number().integer().min(0).required(),
                             maxOffset: Joi.number().integer().min(0).required(),
                         }).required(),
                         levelTwo: Joi.object({
-                            concurrency: Joi.number().integer().min(1).required(),
+                            concurrency: Joi.number().integer().min(0).required(),
                             queueLimit: Joi.number().integer().min(0).required(),
                         }).required(),
                     }).required(),
                     memory: Joi.object({
                         levelOne: Joi.object({
-                            concurrency: Joi.number().integer().min(1).required(),
+                            concurrency: Joi.number().integer().min(0).required(),
                             queueLimit: Joi.number().integer().min(0).required(),
                             maxOffset: Joi.number().integer().min(0).required(),
                         }).required(),
                         levelTwo: Joi.object({
-                            concurrency: Joi.number().integer().min(1).required(),
+                            concurrency: Joi.number().integer().min(0).required(),
                             queueLimit: Joi.number().integer().min(0).required(),
                         }).required(),
                     }).required(),


### PR DESCRIPTION
## Summary

Set queueLimit to 5. And allow setting concurrency to 0. 

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged
