### PR TITLE
fix(core-database): remove delegate registration expression

### DIFF
--- a/__tests__/integration/core-api/handlers/transactions.test.ts
+++ b/__tests__/integration/core-api/handlers/transactions.test.ts
@@ -208,7 +208,7 @@ describe("API 2.0 - Transactions", () => {
             const response = await api.request("GET", "transactions", { recipientId: recipientAddress });
             expect(response).toBeSuccessfulResponse();
             expect(response.data.data).toBeArray();
-            expect(response.data.data).toHaveLength(3);
+            expect(response.data.data).toHaveLength(2);
 
             for (const transaction of response.data.data) {
                 api.expectTransaction(transaction);
@@ -224,7 +224,7 @@ describe("API 2.0 - Transactions", () => {
             expect(response).toBeSuccessfulResponse();
 
             expect(response.data.data).toBeArray();
-            expect(response.data.data).toHaveLength(6);
+            expect(response.data.data).toHaveLength(4);
 
             for (const transaction of response.data.data) {
                 api.expectTransaction(transaction);

--- a/__tests__/unit/core-database/transaction-filter.test.ts
+++ b/__tests__/unit/core-database/transaction-filter.test.ts
@@ -26,7 +26,7 @@ describe("TransactionFilter.getExpression", () => {
     });
 
     describe("TransactionCriteria.address", () => {
-        it("should compare senderPublicKey, recipientId, multipayment recipientId, delegate registration sender", async () => {
+        it("should compare senderPublicKey, recipientId, multipayment recipientId", async () => {
             walletRepository.hasByAddress.mockReturnValue(true);
             walletRepository.findByAddress
                 .mockReturnValueOnce({
@@ -56,14 +56,6 @@ describe("TransactionFilter.getExpression", () => {
                             { property: "typeGroup", op: "equal", value: Enums.TransactionTypeGroup.Core },
                             { property: "type", op: "equal", value: Enums.TransactionType.MultiPayment },
                             { property: "asset", op: "contains", value: { payments: [{ recipientId: "123" }] } },
-                        ],
-                    },
-                    {
-                        op: "and",
-                        expressions: [
-                            { property: "typeGroup", op: "equal", value: Enums.TransactionTypeGroup.Core },
-                            { property: "type", op: "equal", value: Enums.TransactionType.DelegateRegistration },
-                            { property: "senderPublicKey", op: "equal", value: "456" },
                         ],
                     },
                 ],
@@ -125,7 +117,7 @@ describe("TransactionFilter.getExpression", () => {
     });
 
     describe("TransactionCriteria.recipientId", () => {
-        it("should compare using equal expression and include multipayment and include delegate registration transaction", async () => {
+        it("should compare using equal expression and include multipayment", async () => {
             walletRepository.hasByAddress.mockReturnValue(true);
             walletRepository.findByAddress.mockReturnValueOnce({
                 getPublicKey: () => {
@@ -136,40 +128,6 @@ describe("TransactionFilter.getExpression", () => {
             const transactionFilter = container.resolve(TransactionFilter);
             const expression = await transactionFilter.getExpression({ recipientId: "123" });
 
-            expect(walletRepository.hasByAddress).toBeCalledWith("123");
-            expect(walletRepository.findByAddress).toBeCalledWith("123");
-            expect(expression).toEqual({
-                op: "or",
-                expressions: [
-                    { property: "recipientId", op: "equal", value: "123" },
-                    {
-                        op: "and",
-                        expressions: [
-                            { property: "typeGroup", op: "equal", value: Enums.TransactionTypeGroup.Core },
-                            { property: "type", op: "equal", value: Enums.TransactionType.MultiPayment },
-                            { property: "asset", op: "contains", value: { payments: [{ recipientId: "123" }] } },
-                        ],
-                    },
-                    {
-                        op: "and",
-                        expressions: [
-                            { property: "typeGroup", op: "equal", value: Enums.TransactionTypeGroup.Core },
-                            { property: "type", op: "equal", value: Enums.TransactionType.DelegateRegistration },
-                            { property: "senderPublicKey", op: "equal", value: "456" },
-                        ],
-                    },
-                ],
-            });
-        });
-
-        it("should compare using equal expression and include multipayment when wallet not found", async () => {
-            walletRepository.hasByAddress.mockReturnValue(false);
-
-            const transactionFilter = container.resolve(TransactionFilter);
-            const expression = await transactionFilter.getExpression({ recipientId: "123" });
-
-            expect(walletRepository.hasByAddress).toBeCalledWith("123");
-            expect(walletRepository.findByAddress).not.toBeCalled();
             expect(expression).toEqual({
                 op: "or",
                 expressions: [

--- a/packages/core-database/src/transaction-filter.ts
+++ b/packages/core-database/src/transaction-filter.ts
@@ -142,29 +142,6 @@ export class TransactionFilter implements Contracts.Database.TransactionFilter {
             ],
         };
 
-        if (this.walletRepository.hasByAddress(criteria)) {
-            const recipientWallet = this.walletRepository.findByAddress(criteria);
-            if (recipientWallet && recipientWallet.getPublicKey()) {
-                const delegateRegistrationExpression: Contracts.Search.AndExpression<Transaction> = {
-                    op: "and",
-                    expressions: [
-                        { op: "equal", property: "typeGroup", value: Enums.TransactionTypeGroup.Core },
-                        { op: "equal", property: "type", value: Enums.TransactionType.DelegateRegistration },
-                        { op: "equal", property: "senderPublicKey", value: recipientWallet.getPublicKey() },
-                    ],
-                };
-
-                return {
-                    op: "or",
-                    expressions: [
-                        recipientIdExpression,
-                        multipaymentRecipientIdExpression,
-                        delegateRegistrationExpression,
-                    ],
-                };
-            }
-        }
-
         return {
             op: "or",
             expressions: [recipientIdExpression, multipaymentRecipientIdExpression],


### PR DESCRIPTION
## Summary

Remove the delegateRegistrationExpression, because it is unnecessary expression. Generated query is already comparing senderPublicKey.

Expression:
```
{
    op: "or",
    expressions: [
        { property: "senderPublicKey", op: "equal", value: "456" },
        { property: "recipientId", op: "equal", value: "123" },
        {
            op: "and",
            expressions: [
                { property: "typeGroup", op: "equal", value: Enums.TransactionTypeGroup.Core },
                { property: "type", op: "equal", value: Enums.TransactionType.MultiPayment },
                { property: "asset", op: "contains", value: { payments: [{ recipientId: "123" }] } },
            ],
        },
        {
            op: "and",
            expressions: [
                { property: "typeGroup", op: "equal", value: Enums.TransactionTypeGroup.Core },
                { property: "type", op: "equal", value: Enums.TransactionType.DelegateRegistration },
                { property: "senderPublicKey", op: "equal", value: "456" },
            ],
        },
    ],
}
```

can be shorten to:
```
{
    op: "or",
    expressions: [
        { property: "senderPublicKey", op: "equal", value: "456" },
        { property: "recipientId", op: "equal", value: "123" },
        {
            op: "and",
            expressions: [
                { property: "typeGroup", op: "equal", value: Enums.TransactionTypeGroup.Core },
                { property: "type", op: "equal", value: Enums.TransactionType.MultiPayment },
                { property: "asset", op: "contains", value: { payments: [{ recipientId: "123" }] } },
            ],
        },
    ],
}
```

because we already use: 

`{ property: "senderPublicKey", op: "equal", value: "456" },`

and removed expression can only return the subset of that expressions. 

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged

