### PR TITLE
feat(core-blockchain): increase block download frequency using fastSync option 

### DIFF
--- a/packages/core-blockchain/src/blockchain.ts
+++ b/packages/core-blockchain/src/blockchain.ts
@@ -161,9 +161,12 @@ export class Blockchain implements Contracts.Blockchain.Blockchain {
      * Set wakeup timeout to check the network for new blocks.
      */
     public setWakeUp(): void {
-        this.stateStore.setWakeUpTimeout(() => {
-            this.dispatch("WAKEUP");
-        }, 60000);
+        this.stateStore.setWakeUpTimeout(
+            () => {
+                this.dispatch("WAKEUP");
+            },
+            this.configuration.getRequired<boolean>("fastSync") ? 8000 : 60000,
+        );
     }
 
     /**
@@ -437,8 +440,11 @@ export class Blockchain implements Contracts.Blockchain.Blockchain {
 
         block = block || this.getLastBlock().data;
 
+        const blockCount = this.configuration.getRequired<boolean>("fastSync") ? 1 : 3;
+
         return (
-            Crypto.Slots.getTime() - block.timestamp < 3 * Managers.configManager.getMilestone(block.height).blocktime
+            Crypto.Slots.getTime() - block.timestamp <
+            blockCount * Managers.configManager.getMilestone(block.height).blocktime
         );
     }
 

--- a/packages/core-blockchain/src/defaults.ts
+++ b/packages/core-blockchain/src/defaults.ts
@@ -1,4 +1,5 @@
 export const defaults = {
+    fastSync: !!process.env.CORE_BLOCKCHAIN_FAST_SYNC, // Improves sync rate for readonly nodes, that have a p2p port closed to public. Such node doesn't broadcast data
     databaseRollback: {
         maxBlockRewind: 10000,
         steps: 1000,

--- a/packages/core-blockchain/src/service-provider.ts
+++ b/packages/core-blockchain/src/service-provider.ts
@@ -29,6 +29,7 @@ export class ServiceProvider extends Providers.ServiceProvider {
 
     public configSchema(): object {
         return Joi.object({
+            fastSync: Joi.bool().required(),
             databaseRollback: Joi.object({
                 maxBlockRewind: Joi.number().integer().min(1).required(),
                 steps: Joi.number().integer().min(1).required(),


### PR DESCRIPTION
## Summary

On readonly nodes that have p2p disabled or doesn't expose public IP fastSync mode can be used to improve the download block frequency. Node that have fastSync enabled will use the 8 sec rate over the default 60 sec rate to improve sync. This results in more frequent block download actions. 

Feature can be enabled via: **CORE_BLOCKCHAIN_FAST_SYNC** env variable. 

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged

