### PR TITLE
fix(core-api): add `address` into transactionQueryLevelOptions

### DIFF
--- a/packages/core-api/src/resources-new/transaction.ts
+++ b/packages/core-api/src/resources-new/transaction.ts
@@ -32,4 +32,5 @@ export const transactionQueryLevelOptions = [
     { field: "blockId", asc: false, desc: false, allowSecondOrderBy: false, diverse: true },
     { field: "senderPublicKey", asc: false, desc: false, allowSecondOrderBy: false, diverse: true },
     { field: "recipientId", asc: false, desc: false, allowSecondOrderBy: false, diverse: true },
+    { field: "address", asc: false, desc: false, allowSecondOrderBy: false, diverse: true },
 ];


### PR DESCRIPTION
## Summary

Add `address` into transactionQueryLevelOptions. Queries which filter by address are marked as L1 in semaphore plugin. This is because request is transformed to query that is using recipientId and senderPublicKey, which are both indexed fields on transactions table. 

## Checklist

- [x] Ready to be merged

